### PR TITLE
Fix Other category placement

### DIFF
--- a/template-survey.json
+++ b/template-survey.json
@@ -673,67 +673,37 @@
     "Neutral": []
   },
   "Other": {
-    "Giving": [
-      {
-        "name": "Feet",
-        "rating": null
-      },
-      {
-        "name": "Boots",
-        "rating": null
-      },
-      {
-        "name": "Underwear",
-        "rating": null
-      },
-      {
-        "name": "Chastity devices",
-        "rating": null
-      },
-      {
-        "name": "Masks",
-        "rating": null
-      },
-      {
-        "name": "Breeding",
-        "rating": null
-      },
-      {
-        "name": "Leather clothing",
-        "rating": null
-      }
-    ],
-    "Receiving": [
-      {
-        "name": "Feet",
-        "rating": null
-      },
-      {
-        "name": "Boots",
-        "rating": null
-      },
-      {
-        "name": "Underwear",
-        "rating": null
-      },
-      {
-        "name": "Chastity devices",
-        "rating": null
-      },
-      {
-        "name": "Masks",
-        "rating": null
-      },
-      {
-        "name": "Breeding",
-        "rating": null
-      },
-      {
-        "name": "Leather clothing",
-        "rating": null
-      }
-    ],
+    "Giving": [],
+    "Receiving": [],
     "Neutral": [
+      {
+        "name": "Feet",
+        "rating": null
+      },
+      {
+        "name": "Boots",
+        "rating": null
+      },
+      {
+        "name": "Underwear",
+        "rating": null
+      },
+      {
+        "name": "Chastity devices",
+        "rating": null
+      },
+      {
+        "name": "Masks",
+        "rating": null
+      },
+      {
+        "name": "Breeding",
+        "rating": null
+      },
+      {
+        "name": "Leather clothing",
+        "rating": null
+      },
       {
         "name": "Romance / affection",
         "rating": null


### PR DESCRIPTION
## Summary
- move clothing-related items to neutral for the `Other` category so they appear under "General"

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685e25eb644c832c8fa8bb9edbed63d3