### PR TITLE
Add survey export pruning

### DIFF
--- a/js/pruneSurvey.js
+++ b/js/pruneSurvey.js
@@ -1,0 +1,35 @@
+export function pruneSurvey(survey) {
+  const result = {};
+  if (!survey || typeof survey !== 'object') return result;
+
+  for (const [category, data] of Object.entries(survey)) {
+    const cat = {};
+    ['Giving', 'Receiving', 'General'].forEach(role => {
+      const items = Array.isArray(data[role]) ? data[role] : [];
+      const filled = items.filter(it => {
+        if (it.type === 'text') {
+          return !!(it.value && String(it.value).trim());
+        }
+        if (it.type === 'multi') {
+          return Array.isArray(it.value) && it.value.length > 0;
+        }
+        if (it.type === 'dropdown') {
+          return it.value !== undefined && it.value !== '';
+        }
+        return typeof it.rating === 'number';
+      }).map(it => {
+        const out = { name: it.name };
+        if (typeof it.rating === 'number') out.rating = it.rating;
+        if (it.type) out.type = it.type;
+        if (it.options) out.options = it.options;
+        if (it.value !== undefined) out.value = it.value;
+        if (it.roles) out.roles = it.roles;
+        return out;
+      });
+      if (filled.length) cat[role] = filled;
+    });
+    if (Object.keys(cat).length) result[category] = cat;
+  }
+
+  return result;
+}

--- a/js/script.js
+++ b/js/script.js
@@ -1,4 +1,5 @@
 import { calculateCompatibility } from './compatibility.js';
+import { pruneSurvey } from './pruneSurvey.js';
 
 // ================== Password Protection ==================
 const PASSWORD = 'NadaHeartsDuckies';
@@ -511,7 +512,7 @@ document.getElementById('downloadBtn').addEventListener('click', () => {
     alert('No survey loaded.');
     return;
   }
-  const exportObj = { survey: surveyA };
+  const exportObj = { survey: pruneSurvey(surveyA) };
   const blob = new Blob([JSON.stringify(exportObj, null, 2)], { type: 'application/json' });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');

--- a/test/pruneSurvey.test.js
+++ b/test/pruneSurvey.test.js
@@ -1,0 +1,34 @@
+import assert from 'node:assert';
+import test from 'node:test';
+import { pruneSurvey } from '../js/pruneSurvey.js';
+
+test('pruneSurvey removes empty entries', () => {
+  const survey = {
+    Cat: {
+      Giving: [
+        { name: 'A', rating: null },
+        { name: 'B', rating: 3 }
+      ],
+      Receiving: [
+        { name: 'C', rating: 0 }
+      ],
+      General: [
+        { name: 'D', type: 'text', value: '' },
+        { name: 'E', type: 'multi', value: [] },
+        { name: 'F', type: 'dropdown', value: 'X' }
+      ]
+    },
+    Empty: {
+      Giving: [{ name: 'Z', rating: null }]
+    }
+  };
+
+  const result = pruneSurvey(survey);
+  assert.deepStrictEqual(result, {
+    Cat: {
+      Giving: [{ name: 'B', rating: 3 }],
+      Receiving: [{ name: 'C', rating: 0 }],
+      General: [{ name: 'F', type: 'dropdown', value: 'X' }]
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add `pruneSurvey` helper to trim empty responses from survey exports
- export only pruned survey data in `Export My List` button handler
- cover pruning logic with unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860b1fbdba4832ca925d26f32ac7463