### PR TITLE
Add manual compatibility calculation

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -16,6 +16,9 @@
     <span>Upload Partner's Survey</span>
     <input type="file" id="fileB" hidden />
   </label>
+  <button id="calculateCompatibility" class="survey-button">
+    Calculate Partner Compatibility
+  </button>
   <div id="comparisonResult"></div>
   <script src="js/template-survey.js"></script>
   <script type="module" src="js/compatibilityPage.js"></script>

--- a/index.html
+++ b/index.html
@@ -176,20 +176,6 @@
     <!-- Spacer -->
     <div class="section-spacing"></div>
 
-    <!-- Upload buttons -->
-    <label class="survey-button file-upload">
-      <span>Upload Your Survey</span>
-      <input type="file" id="fileA" hidden />
-    </label>
-
-    <label class="survey-button file-upload">
-      <span>Upload Partner's Survey</span>
-      <input type="file" id="fileB" hidden />
-    </label>
-
-    <!-- Spacer -->
-    <div class="section-spacing"></div>
-
     <!-- Compatibility button -->
     <button id="compatibilityBtn" class="survey-button" onclick="location.href='compatibility.html'">See Our Compatibility</button>
     <button id="roleDefinitionsBtn" class="survey-button">Role Definitions</button>

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -103,7 +103,6 @@ function loadFileA(file) {
       mergeSurveyWithTemplate(surveyA, window.templateSurvey);
       normalizeRatings(surveyA);
       filterGeneralOptions(surveyA);
-      checkAndCompare();
     } catch {
       alert('Invalid JSON for Survey A.');
     }
@@ -124,7 +123,6 @@ function loadFileB(file) {
       mergeSurveyWithTemplate(surveyB, window.templateSurvey);
       normalizeRatings(surveyB);
       filterGeneralOptions(surveyB);
-      checkAndCompare();
     } catch {
       alert('Invalid JSON for Survey B.');
     }
@@ -150,10 +148,21 @@ function checkAndCompare() {
   output.innerHTML = html;
 }
 
-document.getElementById('fileA').addEventListener('change', e => {
-  loadFileA(e.target.files[0]);
-});
+const fileAInput = document.getElementById('fileA');
+if (fileAInput) {
+  fileAInput.addEventListener('change', e => {
+    loadFileA(e.target.files[0]);
+  });
+}
 
-document.getElementById('fileB').addEventListener('change', e => {
-  loadFileB(e.target.files[0]);
-});
+const fileBInput = document.getElementById('fileB');
+if (fileBInput) {
+  fileBInput.addEventListener('change', e => {
+    loadFileB(e.target.files[0]);
+  });
+}
+
+const calcBtn = document.getElementById('calculateCompatibility');
+if (calcBtn) {
+  calcBtn.addEventListener('click', checkAndCompare);
+}

--- a/js/script.js
+++ b/js/script.js
@@ -337,33 +337,39 @@ function loadSurveyAFile(file) {
   reader.readAsText(file);
 }
 
-document.getElementById('fileA').addEventListener('change', e => {
-  loadSurveyAFile(e.target.files[0]);
-});
+const fileAInput = document.getElementById('fileA');
+if (fileAInput) {
+  fileAInput.addEventListener('change', e => {
+    loadSurveyAFile(e.target.files[0]);
+  });
+}
 
-document.getElementById('fileB').addEventListener('change', e => {
-  const fileInput = e.target;
-  if (!fileInput.files.length) {
-    return;
-  }
+const fileBInput = document.getElementById('fileB');
+if (fileBInput) {
+  fileBInput.addEventListener('change', e => {
+    const fileInput = e.target;
+    if (!fileInput.files.length) {
+      return;
+    }
   if (!confirm('Have you reviewed consent with your partner?')) {
     fileInput.value = '';
     return;
   }
-  const reader = new FileReader();
-  reader.onload = ev => {
-    try {
-      const parsed = JSON.parse(ev.target.result);
-      surveyB = normalizeSurveyFormat(parsed.survey || parsed);
-      mergeSurveyWithTemplate(surveyB, window.templateSurvey);
-      normalizeRatings(surveyB);
-      filterGeneralOptions(surveyB);
-    } catch {
-      alert('Invalid JSON for Survey B.');
-    }
-  };
-  reader.readAsText(fileInput.files[0]);
-});
+    const reader = new FileReader();
+    reader.onload = ev => {
+      try {
+        const parsed = JSON.parse(ev.target.result);
+        surveyB = normalizeSurveyFormat(parsed.survey || parsed);
+        mergeSurveyWithTemplate(surveyB, window.templateSurvey);
+        normalizeRatings(surveyB);
+        filterGeneralOptions(surveyB);
+      } catch {
+        alert('Invalid JSON for Survey B.');
+      }
+    };
+    reader.readAsText(fileInput.files[0]);
+  });
+}
 
 
 document.getElementById('newSurveyBtn').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- remove survey upload buttons on main page
- add a compatibility calculation button on compatibility page
- update compatibility script to handle the new button
- avoid errors when upload inputs are not present on index page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864c0d3e58c832c9d42de2141c5fae4