### PR TITLE
Improve mobile category overlay scrolling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -516,6 +516,8 @@ body.theme-rainbow #comparisonResult {
   align-items: center;
   justify-content: center;
   padding: 32px;
+  overflow-y: auto;
+  scroll-behavior: smooth;
 }
 
 #categoryPanel {
@@ -531,6 +533,8 @@ body.theme-rainbow #comparisonResult {
   max-width: 450px;
   box-sizing: border-box;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+  max-height: 90vh;
+  overflow-y: auto;
 }
 
 #categoryPanel h3 {


### PR DESCRIPTION
## Summary
- allow scrolling within the category overlay on small screens
- constrain the category panel height so it fits in the viewport

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f3b20c668832c9b3d4a378e62f510