### PR TITLE
Fix role score calculation for string entries

### DIFF
--- a/js/calculateRoleScores.js
+++ b/js/calculateRoleScores.js
@@ -7,8 +7,8 @@ function calculateRoleScores(surveyData, maxRating = 5) {
     for (const item of items) {
       if (item.rating !== null && Array.isArray(item.roles)) {
         for (const role of item.roles) {
-          const roleName = role.name;
-          const weight = role.weight || 1;
+          const roleName = typeof role === 'string' ? role : role.name;
+          const weight = typeof role === 'object' && role.weight !== undefined ? role.weight : 1;
           const score = item.rating * weight;
           const maxScore = maxRating * weight;
 

--- a/js/roleScores.js
+++ b/js/roleScores.js
@@ -10,8 +10,8 @@ export function calculateRoleScores(surveyData, maxRating = 5) {
       items.forEach(item => {
         if (item && typeof item.rating === 'number' && item.roles) {
           item.roles.forEach(r => {
-            const name = r.name;
-            const weight = r.weight ?? 1;
+            const name = typeof r === 'string' ? r : r.name;
+            const weight = typeof r === 'object' && r.weight !== undefined ? r.weight : 1;
             if (!roleScores[name]) roleScores[name] = 0;
             if (!roleMaxScores[name]) roleMaxScores[name] = 0;
             roleScores[name] += item.rating * weight;


### PR DESCRIPTION
## Summary
- handle roles recorded as strings when calculating role scores

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861a0c62b60832ca48c2c08c8a94228