### PR TITLE
Add role definitions panel

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -65,6 +65,18 @@ body.light-mode #closeSubSidebarBtn {
   color: #2f4f2f;
 }
 
+#closeRoleDefinitionsBtn {
+  text-align: right;
+  background: none;
+  border: none;
+  color: #ccc;
+  font-size: 18px;
+  width: 100%;
+}
+body.light-mode #closeRoleDefinitionsBtn {
+  color: #2f4f2f;
+}
+
 /* Mobile open sidebar button */
 #openSidebarBtn {
   display: none;
@@ -88,6 +100,16 @@ body.light-mode #closeSubSidebarBtn {
   }
 
   #categoryPanel.visible {
+    left: 0;
+  }
+
+  #roleDefinitionsPanel {
+    width: 90%;
+    max-width: 320px;
+    left: -100%;
+  }
+
+  #roleDefinitionsPanel.visible {
     left: 0;
   }
 

--- a/index.html
+++ b/index.html
@@ -63,6 +63,21 @@
   </div>
   <div id="categoryOverlay" class="overlay"></div>
 
+  <!-- Role Definitions Panel -->
+  <div id="roleDefinitionsPanel" class="category-panel">
+    <button id="closeRoleDefinitionsBtn">✖</button>
+    <h2>Role Definitions</h2>
+    <ul>
+      <li><strong>Sadist:</strong> Enjoys inflicting consensual pain or discomfort.</li>
+      <li><strong>Masochist:</strong> Enjoys receiving pain as part of erotic experience.</li>
+      <li><strong>Service Submissive:</strong> Gains satisfaction through acts of service or utility.</li>
+      <li><strong>Emotional Masochist:</strong> Aroused by emotional challenge, exposure, or shame.</li>
+      <li><strong>Prey:</strong> Finds fulfillment in being hunted, stalked, or emotionally pursued.</li>
+      <li><strong>Owner:</strong> Takes structured responsibility or control over another person’s expression or habits.</li>
+    </ul>
+  </div>
+  <div id="roleDefinitionsOverlay" class="overlay"></div>
+
   <!-- Password Overlay -->
   <div id="passwordOverlay">
     <div class="password-modal">
@@ -75,6 +90,7 @@
   <!-- Buttons -->
   <div class="button-group">
     <!-- Top two buttons -->
+    <button id="roleDefinitionsBtn" class="survey-button">Role Definitions</button>
     <button id="downloadBtn" class="survey-button">Export My List</button>
     <button id="newSurveyBtn" class="survey-button">Start New Survey</button>
 

--- a/js/script.js
+++ b/js/script.js
@@ -220,6 +220,10 @@ const closeSubSidebarBtn = document.getElementById('closeSubSidebarBtn');
 const openSidebarBtn = document.getElementById('openSidebarBtn');
 const ratingLegend = document.getElementById('ratingLegend');
 const categoryOverlay = document.getElementById('categoryOverlay');
+const roleDefinitionsPanel = document.getElementById('roleDefinitionsPanel');
+const roleDefinitionsOverlay = document.getElementById('roleDefinitionsOverlay');
+const roleDefinitionsBtn = document.getElementById('roleDefinitionsBtn');
+const closeRoleDefinitionsBtn = document.getElementById('closeRoleDefinitionsBtn');
 
 function showRatingLegend(target) {
   const rect = target.getBoundingClientRect();
@@ -244,6 +248,20 @@ function showOverlay() {
 
 function hideOverlay() {
   categoryOverlay.style.display = 'none';
+}
+
+function showRolePanel() {
+  roleDefinitionsPanel.style.display = 'block';
+  if (window.innerWidth <= 768) {
+    roleDefinitionsPanel.classList.add('visible');
+  }
+  roleDefinitionsOverlay.style.display = 'block';
+}
+
+function hideRolePanel() {
+  roleDefinitionsPanel.classList.remove('visible');
+  roleDefinitionsPanel.style.display = 'none';
+  roleDefinitionsOverlay.style.display = 'none';
 }
 
 categoryPanel.style.display = 'none'; // Hide by default
@@ -278,6 +296,10 @@ categoryOverlay.addEventListener('click', () => {
   hideOverlay();
   if (window.innerWidth <= 768) openSidebarBtn.style.display = 'block';
 });
+
+roleDefinitionsBtn.addEventListener('click', showRolePanel);
+closeRoleDefinitionsBtn.addEventListener('click', hideRolePanel);
+roleDefinitionsOverlay.addEventListener('click', hideRolePanel);
 
 function loadSurveyAFile(file) {
   if (!file) return;
@@ -586,6 +608,7 @@ window.addEventListener('resize', () => {
     hideOverlay();
     categoryPanel.classList.remove('visible');
     openSidebarBtn.style.display = 'none';
+    hideRolePanel();
   } else if (!categoryPanel.classList.contains('visible')) {
     openSidebarBtn.style.display = 'block';
   }


### PR DESCRIPTION
## Summary
- add a new **Role Definitions** button at the top of the controls
- show a new left slide-out panel with static role info
- style the new panel and close button
- handle panel open/close events in JS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68617d11fe14832cbdce7e7ccd630755