### PR TITLE
Fix role score aggregation

### DIFF
--- a/js/calculateRoleScores.js
+++ b/js/calculateRoleScores.js
@@ -1,39 +1,58 @@
+const roles = [
+  'dominant',
+  'switch',
+  'sadist',
+  'emotional sadist',
+  'primal (hunter)',
+  'emotional primal',
+  'owner',
+  'handler',
+  'caregiver',
+  'service top',
+  'mindfuck dominant / manipulator',
+  'objectifier / dehumanizer',
+  'masochist',
+  'emotional masochist',
+  'prey',
+  'emotional prey',
+  'pet',
+  'little',
+  'service submissive',
+  'brat',
+  'internal conflict sub',
+  'performance sub',
+  'mindfuck enthusiast / manipulation sub'
+];
+
 function calculateRoleScores(surveyData, maxRating = 5) {
-  const roleScores = {};
-  const roleMaxScores = {};
+  const scores = {};
+  const counts = {};
+  roles.forEach(r => {
+    scores[r] = 0;
+    counts[r] = 0;
+  });
 
   for (const category in surveyData) {
     const items = surveyData[category];
     for (const item of items) {
-      if (item.rating !== null && Array.isArray(item.roles)) {
+      if (item && typeof item.rating === 'number' && item.rating > 0 && Array.isArray(item.roles)) {
         for (const role of item.roles) {
-          const roleName = typeof role === 'string' ? role : role.name;
-          const weight = typeof role === 'object' && role.weight !== undefined ? role.weight : 1;
-          const score = item.rating * weight;
-          const maxScore = maxRating * weight;
-
-          if (!roleScores[roleName]) {
-            roleScores[roleName] = 0;
-            roleMaxScores[roleName] = 0;
-          }
-
-          roleScores[roleName] += score;
-          roleMaxScores[roleName] += maxScore;
+          const roleName = (typeof role === 'string' ? role : role.name).toLowerCase();
+          if (scores[roleName] === undefined) continue;
+          scores[roleName] += item.rating;
+          counts[roleName] += maxRating;
         }
       }
     }
   }
 
-  const results = Object.keys(roleScores).map(role => {
-    const percent = (roleScores[role] / roleMaxScores[role]) * 100;
-    return {
-      name: role,
-      percent: Math.round(percent)
-    };
-  });
+  const results = roles.map(role => ({
+    name: role,
+    percent: counts[role] > 0 ? Math.round((scores[role] / counts[role]) * 100) : 0
+  }));
 
   results.sort((a, b) => b.percent - a.percent);
   return results;
 }
 
-export { calculateRoleScores };
+export { calculateRoleScores, roles };

--- a/js/roleScores.js
+++ b/js/roleScores.js
@@ -1,35 +1,61 @@
+const roles = [
+  'dominant',
+  'switch',
+  'sadist',
+  'emotional sadist',
+  'primal (hunter)',
+  'emotional primal',
+  'owner',
+  'handler',
+  'caregiver',
+  'service top',
+  'mindfuck dominant / manipulator',
+  'objectifier / dehumanizer',
+  'masochist',
+  'emotional masochist',
+  'prey',
+  'emotional prey',
+  'pet',
+  'little',
+  'service submissive',
+  'brat',
+  'internal conflict sub',
+  'performance sub',
+  'mindfuck enthusiast / manipulation sub'
+];
+
 export function calculateRoleScores(surveyData, maxRating = 5) {
-  const roleScores = {};
-  const roleMaxScores = {};
   if (!surveyData || typeof surveyData !== 'object') return [];
 
-  // Iterate over categories
+  const scores = {};
+  const counts = {};
+  roles.forEach(role => {
+    scores[role] = 0;
+    counts[role] = 0;
+  });
+
   Object.values(surveyData).forEach(category => {
     ['Giving', 'Receiving', 'General'].forEach(action => {
       const items = Array.isArray(category[action]) ? category[action] : [];
       items.forEach(item => {
-        if (item && typeof item.rating === 'number' && item.roles) {
+        if (item && typeof item.rating === 'number' && item.rating > 0 && item.roles) {
           item.roles.forEach(r => {
-            const name = typeof r === 'string' ? r : r.name;
-            const weight = typeof r === 'object' && r.weight !== undefined ? r.weight : 1;
-            if (!roleScores[name]) roleScores[name] = 0;
-            if (!roleMaxScores[name]) roleMaxScores[name] = 0;
-            roleScores[name] += item.rating * weight;
-            roleMaxScores[name] += maxRating * weight;
+            const name = (typeof r === 'string' ? r : r.name).toLowerCase();
+            if (scores[name] === undefined) return;
+            scores[name] += item.rating;
+            counts[name] += maxRating;
           });
-        } else if (item && typeof item.rating === 'number') {
-          // if item has rating but no roles, do nothing
         }
       });
     });
   });
 
-  return Object.keys(roleScores)
+  return roles
     .map(role => ({
       name: role,
-      percent: roleMaxScores[role]
-        ? Math.round((roleScores[role] / roleMaxScores[role]) * 100)
-        : 0
+      percent: counts[role] > 0 ? Math.round((scores[role] / counts[role]) * 100) : 0
     }))
     .sort((a, b) => b.percent - a.percent);
 }
+
+export { roles };

--- a/test/roleScores.test.js
+++ b/test/roleScores.test.js
@@ -26,29 +26,23 @@ const sampleSurvey = {
 
 test('calculates percentages based on rating and weight', () => {
   const result = calculateRoleScores(sampleSurvey);
-  const expected = [
-    { name: 'Masochist', percent: 100 },
-    { name: 'Sadist', percent: 100 }
-  ];
-  // result order isn't guaranteed when percentages tie
-  assert.deepStrictEqual(
-    result.sort((a, b) => a.name.localeCompare(b.name)),
-    expected.sort((a, b) => a.name.localeCompare(b.name))
-  );
+  const mas = result.find(r => r.name === 'masochist');
+  const sad = result.find(r => r.name === 'sadist');
+  assert.strictEqual(mas.percent, 100);
+  assert.strictEqual(sad.percent, 100);
 });
 
 test('handles partial scores and missing weights', () => {
   const survey = {
     Cat: {
       Giving: [
-        { name: 'X', rating: 3, roles: [{ name: 'Dom' }] }
+        { name: 'X', rating: 3, roles: [{ name: 'dominant' }] }
       ],
       Receiving: [],
       General: []
     }
   };
   const result = calculateRoleScores(survey);
-  assert.deepStrictEqual(result, [
-    { name: 'Dom', percent: 60 }
-  ]);
+  const dom = result.find(r => r.name === 'dominant');
+  assert.strictEqual(dom.percent, 60);
 });


### PR DESCRIPTION
## Summary
- expand list of roles to track
- refine calculateRoleScores logic to tally only rated roles
- normalize role names to lowercase
- update tests for new logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6861a4e0aba0832cb3b4e731ac14fc36