### PR TITLE
Improve mobile new survey UX

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,7 +38,7 @@
   </div>
 
   <!-- Mobile Open Sidebar Button -->
-  <button id="openSidebarBtn">☰</button>
+  <button id="openSidebarBtn" title="Open categories">☰ Categories</button>
 
   <!-- Tabs and Categories -->
   <div class="tab-toggle-group">

--- a/js/script.js
+++ b/js/script.js
@@ -347,6 +347,11 @@ document.getElementById('newSurveyBtn').addEventListener('click', () => {
     categoryPanel.classList.remove('extended');
     categoryButton.style.display = window.innerWidth <= 768 ? 'block' : 'none';
     openSidebarBtn.style.display = window.innerWidth <= 768 ? 'block' : 'none';
+    if (window.innerWidth <= 768) {
+      categoryPanel.classList.add('visible');
+      showOverlay();
+      openSidebarBtn.style.display = 'none';
+    }
     renderMainCategories();
     showCategories();
     saveProgress();


### PR DESCRIPTION
## Summary
- label the sidebar button so mobile users understand it
- auto-open the sidebar when starting a new survey on mobile

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f2689c01c832c82d7514a0786d948