### PR TITLE
Fix upload wrapper styles

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -407,7 +407,11 @@ body.light-mode button:hover {
 }
 
 /* Input Fields */
-input[type="file"] {
+#uploadWrapper {
+  margin-bottom: 20px;
+}
+
+#uploadWrapper input[type="file"] {
   display: block;
   margin: 10px 0;
 }


### PR DESCRIPTION
## Summary
- clean up upload field rules and keep `#uploadWrapper` margins
- preserve spacing for `#fileB` and `#loadMyBtn`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685f38e4b31c832ca4a204b44ccd5e7e