### PR TITLE
Fix offline survey init

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,14 @@ The website is built from the following files in this repository:
 - `js/script.js`
 - `template-survey.json`
 
-The **Start New Survey** button fetches `template-survey.json` each time it is
-clicked so you always start with a fresh set of kinks.
+The **Start New Survey** button fetches `template-survey.json` when the page is
+served over HTTP so you always start with a fresh set of kinks. If you open
+`index.html` directly from your file system, the script falls back to an
+embedded copy of the template.
 
-**Note:** Because this file is fetched dynamically, opening `index.html`
-directly from your file system can produce errors like
-`Failed to load template: Unexpected token < ...`. Run a local web server (see
-below) when previewing the site so the template file loads correctly.
+Running a local web server is still recommended while developing so the latest
+JSON is loaded and all paths behave consistently. See below for quick server
+options.
 
 ## Setup
 

--- a/js/script.js
+++ b/js/script.js
@@ -332,20 +332,27 @@ function startNewSurvey() {
     }
   };
 
-  fetch('template-survey.json', { cache: 'no-store' })
-    .then(res => res.json())
-    .then(data => {
-      window.templateSurvey = normalizeSurveyFormat(data);
-      initialize(JSON.parse(JSON.stringify(window.templateSurvey)));
-    })
-    .catch(err => {
-      if (window.templateSurvey) {
-        console.warn('Failed to load template, using embedded copy:', err);
+  if (location.protocol.startsWith('http')) {
+    fetch('template-survey.json', { cache: 'no-store' })
+      .then(res => res.json())
+      .then(data => {
+        window.templateSurvey = normalizeSurveyFormat(data);
         initialize(JSON.parse(JSON.stringify(window.templateSurvey)));
-      } else {
-        alert('Failed to load template: ' + err.message);
-      }
-    });
+      })
+      .catch(err => {
+        if (window.templateSurvey) {
+          console.warn('Failed to load template, using embedded copy:', err);
+          initialize(JSON.parse(JSON.stringify(window.templateSurvey)));
+        } else {
+          alert('Failed to load template: ' + err.message);
+        }
+      });
+  } else if (window.templateSurvey) {
+    // When opened directly from the file system, use the embedded template
+    initialize(JSON.parse(JSON.stringify(window.templateSurvey)));
+  } else {
+    alert('Failed to load template: unsupported protocol');
+  }
 }
 
 startSurveyBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- use embedded survey template when page is opened without http protocol
- clarify fallback behavior in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686f08ac66c8832caae384096720d371