### PR TITLE
Adjust dark theme colors

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -170,9 +170,9 @@ body.light-mode #mainCategoryList button.active {
   border: 1px solid #000;
 }
 body.dark-mode #mainCategoryList button.active {
-  background-color: #00bfff;
-  color: #000;
-  border: 1px solid #0099cc;
+  background-color: #146b3a;
+  color: #d0eaff;
+  border: 1px solid #0d4b2a;
 }
 body.theme-blue #mainCategoryList button.active {
   background-color: #0055aa;
@@ -197,13 +197,13 @@ body.theme-rainbow #mainCategoryList button.active {
 
 /* Theme Styling */
 body.dark-mode {
-  background-color: #121212;
-  color: #e0e0e0;
-  --panel-color: #1e1e2f;
-  --text-color: #e0e0e0;
-  --button-bg: #7c5fe9;
-  --button-text: #ffffff;
-  --button-hover-bg: #9b84ff;
+  background-color: #013220;
+  color: #5fa1d7;
+  --panel-color: #025f3d;
+  --text-color: #5fa1d7;
+  --button-bg: #146b3a;
+  --button-text: #d0eaff;
+  --button-hover-bg: #1b8a55;
 }
 body.light-mode {
   background-color: #b8c5b8;
@@ -341,13 +341,13 @@ body.light-mode .tab.active {
   border: 1px solid #000;
 }
 body.dark-mode .tab {
-  background-color: #222;
-  color: #f5f5f5;
+  background-color: #025f3d;
+  color: #5fa1d7;
 }
 body.dark-mode .tab.active {
-  background-color: #00bfff;
-  color: #000;
-  border: 1px solid #0099cc;
+  background-color: #146b3a;
+  color: #d0eaff;
+  border: 1px solid #0d4b2a;
 }
 body.theme-blue .tab {
   background-color: #003366;
@@ -445,9 +445,9 @@ body.light-mode #categoryContainer button.active {
   border: 1px solid #000;
 }
 body.dark-mode #categoryContainer button.active {
-  background-color: #00bfff;
-  color: #000;
-  border: 1px solid #0099cc;
+  background-color: #146b3a;
+  color: #d0eaff;
+  border: 1px solid #0d4b2a;
 }
 body.theme-blue #categoryContainer button.active {
   background-color: #0055aa;
@@ -478,9 +478,9 @@ body.theme-rainbow #categoryContainer button.active {
   border: 1px solid #ccc;
 }
 body.dark-mode #comparisonResult {
-  background-color: #1f1f1f;
-  color: #e0e0e0;
-  border-color: #444;
+  background-color: #025f3d;
+  color: #5fa1d7;
+  border-color: #0d4b2a;
 }
 body.light-mode #comparisonResult {
   background-color: #a9b8a9;
@@ -749,8 +749,8 @@ body.light-mode #surveyIntro .intro-modal {
 }
 
 body.dark-mode .expandable-panel summary {
-  background-color: #333;
-  color: #f5f5f5;
+  background-color: #025f3d;
+  color: #5fa1d7;
 }
 body.light-mode .expandable-panel summary {
   background-color: #a9b8a9;
@@ -1135,7 +1135,7 @@ body.light-mode .static-rating-legend {
 /* Match progress bar background to theme */
 body.dark-mode .progress-container,
 body.dark-mode .progress-bar {
-  background-color: #121212;
+  background-color: #013220;
 }
 body.light-mode .progress-container,
 body.light-mode .progress-bar {

--- a/css/theme.css
+++ b/css/theme.css
@@ -19,12 +19,13 @@
 
 .theme-darkviolet,
 .dark-mode {
-  --bg-color: #1a1a2e;
-  --panel-color: #292b3d;
-  --text-color: #f0f0f0;
-  --button-bg: #7c5fe9;
-  --button-text: #ffffff;
-  --button-hover-bg: #9b84ff;
+  /* Dark forest green theme */
+  --bg-color: #013220;
+  --panel-color: #025f3d;
+  --text-color: #5fa1d7;
+  --button-bg: #146b3a;
+  --button-text: #d0eaff;
+  --button-hover-bg: #1b8a55;
 }
 
 .theme-blue {


### PR DESCRIPTION
## Summary
- update the default dark theme to use a forest green palette
- adjust dark mode buttons, tabs and panels to match the new theme

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f6ed5ae24832c931222fb7491c7a7