### PR TITLE
Combine protocol categories

### DIFF
--- a/basic-survey.html
+++ b/basic-survey.html
@@ -156,7 +156,6 @@
       { title: "Headspace & Regression", question: "How do you feel about headspace & regression?" },
       { title: "Performance & Internal Struggle", question: "How do you feel about performance & internal struggle?" },
       { title: "Mindfuck & Manipulation", question: "How do you feel about mindfuck & manipulation?" },
-      { title: "Protocol Play", question: "How do you feel about protocol play?" },
       { title: "Mouth Play", question: "How do you feel about mouth play?" },
       { title: "Impact Play", question: "How do you feel about impact play?" },
       { title: "Medical Play", question: "How do you feel about medical play?" },

--- a/css/style.css
+++ b/css/style.css
@@ -949,7 +949,7 @@ body.theme-rainbow .progress-bar {
 }
 
 /* ✅ Codex Instructions: Accordion Overflow Fix for Bottom Categories
-   Goal: Prevent bottom categories like “Protocol Play” and “Mouth Play” from visually spilling out or stretching beyond the accordion layout.
+   Goal: Prevent bottom categories like “Protocol and Ritual” and “Mouth Play” from visually spilling out or stretching beyond the accordion layout.
    These styles ensure the open section is scrollable, sized appropriately, and visually contained like the top categories.
 */
 /* Codex update: prevent accordion items from stretching */

--- a/js/template-survey.js
+++ b/js/template-survey.js
@@ -1962,6 +1962,86 @@ window.templateSurvey =
       {
         "name": "Ritualized aftercare or scene closure",
         "rating": null
+      },
+      {
+        "name": "Object retrieval on all fours with item in mouth",
+        "rating": null
+      },
+      {
+        "name": "Fetching hairbrush or punishment tool from dresser while crawling",
+        "rating": null
+      },
+      {
+        "name": "Presenting chosen discipline tool in kneeling posture",
+        "rating": null
+      },
+      {
+        "name": "Assigned posture or kneeling positions as ritual",
+        "rating": null
+      },
+      {
+        "name": "Requesting permission using specific protocol phrases",
+        "rating": null
+      },
+      {
+        "name": "Carrying items in mouth as submissive gesture",
+        "rating": null
+      },
+      {
+        "name": "Crawling back with object to Dominant after retrieval",
+        "rating": null
+      },
+      {
+        "name": "Following via nipple leash as protocol or punishment",
+        "rating": null
+      },
+      {
+        "name": "Crawling assigned paths as ritual or obedience training",
+        "rating": null
+      },
+      {
+        "name": "Crawling rituals (e.g., object retrieval)",
+        "rating": null
+      },
+      {
+        "name": "Carrying objects in mouth as obedience",
+        "rating": null
+      },
+      {
+        "name": "Presenting tools or toys in posture",
+        "rating": null
+      },
+      {
+        "name": "Using honorifics or preset protocol language",
+        "rating": null
+      },
+      {
+        "name": "Greeting rituals (e.g., kneeling, kissing feet)",
+        "rating": null
+      },
+      {
+        "name": "Daily check-ins or structured reports",
+        "rating": null
+      },
+      {
+        "name": "Clothing restrictions or uniforms",
+        "rating": null
+      },
+      {
+        "name": "Posture training (sitting, kneeling, standing)",
+        "rating": null
+      },
+      {
+        "name": "Punishments for incorrect behavior or tone",
+        "rating": null
+      },
+      {
+        "name": "Crawling with items in mouth (e.g., hairbrush, spoon)",
+        "rating": null
+      },
+      {
+        "name": "Earning permission for meals, bathroom use, or rest",
+        "rating": null
       }
     ],
     "Receiving": [
@@ -2003,6 +2083,86 @@ window.templateSurvey =
       },
       {
         "name": "Ritualized aftercare or scene closure",
+        "rating": null
+      },
+      {
+        "name": "Object retrieval on all fours with item in mouth",
+        "rating": null
+      },
+      {
+        "name": "Fetching hairbrush or punishment tool from dresser while crawling",
+        "rating": null
+      },
+      {
+        "name": "Presenting chosen discipline tool in kneeling posture",
+        "rating": null
+      },
+      {
+        "name": "Assigned posture or kneeling positions as ritual",
+        "rating": null
+      },
+      {
+        "name": "Requesting permission using specific protocol phrases",
+        "rating": null
+      },
+      {
+        "name": "Carrying items in mouth as submissive gesture",
+        "rating": null
+      },
+      {
+        "name": "Crawling back with object to Dominant after retrieval",
+        "rating": null
+      },
+      {
+        "name": "Following via nipple leash as protocol or punishment",
+        "rating": null
+      },
+      {
+        "name": "Crawling assigned paths as ritual or obedience training",
+        "rating": null
+      },
+      {
+        "name": "Crawling rituals (e.g., object retrieval)",
+        "rating": null
+      },
+      {
+        "name": "Carrying objects in mouth as obedience",
+        "rating": null
+      },
+      {
+        "name": "Presenting tools or toys in posture",
+        "rating": null
+      },
+      {
+        "name": "Using honorifics or preset protocol language",
+        "rating": null
+      },
+      {
+        "name": "Greeting rituals (e.g., kneeling, kissing feet)",
+        "rating": null
+      },
+      {
+        "name": "Daily check-ins or structured reports",
+        "rating": null
+      },
+      {
+        "name": "Clothing restrictions or uniforms",
+        "rating": null
+      },
+      {
+        "name": "Posture training (sitting, kneeling, standing)",
+        "rating": null
+      },
+      {
+        "name": "Punishments for incorrect behavior or tone",
+        "rating": null
+      },
+      {
+        "name": "Crawling with items in mouth (e.g., hairbrush, spoon)",
+        "rating": null
+      },
+      {
+        "name": "Earning permission for meals, bathroom use, or rest",
         "rating": null
       }
     ],
@@ -2483,117 +2643,6 @@ window.templateSurvey =
       },
       {
         "name": "Emotional trickery as arousal",
-        "rating": null
-      }
-    ],
-    "General": []
-  },
-  "Protocol Play": {
-    "Giving": [
-      {
-        "name": "Object retrieval on all fours with item in mouth",
-        "rating": null
-      },
-      {
-        "name": "Fetching hairbrush or punishment tool from dresser while crawling",
-        "rating": null
-      },
-      {
-        "name": "Presenting chosen discipline tool in kneeling posture",
-        "rating": null
-      },
-      {
-        "name": "Assigned posture or kneeling positions as ritual",
-        "rating": null
-      },
-      {
-        "name": "Requesting permission using specific protocol phrases",
-        "rating": null
-      },
-      {
-        "name": "Carrying items in mouth as submissive gesture",
-        "rating": null
-      },
-      {
-        "name": "Crawling back with object to Dominant after retrieval",
-        "rating": null
-      },
-      {
-        "name": "Following via nipple leash as protocol or punishment",
-        "rating": null
-      },
-      {
-        "name": "Crawling assigned paths as ritual or obedience training",
-        "rating": null
-      },
-      {
-        "name": "Crawling rituals (e.g., object retrieval)",
-        "rating": null
-      },
-      {
-        "name": "Carrying objects in mouth as obedience",
-        "rating": null
-      },
-      {
-        "name": "Presenting tools or toys in posture",
-        "rating": null
-      },
-      {
-        "name": "Using honorifics or preset protocol language",
-        "rating": null
-      }
-    ],
-    "Receiving": [
-      {
-        "name": "Object retrieval on all fours with item in mouth",
-        "rating": null
-      },
-      {
-        "name": "Fetching hairbrush or punishment tool from dresser while crawling",
-        "rating": null
-      },
-      {
-        "name": "Presenting chosen discipline tool in kneeling posture",
-        "rating": null
-      },
-      {
-        "name": "Assigned posture or kneeling positions as ritual",
-        "rating": null
-      },
-      {
-        "name": "Requesting permission using specific protocol phrases",
-        "rating": null
-      },
-      {
-        "name": "Carrying items in mouth as submissive gesture",
-        "rating": null
-      },
-      {
-        "name": "Crawling back with object to Dominant after retrieval",
-        "rating": null
-      },
-      {
-        "name": "Following via nipple leash as protocol or punishment",
-        "rating": null
-      },
-      {
-        "name": "Crawling assigned paths as ritual or obedience training",
-        "rating": null
-      },
-      {
-        "name": "Crawling rituals (e.g., object retrieval)",
-        "rating": null
-      },
-      {
-        "name": "Carrying objects in mouth as obedience",
-        "rating": null
-      },
-      {
-        "name": "Presenting tools or toys in posture",
-        "rating": null
-      },
-      {
-        "name": "Using honorifics or preset protocol language",
         "rating": null
       }
     ],

--- a/template-survey.json
+++ b/template-survey.json
@@ -1961,6 +1961,86 @@
       {
         "name": "Ritualized aftercare or scene closure",
         "rating": null
+      },
+      {
+        "name": "Object retrieval on all fours with item in mouth",
+        "rating": null
+      },
+      {
+        "name": "Fetching hairbrush or punishment tool from dresser while crawling",
+        "rating": null
+      },
+      {
+        "name": "Presenting chosen discipline tool in kneeling posture",
+        "rating": null
+      },
+      {
+        "name": "Assigned posture or kneeling positions as ritual",
+        "rating": null
+      },
+      {
+        "name": "Requesting permission using specific protocol phrases",
+        "rating": null
+      },
+      {
+        "name": "Carrying items in mouth as submissive gesture",
+        "rating": null
+      },
+      {
+        "name": "Crawling back with object to Dominant after retrieval",
+        "rating": null
+      },
+      {
+        "name": "Following via nipple leash as protocol or punishment",
+        "rating": null
+      },
+      {
+        "name": "Crawling assigned paths as ritual or obedience training",
+        "rating": null
+      },
+      {
+        "name": "Crawling rituals (e.g., object retrieval)",
+        "rating": null
+      },
+      {
+        "name": "Carrying objects in mouth as obedience",
+        "rating": null
+      },
+      {
+        "name": "Presenting tools or toys in posture",
+        "rating": null
+      },
+      {
+        "name": "Using honorifics or preset protocol language",
+        "rating": null
+      },
+      {
+        "name": "Greeting rituals (e.g., kneeling, kissing feet)",
+        "rating": null
+      },
+      {
+        "name": "Daily check-ins or structured reports",
+        "rating": null
+      },
+      {
+        "name": "Clothing restrictions or uniforms",
+        "rating": null
+      },
+      {
+        "name": "Posture training (sitting, kneeling, standing)",
+        "rating": null
+      },
+      {
+        "name": "Punishments for incorrect behavior or tone",
+        "rating": null
+      },
+      {
+        "name": "Crawling with items in mouth (e.g., hairbrush, spoon)",
+        "rating": null
+      },
+      {
+        "name": "Earning permission for meals, bathroom use, or rest",
+        "rating": null
       }
     ],
     "Receiving": [
@@ -2002,6 +2082,86 @@
       },
       {
         "name": "Ritualized aftercare or scene closure",
+        "rating": null
+      },
+      {
+        "name": "Object retrieval on all fours with item in mouth",
+        "rating": null
+      },
+      {
+        "name": "Fetching hairbrush or punishment tool from dresser while crawling",
+        "rating": null
+      },
+      {
+        "name": "Presenting chosen discipline tool in kneeling posture",
+        "rating": null
+      },
+      {
+        "name": "Assigned posture or kneeling positions as ritual",
+        "rating": null
+      },
+      {
+        "name": "Requesting permission using specific protocol phrases",
+        "rating": null
+      },
+      {
+        "name": "Carrying items in mouth as submissive gesture",
+        "rating": null
+      },
+      {
+        "name": "Crawling back with object to Dominant after retrieval",
+        "rating": null
+      },
+      {
+        "name": "Following via nipple leash as protocol or punishment",
+        "rating": null
+      },
+      {
+        "name": "Crawling assigned paths as ritual or obedience training",
+        "rating": null
+      },
+      {
+        "name": "Crawling rituals (e.g., object retrieval)",
+        "rating": null
+      },
+      {
+        "name": "Carrying objects in mouth as obedience",
+        "rating": null
+      },
+      {
+        "name": "Presenting tools or toys in posture",
+        "rating": null
+      },
+      {
+        "name": "Using honorifics or preset protocol language",
+        "rating": null
+      },
+      {
+        "name": "Greeting rituals (e.g., kneeling, kissing feet)",
+        "rating": null
+      },
+      {
+        "name": "Daily check-ins or structured reports",
+        "rating": null
+      },
+      {
+        "name": "Clothing restrictions or uniforms",
+        "rating": null
+      },
+      {
+        "name": "Posture training (sitting, kneeling, standing)",
+        "rating": null
+      },
+      {
+        "name": "Punishments for incorrect behavior or tone",
+        "rating": null
+      },
+      {
+        "name": "Crawling with items in mouth (e.g., hairbrush, spoon)",
+        "rating": null
+      },
+      {
+        "name": "Earning permission for meals, bathroom use, or rest",
         "rating": null
       }
     ],
@@ -2530,173 +2690,6 @@
       },
       {
         "name": "Told 'you asked for this' or 'you love this' when resisting",
-        "rating": null
-      }
-    ],
-    "General": []
-  },
-  "Protocol Play": {
-    "Giving": [
-      {
-        "name": "Object retrieval on all fours with item in mouth",
-        "rating": null
-      },
-      {
-        "name": "Fetching hairbrush or punishment tool from dresser while crawling",
-        "rating": null
-      },
-      {
-        "name": "Presenting chosen discipline tool in kneeling posture",
-        "rating": null
-      },
-      {
-        "name": "Assigned posture or kneeling positions as ritual",
-        "rating": null
-      },
-      {
-        "name": "Requesting permission using specific protocol phrases",
-        "rating": null
-      },
-      {
-        "name": "Carrying items in mouth as submissive gesture",
-        "rating": null
-      },
-      {
-        "name": "Crawling back with object to Dominant after retrieval",
-        "rating": null
-      },
-      {
-        "name": "Following via nipple leash as protocol or punishment",
-        "rating": null
-      },
-      {
-        "name": "Crawling assigned paths as ritual or obedience training",
-        "rating": null
-      },
-      {
-        "name": "Crawling rituals (e.g., object retrieval)",
-        "rating": null
-      },
-      {
-        "name": "Carrying objects in mouth as obedience",
-        "rating": null
-      },
-      {
-        "name": "Presenting tools or toys in posture",
-        "rating": null
-      },
-      {
-        "name": "Using honorifics or preset protocol language",
-        "rating": null
-      },
-      {
-        "name": "Greeting rituals (e.g., kneeling, kissing feet)",
-        "rating": null
-      },
-      {
-        "name": "Daily check-ins or structured reports",
-        "rating": null
-      },
-      {
-        "name": "Clothing restrictions or uniforms",
-        "rating": null
-      },
-      {
-        "name": "Posture training (sitting, kneeling, standing)",
-        "rating": null
-      },
-      {
-        "name": "Punishments for incorrect behavior or tone",
-        "rating": null
-      },
-      {
-        "name": "Crawling with items in mouth (e.g., hairbrush, spoon)",
-        "rating": null
-      },
-      {
-        "name": "Earning permission for meals, bathroom use, or rest",
-        "rating": null
-      }
-    ],
-    "Receiving": [
-      {
-        "name": "Object retrieval on all fours with item in mouth",
-        "rating": null
-      },
-      {
-        "name": "Fetching hairbrush or punishment tool from dresser while crawling",
-        "rating": null
-      },
-      {
-        "name": "Presenting chosen discipline tool in kneeling posture",
-        "rating": null
-      },
-      {
-        "name": "Assigned posture or kneeling positions as ritual",
-        "rating": null
-      },
-      {
-        "name": "Requesting permission using specific protocol phrases",
-        "rating": null
-      },
-      {
-        "name": "Carrying items in mouth as submissive gesture",
-        "rating": null
-      },
-      {
-        "name": "Crawling back with object to Dominant after retrieval",
-        "rating": null
-      },
-      {
-        "name": "Following via nipple leash as protocol or punishment",
-        "rating": null
-      },
-      {
-        "name": "Crawling assigned paths as ritual or obedience training",
-        "rating": null
-      },
-      {
-        "name": "Crawling rituals (e.g., object retrieval)",
-        "rating": null
-      },
-      {
-        "name": "Carrying objects in mouth as obedience",
-        "rating": null
-      },
-      {
-        "name": "Presenting tools or toys in posture",
-        "rating": null
-      },
-      {
-        "name": "Using honorifics or preset protocol language",
-        "rating": null
-      },
-      {
-        "name": "Greeting rituals (e.g., kneeling, kissing feet)",
-        "rating": null
-      },
-      {
-        "name": "Daily check-ins or structured reports",
-        "rating": null
-      },
-      {
-        "name": "Clothing restrictions or uniforms",
-        "rating": null
-      },
-      {
-        "name": "Posture training (sitting, kneeling, standing)",
-        "rating": null
-      },
-      {
-        "name": "Punishments for incorrect behavior or tone",
-        "rating": null
-      },
-      {
-        "name": "Crawling with items in mouth (e.g., hairbrush, spoon)",
-        "rating": null
-      },
-      {
-        "name": "Earning permission for meals, bathroom use, or rest",
         "rating": null
       }
     ],


### PR DESCRIPTION
## Summary
- fold `Protocol Play` kinks into `Protocol and Ritual`
- drop the separate `Protocol Play` category from HTML and data files
- update accordion help text mentioning the new category name

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e941aabf8832ca65e02597a98112b