### PR TITLE
Fix missing subcategories in new surveys

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -170,7 +170,19 @@ function normalizeSurveyFormat(obj) {
       }
     };
   }
-  return obj;
+
+  const normalized = {};
+  Object.entries(obj).forEach(([cat, val]) => {
+    if (Array.isArray(val)) {
+      normalized[cat] = { Giving: [], Receiving: [], General: val };
+    } else {
+      normalized[cat] = { ...val };
+      actions.forEach(role => {
+        if (!Array.isArray(normalized[cat][role])) normalized[cat][role] = [];
+      });
+    }
+  });
+  return normalized;
 }
 
 // Ensure a survey object includes all categories and items from the template


### PR DESCRIPTION
## Summary
- normalize survey data when a category is an array

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6864b835a5fc832cb42b3bf5ce3bee9f