### PR TITLE
Add role score calculator

### DIFF
--- a/js/roleScores.js
+++ b/js/roleScores.js
@@ -1,0 +1,35 @@
+export function calculateRoleScores(surveyData, maxRating = 5) {
+  const roleScores = {};
+  const roleMaxScores = {};
+  if (!surveyData || typeof surveyData !== 'object') return [];
+
+  // Iterate over categories
+  Object.values(surveyData).forEach(category => {
+    ['Giving', 'Receiving', 'General'].forEach(action => {
+      const items = Array.isArray(category[action]) ? category[action] : [];
+      items.forEach(item => {
+        if (item && typeof item.rating === 'number' && item.roles) {
+          item.roles.forEach(r => {
+            const name = r.name;
+            const weight = r.weight ?? 1;
+            if (!roleScores[name]) roleScores[name] = 0;
+            if (!roleMaxScores[name]) roleMaxScores[name] = 0;
+            roleScores[name] += item.rating * weight;
+            roleMaxScores[name] += maxRating * weight;
+          });
+        } else if (item && typeof item.rating === 'number') {
+          // if item has rating but no roles, do nothing
+        }
+      });
+    });
+  });
+
+  return Object.keys(roleScores)
+    .map(role => ({
+      name: role,
+      percent: roleMaxScores[role]
+        ? Math.round((roleScores[role] / roleMaxScores[role]) * 100)
+        : 0
+    }))
+    .sort((a, b) => b.percent - a.percent);
+}

--- a/test/roleScores.test.js
+++ b/test/roleScores.test.js
@@ -1,0 +1,54 @@
+import assert from 'node:assert';
+import test from 'node:test';
+import { calculateRoleScores } from '../js/roleScores.js';
+
+const sampleSurvey = {
+  Category: {
+    Giving: [
+      {
+        name: 'Edge',
+        rating: 5,
+        roles: [
+          { name: 'Sadist', weight: 1 },
+          { name: 'Masochist', weight: 2 }
+        ]
+      },
+      {
+        name: 'Ignore',
+        rating: null,
+        roles: [{ name: 'Dominant', weight: 1 }]
+      }
+    ],
+    Receiving: [],
+    General: []
+  }
+};
+
+test('calculates percentages based on rating and weight', () => {
+  const result = calculateRoleScores(sampleSurvey);
+  const expected = [
+    { name: 'Masochist', percent: 100 },
+    { name: 'Sadist', percent: 100 }
+  ];
+  // result order isn't guaranteed when percentages tie
+  assert.deepStrictEqual(
+    result.sort((a, b) => a.name.localeCompare(b.name)),
+    expected.sort((a, b) => a.name.localeCompare(b.name))
+  );
+});
+
+test('handles partial scores and missing weights', () => {
+  const survey = {
+    Cat: {
+      Giving: [
+        { name: 'X', rating: 3, roles: [{ name: 'Dom' }] }
+      ],
+      Receiving: [],
+      General: []
+    }
+  };
+  const result = calculateRoleScores(survey);
+  assert.deepStrictEqual(result, [
+    { name: 'Dom', percent: 60 }
+  ]);
+});


### PR DESCRIPTION
## Summary
- implement `calculateRoleScores` utility for computing role match percentages
- test the new function with node's test runner

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860a8f61e40832c8a86f822120b1a33