### PR TITLE
Add Node-based compatibility tests

### DIFF
--- a/js/compatibility.js
+++ b/js/compatibility.js
@@ -1,0 +1,82 @@
+function calculateCompatibility(surveyA, surveyB) {
+  const categories = Object.keys(surveyA);
+  let totalScore = 0;
+  let count = 0;
+  let redFlags = [];
+  let yellowFlags = [];
+
+  categories.forEach(category => {
+    if (!surveyB[category]) return;
+
+    ['Giving', 'Receiving', 'Neutral'].forEach(action => {
+      const listA = surveyA[category][action] || [];
+      const listB = surveyB[category][
+        action === 'Giving' ? 'Receiving' :
+        action === 'Receiving' ? 'Giving' : 'Neutral'
+      ] || [];
+
+      listA.forEach(itemA => {
+        const match = listB.find(itemB =>
+          itemB.name.trim().toLowerCase() === itemA.name.trim().toLowerCase()
+        );
+        if (match) {
+          const ratingA = parseInt(itemA.rating);
+          const ratingB = parseInt(match.rating);
+          if (Number.isInteger(ratingA) && Number.isInteger(ratingB)) {
+            const diff = Math.abs(ratingA - ratingB);
+            totalScore += Math.max(0, 100 - diff * 20);
+            count++;
+            if ((ratingA === 6 && ratingB === 1) || (ratingA === 1 && ratingB === 6)) {
+              redFlags.push(itemA.name);
+            } else if (
+              (ratingA === 6 && ratingB === 2) || (ratingA === 2 && ratingB === 6) ||
+              (ratingA === 5 && ratingB === 1) || (ratingA === 1 && ratingB === 5)
+            ) {
+              yellowFlags.push(itemA.name);
+            }
+          }
+        }
+      });
+    });
+  });
+
+  const avg = count ? Math.round(totalScore / count) : 0;
+
+  // Similarity Score (same role)
+  let simScore = 0;
+  let simCount = 0;
+  categories.forEach(category => {
+    if (!surveyB[category]) return;
+    ['Giving', 'Receiving', 'Neutral'].forEach(action => {
+      const listA = surveyA[category][action] || [];
+      const listB = surveyB[category][action] || [];
+      listA.forEach(itemA => {
+        const match = listB.find(itemB =>
+          itemB.name.trim().toLowerCase() === itemA.name.trim().toLowerCase()
+        );
+        if (match) {
+          const ratingA = parseInt(itemA.rating);
+          const ratingB = parseInt(match.rating);
+          if (Number.isInteger(ratingA) && Number.isInteger(ratingB)) {
+            const diff = Math.abs(ratingA - ratingB);
+            simScore += Math.max(0, 100 - diff * 20);
+            simCount++;
+          }
+        }
+      });
+    });
+  });
+
+  const avgSim = simCount ? Math.round(simScore / simCount) : 0;
+
+  return {
+    compatibilityScore: avg,
+    similarityScore: avgSim,
+    redFlags: [...new Set(redFlags)],
+    yellowFlags: [...new Set(yellowFlags)]
+  };
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { calculateCompatibility };
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "duckieslove",
+  "version": "1.0.0",
+  "description": "This repository hosts the static files for the Talk Kink website.",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/test/survey.test.js
+++ b/test/survey.test.js
@@ -1,0 +1,26 @@
+const { calculateCompatibility } = require('../js/compatibility');
+const assert = require('node:assert');
+const test = require('node:test');
+
+test('opposite ratings trigger red flag and zero score', () => {
+  const surveyA = { Cat: { Giving: [{ name: 'A', rating: 6 }], Receiving: [], Neutral: [] } };
+  const surveyB = { Cat: { Giving: [], Receiving: [{ name: 'A', rating: 1 }], Neutral: [] } };
+  const result = calculateCompatibility(surveyA, surveyB);
+  assert.strictEqual(result.compatibilityScore, 0);
+  assert.ok(result.redFlags.includes('A'));
+});
+
+test('rating difference of two yields 60 score', () => {
+  const surveyA = { Cat: { Giving: [{ name: 'A', rating: 5 }], Receiving: [], Neutral: [] } };
+  const surveyB = { Cat: { Giving: [], Receiving: [{ name: 'A', rating: 3 }], Neutral: [] } };
+  const result = calculateCompatibility(surveyA, surveyB);
+  assert.strictEqual(result.compatibilityScore, 60);
+  assert.deepStrictEqual(result.redFlags, []);
+});
+
+test('similar ratings in same role produce similarity score', () => {
+  const surveyA = { Cat: { Giving: [{ name: 'X', rating: 2 }], Receiving: [], Neutral: [] } };
+  const surveyB = { Cat: { Giving: [{ name: 'X', rating: 2 }], Receiving: [], Neutral: [] } };
+  const result = calculateCompatibility(surveyA, surveyB);
+  assert.strictEqual(result.similarityScore, 100);
+});


### PR DESCRIPTION
## Summary
- set up a minimal Node test runner
- add `calculateCompatibility` helper
- test the scoring logic with several cases

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e04ab4ed0832c8f6cf888eebb5326