### PR TITLE
Add role results page

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,6 +97,7 @@
 
     <!-- Compatibility button -->
     <button id="compareBtn" class="survey-button">See Our Compatibility</button>
+    <button id="roleResultsBtn" class="survey-button" onclick="location.href='your-roles.html'">View Role Results</button>
   </div>
   <div id="comparisonResult"></div>
 

--- a/js/calculateRoleScores.js
+++ b/js/calculateRoleScores.js
@@ -1,0 +1,39 @@
+function calculateRoleScores(surveyData, maxRating = 5) {
+  const roleScores = {};
+  const roleMaxScores = {};
+
+  for (const category in surveyData) {
+    const items = surveyData[category];
+    for (const item of items) {
+      if (item.rating !== null && Array.isArray(item.roles)) {
+        for (const role of item.roles) {
+          const roleName = role.name;
+          const weight = role.weight || 1;
+          const score = item.rating * weight;
+          const maxScore = maxRating * weight;
+
+          if (!roleScores[roleName]) {
+            roleScores[roleName] = 0;
+            roleMaxScores[roleName] = 0;
+          }
+
+          roleScores[roleName] += score;
+          roleMaxScores[roleName] += maxScore;
+        }
+      }
+    }
+  }
+
+  const results = Object.keys(roleScores).map(role => {
+    const percent = (roleScores[role] / roleMaxScores[role]) * 100;
+    return {
+      name: role,
+      percent: Math.round(percent)
+    };
+  });
+
+  results.sort((a, b) => b.percent - a.percent);
+  return results;
+}
+
+export { calculateRoleScores };

--- a/test/roles.test.js
+++ b/test/roles.test.js
@@ -1,0 +1,18 @@
+import { calculateRoleScores } from '../js/calculateRoleScores.js';
+import assert from 'node:assert';
+import test from 'node:test';
+
+test('calculateRoleScores aggregates role percentages', () => {
+  const survey = {
+    all: [
+      { rating: 5, roles: [{ name: 'dominant' }] },
+      { rating: 3, roles: [{ name: 'dominant' }, { name: 'sadist', weight: 2 }] },
+      { rating: null, roles: [{ name: 'switch' }] }
+    ]
+  };
+  const results = calculateRoleScores(survey, 5);
+  const dominant = results.find(r => r.name === 'dominant').percent;
+  const sadist = results.find(r => r.name === 'sadist').percent;
+  assert.strictEqual(dominant, 80);
+  assert.strictEqual(sadist, 60);
+});

--- a/your-roles.html
+++ b/your-roles.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Your Role Matches</title>
+  <link rel="stylesheet" href="css/style.css" />
+</head>
+<body class="dark-mode">
+  <h1>Your Role Matches</h1>
+  <p>Upload your exported survey to see how your kinks align with common roles.</p>
+
+  <label class="survey-button file-upload">
+    <span>Select Survey File</span>
+    <input type="file" id="roleFile" hidden />
+  </label>
+
+  <div id="rolesOutput"></div>
+
+  <script type="module">
+    import { calculateRoleScores } from './js/calculateRoleScores.js';
+
+    function flattenSurvey(survey) {
+      const items = [];
+      Object.values(survey).forEach(cat => {
+        ['Giving', 'Receiving', 'General'].forEach(role => {
+          if (Array.isArray(cat[role])) {
+            items.push(...cat[role]);
+          }
+        });
+      });
+      return items;
+    }
+
+    document.getElementById('roleFile').addEventListener('change', e => {
+      const file = e.target.files[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = ev => {
+        try {
+          const parsed = JSON.parse(ev.target.result);
+          const survey = parsed.survey || parsed;
+          const scores = calculateRoleScores({ all: flattenSurvey(survey) });
+          const container = document.getElementById('rolesOutput');
+          if (!scores.length) {
+            container.textContent = 'No role data found.';
+            return;
+          }
+          const ul = document.createElement('ul');
+          scores.forEach(s => {
+            const li = document.createElement('li');
+            li.textContent = `${s.name}: ${s.percent}%`;
+            ul.appendChild(li);
+          });
+          container.innerHTML = '';
+          container.appendChild(ul);
+        } catch (err) {
+          document.getElementById('rolesOutput').textContent = 'Invalid file.';
+        }
+      };
+      reader.readAsText(file);
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `calculateRoleScores.js`
- create `your-roles.html` page for uploading a survey and calculating role percentages
- expose a "View Role Results" button linking to the new page
- test role score calculations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860ab2796dc832c901d3648943bf150