### PR TITLE
Update survey to include high intensity warning

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1028,6 +1028,3 @@ body.light-mode .json-display {
   font-style: italic;
 }
 
-.toggle-advanced {
-  margin: 10px 0;
-}

--- a/index.html
+++ b/index.html
@@ -47,9 +47,6 @@
     </ul>
   </div>
 
-  <div class="toggle-advanced">
-    <label><input type="checkbox" id="highIntensityToggle" /> Show advanced high-intensity kink options?</label>
-  </div>
 
   <!-- Tabs -->
   <div class="tab-toggle-group">

--- a/js/script.js
+++ b/js/script.js
@@ -237,7 +237,6 @@ const closeRoleDefinitionsBtn = document.getElementById('closeRoleDefinitionsBtn
 const surveyIntro = document.getElementById('surveyIntro');
 const startSurveyBtn = document.getElementById('startSurveyBtn');
 const categoryDescription = document.getElementById('categoryDescription');
-const highIntensityToggle = document.getElementById('highIntensityToggle');
 const newSurveyBtn = document.getElementById('newSurveyBtn');
 const downloadBtn = document.getElementById('downloadBtn');
 const progressBanner = document.getElementById('progressBanner');
@@ -290,7 +289,9 @@ function startNewSurvey() {
   if (homeBtn) homeBtn.style.display = 'block';
 
   const initialize = data => {
-    if (!highIntensityToggle.checked) {
+    if (!confirm(
+      'The High-Intensity Kinks category includes intense but SSC-aware options that require strong negotiation, emotional readiness, and safe aftercare. Only explore if you feel prepared.\n\nInclude this category?'
+    )) {
       delete data["High-Intensity Kinks (SSC-Aware)"];
     }
     surveyA = data;


### PR DESCRIPTION
## Summary
- remove the UI toggle for high-intensity kinks
- prompt the user to confirm including the high-intensity category when starting a survey
- clean up unused CSS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686eb5eec384832c822ec64f1decb2a1