### PR TITLE
Add expandable subcategory sidebar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -21,6 +21,21 @@ body {
   transition: left 0.3s ease;
 }
 
+.subcategory-panel {
+  position: fixed;
+  left: 240px;
+  top: 240px;
+  width: 260px;
+  background-color: #1e1e2f;
+  border-left: 2px solid #444;
+  padding: 15px;
+  height: calc(100% - 240px);
+  overflow-y: auto;
+  z-index: 199;
+  display: none;
+  transition: left 0.3s ease;
+}
+
 #closeSidebarBtn {
   text-align: right;
   background: none;
@@ -29,6 +44,15 @@ body {
   font-size: 18px;
   width: 100%;
   display: none;
+}
+
+#closeSubSidebarBtn {
+  text-align: right;
+  background: none;
+  border: none;
+  color: #ccc;
+  font-size: 18px;
+  width: 100%;
 }
 
 #toggleSidebarBtn {
@@ -59,7 +83,18 @@ body {
     left: 10px;
   }
 
+  #subCategoryPanel {
+    left: -230px;
+  }
+
+  #subCategoryPanel.visible {
+    left: 240px;
+  }
+
   #closeSidebarBtn {
+    display: block;
+  }
+  #closeSubSidebarBtn {
     display: block;
   }
 }

--- a/index.html
+++ b/index.html
@@ -45,9 +45,11 @@
       <button id="closeSidebarBtn">✖ Close</button>
       <div id="categoryContainer"></div>
     </div>
-    <div class="content-panel">
+    <div id="subCategoryPanel" class="subcategory-panel">
+      <button id="closeSubSidebarBtn">✖ Close</button>
       <div id="kinkList"></div>
     </div>
+    <div class="content-panel"></div>
   </div>
 
   <!-- Buttons -->

--- a/js/script.js
+++ b/js/script.js
@@ -93,18 +93,30 @@ function markUnsaved() {
 const categoryContainer = document.getElementById('categoryContainer');
 const kinkList = document.getElementById('kinkList');
 const categoryPanel = document.getElementById('categoryPanel');
+const subCategoryPanel = document.getElementById('subCategoryPanel');
 const toggleSidebarBtn = document.getElementById('toggleSidebarBtn');
 const closeSidebarBtn = document.getElementById('closeSidebarBtn');
+const closeSubSidebarBtn = document.getElementById('closeSubSidebarBtn');
 
 categoryPanel.style.display = 'none'; // Hide by default
+subCategoryPanel.style.display = 'none';
 toggleSidebarBtn.style.display = 'none';
 
 toggleSidebarBtn.addEventListener('click', () => {
   categoryPanel.classList.toggle('visible');
+  subCategoryPanel.classList.remove('visible');
+  subCategoryPanel.style.display = 'none';
 });
 
 closeSidebarBtn.addEventListener('click', () => {
   categoryPanel.classList.remove('visible');
+  subCategoryPanel.classList.remove('visible');
+  subCategoryPanel.style.display = 'none';
+});
+
+closeSubSidebarBtn.addEventListener('click', () => {
+  subCategoryPanel.classList.remove('visible');
+  subCategoryPanel.style.display = 'none';
 });
 
 document.getElementById('fileA').addEventListener('change', (e) => {
@@ -115,6 +127,8 @@ document.getElementById('fileA').addEventListener('change', (e) => {
     try {
       surveyA = JSON.parse(ev.target.result);
       categoryPanel.style.display = 'block';
+      subCategoryPanel.style.display = 'none';
+      subCategoryPanel.classList.remove('visible');
       toggleSidebarBtn.style.display = window.innerWidth <= 768 ? 'block' : 'none';
       showCategories();
       saveProgress();
@@ -145,6 +159,8 @@ document.getElementById('newSurveyBtn').addEventListener('click', () => {
     .then(data => {
       surveyA = data;
       categoryPanel.style.display = 'block'; // Show sidebar
+      subCategoryPanel.style.display = 'none';
+      subCategoryPanel.classList.remove('visible');
       toggleSidebarBtn.style.display = window.innerWidth <= 768 ? 'block' : 'none';
       showCategories();
       saveProgress();
@@ -179,6 +195,8 @@ function showKinks(category) {
   currentCategory = category;
   kinkList.innerHTML = '';
   const kinks = surveyA[category]?.[currentAction];
+  subCategoryPanel.style.display = 'block';
+  subCategoryPanel.classList.add('visible');
   if (!kinks || kinks.length === 0) {
     kinkList.textContent = 'No items here.';
     return;
@@ -334,6 +352,8 @@ window.addEventListener('DOMContentLoaded', () => {
     if (confirm('Resume unfinished survey?')) {
       surveyA = JSON.parse(saved);
       categoryPanel.style.display = 'block';
+      subCategoryPanel.style.display = 'none';
+      subCategoryPanel.classList.remove('visible');
       toggleSidebarBtn.style.display = window.innerWidth <= 768 ? 'block' : 'none';
       showCategories();
     } else {


### PR DESCRIPTION
## Summary
- add a second sidebar to hold subcategory items
- style the new sidebar and close button
- update JS to open/close the subcategory panel

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685cccdb48b8832caa34c164e487ef16