### PR TITLE
Add dedicated compatibility page

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>See Our Compatibility</title>
+  <link rel="stylesheet" href="css/style.css" />
+</head>
+<body class="dark-mode">
+  <h1>See Our Compatibility</h1>
+  <label class="survey-button file-upload">
+    <span>Upload Your Survey</span>
+    <input type="file" id="fileA" hidden />
+  </label>
+  <label class="survey-button file-upload">
+    <span>Upload Partner's Survey</span>
+    <input type="file" id="fileB" hidden />
+  </label>
+  <div id="comparisonResult"></div>
+  <script src="js/template-survey.js"></script>
+  <script type="module" src="js/compatibilityPage.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -191,12 +191,11 @@
     <div class="section-spacing"></div>
 
     <!-- Compatibility button -->
-    <button id="compareBtn" class="survey-button">See Our Compatibility</button>
+    <button id="compatibilityBtn" class="survey-button" onclick="location.href='compatibility.html'">See Our Compatibility</button>
     <button id="roleDefinitionsBtn" class="survey-button">Role Definitions</button>
     <button id="roleResultsBtn" class="survey-button" onclick="location.href='your-roles.html'">View Role Results</button>
     <button id="kinkListBtn" class="survey-button" onclick="location.href='kink-list.html'">View Kink List</button>
   </div>
-  <div id="comparisonResult"></div>
 
   <!-- Script -->
   <script src="js/template-survey.js"></script>

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -1,0 +1,159 @@
+import { calculateCompatibility } from './compatibility.js';
+
+let surveyA = null;
+let surveyB = null;
+
+function filterGeneralOptions(survey) {
+  Object.values(survey).forEach(cat => {
+    if (!cat.General) return;
+    const neutralNames = new Set(cat.General.map(k => k.name.trim().toLowerCase()));
+    ['Giving', 'Receiving'].forEach(role => {
+      if (Array.isArray(cat[role])) {
+        cat[role] = cat[role].filter(k => !neutralNames.has(k.name.trim().toLowerCase()));
+      }
+    });
+  });
+}
+
+function normalizeRatings(survey) {
+  Object.values(survey).forEach(cat => {
+    ['Giving', 'Receiving', 'General'].forEach(role => {
+      if (Array.isArray(cat[role])) {
+        cat[role].forEach(item => {
+          if (typeof item.rating === 'number') {
+            if (item.rating > 5) item.rating = 5;
+            if (item.rating < 0) item.rating = 0;
+          }
+        });
+      }
+    });
+  });
+}
+
+function normalizeSurveyFormat(obj) {
+  if (!obj || typeof obj !== 'object' || Array.isArray(obj)) return obj;
+  const actions = ['Giving', 'Receiving', 'General'];
+  const keys = Object.keys(obj);
+  if (keys.every(k => actions.includes(k))) {
+    return {
+      Misc: {
+        Giving: Array.isArray(obj.Giving) ? obj.Giving : [],
+        Receiving: Array.isArray(obj.Receiving) ? obj.Receiving : [],
+        General: Array.isArray(obj.General) ? obj.General : []
+      }
+    };
+  }
+
+  const normalized = {};
+  Object.entries(obj).forEach(([cat, val]) => {
+    if (Array.isArray(val)) {
+      normalized[cat] = { Giving: [], Receiving: [], General: val };
+    } else {
+      normalized[cat] = { ...val };
+      actions.forEach(role => {
+        if (!Array.isArray(normalized[cat][role])) normalized[cat][role] = [];
+      });
+    }
+  });
+  return normalized;
+}
+
+function mergeSurveyWithTemplate(survey, template) {
+  if (!template || typeof template !== 'object') return;
+  Object.entries(template).forEach(([cat, tmpl]) => {
+    if (!survey[cat]) {
+      survey[cat] = JSON.parse(JSON.stringify(tmpl));
+      return;
+    }
+    ['Giving', 'Receiving', 'General'].forEach(role => {
+      const tItems = Array.isArray(tmpl[role]) ? tmpl[role] : [];
+      if (!Array.isArray(survey[cat][role])) survey[cat][role] = [];
+      const existing = new Set(
+        survey[cat][role].map(i => (i.name || '').trim().toLowerCase())
+      );
+      tItems.forEach(it => {
+        if (!existing.has(it.name.trim().toLowerCase())) {
+          const obj = { name: it.name, rating: null };
+          if (it.type) obj.type = it.type;
+          if (it.options) obj.options = it.options;
+          if (it.roles) obj.roles = it.roles;
+          survey[cat][role].push(obj);
+        } else {
+          const ex = survey[cat][role].find(
+            i => i.name.trim().toLowerCase() === it.name.trim().toLowerCase()
+          );
+          if (ex) {
+            if (it.type) ex.type = it.type;
+            if (it.options) ex.options = it.options;
+            if (it.roles) ex.roles = it.roles;
+          }
+        }
+      });
+    });
+  });
+}
+
+function loadFileA(file) {
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = ev => {
+    try {
+      const parsed = JSON.parse(ev.target.result);
+      surveyA = normalizeSurveyFormat(parsed.survey || parsed);
+      mergeSurveyWithTemplate(surveyA, window.templateSurvey);
+      normalizeRatings(surveyA);
+      filterGeneralOptions(surveyA);
+      checkAndCompare();
+    } catch {
+      alert('Invalid JSON for Survey A.');
+    }
+  };
+  reader.readAsText(file);
+}
+
+function loadFileB(file) {
+  if (!file) return;
+  if (!confirm('Have you reviewed consent with your partner?')) {
+    return;
+  }
+  const reader = new FileReader();
+  reader.onload = ev => {
+    try {
+      const parsed = JSON.parse(ev.target.result);
+      surveyB = normalizeSurveyFormat(parsed.survey || parsed);
+      mergeSurveyWithTemplate(surveyB, window.templateSurvey);
+      normalizeRatings(surveyB);
+      filterGeneralOptions(surveyB);
+      checkAndCompare();
+    } catch {
+      alert('Invalid JSON for Survey B.');
+    }
+  };
+  reader.readAsText(file);
+}
+
+function checkAndCompare() {
+  const output = document.getElementById('comparisonResult');
+  if (!surveyA || !surveyB) {
+    output.textContent = surveyA || surveyB ? 'Please upload both surveys to view compatibility.' : '';
+    return;
+  }
+  const result = calculateCompatibility(surveyA, surveyB);
+  let html = `<h3>Compatibility Score: ${result.compatibilityScore}%</h3>`;
+  html += `<h4>Similarity Score: ${result.similarityScore}%</h4>`;
+  if (result.redFlags.length) {
+    html += `<p>🚩 Red flags: ${result.redFlags.join(', ')}</p>`;
+  }
+  if (result.yellowFlags.length) {
+    html += `<p>⚠️ Yellow flags: ${result.yellowFlags.join(', ')}</p>`;
+  }
+  output.innerHTML = html;
+}
+
+document.getElementById('fileA').addEventListener('change', e => {
+  loadFileA(e.target.files[0]);
+});
+
+document.getElementById('fileB').addEventListener('change', e => {
+  loadFileB(e.target.files[0]);
+});

--- a/js/script.js
+++ b/js/script.js
@@ -560,7 +560,8 @@ document.getElementById('downloadBtn').addEventListener('click', () => {
 });
 
 // ================== See Our Compatibility ==================
-document.getElementById('compareBtn').addEventListener('click', () => {
+const compareBtn = document.getElementById('compareBtn');
+if (compareBtn) compareBtn.addEventListener('click', () => {
   const resultDiv = document.getElementById('comparisonResult');
   resultDiv.innerHTML = '';
 


### PR DESCRIPTION
## Summary
- redirect the compatibility button on the main page to a new page
- implement `compatibility.html` for uploading both surveys
- add `js/compatibilityPage.js` to process uploads and compute scores
- guard old compatibility logic so it only runs when the button exists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864bec1e17c832c9cdf8ff385154dce