### PR TITLE
Fix long kink names overflowing sidebar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -22,14 +22,14 @@ body {
 }
 
 .category-panel.extended {
-  width: 480px;
+  width: 560px;
 }
 
 .subcategory-wrapper {
   position: absolute;
   left: 220px;
   top: 0;
-  width: 260px;
+  width: 340px;
   background-color: #1e1e2f;
   border-left: 2px solid #444;
   padding: 15px;

--- a/js/script.js
+++ b/js/script.js
@@ -354,6 +354,7 @@ function showKinks(category) {
     container.style.display = 'flex';
     container.style.justifyContent = 'space-between';
     container.style.alignItems = 'center';
+    container.style.whiteSpace = 'nowrap';
 
     const label = document.createElement('span');
     label.textContent = kink.name + ': ';


### PR DESCRIPTION
## Summary
- widen the sidebar for kink subcategories
- prevent wrapping in kink entry rows

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685e52d21700832c940936bd84068d12