### PR TITLE
Improve rating panel layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -22,14 +22,14 @@ body {
 }
 
 .category-panel.extended {
-  width: 780px;
+  width: 840px;
 }
 
 .subcategory-wrapper {
   position: absolute;
   left: 220px;
   top: 0;
-  width: 560px;
+  width: 620px;
   background-color: #1e1e2f;
   border-left: 2px solid #444;
   padding: 15px;
@@ -553,7 +553,15 @@ button .ripple {
   border-radius: 5px;
   padding: 8px 12px;
   z-index: 1000;
-  max-width: 480px;
+  max-width: 520px;
+  white-space: normal;
+}
+#ratingLegend ul {
+  margin: 0;
+  padding-left: 20px;
+}
+#ratingLegend li {
+  margin: 2px 0;
 }
 body.light-mode #ratingLegend {
   background-color: #a9b8a9;

--- a/index.html
+++ b/index.html
@@ -36,8 +36,14 @@
 
   <div id="saveStatus"></div>
   <div id="ratingLegend">
-    0 = Hard limit / dislike | 1 = Disinterested | 2 = Neutral | 3 = Like it<br />
-    4 = Really like it | 5 = Core turn-on
+    <ul>
+      <li>0 = Hard limit / dislike</li>
+      <li>1 = Disinterested</li>
+      <li>2 = Neutral</li>
+      <li>3 = Like it</li>
+      <li>4 = Really like it</li>
+      <li>5 = Core turn-on</li>
+    </ul>
   </div>
 
   <!-- Tabs and Categories -->


### PR DESCRIPTION
## Summary
- widen the subcategory area so the rating dropdown isn't flush against the scrollbar
- restyle the rating legend with a bullet list and allow text wrapping

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e62b1f368832cb99b4c34c0c360d7