### PR TITLE
Fix survey load failure without theme selector

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -26,13 +26,16 @@ const themeSelector = document.getElementById('themeSelector');
 
 const savedTheme = localStorage.getItem('selectedTheme') || 'dark-mode';
 document.body.className = savedTheme;
-themeSelector.value = savedTheme;
 
-themeSelector.addEventListener('change', () => {
-  const selectedTheme = themeSelector.value;
-  document.body.className = selectedTheme;
-  localStorage.setItem('selectedTheme', selectedTheme);
-});
+if (themeSelector) {
+  themeSelector.value = savedTheme;
+
+  themeSelector.addEventListener('change', () => {
+    const selectedTheme = themeSelector.value;
+    document.body.className = selectedTheme;
+    localStorage.setItem('selectedTheme', selectedTheme);
+  });
+}
 
 
 // ================== Tab Switching ==================


### PR DESCRIPTION
## Summary
- avoid runtime error when theme selector element is missing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686df165f6c4832cb330949271ab5ea1