### PR TITLE
Make survey categories start unchecked

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -54,6 +54,7 @@ const RATING_LABELS = {
   4: 'Like',
   5: 'Love / Core Interest'
 };
+const HIGH_INTENSITY_CATEGORY = 'High-Intensity Kinks (SSC-Aware)';
 function applyAnimation(el, cls) {
   el.classList.add(cls);
   el.addEventListener('animationend', () => el.classList.remove(cls), { once: true });
@@ -299,11 +300,6 @@ function startNewSurvey() {
   if (mainNavButtons) mainNavButtons.style.display = 'none';
 
   const initialize = data => {
-    if (!confirm(
-      'The High-Intensity Kinks category includes intense but SSC-aware options that require strong negotiation, emotional readiness, and safe aftercare. Only explore if you feel prepared.\n\nInclude this category?'
-    )) {
-      delete data["High-Intensity Kinks (SSC-Aware)"];
-    }
     surveyA = data;
     normalizeRatings(surveyA);
     filterGeneralOptions(surveyA);
@@ -314,7 +310,16 @@ function startNewSurvey() {
       const cb = document.createElement('input');
       cb.type = 'checkbox';
       cb.value = cat;
-      cb.checked = true;
+      cb.checked = false;
+      if (cat === HIGH_INTENSITY_CATEGORY) {
+        cb.addEventListener('change', () => {
+          if (cb.checked) {
+            if (!confirm('The High-Intensity Kinks category includes intense but SSC-aware kink options that require strong negotiation, emotional readiness, and safe aftercare. Only explore if you feel prepared.')) {
+              cb.checked = false;
+            }
+          }
+        });
+      }
       label.appendChild(cb);
       label.append(' ' + cat);
       previewList.appendChild(label);
@@ -354,7 +359,14 @@ if (newSurveyBtn) {
 if (selectAllBtn) {
   selectAllBtn.addEventListener('click', () => {
     previewList.querySelectorAll('input[type="checkbox"]').forEach(cb => {
-      cb.checked = true;
+      if (cb.value === HIGH_INTENSITY_CATEGORY) {
+        if (cb.checked) return;
+        if (confirm('The High-Intensity Kinks category includes intense but SSC-aware kink options that require strong negotiation, emotional readiness, and safe aftercare. Only explore if you feel prepared.')) {
+          cb.checked = true;
+        }
+      } else {
+        cb.checked = true;
+      }
     });
   });
 }


### PR DESCRIPTION
## Summary
- don't pre-select categories when starting a new survey
- add constant for the high-intensity kink category
- warn about high-intensity kinks only when that checkbox is selected
- check the warning when using the **Select All** option

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ed9944ecc832c942604877f60ea35