### PR TITLE
Fix category dropdown padding

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -557,7 +557,10 @@ body.light-mode #ratingLegend {
 
 #categoryList {
   max-height: 0;
-  overflow: hidden;
+  padding-top: 20px;
+  padding-bottom: 20px;
+  overflow-y: auto; /* Ensure scrolling still works */
+  overflow-x: hidden;
   transition: max-height 0.3s ease;
 }
 


### PR DESCRIPTION
## Summary
- add padding to the mobile category list so first/last buttons aren't flush with the edges

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686087f6586c832cab9a3024c920fb67