### PR TITLE
Center compatibility page buttons

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -9,18 +9,20 @@
 <body class="dark-mode">
   <div class="scroll-container">
     <h1>See Our Compatibility</h1>
-    <label class="survey-button file-upload">
-      <span>Upload Your Survey</span>
-      <input type="file" id="fileA" hidden />
-    </label>
-    <label class="survey-button file-upload">
-      <span>Upload Partner's Survey</span>
-      <input type="file" id="fileB" hidden />
-    </label>
-    <button id="calculateCompatibility" class="survey-button">
-      Calculate Partner Compatibility
-    </button>
-    <button id="downloadResults" class="survey-button">Download Results</button>
+    <div class="button-grid">
+      <label class="survey-button file-upload">
+        <span>Upload Your Survey</span>
+        <input type="file" id="fileA" hidden />
+      </label>
+      <label class="survey-button file-upload">
+        <span>Upload Partner's Survey</span>
+        <input type="file" id="fileB" hidden />
+      </label>
+      <button id="calculateCompatibility" class="survey-button">
+        Calculate Partner Compatibility
+      </button>
+      <button id="downloadResults" class="survey-button">Download Results</button>
+    </div>
     <div id="comparisonResult"></div>
   </div>
   <script src="js/template-survey.js"></script>

--- a/css/style.css
+++ b/css/style.css
@@ -724,6 +724,16 @@ body.light-mode #ratingLegend {
   margin-bottom: 20px;
 }
 
+/* Grid layout for compatibility page buttons */
+.button-grid {
+  display: grid;
+  grid-template-columns: repeat(2, auto);
+  gap: 20px;
+  justify-content: center;
+  justify-items: center;
+  margin-bottom: 20px;
+}
+
 .file-upload input[type="file"] {
   display: none;
 }


### PR DESCRIPTION
## Summary
- arrange compatibility page buttons in a centered 2x2 grid
- add CSS grid styles for `.button-grid`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68686624c184832ca53c543486772968