### PR TITLE
Add local development instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,33 @@ The website is built from the following files in this repository:
 - `css/style.css`
 - `js/script.js`
 - `template-survey.json`
+
+## Local Development
+
+Serve the static files locally to preview changes before pushing them to GitHub.
+
+### Using Python
+
+If you have Python 3 installed, run:
+
+```bash
+python3 -m http.server
+```
+
+Then open <http://localhost:8000> in your browser.
+
+### Using Node
+
+First install the `serve` package globally if you haven’t already:
+
+```bash
+npm install -g serve
+```
+
+Start the server from the repository root:
+
+```bash
+serve .
+```
+
+This will default to <http://localhost:3000>.


### PR DESCRIPTION
## Summary
- add instructions for serving the static site locally using Python or Node

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cffc23ae8832c87a99580969dbd9b