### PR TITLE
Add Greenlight password protection

### DIFF
--- a/greenlight/README.md
+++ b/greenlight/README.md
@@ -1,0 +1,60 @@
+## \ud83d\udce6 Setup Instructions for *Beneath the Greenlight* Ritual Tracker
+
+**Hosted under your GitHub Pages domain: [https://duckieslove.github.io](https://duckieslove.github.io)**
+
+This neurodivergent-friendly devotion tracker installs in its own folder so it won't interfere with your main site.
+
+---
+
+### \ud83c\udf10 Live App URL
+After setup, access the tracker at:
+[https://duckieslove.github.io/greenlight/](https://duckieslove.github.io/greenlight/)
+
+Add it to your mobile home screen for an app-like experience.
+
+The page is protected with the password **Duckies**. You'll be prompted to enter
+it the first time you visit.
+
+---
+
+### \ud83d\udcc1 Folder & File Structure
+Place the tracker files in a subfolder named `greenlight` at the root of your repo:
+
+```
+DuckiesLove/
+  greenlight/
+    index.html
+    style.css
+    script.js
+```
+
+---
+
+### \ud83d\ude80 Development Setup
+1. Clone your repository and enter it:
+   ```bash
+   git clone https://github.com/duckieslove/DuckiesLove.git
+   cd DuckiesLove
+   ```
+2. (Optional) Install the `serve` package if you want a quick local preview:
+   ```bash
+   npm install -g serve
+   ```
+3. Start a local server from the repository root:
+   ```bash
+   serve .
+   ```
+   Then open `http://localhost:3000/greenlight/` in your browser.
+
+---
+
+### \ud83d\udd04 Updating the Tracker
+Edit the files inside the `greenlight` folder and push your changes. GitHub Pages will automatically publish them to `https://duckieslove.github.io/greenlight/`.
+
+### \ud83c\udf1f Embedding the Tracker
+Link to the tracker from other pages with:
+
+```html
+<a href="https://duckieslove.github.io/greenlight/">Open Beneath the Greenlight</a>
+```
+

--- a/greenlight/index.html
+++ b/greenlight/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Beneath the Greenlight</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>Beneath the Greenlight</h1>
+  <p>This is a placeholder for the ritual tracker.</p>
+  <!-- Password Overlay -->
+  <div id="passwordOverlay">
+    <div class="password-modal">
+      <label for="passwordInput">Enter Password:</label>
+      <input type="password" id="passwordInput" />
+      <button id="passwordSubmit">Enter</button>
+    </div>
+  </div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/greenlight/script.js
+++ b/greenlight/script.js
@@ -1,0 +1,21 @@
+const PASSWORD = 'Duckies';
+
+function setupPassword() {
+  const overlay = document.getElementById('passwordOverlay');
+  if (sessionStorage.getItem('greenlight-auth') === 'true') {
+    if (overlay) overlay.style.display = 'none';
+    return;
+  }
+  overlay.style.display = 'flex';
+  document.getElementById('passwordSubmit').onclick = () => {
+    const val = document.getElementById('passwordInput').value;
+    if (val === PASSWORD) {
+      sessionStorage.setItem('greenlight-auth', 'true');
+      overlay.style.display = 'none';
+    } else {
+      alert('Incorrect password');
+    }
+  };
+}
+
+window.addEventListener('DOMContentLoaded', setupPassword);

--- a/greenlight/style.css
+++ b/greenlight/style.css
@@ -1,0 +1,28 @@
+body {
+  font-family: Arial, sans-serif;
+  background-color: #222;
+  color: #eee;
+  margin: 0;
+  padding: 20px;
+}
+
+/* Overlay for password prompt */
+#passwordOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.8);
+  z-index: 1000;
+  display: none;
+  align-items: center;
+  justify-content: center;
+}
+
+.password-modal {
+  background-color: #333;
+  padding: 20px;
+  border-radius: 8px;
+  color: #eee;
+}


### PR DESCRIPTION
## Summary
- prompt for a password on the Greenlight page
- style the overlay and mention the password in the setup instructions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686f6446e4ac832cb04b0a98c23ac7d2