### PR TITLE
Short progress indicator

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -828,7 +828,8 @@ body.light-mode #ratingLegend {
 
 /* Progress bar styles */
 .progress-container {
-  width: 60%;
+  width: 80%;
+  max-width: 300px;
   margin: 20px auto;
   background-color: #2b2b2b;
   border-radius: 10px;

--- a/js/script.js
+++ b/js/script.js
@@ -534,7 +534,8 @@ function updateProgress() {
   progressBanner.style.display = 'block';
   const total = categoryOrder.length;
   const percent = (categoryIndex / total) * 100;
-  progressLabel.textContent = `Category ${categoryIndex + 1} of ${total}`;
+  const remaining = total - categoryIndex - 1;
+  progressLabel.textContent = `Category ${categoryIndex + 1} of ${total} (${remaining} left)`;
   progressFill.style.width = `${percent}%`;
 }
 


### PR DESCRIPTION
## Summary
- shorten progress bar so it doesn't stretch across the screen
- show remaining categories in the label so users know how much is left

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686dfb5d7144832c9b2152a95d3612cb