### PR TITLE
Fix desktop category sidebar

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6,6 +6,12 @@ body {
   background-color: #121212;
   color: #e0e0e0;
 }
+
+/* Default panel colors */
+:root {
+  --panel-bg: #1e1e2f;
+  --text-color: #e0e0e0;
+}
 .category-panel {
   position: fixed;
   left: 0;
@@ -63,6 +69,19 @@ body.light-mode #closeRoleDefinitionsBtn {
     left: 0;
   }
 
+  .category-sidebar {
+    width: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    align-items: center;
+    justify-content: center;
+  }
+
+  .category-sidebar #categoryPanel {
+    background-color: var(--panel-bg, #1e1e1e);
+    max-width: 450px;
+    width: 90%;
+    max-height: 90vh;
+  }
 
   /* mobile adjustments left intentionally blank after sidebar removal */
 }
@@ -176,28 +195,40 @@ body.theme-rainbow #mainCategoryList button.active {
 body.dark-mode {
   background-color: #121212;
   color: #e0e0e0;
+  --panel-bg: #1e1e2f;
+  --text-color: #e0e0e0;
 }
 body.light-mode {
   background-color: #b8c5b8;
   color: #2f4f2f;
+  --panel-bg: #a9b8a9;
+  --text-color: #2f4f2f;
 }
 body.theme-blue {
   background-color: #001933;
   color: #fff;
+  --panel-bg: #002244;
+  --text-color: #fff;
 }
 body.theme-echoes-beyond {
   /* Outer Wilds inspired colors */
   background-color: #14213d;
   color: #fca311;
+  --panel-bg: #1b263b;
+  --text-color: #fca311;
 }
 body.theme-love-notes-lipstick {
   /* Monster Prom inspired colors */
   background-color: #311847;
   color: #ff6bd6;
+  --panel-bg: #3f206b;
+  --text-color: #ff6bd6;
 }
 body.theme-rainbow {
   background: linear-gradient(135deg, #ff9a9e, #fad0c4, #fbc2eb, #a18cd1);
   color: #000;
+  --panel-bg: #fff;
+  --text-color: #000;
 }
 
 /* Theme-specific panel colors */
@@ -520,11 +551,27 @@ body.theme-rainbow #comparisonResult {
   scroll-behavior: smooth;
 }
 
+.category-sidebar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100vh;
+  width: 320px;
+  background-color: var(--panel-bg, #1e1e1e);
+  color: var(--text-color, #ffffff);
+  overflow-y: auto;
+  padding: 24px 20px;
+  z-index: 1000;
+  box-shadow: 2px 0 10px rgba(0, 0, 0, 0.4);
+  display: none;
+  flex-direction: column;
+}
+
 #categoryPanel {
-  background-color: #fff;
+  background-color: var(--panel-bg, #fff);
   padding: 24px;
   border-radius: 8px;
-  color: #2c442e;
+  color: var(--text-color, #2c442e);
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -533,7 +580,7 @@ body.theme-rainbow #comparisonResult {
   max-width: 450px;
   box-sizing: border-box;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-  max-height: 90vh;
+  height: 100%;
   overflow-y: auto;
 }
 
@@ -541,7 +588,7 @@ body.theme-rainbow #comparisonResult {
   font-size: 20px;
   font-weight: bold;
   margin: 0 0 16px;
-  color: #2c442e;
+  color: var(--text-color, #2c442e);
 }
 
 
@@ -554,6 +601,7 @@ body.theme-rainbow #comparisonResult {
   padding-top: 20px;
   padding-bottom: 20px;
   overflow-y: auto;
+  flex: 1 1 auto;
 }
 
 /* Category selection checkboxes */

--- a/index.html
+++ b/index.html
@@ -190,7 +190,7 @@
   </div>
 
   <!-- Category Selection Panel -->
-  <div id="categoryOverlay" class="overlay" style="display:none">
+  <div id="categoryOverlay" class="overlay category-sidebar" style="display:none">
     <div id="categoryPanel">
       <h3>Select the categories you want to include:</h3>
       <div class="category-controls">


### PR DESCRIPTION
## Summary
- style the category selection panel as a fixed sidebar
- theme-aware colors via CSS variables
- keep mobile overlay behaviour

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686f4277c7c4832c89efd1eb52165908