### PR TITLE
Expand kink survey categories with toggle

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1022,3 +1022,12 @@ body.light-mode .json-display {
   background-color: #fff;
   color: #2f4f2f;
 }
+
+#categoryDescription {
+  margin-bottom: 10px;
+  font-style: italic;
+}
+
+.toggle-advanced {
+  margin: 10px 0;
+}

--- a/glossary.json
+++ b/glossary.json
@@ -1,0 +1,3 @@
+{
+  "High-Intensity Kinks (SSC-Aware)": "Scenes that are emotionally, physically, or psychologically advanced but follow safe, sane, consensual principles."
+}

--- a/index.html
+++ b/index.html
@@ -47,6 +47,10 @@
     </ul>
   </div>
 
+  <div class="toggle-advanced">
+    <label><input type="checkbox" id="highIntensityToggle" /> Show advanced high-intensity kink options?</label>
+  </div>
+
   <!-- Tabs -->
   <div class="tab-toggle-group">
     <div class="tab-container">
@@ -61,6 +65,7 @@
     <div class="content-panel">
       <div id="surveyContainer">
         <h2 id="categoryTitle"></h2>
+        <p id="categoryDescription" style="display:none;"></p>
         <div id="kinkList"></div>
         <div class="nav-buttons">
           <button id="nextCategoryBtn">Next Category</button>

--- a/js/script.js
+++ b/js/script.js
@@ -236,6 +236,8 @@ const roleDefinitionsBtn = document.getElementById('roleDefinitionsBtn');
 const closeRoleDefinitionsBtn = document.getElementById('closeRoleDefinitionsBtn');
 const surveyIntro = document.getElementById('surveyIntro');
 const startSurveyBtn = document.getElementById('startSurveyBtn');
+const categoryDescription = document.getElementById('categoryDescription');
+const highIntensityToggle = document.getElementById('highIntensityToggle');
 const newSurveyBtn = document.getElementById('newSurveyBtn');
 const downloadBtn = document.getElementById('downloadBtn');
 const progressBanner = document.getElementById('progressBanner');
@@ -288,6 +290,9 @@ function startNewSurvey() {
   if (homeBtn) homeBtn.style.display = 'block';
 
   const initialize = data => {
+    if (!highIntensityToggle.checked) {
+      delete data["High-Intensity Kinks (SSC-Aware)"];
+    }
     surveyA = data;
     normalizeRatings(surveyA);
     filterGeneralOptions(surveyA);
@@ -450,6 +455,13 @@ function showKinks(category) {
   currentCategory = category;
   kinkList.innerHTML = '';
   categoryTitle.textContent = category;
+  if (category === 'High-Intensity Kinks (SSC-Aware)') {
+    categoryDescription.textContent = 'This category includes intense but SSC-aware kink options. These scenes require strong negotiation, emotional readiness, and safe aftercare. Only explore if you feel prepared.';
+    categoryDescription.style.display = 'block';
+  } else {
+    categoryDescription.textContent = '';
+    categoryDescription.style.display = 'none';
+  }
   surveyContainer.style.display = 'block';
   finalScreen.style.display = 'none';
   const categoryData = surveyA[category];

--- a/js/template-survey.js
+++ b/js/template-survey.js
@@ -2940,5 +2940,111 @@ window.templateSurvey =
       { "name": "Clothing and appearance", "rating": null },
       { "name": "Exploration of identity", "rating": null }
     ]
+  },
+  "Chastity Devices": {
+    "Giving": [
+      { "name": "Wearing a chastity cage (short term)", "rating": null },
+      { "name": "Long-term chastity training", "rating": null },
+      { "name": "Chastity device control with permission to unlock", "rating": null },
+      { "name": "Locked remotely by another person", "rating": null },
+      { "name": "Orgasm denial enforced by chastity", "rating": null },
+      { "name": "Wearing a belt-style chastity device", "rating": null },
+      { "name": "Humiliation while locked in chastity", "rating": null },
+      { "name": "Sleep in chastity (overnight)", "rating": null },
+      { "name": "Being teased while unable to touch yourself", "rating": null },
+      { "name": "Begging for release from chastity", "rating": null }
+    ],
+    "Receiving": [
+      { "name": "Wearing a chastity cage (short term)", "rating": null },
+      { "name": "Long-term chastity training", "rating": null },
+      { "name": "Chastity device control with permission to unlock", "rating": null },
+      { "name": "Locked remotely by another person", "rating": null },
+      { "name": "Orgasm denial enforced by chastity", "rating": null },
+      { "name": "Wearing a belt-style chastity device", "rating": null },
+      { "name": "Humiliation while locked in chastity", "rating": null },
+      { "name": "Sleep in chastity (overnight)", "rating": null },
+      { "name": "Being teased while unable to touch yourself", "rating": null },
+      { "name": "Begging for release from chastity", "rating": null }
+    ],
+    "General": []
+  },
+  "Shibari & Rope Bondage": {
+    "Giving": [
+      { "name": "Being tied in aesthetic rope patterns (Shibari)", "rating": null },
+      { "name": "Rope bondage for restraint and control", "rating": null },
+      { "name": "Rope suspension (partial or full)", "rating": null },
+      { "name": "Learning to tie rope as a form of dominance", "rating": null },
+      { "name": "Being tied in vulnerable or exposing poses", "rating": null },
+      { "name": "Practicing rope with emotional connection", "rating": null },
+      { "name": "Enduring discomfort for the beauty of the rope", "rating": null },
+      { "name": "Being tied in a mirror and told to look", "rating": null },
+      { "name": "Punishment ties (e.g., uncomfortable or humiliating positions)", "rating": null },
+      { "name": "Solo rope practice for mindfulness or masochism", "rating": null }
+    ],
+    "Receiving": [
+      { "name": "Being tied in aesthetic rope patterns (Shibari)", "rating": null },
+      { "name": "Rope bondage for restraint and control", "rating": null },
+      { "name": "Rope suspension (partial or full)", "rating": null },
+      { "name": "Learning to tie rope as a form of dominance", "rating": null },
+      { "name": "Being tied in vulnerable or exposing poses", "rating": null },
+      { "name": "Practicing rope with emotional connection", "rating": null },
+      { "name": "Enduring discomfort for the beauty of the rope", "rating": null },
+      { "name": "Being tied in a mirror and told to look", "rating": null },
+      { "name": "Punishment ties (e.g., uncomfortable or humiliating positions)", "rating": null },
+      { "name": "Solo rope practice for mindfulness or masochism", "rating": null }
+    ],
+    "General": []
+  },
+  "Cosplay & Identity Play": {
+    "Giving": [
+      { "name": "Dressing up in costumes for scenes", "rating": null },
+      { "name": "Playing as fictional characters", "rating": null },
+      { "name": "Petplay with collars, ears, or tails", "rating": null },
+      { "name": "Pretending to be a doll, robot, or object", "rating": null },
+      { "name": "Master/slave cosplay dynamic (non-24/7)", "rating": null },
+      { "name": "Roleplaying as a fantasy species or non-human", "rating": null },
+      { "name": "Using cosplay to deepen power exchange", "rating": null },
+      { "name": "Scene built around a character’s story or world", "rating": null },
+      { "name": "Fantasy uniforms (nurse, teacher, etc.)", "rating": null }
+    ],
+    "Receiving": [
+      { "name": "Dressing up in costumes for scenes", "rating": null },
+      { "name": "Playing as fictional characters", "rating": null },
+      { "name": "Petplay with collars, ears, or tails", "rating": null },
+      { "name": "Pretending to be a doll, robot, or object", "rating": null },
+      { "name": "Master/slave cosplay dynamic (non-24/7)", "rating": null },
+      { "name": "Roleplaying as a fantasy species or non-human", "rating": null },
+      { "name": "Using cosplay to deepen power exchange", "rating": null },
+      { "name": "Scene built around a character’s story or world", "rating": null },
+      { "name": "Fantasy uniforms (nurse, teacher, etc.)", "rating": null }
+    ],
+    "General": []
+  },
+  "High-Intensity Kinks (SSC-Aware)": {
+    "Giving": [
+      { "name": "Intense breath play (e.g., smothering or pressure)", "rating": null },
+      { "name": "Knife play or blade play (without injury)", "rating": null },
+      { "name": "Fear play using known or negotiated triggers", "rating": null },
+      { "name": "Abduction or home-invasion style roleplay (negotiated)", "rating": null },
+      { "name": "Medical-themed scenes with sharp objects (not bloodletting)", "rating": null },
+      { "name": "Sensory deprivation with added disorientation or helplessness", "rating": null },
+      { "name": "Scenes involving heavy objectification or emotional manipulation (with care)", "rating": null },
+      { "name": "Mock interrogation or intense role pressure", "rating": null },
+      { "name": "Consensual threats without follow-through (e.g. 'If you don’t...')", "rating": null },
+      { "name": "High-intensity primal scenes involving struggle or fear", "rating": null }
+    ],
+    "Receiving": [
+      { "name": "Intense breath play (e.g., smothering or pressure)", "rating": null },
+      { "name": "Knife play or blade play (without injury)", "rating": null },
+      { "name": "Fear play using known or negotiated triggers", "rating": null },
+      { "name": "Abduction or home-invasion style roleplay (negotiated)", "rating": null },
+      { "name": "Medical-themed scenes with sharp objects (not bloodletting)", "rating": null },
+      { "name": "Sensory deprivation with added disorientation or helplessness", "rating": null },
+      { "name": "Scenes involving heavy objectification or emotional manipulation (with care)", "rating": null },
+      { "name": "Mock interrogation or intense role pressure", "rating": null },
+      { "name": "Consensual threats without follow-through (e.g. 'If you don’t...')", "rating": null },
+      { "name": "High-intensity primal scenes involving struggle or fear", "rating": null }
+    ],
+    "General": []
   }
 };

--- a/template-survey.json
+++ b/template-survey.json
@@ -3035,5 +3035,111 @@
       { "name": "Clothing and appearance", "rating": null },
       { "name": "Exploration of identity", "rating": null }
     ]
+  },
+  "Chastity Devices": {
+    "Giving": [
+      { "name": "Wearing a chastity cage (short term)", "rating": null },
+      { "name": "Long-term chastity training", "rating": null },
+      { "name": "Chastity device control with permission to unlock", "rating": null },
+      { "name": "Locked remotely by another person", "rating": null },
+      { "name": "Orgasm denial enforced by chastity", "rating": null },
+      { "name": "Wearing a belt-style chastity device", "rating": null },
+      { "name": "Humiliation while locked in chastity", "rating": null },
+      { "name": "Sleep in chastity (overnight)", "rating": null },
+      { "name": "Being teased while unable to touch yourself", "rating": null },
+      { "name": "Begging for release from chastity", "rating": null }
+    ],
+    "Receiving": [
+      { "name": "Wearing a chastity cage (short term)", "rating": null },
+      { "name": "Long-term chastity training", "rating": null },
+      { "name": "Chastity device control with permission to unlock", "rating": null },
+      { "name": "Locked remotely by another person", "rating": null },
+      { "name": "Orgasm denial enforced by chastity", "rating": null },
+      { "name": "Wearing a belt-style chastity device", "rating": null },
+      { "name": "Humiliation while locked in chastity", "rating": null },
+      { "name": "Sleep in chastity (overnight)", "rating": null },
+      { "name": "Being teased while unable to touch yourself", "rating": null },
+      { "name": "Begging for release from chastity", "rating": null }
+    ],
+    "General": []
+  },
+  "Shibari & Rope Bondage": {
+    "Giving": [
+      { "name": "Being tied in aesthetic rope patterns (Shibari)", "rating": null },
+      { "name": "Rope bondage for restraint and control", "rating": null },
+      { "name": "Rope suspension (partial or full)", "rating": null },
+      { "name": "Learning to tie rope as a form of dominance", "rating": null },
+      { "name": "Being tied in vulnerable or exposing poses", "rating": null },
+      { "name": "Practicing rope with emotional connection", "rating": null },
+      { "name": "Enduring discomfort for the beauty of the rope", "rating": null },
+      { "name": "Being tied in a mirror and told to look", "rating": null },
+      { "name": "Punishment ties (e.g., uncomfortable or humiliating positions)", "rating": null },
+      { "name": "Solo rope practice for mindfulness or masochism", "rating": null }
+    ],
+    "Receiving": [
+      { "name": "Being tied in aesthetic rope patterns (Shibari)", "rating": null },
+      { "name": "Rope bondage for restraint and control", "rating": null },
+      { "name": "Rope suspension (partial or full)", "rating": null },
+      { "name": "Learning to tie rope as a form of dominance", "rating": null },
+      { "name": "Being tied in vulnerable or exposing poses", "rating": null },
+      { "name": "Practicing rope with emotional connection", "rating": null },
+      { "name": "Enduring discomfort for the beauty of the rope", "rating": null },
+      { "name": "Being tied in a mirror and told to look", "rating": null },
+      { "name": "Punishment ties (e.g., uncomfortable or humiliating positions)", "rating": null },
+      { "name": "Solo rope practice for mindfulness or masochism", "rating": null }
+    ],
+    "General": []
+  },
+  "Cosplay & Identity Play": {
+    "Giving": [
+      { "name": "Dressing up in costumes for scenes", "rating": null },
+      { "name": "Playing as fictional characters", "rating": null },
+      { "name": "Petplay with collars, ears, or tails", "rating": null },
+      { "name": "Pretending to be a doll, robot, or object", "rating": null },
+      { "name": "Master/slave cosplay dynamic (non-24/7)", "rating": null },
+      { "name": "Roleplaying as a fantasy species or non-human", "rating": null },
+      { "name": "Using cosplay to deepen power exchange", "rating": null },
+      { "name": "Scene built around a character’s story or world", "rating": null },
+      { "name": "Fantasy uniforms (nurse, teacher, etc.)", "rating": null }
+    ],
+    "Receiving": [
+      { "name": "Dressing up in costumes for scenes", "rating": null },
+      { "name": "Playing as fictional characters", "rating": null },
+      { "name": "Petplay with collars, ears, or tails", "rating": null },
+      { "name": "Pretending to be a doll, robot, or object", "rating": null },
+      { "name": "Master/slave cosplay dynamic (non-24/7)", "rating": null },
+      { "name": "Roleplaying as a fantasy species or non-human", "rating": null },
+      { "name": "Using cosplay to deepen power exchange", "rating": null },
+      { "name": "Scene built around a character’s story or world", "rating": null },
+      { "name": "Fantasy uniforms (nurse, teacher, etc.)", "rating": null }
+    ],
+    "General": []
+  },
+  "High-Intensity Kinks (SSC-Aware)": {
+    "Giving": [
+      { "name": "Intense breath play (e.g., smothering or pressure)", "rating": null },
+      { "name": "Knife play or blade play (without injury)", "rating": null },
+      { "name": "Fear play using known or negotiated triggers", "rating": null },
+      { "name": "Abduction or home-invasion style roleplay (negotiated)", "rating": null },
+      { "name": "Medical-themed scenes with sharp objects (not bloodletting)", "rating": null },
+      { "name": "Sensory deprivation with added disorientation or helplessness", "rating": null },
+      { "name": "Scenes involving heavy objectification or emotional manipulation (with care)", "rating": null },
+      { "name": "Mock interrogation or intense role pressure", "rating": null },
+      { "name": "Consensual threats without follow-through (e.g. 'If you don’t...')", "rating": null },
+      { "name": "High-intensity primal scenes involving struggle or fear", "rating": null }
+    ],
+    "Receiving": [
+      { "name": "Intense breath play (e.g., smothering or pressure)", "rating": null },
+      { "name": "Knife play or blade play (without injury)", "rating": null },
+      { "name": "Fear play using known or negotiated triggers", "rating": null },
+      { "name": "Abduction or home-invasion style roleplay (negotiated)", "rating": null },
+      { "name": "Medical-themed scenes with sharp objects (not bloodletting)", "rating": null },
+      { "name": "Sensory deprivation with added disorientation or helplessness", "rating": null },
+      { "name": "Scenes involving heavy objectification or emotional manipulation (with care)", "rating": null },
+      { "name": "Mock interrogation or intense role pressure", "rating": null },
+      { "name": "Consensual threats without follow-through (e.g. 'If you don’t...')", "rating": null },
+      { "name": "High-intensity primal scenes involving struggle or fear", "rating": null }
+    ],
+    "General": []
   }
 }


### PR DESCRIPTION
## Summary
- insert Chastity Devices, Shibari & Rope Bondage, Cosplay & Identity Play, and High-Intensity Kinks categories
- add UI toggle to enable advanced high‑intensity kinks and show safety note
- display category description for the high‑intensity section
- style new description and toggle in CSS
- document high‑intensity term in new `glossary.json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686eb271ffa8832c898a20cd69477a18