### PR TITLE
Integrate Beneath the Greenlight tracker

### DIFF
--- a/greenlight/README.md
+++ b/greenlight/README.md
@@ -3,7 +3,13 @@
 A private, local-submissive ritual tracker and devotion log.
 
 ## Features
-- 15 editable devotion cards (e.g. Braiding, Reading, Shibari)
+- 6 editable devotion cards:
+  1. Braiding
+  2. Reading
+  3. Videos to Watch
+  4. Service & Protocol
+  5. Tasks Today
+  6. Shibari Practice
 - Tracks last completed and calculates next due
 - Editable notes per card
 - Drag-and-drop reorder

--- a/greenlight/script.js
+++ b/greenlight/script.js
@@ -1,8 +1,10 @@
 const subjects = [
-  "Braiding", "Reading", "Videos to Watch", "Service & Protocol", "Tasks Today",
-  "Shibari Practice", "Dom’s Assigned Task", "Bathing / Grooming",
-  "Cleaning Assigned Areas", "Daily Check-In Message", "Obedience Without Prompt",
-  "Reflective Journal", "Scene Prep", "Stuffie Time", "App Usage Logged"
+  "Braiding",
+  "Reading",
+  "Videos to Watch",
+  "Service & Protocol",
+  "Tasks Today",
+  "Shibari Practice"
 ];
 
 function createCard(i, subject) {

--- a/index.html
+++ b/index.html
@@ -212,6 +212,7 @@
       <button id="roleDefinitionsBtn" class="survey-button">Role Definitions</button>
       <button id="roleResultsBtn" class="survey-button" onclick="location.href='your-roles.html'">View Role Results</button>
       <button id="kinkListBtn" class="survey-button" onclick="location.href='kink-list.html'">View Kink List</button>
+      <a href="/greenlight/" class="survey-button">🌿 Open Ritual Tracker</a>
     </div>
   </div>
   <button id="homeBtn" class="survey-button" style="display:none;">Home</button>


### PR DESCRIPTION
## Summary
- limit Greenlight ritual tracker to the first six devotion cards
- update tracker README to describe the six-card setup
- link to the ritual tracker from the main homepage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f6fd915d4832c800a919f54fdb7e2