### PR TITLE
Fix light forest theme readability

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -107,7 +107,7 @@ body.light-mode #categoryContainer button {
 }
 body.light-mode #categoryContainer button.active {
   background-color: #548c5a;
-  color: #fff;
+  color: #000;
 }
 
 
@@ -143,7 +143,8 @@ body.light-mode #mainCategoryList button {
 }
 body.light-mode #mainCategoryList button.active {
   background-color: #548c5a;
-  color: #fff;
+  color: #2f4f2f;
+  border: 1px solid #000;
 }
 body.dark-mode #mainCategoryList button.active {
   background-color: #00bfff;
@@ -283,8 +284,8 @@ body.light-mode .tab {
 }
 body.light-mode .tab.active {
   background-color: #548c5a;
-  color: #fff;
-  border: 1px solid #4b7f4b;
+  color: #2f4f2f;
+  border: 1px solid #000;
 }
 body.dark-mode .tab {
   background-color: #222;
@@ -385,8 +386,8 @@ body.light-mode #categoryContainer button {
 }
 body.light-mode #categoryContainer button.active {
   background-color: #548c5a;
-  color: #fff;
-  border: 1px solid #4b7f4b;
+  color: #2f4f2f;
+  border: 1px solid #000;
 }
 body.dark-mode #categoryContainer button.active {
   background-color: #00bfff;


### PR DESCRIPTION
## Summary
- keep dark green text but use black borders for the active buttons and tabs in the Light Forest theme

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686e01de35c0832cae2f18f764a649f9