### PR TITLE
Add accessible light theme

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -52,7 +52,6 @@ body {
   width: 100%;
   display: none;
 }
-
 #closeSubSidebarBtn {
   text-align: right;
   background: none;
@@ -60,6 +59,10 @@ body {
   color: #ccc;
   font-size: 18px;
   width: 100%;
+}
+body.light-mode #closeSidebarBtn,
+body.light-mode #closeSubSidebarBtn {
+  color: #555;
 }
 
 #toggleSidebarBtn {
@@ -122,6 +125,15 @@ body {
   background-color: #666;
   color: white;
 }
+body.light-mode #categoryContainer button {
+  background-color: #e7e7e7;
+  color: #222;
+  border: 1px solid #bbb;
+}
+body.light-mode #categoryContainer button.active {
+  background-color: #3e8e7e;
+  color: #fff;
+}
 
 /* Theme Styling */
 body.dark-mode {
@@ -129,8 +141,8 @@ body.dark-mode {
   color: #e0e0e0;
 }
 body.light-mode {
-  background-color: #ffffff;
-  color: #000;
+  background-color: #f7f7f7;
+  color: #222;
 }
 body.theme-blue {
   background-color: #001933;
@@ -151,14 +163,14 @@ body.theme-rainbow {
 
 /* Theme-specific panel colors */
 body.light-mode .category-panel {
-  background-color: #f9f9f9;
-  color: #000;
-  border-right-color: #ccc;
+  background-color: #ffffff;
+  color: #222;
+  border-right-color: #dcdcdc;
 }
 body.light-mode .subcategory-wrapper {
-  background-color: #f9f9f9;
-  color: #000;
-  border-left-color: #ccc;
+  background-color: #ffffff;
+  color: #222;
+  border-left-color: #dcdcdc;
 }
 body.theme-blue .category-panel {
   background-color: #002244;
@@ -251,12 +263,13 @@ h1 {
 
 /* Tab Colors by Theme */
 body.light-mode .tab {
-  background-color: #e0e0e0;
-  color: #000;
+  background-color: #e7e7e7;
+  color: #222;
 }
 body.light-mode .tab.active {
-  background-color: #007acc;
-  border: 1px solid #005fa3;
+  background-color: #3e8e7e;
+  color: #fff;
+  border: 1px solid #2d6d63;
 }
 body.dark-mode .tab {
   background-color: #222;
@@ -316,6 +329,16 @@ button {
 button:hover {
   background-color: #666;
 }
+body.light-mode button,
+body.light-mode #toggleSidebarBtn {
+  background-color: #3e8e7e;
+  color: #fff;
+  border: 1px solid #2d6d63;
+}
+body.light-mode button:hover,
+body.light-mode #toggleSidebarBtn:hover {
+  background-color: #347369;
+}
 
 /* Spacer below tabs */
 #downloadBtn {
@@ -350,6 +373,15 @@ textarea {
   background-color: #444;
   color: #fff;
 }
+body.light-mode #categoryContainer button {
+  background-color: #e7e7e7;
+  color: #222;
+  border: 1px solid #bbb;
+}
+body.light-mode #categoryContainer button.active {
+  background-color: #3e8e7e;
+  color: #fff;
+}
 
 /* Result Section with Theme Support */
 #comparisonResult {
@@ -364,8 +396,9 @@ body.dark-mode #comparisonResult {
   border-color: #444;
 }
 body.light-mode #comparisonResult {
-  background-color: #f9f9f9;
-  color: #000;
+  background-color: #ffffff;
+  color: #222;
+  border-color: #dcdcdc;
 }
 body.theme-blue #comparisonResult {
   background-color: #002244;


### PR DESCRIPTION
## Summary
- soften the light mode colors and introduce #3e8e7e as the accent

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685deecc34d4832caf6a6eb8cf737f72