### PR TITLE
Fix progress bar text visibility

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -846,9 +846,16 @@ body.light-mode #ratingLegend {
 .progress-bar {
   width: 100%;
   height: 100%;
-  background-color: #2b2b2b;
-  border-radius: 10px;
+  background-color: #2c2c2c;
+  border-radius: 12px;
+  padding: 4px 10px;
+  font-size: 1rem;
+  display: inline-block;
   overflow: hidden;
+}
+.progress-bar-text {
+  color: #ffffff;
+  font-weight: bold;
 }
 .progress-fill {
   height: 100%;

--- a/index.html
+++ b/index.html
@@ -28,8 +28,10 @@
   </div>
 
   <div id="progressBanner" class="progress-container" style="display:none">
-    <div id="progressLabel" class="progress-label"></div>
-    <div class="progress-bar"><div id="progressFill" class="progress-fill"></div></div>
+    <div class="progress-bar">
+      <span id="progressLabel" class="progress-bar-text"></span>
+      <div id="progressFill" class="progress-fill"></div>
+    </div>
   </div>
 
 


### PR DESCRIPTION
## Summary
- show progress text inside the progress bar
- style progress bar and text so contrast is higher

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e8a64bf1c832c967f0cb981edcc19