### PR TITLE
Remove overlay cancel button to restore panel

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -475,21 +475,6 @@ body.theme-rainbow #comparisonResult {
   display: none;
 }
 
-/* Cancel button inside overlays */
-.overlay .cancel-button {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  background: none;
-  border: none;
-  color: #fff;
-  font-size: 20px;
-  cursor: pointer;
-}
-body.light-mode .overlay .cancel-button {
-  color: #2f4f2f;
-}
-
 /* Overlay displayed for password entry */
 #passwordOverlay {
   position: fixed;

--- a/index.html
+++ b/index.html
@@ -190,7 +190,6 @@
 
   <!-- Category Preview Overlay -->
   <div id="categoryPreview" class="overlay" style="display:none">
-    <button id="cancelSurveyBtn" class="cancel-button" aria-label="Cancel Survey">✖</button>
     <div class="intro-modal">
       <p>Select the categories you want to include:</p>
       <div class="selection-buttons">

--- a/js/script.js
+++ b/js/script.js
@@ -255,7 +255,6 @@ const progressFill = document.getElementById('progressFill');
 const nextCategoryBtn = document.getElementById('nextCategoryBtn');
 const skipCategoryBtn = document.getElementById('skipCategoryBtn');
 const mainNavButtons = document.querySelector('.main-nav-buttons');
-const cancelSurveyBtn = document.getElementById('cancelSurveyBtn');
 
 function showRatingLegend(target) {
   const rect = target.getBoundingClientRect();
@@ -405,9 +404,6 @@ returnHomeBtn.addEventListener('click', () => {
   window.location.href = 'index.html';
 });
 if (homeBtn) homeBtn.addEventListener('click', () => {
-  window.location.href = 'index.html';
-});
-if (cancelSurveyBtn) cancelSurveyBtn.addEventListener('click', () => {
   window.location.href = 'index.html';
 });
 


### PR DESCRIPTION
## Summary
- revert cancel button changes on the survey preview overlay
- remove references to `cancelSurveyBtn`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686efc977e58832cb16b42aabf4e3cc0