### PR TITLE
Improve survey UI progress and button behavior

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -828,9 +828,12 @@ body.light-mode #ratingLegend {
 
 /* Progress bar styles */
 .progress-container {
-  width: 100%;
-  max-width: 600px;
-  margin: 8px 0;
+  width: 60%;
+  margin: 20px auto;
+  background-color: #2b2b2b;
+  border-radius: 10px;
+  height: 18px;
+  overflow: hidden;
 }
 .progress-label {
   display: flex;
@@ -840,15 +843,17 @@ body.light-mode #ratingLegend {
 }
 .progress-bar {
   width: 100%;
-  height: 20px;
-  background-color: #333;
-  border-radius: 4px;
+  height: 100%;
+  background-color: #2b2b2b;
+  border-radius: 10px;
   overflow: hidden;
 }
 .progress-fill {
   height: 100%;
   width: 0;
   background-color: #4caf50;
+  transition: width 0.4s ease;
+  border-radius: 10px 0 0 10px;
 }
 
 /* Kink breakdown table */

--- a/js/script.js
+++ b/js/script.js
@@ -235,6 +235,7 @@ const closeRoleDefinitionsBtn = document.getElementById('closeRoleDefinitionsBtn
 const surveyIntro = document.getElementById('surveyIntro');
 const startSurveyBtn = document.getElementById('startSurveyBtn');
 const newSurveyBtn = document.getElementById('newSurveyBtn');
+const downloadBtn = document.getElementById('downloadBtn');
 const progressBanner = document.getElementById('progressBanner');
 const progressLabel = document.getElementById('progressLabel');
 const progressFill = document.getElementById('progressFill');
@@ -280,7 +281,8 @@ roleDefinitionsOverlay.addEventListener('click', hideRolePanel);
 
 function startNewSurvey() {
   guidedMode = true;
-  if (buttonGroup) buttonGroup.style.display = 'none';
+  if (newSurveyBtn) newSurveyBtn.style.display = 'none';
+  if (downloadBtn) downloadBtn.style.display = 'none';
   if (homeBtn) homeBtn.style.display = 'block';
 
   const initialize = data => {
@@ -573,7 +575,7 @@ function exportSurvey() {
   URL.revokeObjectURL(url);
 }
 
-document.getElementById('downloadBtn').addEventListener('click', exportSurvey);
+if (downloadBtn) downloadBtn.addEventListener('click', exportSurvey);
 
 // ================== See Our Compatibility ==================
 const compareBtn = document.getElementById('compareBtn');


### PR DESCRIPTION
## Summary
- center and style the progress bar for guided surveys
- hide *Start New Survey* and *Export My List* once a survey begins

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686df8749270832cb95e2a69faf0e13a