### PR TITLE
Fix mobile panel layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -92,6 +92,14 @@ body.light-mode #closeSubSidebarBtn {
   #closeSubSidebarBtn {
     display: block;
   }
+  #categoryPanel.extended {
+    width: 100%;
+  }
+
+  .subcategory-wrapper {
+    left: 0;
+    width: 100%;
+  }
 }
 
 #categoryContainer button {

--- a/js/script.js
+++ b/js/script.js
@@ -318,9 +318,6 @@ function showCategories() {
           subCategoryWrapper.style.display = 'none';
           categoryPanel.classList.remove('extended');
         }
-        if (window.innerWidth <= 768) {
-          categoryPanel.classList.remove('visible');
-        }
         if (categoryListEl) categoryListEl.classList.remove('show');
       };
       attachRipple(btn);


### PR DESCRIPTION
## Summary
- show entire subcategory panel on small screens
- keep sidebar visible when picking a category on mobile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e5968711c832cb8eee931265567ed