### PR TITLE
Expand survey categories and rename remote play

### DIFF
--- a/basic-survey.html
+++ b/basic-survey.html
@@ -145,7 +145,7 @@
       { title: "Roleplaying", question: "How do you feel about roleplaying?" },
       { title: "Service and Restrictive Behaviour", question: "How do you feel about service and restrictive behaviour?" },
       { title: "Voyeurism/Exhibitionism", question: "How do you feel about voyeurism/exhibitionism?" },
-      { title: "Digital & Remote Play", question: "How do you feel about digital & remote play?" },
+      { title: "Virtual & Long-Distance Play", question: "How do you feel about virtual & long-distance play?" },
       { title: "Communication", question: "How do you feel about communication?" },
       { title: "Body Fluids and Functions", question: "How do you feel about body fluids and functions?" },
       { title: "Psychological Primal / Prey", question: "How do you feel about psychological primal / prey?" },

--- a/js/template-survey.js
+++ b/js/template-survey.js
@@ -383,6 +383,14 @@ window.templateSurvey =
       {
         "name": "Drowning",
         "rating": null
+      },
+      {
+        "name": "Rebreathing into a bag or object",
+        "rating": null
+      },
+      {
+        "name": "Verbal control of breath (e.g., 'hold it' on command)",
+        "rating": null
       }
     ],
     "Receiving": [
@@ -400,6 +408,14 @@ window.templateSurvey =
       },
       {
         "name": "Drowning",
+        "rating": null
+      },
+      {
+        "name": "Rebreathing into a bag or object",
+        "rating": null
+      },
+      {
+        "name": "Verbal control of breath (e.g., 'hold it' on command)",
         "rating": null
       }
     ],
@@ -689,6 +705,18 @@ window.templateSurvey =
       },
       {
         "name": "Leather clothing",
+        "rating": null
+      },
+      {
+        "name": "Training protocols outside scenes (e.g., etiquette, memory)",
+        "rating": null
+      },
+      {
+        "name": "Long-distance training/structure",
+        "rating": null
+      },
+      {
+        "name": "Scene journaling and reflection",
         "rating": null
       }
     ]
@@ -1018,7 +1046,7 @@ window.templateSurvey =
     ],
     "General": []
   },
-  "Digital & Remote Play": {
+  "Virtual & Long-Distance Play": {
     "Giving": [
       {
         "name": "Sending tasks or orders digitally",
@@ -1054,6 +1082,10 @@ window.templateSurvey =
       },
       {
         "name": "Voice message control during scenes",
+        "rating": null
+      },
+      {
+        "name": "Being on-call at specified times",
         "rating": null
       }
     ],
@@ -1093,6 +1125,10 @@ window.templateSurvey =
       {
         "name": "Sending submissive voice clips (obedience, begging, thank-you messages, affirmations, etc.)",
         "rating": null
+      },
+      {
+        "name": "Being on-call at specified times",
+        "rating": null
       }
     ],
     "General": [
@@ -1118,6 +1154,26 @@ window.templateSurvey =
       },
       {
         "name": "Countdown timers to next task, release, or interaction",
+        "rating": null
+      },
+      {
+        "name": "Scheduled good morning/night rituals",
+        "rating": null
+      },
+      {
+        "name": "Participating in video call scenes",
+        "rating": null
+      },
+      {
+        "name": "Digital aftercare (texts, voice, images)",
+        "rating": null
+      },
+      {
+        "name": "Sexting or digital roleplay scenes",
+        "rating": null
+      },
+      {
+        "name": "Voice notes or submissive/dominant affirmations",
         "rating": null
       }
     ]
@@ -2848,9 +2904,17 @@ window.templateSurvey =
           "Romantic partners",
           "Kink partners"
         ]
-      }
-    ]
-  },
+      },
+      { "name": "Monogamous", "rating": null },
+      { "name": "Polyamorous", "rating": null },
+      { "name": "Hierarchical dynamics", "rating": null },
+      { "name": "Non-hierarchical poly", "rating": null },
+      { "name": "Solo-poly", "rating": null },
+      { "name": "Open with boundaries", "rating": null },
+      { "name": "Closed but kinky with others", "rating": null },
+      { "name": "Switch-friendly dynamics", "rating": null }
+      ]
+    },
   "Gender Play & Transformation": {
     "Giving": [
       { "name": "Crossdressing", "rating": null },

--- a/template-survey.json
+++ b/template-survey.json
@@ -382,6 +382,14 @@
       {
         "name": "Drowning",
         "rating": null
+      },
+      {
+        "name": "Rebreathing into a bag or object",
+        "rating": null
+      },
+      {
+        "name": "Verbal control of breath (e.g., 'hold it' on command)",
+        "rating": null
       }
     ],
     "Receiving": [
@@ -399,6 +407,14 @@
       },
       {
         "name": "Drowning",
+        "rating": null
+      },
+      {
+        "name": "Rebreathing into a bag or object",
+        "rating": null
+      },
+      {
+        "name": "Verbal control of breath (e.g., 'hold it' on command)",
         "rating": null
       }
     ],
@@ -688,6 +704,18 @@
       },
       {
         "name": "Leather clothing",
+        "rating": null
+      },
+      {
+        "name": "Training protocols outside scenes (e.g., etiquette, memory)",
+        "rating": null
+      },
+      {
+        "name": "Long-distance training/structure",
+        "rating": null
+      },
+      {
+        "name": "Scene journaling and reflection",
         "rating": null
       }
     ]
@@ -1017,7 +1045,7 @@
     ],
     "General": []
   },
-  "Digital & Remote Play": {
+  "Virtual & Long-Distance Play": {
     "Giving": [
       {
         "name": "Sending tasks or orders digitally",
@@ -1053,6 +1081,10 @@
       },
       {
         "name": "Voice message control during scenes",
+        "rating": null
+      },
+      {
+        "name": "Being on-call at specified times",
         "rating": null
       }
     ],
@@ -1092,6 +1124,10 @@
       {
         "name": "Sending submissive voice clips (obedience, begging, thank-you messages, affirmations, etc.)",
         "rating": null
+      },
+      {
+        "name": "Being on-call at specified times",
+        "rating": null
       }
     ],
     "General": [
@@ -1117,6 +1153,26 @@
       },
       {
         "name": "Countdown timers to next task, release, or interaction",
+        "rating": null
+      },
+      {
+        "name": "Scheduled good morning/night rituals",
+        "rating": null
+      },
+      {
+        "name": "Participating in video call scenes",
+        "rating": null
+      },
+      {
+        "name": "Digital aftercare (texts, voice, images)",
+        "rating": null
+      },
+      {
+        "name": "Sexting or digital roleplay scenes",
+        "rating": null
+      },
+      {
+        "name": "Voice notes or submissive/dominant affirmations",
         "rating": null
       }
     ]
@@ -2943,7 +2999,15 @@
           "Romantic partners",
           "Kink partners"
         ]
-      }
+      },
+      { "name": "Monogamous", "rating": null },
+      { "name": "Polyamorous", "rating": null },
+      { "name": "Hierarchical dynamics", "rating": null },
+      { "name": "Non-hierarchical poly", "rating": null },
+      { "name": "Solo-poly", "rating": null },
+      { "name": "Open with boundaries", "rating": null },
+      { "name": "Closed but kinky with others", "rating": null },
+      { "name": "Switch-friendly dynamics", "rating": null }
     ]
   },
   "Gender Play & Transformation": {


### PR DESCRIPTION
## Summary
- extend Breath Play, Other, and Relationship Preferences
- rename Digital & Remote Play to Virtual & Long-Distance Play
- add remote play entries for control, tasks, ritual & connection
- update survey title list

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686e9f199ba0832c8554b47ce3c7c55e