### PR TITLE
Add password gate for Greenlight

### DIFF
--- a/greenlight/index.html
+++ b/greenlight/index.html
@@ -8,6 +8,15 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
+  <div id="password-overlay" class="password-overlay">
+    <div class="password-box">
+      <label for="password-input">Password:</label>
+      <input type="password" id="password-input" />
+      <button onclick="checkPassword()">Unlock</button>
+      <p id="password-error" style="display:none;color:red;">Incorrect password</p>
+    </div>
+  </div>
+
   <h1>Beneath the Greenlight</h1>
   <p class="section-desc">Devotion Tracker</p>
 

--- a/greenlight/script.js
+++ b/greenlight/script.js
@@ -1,3 +1,33 @@
+const PASSWORD = "Duckies";
+
+function showPasswordOverlay() {
+  const overlay = document.getElementById("password-overlay");
+  if (overlay) overlay.style.display = "flex";
+}
+
+function checkPassword() {
+  const value = document.getElementById("password-input").value;
+  if (value === PASSWORD) {
+    localStorage.setItem("greenlightUnlocked", "true");
+    document.getElementById("password-overlay").style.display = "none";
+    initApp();
+  } else {
+    document.getElementById("password-error").style.display = "block";
+  }
+}
+
+function initApp() {
+  const container = document.getElementById("tracker-container");
+  subjects.forEach((subject, i) =>
+    container.appendChild(createCard(i, subject))
+  );
+
+  if (localStorage.getItem("theme") === "dark") {
+    document.body.classList.add("dark");
+    document.getElementById("theme-toggle").checked = true;
+  }
+}
+
 const subjects = [
   "Braiding", "Reading", "Videos to Watch", "Service & Protocol", "Tasks Today",
   "Shibari Practice", "Dom’s Assigned Task", "Bathing / Grooming",
@@ -82,11 +112,9 @@ function dropCard(e) {
 }
 
 document.addEventListener("DOMContentLoaded", () => {
-  const container = document.getElementById("tracker-container");
-  subjects.forEach((subject, i) => container.appendChild(createCard(i, subject)));
-
-  if (localStorage.getItem("theme") === "dark") {
-    document.body.classList.add("dark");
-    document.getElementById("theme-toggle").checked = true;
+  if (localStorage.getItem("greenlightUnlocked") === "true") {
+    initApp();
+  } else {
+    showPasswordOverlay();
   }
 });

--- a/greenlight/style.css
+++ b/greenlight/style.css
@@ -67,3 +67,25 @@ button {
   align-items: center;
   flex-wrap: wrap;
 }
+
+.password-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: rgba(242, 247, 244, 0.95);
+  display: none;
+  align-items: center;
+  justify-content: center;
+}
+body.dark .password-overlay {
+  background-color: rgba(30, 30, 30, 0.95);
+}
+.password-box {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+}
+.password-box input {
+  padding: 0.5em;
+  border-radius: 4px;
+  border: 1px solid #ccc;
+}


### PR DESCRIPTION
## Summary
- add a simple password overlay to the Greenlight page
- enforce password check in the Greenlight script
- style the overlay

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f6eb18dc4832c89016cdd26c6b6c4