### PR TITLE
Update General tab and survey data

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
   <div class="tab-container">
     <div id="givingTab" class="tab active">Giving</div>
     <div id="receivingTab" class="tab">Receiving</div>
-    <div id="neutralTab" class="tab">Neutral</div>
+    <div id="neutralTab" class="tab">General</div>
   </div>
 
   <!-- Mobile Toggle Button -->

--- a/js/script.js
+++ b/js/script.js
@@ -36,6 +36,21 @@ function attachRipple(btn) {
   btn.addEventListener('click', createRipple);
 }
 
+function updateTabsForCategory(categoryData) {
+  const generalTab = document.getElementById('neutralTab');
+  if (categoryData.Neutral && categoryData.Neutral.length > 0) {
+    generalTab.style.display = 'block';
+    generalTab.classList.remove('disabled');
+    generalTab.title = '';
+  } else {
+    generalTab.style.display = 'none';
+    // fallback to Giving tab if General isn't available
+    if (currentAction === 'Neutral') {
+      switchTab('Giving');
+    }
+  }
+}
+
 function switchTab(action) {
   currentAction = action;
   document.querySelectorAll('.tab').forEach(tab => tab.classList.remove('active'));
@@ -187,7 +202,9 @@ function showCategories() {
 function showKinks(category) {
   currentCategory = category;
   kinkList.innerHTML = '';
-  const kinks = surveyA[category]?.[currentAction];
+  const categoryData = surveyA[category];
+  updateTabsForCategory(categoryData);
+  const kinks = categoryData?.[currentAction];
   subCategoryWrapper.style.display = 'block';
   categoryPanel.classList.add('extended');
   if (!kinks || kinks.length === 0) {

--- a/template-survey.json
+++ b/template-survey.json
@@ -429,6 +429,18 @@
       {
         "name": "Face slapping",
         "rating": null
+      },
+      {
+        "name": "Belly fucking",
+        "rating": null
+      },
+      {
+        "name": "Navel play",
+        "rating": null
+      },
+      {
+        "name": "Licking",
+        "rating": null
       }
     ],
     "Receiving": [
@@ -527,13 +539,21 @@
       {
         "name": "Face slapping",
         "rating": null
-      }
-    ],
-    "Neutral": [
+      },
       {
         "name": "Belly fucking",
         "rating": null
       },
+      {
+        "name": "Navel play",
+        "rating": null
+      },
+      {
+        "name": "Licking",
+        "rating": null
+      }
+    ],
+    "Neutral": [
       {
         "name": "Contraceptives",
         "rating": null
@@ -551,15 +571,7 @@
         "rating": null
       },
       {
-        "name": "Licking",
-        "rating": null
-      },
-      {
         "name": "Masturbation",
-        "rating": null
-      },
-      {
-        "name": "Navel play",
         "rating": null
       },
       {


### PR DESCRIPTION
## Summary
- rename Neutral tab to General in UI
- add dynamic visibility for General tab
- move `Belly fucking`, `Navel play`, and `Licking` to correct lists
- keep other Neutral items under General only

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e0f2ad8e0832cb0fd8243e0f4b02f