### PR TITLE
Remove categories button

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -65,12 +65,6 @@ body.light-mode #closeSubSidebarBtn {
   color: #2f4f2f;
 }
 
-#categoryButton {
-  position: relative;
-  z-index: 1;
-  margin-top: 12px;
-}
-
 /* Mobile open sidebar button */
 #openSidebarBtn {
   display: none;
@@ -83,11 +77,6 @@ body.light-mode #closeSubSidebarBtn {
 }
 
 @media (max-width: 768px) {
-  #categoryButton {
-    display: block;
-    margin-bottom: 10px;
-  }
-
   #openSidebarBtn {
     display: block;
   }
@@ -403,14 +392,12 @@ button {
 button:hover {
   background-color: #666;
 }
-body.light-mode button,
-body.light-mode #categoryButton {
+body.light-mode button {
   background-color: #548c5a;
   color: #fff;
   border: 1px solid #4b7f4b;
 }
-body.light-mode button:hover,
-body.light-mode #categoryButton:hover {
+body.light-mode button:hover {
   background-color: #538753;
 }
 
@@ -591,15 +578,6 @@ body.light-mode #ratingLegend {
   border-color: #9fb49f;
 }
 
-#categoryList {
-  max-height: 0;
-  overflow: hidden;
-  transition: max-height 0.3s ease;
-}
-
-#categoryList.show {
-  max-height: 1000px;
-}
 
 /* Provide spacing between kink dropdowns and scrollbar */
 #kinkList select {

--- a/index.html
+++ b/index.html
@@ -40,15 +40,13 @@
   <!-- Mobile Open Sidebar Button -->
   <button id="openSidebarBtn" title="Open categories">☰</button>
 
-  <!-- Tabs and Categories -->
+  <!-- Tabs -->
   <div class="tab-toggle-group">
     <div class="tab-container">
       <div id="givingTab" class="tab active" onclick="switchTab('Giving')">Giving</div>
       <div id="receivingTab" class="tab" onclick="switchTab('Receiving')">Receiving</div>
       <div id="generalTab" class="tab" onclick="switchTab('General')">Neutral</div>
     </div>
-    <button id="categoryButton" onclick="toggleCategories()">≡ Categories</button>
-    <div id="categoryList" style="display: none;"></div>
   </div>
 
   <!-- Layout -->

--- a/js/script.js
+++ b/js/script.js
@@ -201,8 +201,6 @@ const categoryContainer = document.getElementById('categoryContainer');
 const kinkList = document.getElementById('kinkList');
 const categoryPanel = document.getElementById('categoryPanel');
 const subCategoryWrapper = document.getElementById('subCategoryWrapper');
-const categoryButton = document.getElementById('categoryButton');
-const categoryListEl = document.getElementById('categoryList');
 const closeSidebarBtn = document.getElementById('closeSidebarBtn');
 const closeSubSidebarBtn = document.getElementById('closeSubSidebarBtn');
 const openSidebarBtn = document.getElementById('openSidebarBtn');
@@ -224,12 +222,6 @@ function shouldDisplayItem(item) {
   return true;
 }
 
-function toggleCategories() {
-  if (categoryListEl) {
-    categoryListEl.classList.toggle('show');
-  }
-}
-
 function showOverlay() {
   if (window.innerWidth <= 768) {
     categoryOverlay.style.display = 'block';
@@ -242,7 +234,6 @@ function hideOverlay() {
 
 categoryPanel.style.display = 'none'; // Hide by default
 subCategoryWrapper.style.display = 'none';
-categoryButton.style.display = 'none';
 openSidebarBtn.style.display = 'none';
 
 openSidebarBtn.addEventListener('click', () => {
@@ -251,22 +242,6 @@ openSidebarBtn.addEventListener('click', () => {
   subCategoryWrapper.style.display = 'none';
   showOverlay();
   openSidebarBtn.style.display = 'none';
-});
-
-categoryButton.addEventListener('click', () => {
-  toggleCategories();
-  if (window.innerWidth <= 768) {
-    categoryPanel.classList.toggle('visible');
-    categoryPanel.classList.remove('extended');
-    subCategoryWrapper.style.display = 'none';
-    if (categoryPanel.classList.contains('visible')) {
-      showOverlay();
-      openSidebarBtn.style.display = 'none';
-    } else {
-      hideOverlay();
-      openSidebarBtn.style.display = 'block';
-    }
-  }
 });
 
 closeSidebarBtn.addEventListener('click', () => {
@@ -305,7 +280,6 @@ document.getElementById('fileA').addEventListener('change', (e) => {
       categoryPanel.style.display = 'block';
       subCategoryWrapper.style.display = 'none';
       categoryPanel.classList.remove('extended');
-      categoryButton.style.display = window.innerWidth <= 768 ? 'block' : 'none';
       openSidebarBtn.style.display = window.innerWidth <= 768 ? 'block' : 'none';
       renderMainCategories();
       showCategories();
@@ -345,7 +319,6 @@ document.getElementById('newSurveyBtn').addEventListener('click', () => {
     categoryPanel.style.display = 'block'; // Show sidebar
     subCategoryWrapper.style.display = 'none';
     categoryPanel.classList.remove('extended');
-    categoryButton.style.display = window.innerWidth <= 768 ? 'block' : 'none';
     openSidebarBtn.style.display = window.innerWidth <= 768 ? 'block' : 'none';
     if (window.innerWidth <= 768) {
       categoryPanel.classList.add('visible');
@@ -380,7 +353,6 @@ document.getElementById('newSurveyBtn').addEventListener('click', () => {
 
 function showCategories() {
   categoryContainer.innerHTML = '';
-  if (categoryListEl) categoryListEl.innerHTML = '';
   if (!surveyA) return [];
 
   const categories = Object.keys(surveyA);
@@ -408,17 +380,15 @@ function showCategories() {
           subCategoryWrapper.style.display = 'none';
           categoryPanel.classList.remove('extended');
         }
-        if (categoryListEl) categoryListEl.classList.remove('show');
+        
       };
       attachRipple(btn);
       return btn;
     };
 
     categoryContainer.appendChild(createButton());
-    if (categoryListEl) categoryListEl.appendChild(createButton());
   });
   applyAnimation(categoryContainer, 'fade-in');
-  if (categoryListEl) applyAnimation(categoryListEl, 'fade-in');
   return available;
 }
 
@@ -652,7 +622,6 @@ window.addEventListener('DOMContentLoaded', () => {
       categoryPanel.style.display = 'block';
       subCategoryWrapper.style.display = 'none';
       categoryPanel.classList.remove('extended');
-      categoryButton.style.display = window.innerWidth <= 768 ? 'block' : 'none';
       openSidebarBtn.style.display = window.innerWidth <= 768 ? 'block' : 'none';
       renderMainCategories();
       showCategories();
@@ -675,4 +644,3 @@ window.addEventListener('resize', () => {
   }
 });
 
-window.toggleCategories = toggleCategories;


### PR DESCRIPTION
## Summary
- clean up UI by removing the obsolete "Categories" dropdown button
- drop associated styles and script hooks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f28cfe87c832c858d95e0a47469d7