### PR TITLE
Add simple password gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ Run `setup.sh` to install optional tools for local development. The script
 installs the Node `serve` package when `npm` is available so you can preview
 the site locally.
 
+## Password Gate
+
+When the site loads, a password prompt now appears before any content is shown.
+The expected password hash is defined in `js/login.js`. Update that file to
+change the required password.
+
 ## Local Development
 
 Serve the static files locally to preview changes before pushing them to GitHub.

--- a/css/style.css
+++ b/css/style.css
@@ -564,3 +564,23 @@ body.light-mode #ratingLegend {
 #categoryList.show {
   max-height: 1000px;
 }
+
+#loginOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.85);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+#loginOverlay input[type="password"] {
+  padding: 8px;
+  margin-bottom: 10px;
+}
+

--- a/index.html
+++ b/index.html
@@ -82,6 +82,7 @@
 
   <!-- Script -->
   <script src="js/template-survey.js"></script>
+  <script src="js/login.js"></script>
   <script src="js/script.js"></script>
 </body>
 </html>

--- a/js/login.js
+++ b/js/login.js
@@ -1,0 +1,37 @@
+const PASSWORD_HASH = '51d15f71ae396169aa6d45c74b72f56d921698900135f877d01cce218c8ea10f';
+
+function hashString(str) {
+  const enc = new TextEncoder();
+  return crypto.subtle.digest('SHA-256', enc.encode(str)).then(buf => {
+    return Array.from(new Uint8Array(buf))
+      .map(b => b.toString(16).padStart(2, '0'))
+      .join('');
+  });
+}
+
+async function checkPassword() {
+  const val = document.getElementById('passwordInput').value;
+  const hashed = await hashString(val);
+  if (hashed === PASSWORD_HASH) {
+    localStorage.setItem('accessGranted', 'true');
+    document.getElementById('loginOverlay').style.display = 'none';
+  } else {
+    alert('Incorrect password');
+  }
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  if (localStorage.getItem('accessGranted') === 'true') return;
+  const ov = document.createElement('div');
+  ov.id = 'loginOverlay';
+  const inp = document.createElement('input');
+  inp.type = 'password';
+  inp.id = 'passwordInput';
+  inp.placeholder = 'Enter password';
+  const btn = document.createElement('button');
+  btn.textContent = 'Enter';
+  btn.onclick = checkPassword;
+  ov.appendChild(inp);
+  ov.appendChild(btn);
+  document.body.appendChild(ov);
+});


### PR DESCRIPTION
## Summary
- add login.js with password check and overlay
- add styles for login overlay
- update index.html to load login script
- document password gate in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686087a175b4832c9941a3171895408e