### PR TITLE
Fix Start New Survey fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ The website is built from the following files in this repository:
 The **Start New Survey** button fetches `template-survey.json` each time it is
 clicked so you always start with a fresh set of kinks.
 
+**Note:** Because this file is fetched dynamically, opening `index.html`
+directly from your file system can produce errors like
+`Failed to load template: Unexpected token < ...`. Run a local web server (see
+below) when previewing the site so the template file loads correctly.
+
 ## Setup
 
 Run `setup.sh` to install optional tools for local development. The script

--- a/js/script.js
+++ b/js/script.js
@@ -382,7 +382,12 @@ document.getElementById('newSurveyBtn').addEventListener('click', () => {
       initialize(JSON.parse(JSON.stringify(window.templateSurvey)));
     })
     .catch(err => {
-      alert('Failed to load template: ' + err.message);
+      if (window.templateSurvey) {
+        console.warn('Failed to load template, using embedded copy:', err);
+        initialize(JSON.parse(JSON.stringify(window.templateSurvey)));
+      } else {
+        alert('Failed to load template: ' + err.message);
+      }
     });
 });
 


### PR DESCRIPTION
## Summary
- handle template load errors gracefully
- document need for a local web server when previewing locally

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6863a92010c0832c8f7ad561008a98de