### PR TITLE
Hide nav links during survey

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -648,6 +648,13 @@ body.light-mode #ratingLegend {
   gap: 10px;
 }
 
+.main-nav-buttons {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
 .section-spacing {
   margin-top: 30px;
 }

--- a/index.html
+++ b/index.html
@@ -212,10 +212,12 @@
     <div class="section-spacing"></div>
 
     <!-- Compatibility button -->
-    <button id="compatibilityBtn" class="survey-button" onclick="location.href='compatibility.html'">See Our Compatibility</button>
-    <button id="roleDefinitionsBtn" class="survey-button">Role Definitions</button>
-    <button id="roleResultsBtn" class="survey-button" onclick="location.href='your-roles.html'">View Role Results</button>
-    <button id="kinkListBtn" class="survey-button" onclick="location.href='kink-list.html'">View Kink List</button>
+    <div class="main-nav-buttons">
+      <button id="compatibilityBtn" class="survey-button" onclick="location.href='compatibility.html'">See Our Compatibility</button>
+      <button id="roleDefinitionsBtn" class="survey-button">Role Definitions</button>
+      <button id="roleResultsBtn" class="survey-button" onclick="location.href='your-roles.html'">View Role Results</button>
+      <button id="kinkListBtn" class="survey-button" onclick="location.href='kink-list.html'">View Kink List</button>
+    </div>
   </div>
   <button id="homeBtn" class="survey-button" style="display:none;">Home</button>
   </div>

--- a/js/script.js
+++ b/js/script.js
@@ -244,6 +244,7 @@ const progressLabel = document.getElementById('progressLabel');
 const progressFill = document.getElementById('progressFill');
 const nextCategoryBtn = document.getElementById('nextCategoryBtn');
 const skipCategoryBtn = document.getElementById('skipCategoryBtn');
+const mainNavButtons = document.querySelector('.main-nav-buttons');
 
 function showRatingLegend(target) {
   const rect = target.getBoundingClientRect();
@@ -287,6 +288,7 @@ function startNewSurvey() {
   if (newSurveyBtn) newSurveyBtn.style.display = 'none';
   if (downloadBtn) downloadBtn.style.display = 'none';
   if (homeBtn) homeBtn.style.display = 'block';
+  if (mainNavButtons) mainNavButtons.style.display = 'none';
 
   const initialize = data => {
     if (!confirm(


### PR DESCRIPTION
## Summary
- group navigation buttons under `.main-nav-buttons`
- style `.main-nav-buttons`
- hide nav buttons when the survey starts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ed78e1e04832c9b6be765476621e5