### PR TITLE
Remove obsolete game banners

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -201,16 +201,6 @@ body.theme-rainbow .subcategory-wrapper {
   border-left-color: #603636;
 }
 
-/* Theme Banners */
-.theme-banner {
-  display: none;
-  width: 100%;
-  height: auto;
-  max-height: 250px;
-  object-fit: cover;
-  margin-bottom: 20px;
-  border-radius: 6px;
-}
 
 /* Header */
 h1 {

--- a/index.html
+++ b/index.html
@@ -7,9 +7,6 @@
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body class="dark-mode">
-  <!-- Banners -->
-  <img id="outerWildsBanner" src="https://static.displate.com/380x270/displate/2023-10-13/48fa0ba6447050543f77cc734d746bd6_e644163f144c50f83cbef9fe6e223464.jpg" alt="Outer Wilds Banner" class="theme-banner" />
-  <img id="monsterPromBanner" src="https://freeimghost.net/images/2025/06/20/yourethemaindish_banner.png" alt="Monster Prom Banner" class="theme-banner" />
 
   <h1>Talk Kink</h1>
 

--- a/js/script.js
+++ b/js/script.js
@@ -1,23 +1,14 @@
 // ================== Theme Setup ==================
 const themeSelector = document.getElementById('themeSelector');
-const outerWildsBanner = document.getElementById('outerWildsBanner');
-const monsterPromBanner = document.getElementById('monsterPromBanner');
-
-function updateBannerVisibility(theme) {
-  outerWildsBanner.style.display = theme === 'theme-outer-wilds' ? 'block' : 'none';
-  monsterPromBanner.style.display = theme === 'theme-monster-prom' ? 'block' : 'none';
-}
 
 const savedTheme = localStorage.getItem('selectedTheme') || 'dark-mode';
 document.body.className = savedTheme;
 themeSelector.value = savedTheme;
-updateBannerVisibility(savedTheme);
 
 themeSelector.addEventListener('change', () => {
   const selectedTheme = themeSelector.value;
   document.body.className = selectedTheme;
   localStorage.setItem('selectedTheme', selectedTheme);
-  updateBannerVisibility(selectedTheme);
 });
 
 // ================== Tab Switching ==================


### PR DESCRIPTION
## Summary
- delete Monster Prom and Outer Wilds banner images
- clean up banner-related JavaScript logic
- drop unused `.theme-banner` styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685de9f11028832cbb556b776776c2f8