### PR TITLE
Prompt partner consent on file load

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,6 +74,7 @@
 
   <h3>Upload Partner's Survey</h3>
   <input type="file" id="fileB" />
+  <button id="loadPartnerBtn">Load Partner Survey</button>
 
   <button id="compareBtn">See Our Compatibility</button>
   <div id="comparisonResult"></div>

--- a/js/script.js
+++ b/js/script.js
@@ -291,13 +291,17 @@ document.getElementById('fileA').addEventListener('change', (e) => {
   reader.readAsText(e.target.files[0]);
 });
 
-document.getElementById('fileB').addEventListener('change', (e) => {
+document.getElementById('loadPartnerBtn').addEventListener('click', () => {
+  const fileInput = document.getElementById('fileB');
+  if (!fileInput.files.length) {
+    alert('Please select a partner survey file.');
+    return;
+  }
   if (!confirm('Have you reviewed consent with your partner?')) {
-    e.target.value = '';
     return;
   }
   const reader = new FileReader();
-  reader.onload = (ev) => {
+  reader.onload = ev => {
     try {
       const parsed = JSON.parse(ev.target.result);
       surveyB = parsed.survey || parsed;
@@ -308,7 +312,7 @@ document.getElementById('fileB').addEventListener('change', (e) => {
       alert('Invalid JSON for Survey B.');
     }
   };
-  reader.readAsText(e.target.files[0]);
+  reader.readAsText(fileInput.files[0]);
 });
 
 document.getElementById('newSurveyBtn').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add `Load Partner Survey` button
- prompt for partner consent when loading partner survey instead of on file select

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f2d41217c832cb142b6f8f58aeb0e