### PR TITLE
Fix dropdown spacing near scrollbar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -578,3 +578,8 @@ body.light-mode #ratingLegend {
 #categoryList.show {
   max-height: 1000px;
 }
+
+/* Provide spacing between kink dropdowns and scrollbar */
+#kinkList select {
+  margin-right: 16px;
+}


### PR DESCRIPTION
## Summary
- give dropdowns some margin-right so they're not flush against the sidebar scrollbar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685e71e05644832ca2e5f3d9e4db34b2