### PR TITLE
Restore intro flow before survey

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -731,7 +731,9 @@ switchTab('Giving');
 function init() {
   initTheme();
   document.querySelectorAll('button').forEach(attachRipple);
-  startNewSurvey();
+  if (surveyIntro) {
+    surveyIntro.style.display = 'flex';
+  }
 }
 
 if (document.readyState !== 'loading') {


### PR DESCRIPTION
## Summary
- show the intro overlay and let users start the survey manually

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f2fa99148832cafc0e38ef8d596b8