### PR TITLE
Extend category panel for subcategories

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -18,7 +18,29 @@ body {
   overflow-y: auto;
   z-index: 200;
   display: none; /* hidden until a survey loads */
-  transition: left 0.3s ease;
+  transition: left 0.3s ease, width 0.3s ease;
+}
+
+.category-panel.extended {
+  width: 480px;
+}
+
+.subcategory-wrapper {
+  position: absolute;
+  left: 220px;
+  top: 0;
+  width: 260px;
+  background-color: #1e1e2f;
+  border-left: 2px solid #444;
+  padding: 15px;
+  height: 100%;
+  overflow-y: auto;
+  z-index: 199;
+  display: none;
+}
+
+.category-panel.extended .subcategory-wrapper {
+  display: block;
 }
 
 #closeSidebarBtn {
@@ -29,6 +51,15 @@ body {
   font-size: 18px;
   width: 100%;
   display: none;
+}
+
+#closeSubSidebarBtn {
+  text-align: right;
+  background: none;
+  border: none;
+  color: #ccc;
+  font-size: 18px;
+  width: 100%;
 }
 
 #toggleSidebarBtn {
@@ -59,7 +90,11 @@ body {
     left: 10px;
   }
 
+
   #closeSidebarBtn {
+    display: block;
+  }
+  #closeSubSidebarBtn {
     display: block;
   }
 }
@@ -112,6 +147,58 @@ body.theme-monster-prom {
 body.theme-rainbow {
   background: linear-gradient(135deg, #ff9a9e, #fad0c4, #fbc2eb, #a18cd1);
   color: #000;
+}
+
+/* Theme-specific panel colors */
+body.light-mode .category-panel {
+  background-color: #f9f9f9;
+  color: #000;
+  border-right-color: #ccc;
+}
+body.light-mode .subcategory-wrapper {
+  background-color: #f9f9f9;
+  color: #000;
+  border-left-color: #ccc;
+}
+body.theme-blue .category-panel {
+  background-color: #002244;
+  color: #fff;
+  border-right-color: #003366;
+}
+body.theme-blue .subcategory-wrapper {
+  background-color: #002244;
+  color: #fff;
+  border-left-color: #003366;
+}
+body.theme-outer-wilds .category-panel {
+  background-color: #2a2a3a;
+  color: #ffde8d;
+  border-right-color: #ffde8d;
+}
+body.theme-outer-wilds .subcategory-wrapper {
+  background-color: #2a2a3a;
+  color: #ffde8d;
+  border-left-color: #ffde8d;
+}
+body.theme-monster-prom .category-panel {
+  background-color: #550055;
+  color: #ff69b4;
+  border-right-color: #800080;
+}
+body.theme-monster-prom .subcategory-wrapper {
+  background-color: #550055;
+  color: #ff69b4;
+  border-left-color: #800080;
+}
+body.theme-rainbow .category-panel {
+  background-color: rgba(255,255,255,0.8);
+  color: #000;
+  border-right-color: #603636;
+}
+body.theme-rainbow .subcategory-wrapper {
+  background-color: rgba(255,255,255,0.8);
+  color: #000;
+  border-left-color: #603636;
 }
 
 /* Theme Banners */

--- a/index.html
+++ b/index.html
@@ -44,10 +44,12 @@
     <div id="categoryPanel" class="category-panel">
       <button id="closeSidebarBtn">✖ Close</button>
       <div id="categoryContainer"></div>
+      <div id="subCategoryWrapper" class="subcategory-wrapper">
+        <button id="closeSubSidebarBtn">✖ Close</button>
+        <div id="kinkList"></div>
+      </div>
     </div>
-    <div class="content-panel">
-      <div id="kinkList"></div>
-    </div>
+    <div class="content-panel"></div>
   </div>
 
   <!-- Buttons -->

--- a/js/script.js
+++ b/js/script.js
@@ -93,18 +93,30 @@ function markUnsaved() {
 const categoryContainer = document.getElementById('categoryContainer');
 const kinkList = document.getElementById('kinkList');
 const categoryPanel = document.getElementById('categoryPanel');
+const subCategoryWrapper = document.getElementById('subCategoryWrapper');
 const toggleSidebarBtn = document.getElementById('toggleSidebarBtn');
 const closeSidebarBtn = document.getElementById('closeSidebarBtn');
+const closeSubSidebarBtn = document.getElementById('closeSubSidebarBtn');
 
 categoryPanel.style.display = 'none'; // Hide by default
+subCategoryWrapper.style.display = 'none';
 toggleSidebarBtn.style.display = 'none';
 
 toggleSidebarBtn.addEventListener('click', () => {
   categoryPanel.classList.toggle('visible');
+  categoryPanel.classList.remove('extended');
+  subCategoryWrapper.style.display = 'none';
 });
 
 closeSidebarBtn.addEventListener('click', () => {
   categoryPanel.classList.remove('visible');
+  categoryPanel.classList.remove('extended');
+  subCategoryWrapper.style.display = 'none';
+});
+
+closeSubSidebarBtn.addEventListener('click', () => {
+  categoryPanel.classList.remove('extended');
+  subCategoryWrapper.style.display = 'none';
 });
 
 document.getElementById('fileA').addEventListener('change', (e) => {
@@ -115,6 +127,8 @@ document.getElementById('fileA').addEventListener('change', (e) => {
     try {
       surveyA = JSON.parse(ev.target.result);
       categoryPanel.style.display = 'block';
+      subCategoryWrapper.style.display = 'none';
+      categoryPanel.classList.remove('extended');
       toggleSidebarBtn.style.display = window.innerWidth <= 768 ? 'block' : 'none';
       showCategories();
       saveProgress();
@@ -145,6 +159,8 @@ document.getElementById('newSurveyBtn').addEventListener('click', () => {
     .then(data => {
       surveyA = data;
       categoryPanel.style.display = 'block'; // Show sidebar
+      subCategoryWrapper.style.display = 'none';
+      categoryPanel.classList.remove('extended');
       toggleSidebarBtn.style.display = window.innerWidth <= 768 ? 'block' : 'none';
       showCategories();
       saveProgress();
@@ -179,6 +195,8 @@ function showKinks(category) {
   currentCategory = category;
   kinkList.innerHTML = '';
   const kinks = surveyA[category]?.[currentAction];
+  subCategoryWrapper.style.display = 'block';
+  categoryPanel.classList.add('extended');
   if (!kinks || kinks.length === 0) {
     kinkList.textContent = 'No items here.';
     return;
@@ -334,6 +352,8 @@ window.addEventListener('DOMContentLoaded', () => {
     if (confirm('Resume unfinished survey?')) {
       surveyA = JSON.parse(saved);
       categoryPanel.style.display = 'block';
+      subCategoryWrapper.style.display = 'none';
+      categoryPanel.classList.remove('extended');
       toggleSidebarBtn.style.display = window.innerWidth <= 768 ? 'block' : 'none';
       showCategories();
     } else {


### PR DESCRIPTION
## Summary
- move subcategory markup inside the category panel
- style subcategories as an extension of the sidebar
- show/hide the subcategory area via an `extended` class in JS

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685cccdb48b8832caa34c164e487ef16