### PR TITLE
Restore category selection panels

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -519,6 +519,44 @@ body.theme-rainbow #comparisonResult {
   overflow-y: auto;
 }
 
+/* Category selection panels */
+.category-option {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 12px;
+  margin-bottom: 10px;
+  border: 1px solid #444;
+  border-radius: 8px;
+  background-color: #1e1e2f;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  max-width: 320px;
+  width: 100%;
+  cursor: pointer;
+  text-align: center;
+}
+
+.category-option.selected {
+  background-color: #2a2a3d;
+  border-color: #4caf50;
+}
+
+.category-option input {
+  margin-bottom: 6px;
+}
+
+body.light-mode .category-option {
+  background-color: #fff;
+  color: #2f4f2f;
+  border-color: #9fb49f;
+}
+
+body.light-mode .category-option.selected {
+  background-color: #a9b8a9;
+  border-color: #548c5a;
+}
+
 .selection-buttons {
   display: flex;
   gap: 10px;

--- a/js/script.js
+++ b/js/script.js
@@ -314,19 +314,38 @@ function startNewSurvey() {
     previewList.innerHTML = '';
     Object.keys(surveyA).forEach(cat => {
       const label = document.createElement('label');
+      label.className = 'category-option';
       const cb = document.createElement('input');
       cb.type = 'checkbox';
       cb.value = cat;
       cb.checked = false;
-      if (cat === HIGH_INTENSITY_CATEGORY) {
-        cb.addEventListener('change', () => {
-          if (cb.checked && !confirm(HIGH_INTENSITY_WARNING)) {
-            cb.checked = false;
+
+      const updateSelected = () => {
+        label.classList.toggle('selected', cb.checked);
+      };
+
+      label.addEventListener('click', e => {
+        e.preventDefault();
+        if (!cb.checked) {
+          if (cat === HIGH_INTENSITY_CATEGORY) {
+            if (confirm(HIGH_INTENSITY_WARNING)) {
+              cb.checked = true;
+            }
+          } else {
+            cb.checked = true;
           }
-        });
-      }
+        } else {
+          cb.checked = false;
+        }
+        updateSelected();
+      });
+
+      cb.addEventListener('change', updateSelected);
+
       label.appendChild(cb);
-      label.append(' ' + cat);
+      const span = document.createElement('span');
+      span.textContent = ' ' + cat;
+      label.appendChild(span);
       previewList.appendChild(label);
     });
     if (templateJson) {
@@ -370,18 +389,16 @@ if (newSurveyBtn) {
 if (selectAllBtn) {
   selectAllBtn.addEventListener('click', () => {
     previewList.querySelectorAll('input[type="checkbox"]').forEach(cb => {
-      if (cb.value === HIGH_INTENSITY_CATEGORY) {
-if (!cb.checked) {
-  if (confirm(HIGH_INTENSITY_WARNING)) {
-    cb.checked = true;
-  }
-}
-
+      if (!cb.checked) {
+        if (cb.value === HIGH_INTENSITY_CATEGORY) {
+          if (confirm(HIGH_INTENSITY_WARNING)) {
+            cb.checked = true;
+          }
+        } else {
           cb.checked = true;
         }
-      } else {
-        cb.checked = true;
       }
+      cb.dispatchEvent(new Event('change'));
     });
   });
 }
@@ -390,6 +407,7 @@ if (deselectAllBtn) {
   deselectAllBtn.addEventListener('click', () => {
     previewList.querySelectorAll('input[type="checkbox"]').forEach(cb => {
       cb.checked = false;
+      cb.dispatchEvent(new Event('change'));
     });
   });
 }


### PR DESCRIPTION
## Summary
- style preview checkboxes as panels
- highlight chosen categories
- require confirmation for High-Intensity category on click and select-all

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f2498a80c832caba7c2248471d96b