### PR TITLE
Improve mobile sidebar layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -93,7 +93,9 @@ body.light-mode #closeSubSidebarBtn {
   }
 
   #categoryPanel {
-    left: -220px;
+    width: 90%;
+    max-width: 320px;
+    left: -100%;
   }
 
   #categoryPanel.visible {
@@ -108,7 +110,8 @@ body.light-mode #closeSubSidebarBtn {
     display: block;
   }
   #categoryPanel.extended {
-    width: 100%;
+    width: 90%;
+    max-width: 320px;
   }
 
   .subcategory-wrapper {

--- a/js/script.js
+++ b/js/script.js
@@ -438,7 +438,7 @@ function showKinks(category) {
     container.style.display = 'flex';
     container.style.justifyContent = 'space-between';
     container.style.alignItems = 'center';
-    container.style.whiteSpace = 'nowrap';
+    container.style.whiteSpace = window.innerWidth <= 768 ? 'normal' : 'nowrap';
 
     const label = document.createElement('span');
     label.textContent = kink.name + ': ';


### PR DESCRIPTION
## Summary
- limit mobile sidebar width so it doesn't cover the whole screen
- wrap kink labels when screen width is small

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f1db83a74832ca3439136e8dd1c0e