### PR TITLE
Restrict Other category to General tab

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -205,6 +205,9 @@ function showCategories() {
   if (!surveyA) return [];
 
   const available = Object.keys(surveyA).filter(cat => {
+    if (cat === 'Other' && currentAction !== 'Neutral') {
+      return false;
+    }
     const items = surveyA[cat][currentAction];
     return Array.isArray(items) && items.length > 0;
   });


### PR DESCRIPTION
## Summary
- hide the "Other" category when viewing Giving or Receiving

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e1c87c83c832cb4a2f9c66d1cebdb