### PR TITLE
Implement progress views and instructions

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -7,20 +7,22 @@
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body class="dark-mode">
-  <h1>See Our Compatibility</h1>
-  <label class="survey-button file-upload">
-    <span>Upload Your Survey</span>
-    <input type="file" id="fileA" hidden />
-  </label>
-  <label class="survey-button file-upload">
-    <span>Upload Partner's Survey</span>
-    <input type="file" id="fileB" hidden />
-  </label>
-  <button id="calculateCompatibility" class="survey-button">
-    Calculate Partner Compatibility
-  </button>
-  <button id="downloadResults" class="survey-button">Download Results</button>
-  <div id="comparisonResult"></div>
+  <div class="scroll-container">
+    <h1>See Our Compatibility</h1>
+    <label class="survey-button file-upload">
+      <span>Upload Your Survey</span>
+      <input type="file" id="fileA" hidden />
+    </label>
+    <label class="survey-button file-upload">
+      <span>Upload Partner's Survey</span>
+      <input type="file" id="fileB" hidden />
+    </label>
+    <button id="calculateCompatibility" class="survey-button">
+      Calculate Partner Compatibility
+    </button>
+    <button id="downloadResults" class="survey-button">Download Results</button>
+    <div id="comparisonResult"></div>
+  </div>
   <script src="js/template-survey.js"></script>
   <script type="module" src="js/compatibilityPage.js"></script>
 </body>

--- a/css/style.css
+++ b/css/style.css
@@ -821,3 +821,45 @@ body.light-mode #ratingLegend {
 .kink-list-section p {
   margin-bottom: 20px;
 }
+
+/* Instruction banner on main page */
+.instruction-banner {
+  text-align: center;
+  color: #d0d0d0;
+  max-width: 800px;
+  margin: 10px auto 30px;
+}
+
+/* Centered menu container for main buttons */
+.menu-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 50vh;
+}
+
+/* Progress bar styles */
+.progress-container {
+  width: 100%;
+  max-width: 600px;
+  margin: 8px 0;
+}
+.progress-label {
+  display: flex;
+  justify-content: space-between;
+  font-weight: bold;
+  margin-bottom: 4px;
+}
+.progress-bar {
+  width: 100%;
+  height: 20px;
+  background-color: #333;
+  border-radius: 4px;
+  overflow: hidden;
+}
+.progress-fill {
+  height: 100%;
+  width: 0;
+  background-color: #4caf50;
+}

--- a/index.html
+++ b/index.html
@@ -10,6 +10,10 @@
 
   <h1>Talk Kink</h1>
 
+  <p class="instruction-banner">
+    💡 “After completing the survey, click ‘Export My List’ to download your answers. You can then view or compare your data by uploading it. Your data is never saved — everything happens on your device.”
+  </p>
+
   <!-- Theme Selector -->
   <div id="themeControl">
     <label for="themeSelector">🎨 Select Theme:</label>
@@ -168,6 +172,7 @@
   </div>
 
   <!-- Buttons -->
+  <div class="menu-container">
   <div class="button-group">
     <!-- Top two buttons -->
     <button id="newSurveyBtn" class="survey-button">Start New Survey</button>
@@ -181,6 +186,7 @@
     <button id="roleDefinitionsBtn" class="survey-button">Role Definitions</button>
     <button id="roleResultsBtn" class="survey-button" onclick="location.href='your-roles.html'">View Role Results</button>
     <button id="kinkListBtn" class="survey-button" onclick="location.href='kink-list.html'">View Kink List</button>
+  </div>
   </div>
 
   <!-- Script -->

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -94,6 +94,13 @@ function mergeSurveyWithTemplate(survey, template) {
   });
 }
 
+function getColor(percent) {
+  if (percent >= 75) return '#4caf50';
+  if (percent >= 50) return '#ffcc00';
+  if (percent >= 25) return '#ff9900';
+  return '#ff4444';
+}
+
 function loadFileA(file) {
   if (!file) return;
   const reader = new FileReader();
@@ -139,22 +146,47 @@ function checkAndCompare() {
   }
   const result = calculateCompatibility(surveyA, surveyB);
   lastResult = result;
-  let html = `<h3>Compatibility Score: ${result.compatibilityScore}%</h3>`;
-  html += `<h4>Similarity Score: ${result.similarityScore}%</h4>`;
+  output.innerHTML = '';
+
+  const makeBar = (label, percent) => {
+    const wrap = document.createElement('div');
+    wrap.className = 'progress-container';
+    const lbl = document.createElement('div');
+    lbl.className = 'progress-label';
+    lbl.textContent = label;
+    const percSpan = document.createElement('span');
+    percSpan.textContent = `${percent}%`;
+    lbl.appendChild(percSpan);
+    const bar = document.createElement('div');
+    bar.className = 'progress-bar';
+    const fill = document.createElement('div');
+    fill.className = 'progress-fill';
+    fill.style.width = `${percent}%`;
+    fill.style.backgroundColor = getColor(percent);
+    bar.appendChild(fill);
+    wrap.appendChild(lbl);
+    wrap.appendChild(bar);
+    return wrap;
+  };
+
+  output.appendChild(makeBar('Compatibility Score', result.compatibilityScore));
+  output.appendChild(makeBar('Similarity Score', result.similarityScore));
+
   if (result.categoryBreakdown && Object.keys(result.categoryBreakdown).length) {
-    html += '<ul>';
     Object.entries(result.categoryBreakdown).forEach(([cat, val]) => {
-      html += `<li>${cat}: ${val}%</li>`;
+      output.appendChild(makeBar(cat, val));
     });
-    html += '</ul>';
   }
   if (result.redFlags.length) {
-    html += `<p>🚩 Red flags: ${result.redFlags.join(', ')}</p>`;
+    const p = document.createElement('p');
+    p.textContent = `🚩 Red flags: ${result.redFlags.join(', ')}`;
+    output.appendChild(p);
   }
   if (result.yellowFlags.length) {
-    html += `<p>⚠️ Yellow flags: ${result.yellowFlags.join(', ')}</p>`;
+    const p = document.createElement('p');
+    p.textContent = `⚠️ Yellow flags: ${result.yellowFlags.join(', ')}`;
+    output.appendChild(p);
   }
-  output.innerHTML = html;
 }
 
 const fileAInput = document.getElementById('fileA');

--- a/js/script.js
+++ b/js/script.js
@@ -559,7 +559,8 @@ document.getElementById('downloadBtn').addEventListener('click', () => {
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
-  a.download = 'kink-survey.json';
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  a.download = `kink-survey-${ts}.json`;
   a.click();
   URL.revokeObjectURL(url);
   // Finished export

--- a/kink-list.html
+++ b/kink-list.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body class="dark-mode">
+  <div class="scroll-container">
   <div class="kink-list-section">
     <h2>Your Kink List</h2>
     <p>Upload your exported survey to view an organised list of your kinks.</p>
@@ -18,6 +19,7 @@
   <input type="file" id="listFile" hidden />
 
   <div id="listOutput"></div>
+  </div>
 
     <script src="js/template-survey.js"></script>
     <script type="module">

--- a/your-roles.html
+++ b/your-roles.html
@@ -7,15 +7,17 @@
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body class="dark-mode">
-  <h1>Your Role Matches</h1>
-  <p>Upload your exported survey to see how your kinks align with common roles.</p>
+  <div class="scroll-container">
+    <h1>Your Role Matches</h1>
+    <p>Upload your exported survey to see how your kinks align with common roles.</p>
 
-  <label class="survey-button file-upload">
-    <span>Select Survey File</span>
-    <input type="file" id="roleFile" hidden />
-  </label>
+    <label class="survey-button file-upload">
+      <span>Select Survey File</span>
+      <input type="file" id="roleFile" hidden />
+    </label>
 
-  <div id="rolesOutput"></div>
+    <div id="rolesOutput"></div>
+  </div>
 
   <script type="module">
     import { calculateRoleScores } from './js/calculateRoleScores.js';
@@ -32,6 +34,34 @@
       return items;
     }
 
+    function getColor(percent) {
+      if (percent >= 75) return '#4caf50';
+      if (percent >= 50) return '#ffcc00';
+      if (percent >= 25) return '#ff9900';
+      return '#ff4444';
+    }
+
+    function createBar(name, percent) {
+      const wrap = document.createElement('div');
+      wrap.className = 'progress-container';
+      const label = document.createElement('div');
+      label.className = 'progress-label';
+      label.textContent = name;
+      const percentSpan = document.createElement('span');
+      percentSpan.textContent = `${percent}%`;
+      label.appendChild(percentSpan);
+      const bar = document.createElement('div');
+      bar.className = 'progress-bar';
+      const fill = document.createElement('div');
+      fill.className = 'progress-fill';
+      fill.style.width = `${percent}%`;
+      fill.style.backgroundColor = getColor(percent);
+      bar.appendChild(fill);
+      wrap.appendChild(label);
+      wrap.appendChild(bar);
+      return wrap;
+    }
+
     document.getElementById('roleFile').addEventListener('change', e => {
       const file = e.target.files[0];
       if (!file) return;
@@ -46,14 +76,10 @@
             container.textContent = 'No role data found.';
             return;
           }
-          const ul = document.createElement('ul');
-          scores.forEach(s => {
-            const li = document.createElement('li');
-            li.textContent = `${s.name}: ${s.percent}%`;
-            ul.appendChild(li);
-          });
           container.innerHTML = '';
-          container.appendChild(ul);
+          scores.forEach(s => {
+            container.appendChild(createBar(s.name, s.percent));
+          });
         } catch (err) {
           document.getElementById('rolesOutput').textContent = 'Invalid file.';
         }


### PR DESCRIPTION
## Summary
- add privacy instructions banner to the survey page
- vertically center menu buttons
- output timestamped JSON on export
- show role results and compatibility results with colored progress bars
- center upload pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865bbeed0d4832c9c31a7c91bf353f5