### PR TITLE
Refine rating scale wording

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -9,6 +9,16 @@
 <body class="dark-mode">
   <div class="scroll-container">
     <h1>See Our Compatibility</h1>
+    <div class="static-rating-legend">
+      <ul>
+        <li>0 — Hard No</li>
+        <li>1 — Dislike / Haven’t Considered</li>
+        <li>2 — Would Try for Partner</li>
+        <li>3 — Okay / Neutral</li>
+        <li>4 — Like</li>
+        <li>5 — Love / Core Interest</li>
+      </ul>
+    </div>
     <div class="back-button-container">
       <button onclick="window.location.href='index.html'">&larr; Back</button>
     </div>

--- a/css/style.css
+++ b/css/style.css
@@ -634,6 +634,27 @@ body.light-mode #ratingLegend {
   color: #2f4f2f;
   border-color: #9fb49f;
 }
+.static-rating-legend {
+  background-color: #333;
+  color: #fff;
+  border: 1px solid #555;
+  border-radius: 5px;
+  padding: 8px 12px;
+  max-width: 520px;
+  margin: 10px auto;
+}
+.static-rating-legend ul {
+  margin: 0;
+  padding-left: 20px;
+}
+.static-rating-legend li {
+  margin: 2px 0;
+}
+body.light-mode .static-rating-legend {
+  background-color: #a9b8a9;
+  color: #2f4f2f;
+  border-color: #9fb49f;
+}
 /* Provide spacing at the top and bottom of the kink list */
 #kinkList {
   padding: 10px 0;

--- a/index.html
+++ b/index.html
@@ -38,12 +38,12 @@
   <!-- Rating Legend -->
   <div id="ratingLegend">
     <ul>
-      <li>0 = Hard limit / dislike</li>
-      <li>1 = Disinterested</li>
-      <li>2 = Neutral</li>
-      <li>3 = Like it</li>
-      <li>4 = Really like it</li>
-      <li>5 = Core turn-on</li>
+      <li>0 — Hard No</li>
+      <li>1 — Dislike / Haven’t Considered</li>
+      <li>2 — Would Try for Partner</li>
+      <li>3 — Okay / Neutral</li>
+      <li>4 — Like</li>
+      <li>5 — Love / Core Interest</li>
     </ul>
   </div>
 

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -3,6 +3,20 @@ import { calculateCompatibility } from './compatibility.js';
 let surveyA = null;
 let surveyB = null;
 let lastResult = null;
+const RATING_LABELS = {
+  0: 'Hard No',
+  1: 'Dislike / Haven\u2019t Considered',
+  2: 'Would Try for Partner',
+  3: 'Okay / Neutral',
+  4: 'Like',
+  5: 'Love / Core Interest'
+};
+
+function formatRating(val) {
+  return val === null || val === undefined
+    ? '-'
+    : `${val} - ${RATING_LABELS[val]}`;
+}
 
 function loadSavedSurvey() {
   const saved = localStorage.getItem('savedSurvey');
@@ -215,12 +229,12 @@ function checkAndCompare() {
         const tr = document.createElement('tr');
         const vals = [
           item.name,
-          item.you.giving ?? '-',
-          item.you.receiving ?? '-',
-          item.you.general ?? '-',
-          item.partner.giving ?? '-',
-          item.partner.receiving ?? '-',
-          item.partner.general ?? '-',
+          formatRating(item.you.giving),
+          formatRating(item.you.receiving),
+          formatRating(item.you.general),
+          formatRating(item.partner.giving),
+          formatRating(item.partner.receiving),
+          formatRating(item.partner.general),
           item.indicator
         ];
         vals.forEach(v => {
@@ -273,7 +287,10 @@ if (downloadBtn) {
       alert('No results to download.');
       return;
     }
-    const exportObj = { compatibility: lastResult };
+    const exportObj = {
+      compatibility: lastResult,
+      ratingLabels: RATING_LABELS
+    };
     const blob = new Blob([JSON.stringify(exportObj, null, 2)], {
       type: 'application/json'
     });

--- a/js/script.js
+++ b/js/script.js
@@ -46,6 +46,14 @@ const ACTION_LABELS = {
   General: 'Non-Specific Role'
 };
 const RATING_MAX = 5;
+const RATING_LABELS = {
+  0: 'Hard No',
+  1: 'Dislike / Haven\u2019t Considered',
+  2: 'Would Try for Partner',
+  3: 'Okay / Neutral',
+  4: 'Like',
+  5: 'Love / Core Interest'
+};
 function applyAnimation(el, cls) {
   el.classList.add(cls);
   el.addEventListener('animationend', () => el.classList.remove(cls), { once: true });
@@ -538,7 +546,7 @@ function showKinks(category) {
       for (let i = 0; i <= RATING_MAX; i++) {
         const opt = document.createElement('option');
         opt.value = i;
-        opt.textContent = i;
+        opt.textContent = `${i} - ${RATING_LABELS[i]}`;
         if (kink.rating == i) opt.selected = true;
         select.appendChild(opt);
       }
@@ -596,7 +604,10 @@ function exportSurvey() {
     alert('No survey loaded.');
     return;
   }
-  const exportObj = { survey: pruneSurvey(surveyA) };
+  const exportObj = {
+    survey: pruneSurvey(surveyA),
+    ratingLabels: RATING_LABELS
+  };
   const blob = new Blob([JSON.stringify(exportObj, null, 2)], { type: 'application/json' });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');

--- a/kink-list.html
+++ b/kink-list.html
@@ -24,6 +24,15 @@
     <script src="js/template-survey.js"></script>
     <script type="module">
 
+      const RATING_LABELS = {
+        0: 'Hard No',
+        1: 'Dislike / Haven\u2019t Considered',
+        2: 'Would Try for Partner',
+        3: 'Okay / Neutral',
+        4: 'Like',
+        5: 'Love / Core Interest'
+      };
+
       function mergeSurveyWithTemplate(survey, template) {
         if (!template || typeof template !== 'object') return;
         Object.entries(template).forEach(([cat, tmpl]) => {
@@ -108,7 +117,7 @@
           const ul = document.createElement('ul');
           items.slice().sort((a,b) => (b.rating ?? -1) - (a.rating ?? -1)).forEach(item => {
             const li = document.createElement('li');
-            const rating = item.rating === null || item.rating === undefined ? '—' : item.rating;
+            const rating = item.rating === null || item.rating === undefined ? '—' : `${item.rating} - ${RATING_LABELS[item.rating]}`;
             li.textContent = `${item.name}: ${rating}`;
             ul.appendChild(li);
           });
@@ -133,7 +142,7 @@
               const rating =
                 item.rating === null || item.rating === undefined
                   ? '—'
-                  : item.rating;
+                  : `${item.rating} - ${RATING_LABELS[item.rating]}`;
               text += `    ${item.name}: ${rating}\n`;
             });
         });
@@ -175,6 +184,12 @@
       doc.text('Your Kink Profile', pageWidth / 2, y, { align: 'center' });
       y += 10;
 
+      Object.entries(RATING_LABELS).forEach(([num, label]) => {
+        doc.text(`${num} = ${label}`, 10, y);
+        y += 6;
+      });
+      y += 4;
+
       doc.setLineWidth(0.5);
       doc.setDrawColor(200);
       doc.line(10, y, pageWidth - 10, y);
@@ -198,7 +213,8 @@
         doc.text(`${percent}%`, 10, y);
 
         doc.setTextColor(color);
-        doc.text(item.name, 40, y);
+        const label = RATING_LABELS[item.rating] || '-';
+        doc.text(`${item.name} (${label})`, 40, y);
 
         y += 8;
 


### PR DESCRIPTION
## Summary
- clarify rating labels in the survey legend
- show the 0–5 labels on compatibility page
- add a static rating legend style
- attach labels to rating options and JSON exports
- include rating labels in result tables and PDF output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ed5840c64832c815e92744092d30d