### PR TITLE
Enable category menu on new survey

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -627,7 +627,10 @@ switchTab('Giving');
 
 function init() {
   document.querySelectorAll('button').forEach(attachRipple);
-  if (surveyIntro) surveyIntro.style.display = 'flex';
+  if (surveyIntro) {
+    surveyIntro.style.display = 'none';
+    startNewSurvey();
+  }
 }
 
 if (document.readyState !== 'loading') {


### PR DESCRIPTION
## Summary
- automatically open the category selection menu when starting a new survey

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686df37fd6d4832cb64854da3482c727