### PR TITLE
Improve role definitions panel styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -21,6 +21,13 @@ body {
   transition: left 0.3s ease, width 0.3s ease;
 }
 
+#roleDefinitionsPanel {
+  width: 440px;
+  padding: 20px;
+  font-size: 15px;
+  line-height: 1.6;
+}
+
 .category-panel.extended {
   width: 840px;
 }
@@ -663,4 +670,20 @@ body.light-mode #ratingLegend {
 
 .file-upload span {
   pointer-events: none;
+}
+
+.section-header {
+  margin-top: 20px;
+  margin-bottom: 10px;
+  font-size: 18px;
+  border-bottom: 1px solid #555;
+  padding-bottom: 4px;
+}
+
+.role-block {
+  margin-bottom: 10px;
+  padding: 8px 10px;
+  border: 1px solid #555;
+  border-radius: 4px;
+  background-color: rgba(255, 255, 255, 0.05);
 }

--- a/index.html
+++ b/index.html
@@ -67,34 +67,30 @@
   <div id="roleDefinitionsPanel" class="category-panel">
     <button id="closeRoleDefinitionsBtn">✖</button>
     <h2>Role Definitions</h2>
-    <h3>Dominant / Giver Roles</h3>
-    <ul>
-      <li><strong>Sadist:</strong> Enjoys inflicting consensual pain or discomfort.</li>
-      <li><strong>Emotional Sadist:</strong> Derives satisfaction from creating emotional intensity, psychological pressure, or vulnerability.</li>
-      <li><strong>Primal (Hunter):</strong> Relies on instinct and presence to dominate; enjoys pursuit and overpowering prey.</li>
-      <li><strong>Emotional Primal:</strong> Dominates through emotional overwhelm, intense gaze, and intuitive connection.</li>
-      <li><strong>Owner:</strong> Exercises structured control over a submissive’s body, behavior, or schedule.</li>
-      <li><strong>Handler:</strong> Guides, trains, or controls another person, often in petplay or performance roles.</li>
-      <li><strong>Caregiver:</strong> Provides emotional support, nurturing, and structure to a submissive or little.</li>
-      <li><strong>Service Top:</strong> Offers structured acts (like impact or discipline) with the partner's benefit in mind.</li>
-      <li><strong>Mindfuck Dominant / Manipulator:</strong> Uses confusion, contradiction, or emotional baiting to disorient and control.</li>
-      <li><strong>Objectifier / Dehumanizer:</strong> Strips status or individuality from a partner to enforce obedience or role identity.</li>
-    </ul>
+    <h3 class="section-header">Dominant / Giver Roles</h3>
+    <div class="role-block">😈 <strong>Sadist:</strong> Enjoys inflicting consensual pain or discomfort.</div>
+    <div class="role-block">💢 <strong>Emotional Sadist:</strong> Derives satisfaction from creating emotional intensity, psychological pressure, or vulnerability.</div>
+    <div class="role-block">🐯 <strong>Primal (Hunter):</strong> Relies on instinct and presence to dominate; enjoys pursuit and overpowering prey.</div>
+    <div class="role-block">🔥 <strong>Emotional Primal:</strong> Dominates through emotional overwhelm, intense gaze, and intuitive connection.</div>
+    <div class="role-block">👑 <strong>Owner:</strong> Exercises structured control over a submissive’s body, behavior, or schedule.</div>
+    <div class="role-block">🦮 <strong>Handler:</strong> Guides, trains, or controls another person, often in petplay or performance roles.</div>
+    <div class="role-block">🍼 <strong>Caregiver:</strong> Provides emotional support, nurturing, and structure to a submissive or little.</div>
+    <div class="role-block">🎯 <strong>Service Top:</strong> Offers structured acts (like impact or discipline) with the partner's benefit in mind.</div>
+    <div class="role-block">🧠 <strong>Mindfuck Dominant / Manipulator:</strong> Uses confusion, contradiction, or emotional baiting to disorient and control.</div>
+    <div class="role-block">🗿 <strong>Objectifier / Dehumanizer:</strong> Strips status or individuality from a partner to enforce obedience or role identity.</div>
 
-    <h3>Submissive / Receiver Roles</h3>
-    <ul>
-      <li><strong>Masochist:</strong> Enjoys receiving consensual pain or intense sensation.</li>
-      <li><strong>Emotional Masochist:</strong> Aroused by emotional exposure, degradation, shame, or psychological tension.</li>
-      <li><strong>Prey:</strong> Eroticizes being hunted, stalked, or overwhelmed.</li>
-      <li><strong>Emotional Prey:</strong> Draws pleasure from being emotionally pursued, seen, or broken open.</li>
-      <li><strong>Pet:</strong> Adopts a non-verbal, obedient, or animal-like role for comfort, submission, or training.</li>
-      <li><strong>Little:</strong> Regresses into a childlike or youthful headspace under a caregiver’s guidance.</li>
-      <li><strong>Service Submissive:</strong> Gains fulfillment through helpfulness, obedience, and daily rituals.</li>
-      <li><strong>Brat:</strong> Defies, teases, or resists as a way to provoke control or prove interest.</li>
-      <li><strong>Internal Conflict Sub:</strong> Submits through internal struggle, self-denial, or shame; obedience is hard-earned.</li>
-      <li><strong>Performance Sub:</strong> Aroused by being watched, judged, or evaluated during service or submission.</li>
-      <li><strong>Mindfuck Enthusiast / Manipulation Sub:</strong> Derives excitement from confusion, mental destabilization, or loss of control.</li>
-    </ul>
+    <h3 class="section-header">Submissive / Receiver Roles</h3>
+    <div class="role-block">🤕 <strong>Masochist:</strong> Enjoys receiving consensual pain or intense sensation.</div>
+    <div class="role-block">😭 <strong>Emotional Masochist:</strong> Aroused by emotional exposure, degradation, shame, or psychological tension.</div>
+    <div class="role-block">🐇 <strong>Prey:</strong> Eroticizes being hunted, stalked, or overwhelmed.</div>
+    <div class="role-block">💔 <strong>Emotional Prey:</strong> Draws pleasure from being emotionally pursued, seen, or broken open.</div>
+    <div class="role-block">🐾 <strong>Pet:</strong> Adopts a non-verbal, obedient, or animal-like role for comfort, submission, or training.</div>
+    <div class="role-block">🧸 <strong>Little:</strong> Regresses into a childlike or youthful headspace under a caregiver’s guidance.</div>
+    <div class="role-block">🙇 <strong>Service Submissive:</strong> Gains fulfillment through helpfulness, obedience, and daily rituals.</div>
+    <div class="role-block">😜 <strong>Brat:</strong> Defies, teases, or resists as a way to provoke control or prove interest.</div>
+    <div class="role-block">😖 <strong>Internal Conflict Sub:</strong> Submits through internal struggle, self-denial, or shame; obedience is hard-earned.</div>
+    <div class="role-block">🎭 <strong>Performance Sub:</strong> Aroused by being watched, judged, or evaluated during service or submission.</div>
+    <div class="role-block">🌀 <strong>Mindfuck Enthusiast / Manipulation Sub:</strong> Derives excitement from confusion, mental destabilization, or loss of control.</div>
   </div>
   <div id="roleDefinitionsOverlay" class="overlay"></div>
 


### PR DESCRIPTION
## Summary
- redesign the role definitions panel
- use styled blocks for each role with optional emoji
- widen the definitions panel
- add new CSS classes for section headers and role blocks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686184802ae4832c9148eb91ca06dc89