### PR TITLE
Update role definitions list

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,13 +67,33 @@
   <div id="roleDefinitionsPanel" class="category-panel">
     <button id="closeRoleDefinitionsBtn">✖</button>
     <h2>Role Definitions</h2>
+    <h3>Dominant / Giver Roles</h3>
     <ul>
       <li><strong>Sadist:</strong> Enjoys inflicting consensual pain or discomfort.</li>
-      <li><strong>Masochist:</strong> Enjoys receiving pain as part of erotic experience.</li>
-      <li><strong>Service Submissive:</strong> Gains satisfaction through acts of service or utility.</li>
-      <li><strong>Emotional Masochist:</strong> Aroused by emotional challenge, exposure, or shame.</li>
-      <li><strong>Prey:</strong> Finds fulfillment in being hunted, stalked, or emotionally pursued.</li>
-      <li><strong>Owner:</strong> Takes structured responsibility or control over another person’s expression or habits.</li>
+      <li><strong>Emotional Sadist:</strong> Derives satisfaction from creating emotional intensity, psychological pressure, or vulnerability.</li>
+      <li><strong>Primal (Hunter):</strong> Relies on instinct and presence to dominate; enjoys pursuit and overpowering prey.</li>
+      <li><strong>Emotional Primal:</strong> Dominates through emotional overwhelm, intense gaze, and intuitive connection.</li>
+      <li><strong>Owner:</strong> Exercises structured control over a submissive’s body, behavior, or schedule.</li>
+      <li><strong>Handler:</strong> Guides, trains, or controls another person, often in petplay or performance roles.</li>
+      <li><strong>Caregiver:</strong> Provides emotional support, nurturing, and structure to a submissive or little.</li>
+      <li><strong>Service Top:</strong> Offers structured acts (like impact or discipline) with the partner's benefit in mind.</li>
+      <li><strong>Mindfuck Dominant / Manipulator:</strong> Uses confusion, contradiction, or emotional baiting to disorient and control.</li>
+      <li><strong>Objectifier / Dehumanizer:</strong> Strips status or individuality from a partner to enforce obedience or role identity.</li>
+    </ul>
+
+    <h3>Submissive / Receiver Roles</h3>
+    <ul>
+      <li><strong>Masochist:</strong> Enjoys receiving consensual pain or intense sensation.</li>
+      <li><strong>Emotional Masochist:</strong> Aroused by emotional exposure, degradation, shame, or psychological tension.</li>
+      <li><strong>Prey:</strong> Eroticizes being hunted, stalked, or overwhelmed.</li>
+      <li><strong>Emotional Prey:</strong> Draws pleasure from being emotionally pursued, seen, or broken open.</li>
+      <li><strong>Pet:</strong> Adopts a non-verbal, obedient, or animal-like role for comfort, submission, or training.</li>
+      <li><strong>Little:</strong> Regresses into a childlike or youthful headspace under a caregiver’s guidance.</li>
+      <li><strong>Service Submissive:</strong> Gains fulfillment through helpfulness, obedience, and daily rituals.</li>
+      <li><strong>Brat:</strong> Defies, teases, or resists as a way to provoke control or prove interest.</li>
+      <li><strong>Internal Conflict Sub:</strong> Submits through internal struggle, self-denial, or shame; obedience is hard-earned.</li>
+      <li><strong>Performance Sub:</strong> Aroused by being watched, judged, or evaluated during service or submission.</li>
+      <li><strong>Mindfuck Enthusiast / Manipulation Sub:</strong> Derives excitement from confusion, mental destabilization, or loss of control.</li>
     </ul>
   </div>
   <div id="roleDefinitionsOverlay" class="overlay"></div>


### PR DESCRIPTION
## Summary
- expand the Role Definitions panel with new Dominant/Giver and Submissive/Receiver role descriptions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686182901c78832c8c70780667955dc8