### PR TITLE
Improve sidebar for mobile usability

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -8,17 +8,60 @@ body {
 }
 .category-panel {
   position: fixed;
-  left: 0;
-  top: 270px; /* assumes both banners + margin = ~250px + some spacing */
+  left: 10px;
+  top: 240px;
   width: 220px;
   background-color: #1e1e2f;
   border-right: 2px solid #444;
   padding: 15px;
-  height: calc(100% - 270px);
+  height: calc(100% - 240px);
   overflow-y: auto;
-  z-index: 100;
-  display: none; /* keep hidden until "Start New Survey" is clicked */
+  z-index: 200;
+  display: none; /* hidden until a survey loads */
+  transition: left 0.3s ease;
+}
 
+#closeSidebarBtn {
+  text-align: right;
+  background: none;
+  border: none;
+  color: #ccc;
+  font-size: 18px;
+  width: 100%;
+  display: none;
+}
+
+#toggleSidebarBtn {
+  display: none;
+  padding: 8px 12px;
+  background-color: #333;
+  color: #fff;
+  border: 1px solid #555;
+  border-radius: 5px;
+  cursor: pointer;
+  position: fixed;
+  top: 200px;
+  left: 10px;
+  z-index: 201;
+}
+
+@media (max-width: 768px) {
+  #toggleSidebarBtn {
+    display: block;
+    margin-bottom: 10px;
+  }
+
+  #categoryPanel {
+    left: -230px;
+  }
+
+  #categoryPanel.visible {
+    left: 10px;
+  }
+
+  #closeSidebarBtn {
+    display: block;
+  }
 }
 
 #categoryContainer button {
@@ -248,6 +291,12 @@ body.theme-rainbow #comparisonResult {
   margin-left: 220px; /* Make room for fixed sidebar */
   padding: 20px;
   box-sizing: border-box;
+}
+
+@media (max-width: 768px) {
+  .main-container {
+    margin-left: 0;
+  }
 }
 
 /* Content Area Next to Sidebar */

--- a/index.html
+++ b/index.html
@@ -34,9 +34,13 @@
     <div id="neutralTab" class="tab">Neutral</div>
   </div>
 
+  <!-- Mobile Toggle Button -->
+  <button id="toggleSidebarBtn">☰ Categories</button>
+
   <!-- Layout -->
   <div class="main-container">
     <div id="categoryPanel" class="category-panel">
+      <button id="closeSidebarBtn">✖ Close</button>
       <div id="categoryContainer"></div>
     </div>
     <div class="content-panel">

--- a/js/script.js
+++ b/js/script.js
@@ -42,7 +42,19 @@ let currentCategory = null;
 const categoryContainer = document.getElementById('categoryContainer');
 const kinkList = document.getElementById('kinkList');
 const categoryPanel = document.getElementById('categoryPanel');
- categoryPanel.style.display = 'none'; // Hide by default
+const toggleSidebarBtn = document.getElementById('toggleSidebarBtn');
+const closeSidebarBtn = document.getElementById('closeSidebarBtn');
+
+categoryPanel.style.display = 'none'; // Hide by default
+toggleSidebarBtn.style.display = 'none';
+
+toggleSidebarBtn.addEventListener('click', () => {
+  categoryPanel.classList.toggle('visible');
+});
+
+closeSidebarBtn.addEventListener('click', () => {
+  categoryPanel.classList.remove('visible');
+});
 
 document.getElementById('fileA').addEventListener('change', (e) => {
   const reader = new FileReader();
@@ -50,6 +62,7 @@ document.getElementById('fileA').addEventListener('change', (e) => {
     try {
       surveyA = JSON.parse(ev.target.result);
       categoryPanel.style.display = 'block';
+      toggleSidebarBtn.style.display = window.innerWidth <= 768 ? 'block' : 'none';
       showCategories();
     } catch {
       alert('Invalid JSON for Survey A.');
@@ -76,6 +89,7 @@ document.getElementById('newSurveyBtn').addEventListener('click', () => {
     .then(data => {
       surveyA = data;
       categoryPanel.style.display = 'block'; // Show sidebar
+      toggleSidebarBtn.style.display = window.innerWidth <= 768 ? 'block' : 'none';
       showCategories();
     })
     .catch(err => alert('Failed to load template: ' + err.message));
@@ -94,6 +108,9 @@ function showCategories() {
       currentCategory = cat;
       showCategories();
       showKinks(cat);
+      if (window.innerWidth <= 768) {
+        categoryPanel.classList.remove('visible');
+      }
     };
     categoryContainer.appendChild(btn);
   });


### PR DESCRIPTION
## Summary
- add mobile sidebar toggle and close buttons
- slide sidebar in/out on small screens
- auto-close sidebar when a category is chosen

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685cb959cef0832c8b931f8df627d7ed