### PR TITLE
Stop resume prompt after export

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -356,6 +356,9 @@ document.getElementById('downloadBtn').addEventListener('click', () => {
   a.download = 'kink-survey.json';
   a.click();
   URL.revokeObjectURL(url);
+  // Clear saved progress so the user isn't asked to resume next time
+  localStorage.removeItem('savedSurvey');
+  localStorage.removeItem('lastSaved');
 });
 
 // ================== See Our Compatibility ==================


### PR DESCRIPTION
## Summary
- clear local storage after exporting survey so the user isn't prompted to resume next time

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e4b385dec832c8077705af79c4fe0