### PR TITLE
Improve mobile sidebar usability

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -493,6 +493,18 @@ body.theme-rainbow #comparisonResult {
   padding-left: 20px;
   box-sizing: border-box;
 }
+
+/* Overlay for mobile sidebar */
+.overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  z-index: 180;
+  display: none;
+}
 /* Micro-Animations */
 .fade-in {
   animation: fadeIn 0.3s ease-in-out;

--- a/index.html
+++ b/index.html
@@ -61,6 +61,7 @@
     </div>
     <div class="content-panel"></div>
   </div>
+  <div id="categoryOverlay" class="overlay"></div>
 
   <!-- Buttons -->
   <button id="downloadBtn">Export My List</button>

--- a/js/script.js
+++ b/js/script.js
@@ -206,6 +206,7 @@ const categoryListEl = document.getElementById('categoryList');
 const closeSidebarBtn = document.getElementById('closeSidebarBtn');
 const closeSubSidebarBtn = document.getElementById('closeSubSidebarBtn');
 const ratingLegend = document.getElementById('ratingLegend');
+const categoryOverlay = document.getElementById('categoryOverlay');
 
 function showRatingLegend(target) {
   const rect = target.getBoundingClientRect();
@@ -228,6 +229,16 @@ function toggleCategories() {
   }
 }
 
+function showOverlay() {
+  if (window.innerWidth <= 768) {
+    categoryOverlay.style.display = 'block';
+  }
+}
+
+function hideOverlay() {
+  categoryOverlay.style.display = 'none';
+}
+
 categoryPanel.style.display = 'none'; // Hide by default
 subCategoryWrapper.style.display = 'none';
 categoryButton.style.display = 'none';
@@ -238,6 +249,11 @@ categoryButton.addEventListener('click', () => {
     categoryPanel.classList.toggle('visible');
     categoryPanel.classList.remove('extended');
     subCategoryWrapper.style.display = 'none';
+    if (categoryPanel.classList.contains('visible')) {
+      showOverlay();
+    } else {
+      hideOverlay();
+    }
   }
 });
 
@@ -245,11 +261,19 @@ closeSidebarBtn.addEventListener('click', () => {
   categoryPanel.classList.remove('visible');
   categoryPanel.classList.remove('extended');
   subCategoryWrapper.style.display = 'none';
+  hideOverlay();
 });
 
 closeSubSidebarBtn.addEventListener('click', () => {
   categoryPanel.classList.remove('extended');
   subCategoryWrapper.style.display = 'none';
+});
+
+categoryOverlay.addEventListener('click', () => {
+  categoryPanel.classList.remove('visible');
+  categoryPanel.classList.remove('extended');
+  subCategoryWrapper.style.display = 'none';
+  hideOverlay();
 });
 
 document.getElementById('fileA').addEventListener('change', (e) => {
@@ -617,6 +641,13 @@ window.addEventListener('DOMContentLoaded', () => {
   }
   updateSaveStatus();
   document.querySelectorAll('button').forEach(attachRipple);
+});
+
+window.addEventListener('resize', () => {
+  if (window.innerWidth > 768) {
+    hideOverlay();
+    categoryPanel.classList.remove('visible');
+  }
 });
 
 window.toggleCategories = toggleCategories;


### PR DESCRIPTION
## Summary
- add a full-screen overlay to close the category sidebar on mobile
- show/hide overlay when opening or closing the sidebar
- allow tapping outside the sidebar to close it

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f197cc574832c93550b71e3abe65b