### PR TITLE
Implement weighted compatibility scoring

### DIFF
--- a/js/compatibility.js
+++ b/js/compatibility.js
@@ -8,38 +8,43 @@ export function calculateCompatibility(surveyA, surveyB) {
   categories.forEach(category => {
     if (!surveyB[category]) return;
 
-    ['Giving', 'Receiving', 'General'].forEach(action => {
+    ['Giving', 'Receiving'].forEach(action => {
       const listA = surveyA[category][action] || [];
-      const listB = surveyB[category][
-        action === 'Giving' ? 'Receiving' :
-        action === 'Receiving' ? 'Giving' : 'General'
-      ] || [];
+      const listB =
+        surveyB[category][action === 'Giving' ? 'Receiving' : 'Giving'] || [];
 
       listA.forEach(itemA => {
-        const match = listB.find(itemB =>
-          itemB.name.trim().toLowerCase() === itemA.name.trim().toLowerCase()
+        const match = listB.find(
+          itemB =>
+            itemB.name.trim().toLowerCase() ===
+            itemA.name.trim().toLowerCase()
         );
-        if (match) {
-          const ratingA = parseInt(itemA.rating);
-          const ratingB = parseInt(match.rating);
-          if (Number.isInteger(ratingA) && Number.isInteger(ratingB)) {
-            const diff = Math.abs(ratingA - ratingB);
-            totalScore += Math.max(0, 100 - diff * 20);
-            count++;
-          if ((ratingA >= 5 && ratingB <= 1) || (ratingB >= 5 && ratingA <= 1)) {
-            redFlags.push(itemA.name);
-          } else if (
-              (ratingA >= 4 && ratingB <= 2) || (ratingB >= 4 && ratingA <= 2)
-            ) {
-              yellowFlags.push(itemA.name);
-            }
-          }
+        if (!match) return;
+        const ratingA = parseInt(itemA.rating);
+        const ratingB = parseInt(match.rating);
+        if (!Number.isInteger(ratingA) || !Number.isInteger(ratingB)) return;
+
+        count++;
+
+        if ((ratingA >= 5 && ratingB <= 1) || (ratingB >= 5 && ratingA <= 1)) {
+          redFlags.push(itemA.name);
+        } else if (
+          (ratingA >= 4 && ratingB <= 2) ||
+          (ratingB >= 4 && ratingA <= 2)
+        ) {
+          yellowFlags.push(itemA.name);
+        }
+
+        if (ratingA >= 4 && ratingB >= 4) {
+          totalScore += 1;
+        } else if (ratingA >= 3 && ratingB >= 3) {
+          totalScore += 0.5;
         }
       });
     });
   });
 
-  const avg = count ? Math.round(totalScore / count) : 0;
+  const avg = count ? Math.round((totalScore / count) * 100) : 0;
 
   // Similarity Score (same role)
   let simScore = 0;

--- a/test/survey.test.js
+++ b/test/survey.test.js
@@ -10,12 +10,19 @@ test('opposite ratings trigger red flag and zero score', () => {
   assert.ok(result.redFlags.includes('A'));
 });
 
-test('rating difference of two yields 60 score', () => {
+test('medium ratings yield 50 score', () => {
   const surveyA = { Cat: { Giving: [{ name: 'A', rating: 5 }], Receiving: [], General: [] } };
   const surveyB = { Cat: { Giving: [], Receiving: [{ name: 'A', rating: 3 }], General: [] } };
   const result = calculateCompatibility(surveyA, surveyB);
-  assert.strictEqual(result.compatibilityScore, 60);
+  assert.strictEqual(result.compatibilityScore, 50);
   assert.deepStrictEqual(result.redFlags, []);
+});
+
+test('strong match yields 100 score', () => {
+  const surveyA = { Cat: { Giving: [{ name: 'B', rating: 4 }], Receiving: [], General: [] } };
+  const surveyB = { Cat: { Giving: [], Receiving: [{ name: 'B', rating: 5 }], General: [] } };
+  const result = calculateCompatibility(surveyA, surveyB);
+  assert.strictEqual(result.compatibilityScore, 100);
 });
 
 test('similar ratings in same role produce similarity score', () => {


### PR DESCRIPTION
## Summary
- update `calculateCompatibility` to score giving/receiving matches using strong/medium weights
- adjust compatibility tests and add a strong-match test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68619ba43a1c832cad40d9cee17e9559