### PR TITLE
Improve survey usability

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -518,6 +518,23 @@ body.theme-rainbow #comparisonResult {
   padding-bottom: 20px;
   overflow-y: auto;
 }
+
+.selection-buttons {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+.selection-buttons button {
+  padding: 6px 12px;
+  cursor: pointer;
+  border: none;
+  border-radius: 4px;
+  background-color: #444;
+  color: #fff;
+}
+.selection-buttons button:hover {
+  background-color: #666;
+}
 body.light-mode .password-modal {
   background-color: #fff;
   color: #2f4f2f;

--- a/index.html
+++ b/index.html
@@ -191,6 +191,10 @@
     <div class="intro-modal">
       <p>Select the categories you want to include:</p>
       <div id="previewList" class="scroll-container"></div>
+      <div class="selection-buttons">
+        <button id="selectAllBtn">Select All</button>
+        <button id="deselectAllBtn">Deselect All</button>
+      </div>
       <button id="beginSurveyBtn">Begin Survey</button>
     </div>
   </div>

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -4,6 +4,20 @@ let surveyA = null;
 let surveyB = null;
 let lastResult = null;
 
+function loadSavedSurvey() {
+  const saved = localStorage.getItem('savedSurvey');
+  if (!saved) return;
+  try {
+    const parsed = JSON.parse(saved);
+    surveyA = normalizeSurveyFormat(parsed.survey || parsed);
+    mergeSurveyWithTemplate(surveyA, window.templateSurvey);
+    normalizeRatings(surveyA);
+    filterGeneralOptions(surveyA);
+  } catch (err) {
+    console.warn('Failed to parse saved survey:', err);
+  }
+}
+
 function filterGeneralOptions(survey) {
   Object.values(survey).forEach(cat => {
     if (!cat.General) return;
@@ -271,3 +285,5 @@ if (downloadBtn) {
     URL.revokeObjectURL(url);
   });
 }
+
+document.addEventListener('DOMContentLoaded', loadSavedSurvey);

--- a/js/script.js
+++ b/js/script.js
@@ -225,6 +225,8 @@ const homeBtn = document.getElementById('homeBtn');
 const buttonGroup = document.querySelector('.button-group');
 const categoryPreview = document.getElementById('categoryPreview');
 const previewList = document.getElementById('previewList');
+const selectAllBtn = document.getElementById('selectAllBtn');
+const deselectAllBtn = document.getElementById('deselectAllBtn');
 const templateJson = document.getElementById('templateJson');
 const beginSurveyBtn = document.getElementById('beginSurveyBtn');
 const ratingLegend = document.getElementById('ratingLegend');
@@ -331,6 +333,22 @@ startSurveyBtn.addEventListener('click', () => {
 
 if (newSurveyBtn) {
   newSurveyBtn.addEventListener('click', startNewSurvey);
+}
+
+if (selectAllBtn) {
+  selectAllBtn.addEventListener('click', () => {
+    previewList.querySelectorAll('input[type="checkbox"]').forEach(cb => {
+      cb.checked = true;
+    });
+  });
+}
+
+if (deselectAllBtn) {
+  deselectAllBtn.addEventListener('click', () => {
+    previewList.querySelectorAll('input[type="checkbox"]').forEach(cb => {
+      cb.checked = false;
+    });
+  });
 }
 
 beginSurveyBtn.addEventListener('click', () => {
@@ -574,6 +592,11 @@ function exportSurvey() {
   a.download = `kink-survey-${ts}.json`;
   a.click();
   URL.revokeObjectURL(url);
+  try {
+    localStorage.setItem('savedSurvey', JSON.stringify(exportObj));
+  } catch (err) {
+    console.warn('Failed to save survey to localStorage:', err);
+  }
 }
 
 if (downloadBtn) downloadBtn.addEventListener('click', exportSurvey);


### PR DESCRIPTION
## Summary
- allow selecting or deselecting all categories when starting the survey
- store survey results in localStorage when exporting
- auto-load a saved survey on the compatibility page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e8d4cde64832c9c62f7a1cd5dafbb