### PR TITLE
Remove banner graphics and rename themes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -136,11 +136,11 @@ body.theme-blue {
   background-color: #001933;
   color: #fff;
 }
-body.theme-outer-wilds {
+body.theme-cosmic-dusk {
   background-color: #1e1e2e;
   color: #ffde8d;
 }
-body.theme-monster-prom {
+body.theme-pink-midnight {
   background-color: #400040;
   color: #ff69b4;
 }
@@ -170,22 +170,22 @@ body.theme-blue .subcategory-wrapper {
   color: #fff;
   border-left-color: #003366;
 }
-body.theme-outer-wilds .category-panel {
+body.theme-cosmic-dusk .category-panel {
   background-color: #2a2a3a;
   color: #ffde8d;
   border-right-color: #ffde8d;
 }
-body.theme-outer-wilds .subcategory-wrapper {
+body.theme-cosmic-dusk .subcategory-wrapper {
   background-color: #2a2a3a;
   color: #ffde8d;
   border-left-color: #ffde8d;
 }
-body.theme-monster-prom .category-panel {
+body.theme-pink-midnight .category-panel {
   background-color: #550055;
   color: #ff69b4;
   border-right-color: #800080;
 }
-body.theme-monster-prom .subcategory-wrapper {
+body.theme-pink-midnight .subcategory-wrapper {
   background-color: #550055;
   color: #ff69b4;
   border-left-color: #800080;
@@ -199,17 +199,6 @@ body.theme-rainbow .subcategory-wrapper {
   background-color: rgba(255,255,255,0.8);
   color: #000;
   border-left-color: #603636;
-}
-
-/* Theme Banners */
-.theme-banner {
-  display: none;
-  width: 100%;
-  height: auto;
-  max-height: 250px;
-  object-fit: cover;
-  margin-bottom: 20px;
-  border-radius: 6px;
 }
 
 /* Header */
@@ -285,19 +274,19 @@ body.theme-blue .tab.active {
   background-color: #0055aa;
   border: 1px solid #003377;
 }
-body.theme-outer-wilds .tab {
+body.theme-cosmic-dusk .tab {
   background-color: #2b2b3d;
   color: #ffde8d;
 }
-body.theme-outer-wilds .tab.active {
+body.theme-cosmic-dusk .tab.active {
   background-color: #3b3a5a;
   border: 1px solid #ffde8d;
 }
-body.theme-monster-prom .tab {
+body.theme-pink-midnight .tab {
   background-color: #663366;
   color: #ff69b4;
 }
-body.theme-monster-prom .tab.active {
+body.theme-pink-midnight .tab.active {
   background-color: #ff69b4;
   color: #400040;
   border: 1px solid #800080;
@@ -381,11 +370,11 @@ body.theme-blue #comparisonResult {
   background-color: #002244;
   color: #fff;
 }
-body.theme-outer-wilds #comparisonResult {
+body.theme-cosmic-dusk #comparisonResult {
   background-color: #2a2a3a;
   color: #ffde8d;
 }
-body.theme-monster-prom #comparisonResult {
+body.theme-pink-midnight #comparisonResult {
   background-color: #550055;
   color: #ff69b4;
 }

--- a/index.html
+++ b/index.html
@@ -7,9 +7,6 @@
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body class="dark-mode">
-  <!-- Banners -->
-  <img id="outerWildsBanner" src="https://static.displate.com/380x270/displate/2023-10-13/48fa0ba6447050543f77cc734d746bd6_e644163f144c50f83cbef9fe6e223464.jpg" alt="Outer Wilds Banner" class="theme-banner" />
-  <img id="monsterPromBanner" src="https://freeimghost.net/images/2025/06/20/yourethemaindish_banner.png" alt="Monster Prom Banner" class="theme-banner" />
 
   <h1>Talk Kink</h1>
 
@@ -21,8 +18,8 @@
       <option value="dark-mode">Dark</option>
       <option value="light-mode">Light</option>
       <option value="theme-blue">Blue</option>
-      <option value="theme-outer-wilds">Outer Wilds</option>
-      <option value="theme-monster-prom">Monster Prom</option>
+      <option value="theme-cosmic-dusk">Cosmic Dusk</option>
+      <option value="theme-pink-midnight">Pink Midnight</option>
       <option value="theme-rainbow">Rainbow</option>
     </select>
   </div>

--- a/js/script.js
+++ b/js/script.js
@@ -1,23 +1,13 @@
 // ================== Theme Setup ==================
 const themeSelector = document.getElementById('themeSelector');
-const outerWildsBanner = document.getElementById('outerWildsBanner');
-const monsterPromBanner = document.getElementById('monsterPromBanner');
-
-function updateBannerVisibility(theme) {
-  outerWildsBanner.style.display = theme === 'theme-outer-wilds' ? 'block' : 'none';
-  monsterPromBanner.style.display = theme === 'theme-monster-prom' ? 'block' : 'none';
-}
-
 const savedTheme = localStorage.getItem('selectedTheme') || 'dark-mode';
 document.body.className = savedTheme;
 themeSelector.value = savedTheme;
-updateBannerVisibility(savedTheme);
 
 themeSelector.addEventListener('change', () => {
   const selectedTheme = themeSelector.value;
   document.body.className = selectedTheme;
   localStorage.setItem('selectedTheme', selectedTheme);
-  updateBannerVisibility(selectedTheme);
 });
 
 // ================== Tab Switching ==================


### PR DESCRIPTION
## Summary
- remove banner images from page and stylesheet
- rename custom themes from "Outer Wilds" and "Monster Prom" to "Cosmic Dusk" and "Pink Midnight"
- keep original color values while simplifying theme selection logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d0fc85470832c82c975efc94eb6e8