### PR TITLE
Add home button during survey

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,6 +209,7 @@
     <button id="roleResultsBtn" class="survey-button" onclick="location.href='your-roles.html'">View Role Results</button>
     <button id="kinkListBtn" class="survey-button" onclick="location.href='kink-list.html'">View Kink List</button>
   </div>
+  <button id="homeBtn" class="survey-button" style="display:none;">Home</button>
   </div>
 
   <!-- Script -->

--- a/js/script.js
+++ b/js/script.js
@@ -218,6 +218,8 @@ const surveyContainer = document.getElementById('surveyContainer');
 const finalScreen = document.getElementById('finalScreen');
 const saveSurveyBtn = document.getElementById('saveSurveyBtn');
 const returnHomeBtn = document.getElementById('returnHomeBtn');
+const homeBtn = document.getElementById('homeBtn');
+const buttonGroup = document.querySelector('.button-group');
 const categoryPreview = document.getElementById('categoryPreview');
 const previewList = document.getElementById('previewList');
 const beginSurveyBtn = document.getElementById('beginSurveyBtn');
@@ -293,6 +295,9 @@ saveSurveyBtn.addEventListener('click', exportSurvey);
 returnHomeBtn.addEventListener('click', () => {
   window.location.href = 'index.html';
 });
+if (homeBtn) homeBtn.addEventListener('click', () => {
+  window.location.href = 'index.html';
+});
 
 if (nextCategoryBtn) nextCategoryBtn.addEventListener('click', nextCategory);
 if (skipCategoryBtn) skipCategoryBtn.addEventListener('click', skipCategory);
@@ -361,6 +366,8 @@ if (fileBInput) {
 
 document.getElementById('newSurveyBtn').addEventListener('click', () => {
   guidedMode = true;
+  if (buttonGroup) buttonGroup.style.display = 'none';
+  if (homeBtn) homeBtn.style.display = 'block';
 
   const initialize = data => {
     surveyA = data;


### PR DESCRIPTION
## Summary
- add a hidden Home button to the menu
- hide all menu buttons when starting a new survey and show the Home button instead
- allow Home button to return to the main page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686dde15f110832cb3770219e9977c27