### PR TITLE
Add persistent main category sidebar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -135,6 +135,42 @@ body.light-mode #categoryContainer button.active {
   color: #fff;
 }
 
+
+/* Main Category List */
+#mainCategoryList {
+  margin-bottom: 10px;
+}
+#mainCategoryList button {
+  display: block;
+  width: 100%;
+  margin: 8px 0;
+  padding: 10px;
+  font-weight: bold;
+  background-color: #333;
+  color: #f8f8f8;
+  border: 1px solid #555;
+  border-radius: 5px;
+  cursor: pointer;
+  text-align: left;
+  transition: background-color 0.2s;
+}
+#mainCategoryList button:hover {
+  background-color: #444;
+}
+#mainCategoryList button.active {
+  background-color: #666;
+  color: white;
+}
+body.light-mode #mainCategoryList button {
+  background-color: #a9b8a9;
+  color: #2f4f2f;
+  border: 1px solid #9fb49f;
+}
+body.light-mode #mainCategoryList button.active {
+  background-color: #548c5a;
+  color: #fff;
+}
+
 /* Theme Styling */
 body.dark-mode {
   background-color: #121212;

--- a/index.html
+++ b/index.html
@@ -26,8 +26,8 @@
 
   <div id="saveStatus"></div>
 
-  <!-- Tabs -->
-  <div class="tab-container">
+  <!-- Tabs (hidden, categories rendered in sidebar) -->
+  <div class="tab-container" style="display:none;">
     <div id="givingTab" class="tab active">Giving</div>
     <div id="receivingTab" class="tab">Receiving</div>
     <div id="neutralTab" class="tab">General</div>
@@ -40,6 +40,7 @@
   <div class="main-container">
     <div id="categoryPanel" class="category-panel">
       <button id="closeSidebarBtn">✖ Close</button>
+      <div id="mainCategoryList" class="main-category-list"></div>
       <div id="categoryContainer"></div>
       <div id="subCategoryWrapper" class="subcategory-wrapper">
         <button id="closeSubSidebarBtn">✖ Close</button>

--- a/js/script.js
+++ b/js/script.js
@@ -55,17 +55,32 @@ function updateTabsForCategory(categoryData) {
 function switchTab(action) {
   currentAction = action;
   document.querySelectorAll('.tab').forEach(tab => tab.classList.remove('active'));
-  document.getElementById(`${action.toLowerCase()}Tab`).classList.add('active');
+  const tabEl = document.getElementById(`${action.toLowerCase()}Tab`);
+  if (tabEl) tabEl.classList.add('active');
+  renderMainCategories();
   const cats = showCategories();
   if (!cats.includes(currentCategory)) {
     currentCategory = null;
   }
   if (currentCategory) {
     showKinks(currentCategory);
-  } else if (cats.length > 0) {
-    showKinks(cats[0]);
+  } else {
+    subCategoryWrapper.style.display = 'none';
+    categoryPanel.classList.remove('extended');
   }
-  applyAnimation(kinkList, 'bounce-in');
+  applyAnimation(categoryContainer, 'fade-in');
+}
+
+function renderMainCategories() {
+  mainCategoryList.innerHTML = '';
+  ['Giving', 'Receiving', 'Neutral'].forEach(action => {
+    const btn = document.createElement('button');
+    btn.textContent = action;
+    if (action === currentAction) btn.classList.add('active');
+    btn.onclick = () => switchTab(action);
+    attachRipple(btn);
+    mainCategoryList.appendChild(btn);
+  });
 }
 
 document.getElementById('givingTab').onclick = () => switchTab('Giving');
@@ -117,6 +132,7 @@ function markUnsaved() {
   unsavedTimer = setTimeout(saveProgress, 1000);
 }
 
+const mainCategoryList = document.getElementById('mainCategoryList');
 const categoryContainer = document.getElementById('categoryContainer');
 const kinkList = document.getElementById('kinkList');
 const categoryPanel = document.getElementById('categoryPanel');
@@ -159,6 +175,7 @@ document.getElementById('fileA').addEventListener('change', (e) => {
       subCategoryWrapper.style.display = 'none';
       categoryPanel.classList.remove('extended');
       toggleSidebarBtn.style.display = window.innerWidth <= 768 ? 'block' : 'none';
+      renderMainCategories();
       showCategories();
       saveProgress();
     } catch {
@@ -194,6 +211,7 @@ document.getElementById('newSurveyBtn').addEventListener('click', () => {
       subCategoryWrapper.style.display = 'none';
       categoryPanel.classList.remove('extended');
       toggleSidebarBtn.style.display = window.innerWidth <= 768 ? 'block' : 'none';
+      renderMainCategories();
       showCategories();
       saveProgress();
     })
@@ -402,6 +420,7 @@ window.addEventListener('DOMContentLoaded', () => {
       subCategoryWrapper.style.display = 'none';
       categoryPanel.classList.remove('extended');
       toggleSidebarBtn.style.display = window.innerWidth <= 768 ? 'block' : 'none';
+      renderMainCategories();
       showCategories();
     } else {
       localStorage.removeItem('savedSurvey');


### PR DESCRIPTION
## Summary
- hide tab navigation and instead render main categories in sidebar
- style new `mainCategoryList`
- render main categories after loading surveys or resuming saved data

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685e20b4db60832cb599ff319e408b54