### PR TITLE
Add compatibility breakdown export

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -19,6 +19,7 @@
   <button id="calculateCompatibility" class="survey-button">
     Calculate Partner Compatibility
   </button>
+  <button id="downloadResults" class="survey-button">Download Results</button>
   <div id="comparisonResult"></div>
   <script src="js/template-survey.js"></script>
   <script type="module" src="js/compatibilityPage.js"></script>

--- a/js/compatibility.js
+++ b/js/compatibility.js
@@ -4,9 +4,13 @@ export function calculateCompatibility(surveyA, surveyB) {
   let count = 0;
   let redFlags = [];
   let yellowFlags = [];
+  const catTotals = {};
+  const catCounts = {};
 
   categories.forEach(category => {
     if (!surveyB[category]) return;
+    catTotals[category] = 0;
+    catCounts[category] = 0;
 
     ['Giving', 'Receiving'].forEach(action => {
       const listA = surveyA[category][action] || [];
@@ -25,6 +29,7 @@ export function calculateCompatibility(surveyA, surveyB) {
         if (!Number.isInteger(ratingA) || !Number.isInteger(ratingB)) return;
 
         count++;
+        catCounts[category]++;
 
         if ((ratingA >= 5 && ratingB <= 1) || (ratingB >= 5 && ratingA <= 1)) {
           redFlags.push(itemA.name);
@@ -37,8 +42,10 @@ export function calculateCompatibility(surveyA, surveyB) {
 
         if (ratingA >= 4 && ratingB >= 4) {
           totalScore += 1;
+          catTotals[category] += 1;
         } else if (ratingA >= 3 && ratingB >= 3) {
           totalScore += 0.5;
+          catTotals[category] += 0.5;
         }
       });
     });
@@ -73,11 +80,18 @@ export function calculateCompatibility(surveyA, surveyB) {
 
   const avgSim = simCount ? Math.round(simScore / simCount) : 0;
 
+  const categoryBreakdown = {};
+  Object.keys(catTotals).forEach(cat => {
+    const c = catCounts[cat];
+    categoryBreakdown[cat] = c ? Math.round((catTotals[cat] / c) * 100) : 0;
+  });
+
   return {
     compatibilityScore: avg,
     similarityScore: avgSim,
     redFlags: [...new Set(redFlags)],
-    yellowFlags: [...new Set(yellowFlags)]
+    yellowFlags: [...new Set(yellowFlags)],
+    categoryBreakdown
   };
 }
 

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -2,6 +2,7 @@ import { calculateCompatibility } from './compatibility.js';
 
 let surveyA = null;
 let surveyB = null;
+let lastResult = null;
 
 function filterGeneralOptions(survey) {
   Object.values(survey).forEach(cat => {
@@ -137,8 +138,16 @@ function checkAndCompare() {
     return;
   }
   const result = calculateCompatibility(surveyA, surveyB);
+  lastResult = result;
   let html = `<h3>Compatibility Score: ${result.compatibilityScore}%</h3>`;
   html += `<h4>Similarity Score: ${result.similarityScore}%</h4>`;
+  if (result.categoryBreakdown && Object.keys(result.categoryBreakdown).length) {
+    html += '<ul>';
+    Object.entries(result.categoryBreakdown).forEach(([cat, val]) => {
+      html += `<li>${cat}: ${val}%</li>`;
+    });
+    html += '</ul>';
+  }
   if (result.redFlags.length) {
     html += `<p>🚩 Red flags: ${result.redFlags.join(', ')}</p>`;
   }
@@ -165,4 +174,24 @@ if (fileBInput) {
 const calcBtn = document.getElementById('calculateCompatibility');
 if (calcBtn) {
   calcBtn.addEventListener('click', checkAndCompare);
+}
+
+const downloadBtn = document.getElementById('downloadResults');
+if (downloadBtn) {
+  downloadBtn.addEventListener('click', () => {
+    if (!lastResult) {
+      alert('No results to download.');
+      return;
+    }
+    const exportObj = { compatibility: lastResult };
+    const blob = new Blob([JSON.stringify(exportObj, null, 2)], {
+      type: 'application/json'
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'compatibility-results.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  });
 }

--- a/test/survey.test.js
+++ b/test/survey.test.js
@@ -31,3 +31,10 @@ test('similar ratings in same role produce similarity score', () => {
   const result = calculateCompatibility(surveyA, surveyB);
   assert.strictEqual(result.similarityScore, 100);
 });
+
+test('returns breakdown per category', () => {
+  const surveyA = { Cat: { Giving: [{ name: 'A', rating: 5 }], Receiving: [], General: [] } };
+  const surveyB = { Cat: { Giving: [], Receiving: [{ name: 'A', rating: 5 }], General: [] } };
+  const result = calculateCompatibility(surveyA, surveyB);
+  assert.strictEqual(result.categoryBreakdown.Cat, 100);
+});


### PR DESCRIPTION
## Summary
- compute compatibility percentages per category
- display breakdown and store last result in `compatibilityPage.js`
- allow downloading comparison results from the compatibility page
- test new category breakdown logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6864c30c18b4832cb3c7c801fbf9979c