### PR TITLE
Fix start survey button by loading JSON template

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ The website is built from the following files in this repository:
 - `js/script.js`
 - `template-survey.json`
 
+The **Start New Survey** button fetches `template-survey.json` to load the
+initial set of kinks.
+
 ## Setup
 
 Run `setup.sh` to install optional tools for local development. The script

--- a/index.html
+++ b/index.html
@@ -93,7 +93,6 @@
   <div id="comparisonResult"></div>
 
   <!-- Script -->
-  <script src="js/template-survey.js"></script>
   <script src="js/script.js"></script>
 </body>
 </html>

--- a/js/script.js
+++ b/js/script.js
@@ -344,8 +344,19 @@ document.getElementById('newSurveyBtn').addEventListener('click', () => {
     saveProgress();
   };
 
-  const data = window.templateSurvey;
-  initialize(data);
+  const loadFromJson = () =>
+    fetch('template-survey.json')
+      .then(res => res.json())
+      .then(initialize)
+      .catch(err => {
+        alert('Failed to load template: ' + err.message);
+      });
+
+  if (window.templateSurvey) {
+    initialize(window.templateSurvey);
+  } else {
+    loadFromJson();
+  }
 });
 
 // ================== Category + Kink Display ==================

--- a/template-survey.json
+++ b/template-survey.json
@@ -1,0 +1,31 @@
+{
+  "Giving": [ { "name": "Licking", "rating": null } ],
+  "Receiving": [ { "name": "Licking", "rating": null } ],
+  "General": [
+    { "name": "Temperature play", "rating": null },
+    { "name": "Navel play", "rating": null },
+    { "name": "Belly fucking", "rating": null },
+    { "name": "Begging", "rating": null },
+    { "name": "Fear play", "rating": null },
+    { "name": "Masochism (general)", "rating": null },
+    { "name": "Psychological masochism", "rating": null },
+    { "name": "Sadism (general)", "rating": null },
+    { "name": "Psychological sadism", "rating": null },
+    { "name": "Resistance play", "rating": null },
+    { "name": "Obedience training", "rating": null },
+    { "name": "Manipulation", "rating": null },
+    { "name": "Mind games", "rating": null },
+    { "name": "Intelligence kink", "rating": null },
+    { "name": "Service dynamics", "rating": null },
+    { "name": "Power exchange", "rating": null },
+    { "name": "Rituals and protocol", "rating": null },
+    { "name": "Dehumanization", "rating": null },
+    { "name": "Humiliation (general)", "rating": null },
+    { "name": "Emotional edge", "rating": null },
+    { "name": "Verbal play (general)", "rating": null },
+    { "name": "Praise kink", "rating": null },
+    { "name": "Shame kink", "rating": null },
+    { "name": "Ownership", "rating": null },
+    { "name": "Sensory play", "rating": null }
+  ]
+}


### PR DESCRIPTION
## Summary
- reintroduce `template-survey.json` for the default survey
- fetch the JSON template when starting a new survey
- remove the unused script include
- document how the template is loaded

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686059f237ec832ca3b5e59b46ccd305