### PR TITLE
Apply dark green theme to Greenlight tracker

### DIFF
--- a/greenlight/index.html
+++ b/greenlight/index.html
@@ -21,15 +21,15 @@
   <p class="section-desc">Devotion Tracker</p>
 
   <div class="toolbar">
-    <label for="sort-method">Sort:</label>
-    <select id="sort-method" onchange="sortCards()">
+    <label for="sort-method" class="toggle-label">Sort:</label>
+    <select id="sort-method" class="sort-select" onchange="sortCards()">
       <option value="default">Default</option>
       <option value="alphabetical">A–Z</option>
       <option value="lastdone">Last Done</option>
     </select>
 
-    <label for="theme-toggle">Dark Mode:</label>
-    <input type="checkbox" id="theme-toggle" onchange="toggleTheme()" />
+    <label for="theme-toggle" class="toggle-label">Dark Mode:</label>
+    <input type="checkbox" id="theme-toggle" class="toggle-input" onchange="toggleTheme()" />
   </div>
 
   <div class="tracker-container" id="tracker-container">

--- a/greenlight/script.js
+++ b/greenlight/script.js
@@ -50,14 +50,14 @@ function createCard(i, subject) {
     <input class="tracker-title" value="${savedTitle}" />
     <p>Last done: <span id="last-done-${i}">${savedTime}</span></p>
     <p>Next due: <span id="next-due-${i}">–</span></p>
-    <textarea placeholder="Notes...">${savedNotes}</textarea>
-    <button onclick="markDone(${i})">Mark as Done</button>
+    <textarea class="notes" placeholder="Notes...">${savedNotes}</textarea>
+    <button class="mark-done" onclick="markDone(${i})">Mark as Done</button>
   `;
 
   card.querySelector(".tracker-title").addEventListener("input", (e) =>
     localStorage.setItem(`title-${i}`, e.target.value)
   );
-  card.querySelector("textarea").addEventListener("input", (e) =>
+  card.querySelector(".notes").addEventListener("input", (e) =>
     localStorage.setItem(`notes-${i}`, e.target.value)
   );
   card.addEventListener("dragstart", dragStart);

--- a/greenlight/style.css
+++ b/greenlight/style.css
@@ -1,9 +1,9 @@
 body {
   font-family: 'Segoe UI', sans-serif;
-  background-color: #e6f5ea;
+  background-color: #1D2E28;
   margin: 0;
   padding: 2em;
-  color: #244e6a;
+  color: #ffffff;
   transition: background-color 0.3s, color 0.3s;
 }
 body.dark {
@@ -11,10 +11,10 @@ body.dark {
   color: #aaccee;
 }
 h1 {
-  color: #2e8540;
+  color: #0F5132;
 }
 .section-desc {
-  color: #337a4a;
+  color: #0F5132;
   margin-bottom: 1.5em;
 }
 .tracker-container {
@@ -23,43 +23,47 @@ h1 {
   gap: 1em;
 }
 .tracker-card {
-  background: #ffffff;
-  padding: 1em;
+  border: 2px solid #33ccff;
   border-radius: 10px;
-  border: 1px solid #3a7ca5;
+  background-color: #1D2E28;
+  color: white;
+  padding: 1em;
   box-shadow: 0 2px 4px rgba(58, 124, 165, 0.1);
   width: calc(100% - 2em);
   max-width: 320px;
   display: flex;
   flex-direction: column;
 }
-body.dark .tracker-card {
-  background: #2a2a2a;
-}
 .tracker-title {
   font-size: 1.1em;
   margin-bottom: 0.5em;
   border: none;
-  border-bottom: 1px solid #3a7ca5;
+  border-bottom: 1px solid #33ccff;
   background: none;
-  color: inherit;
+  color: #0F5132;
+  font-weight: 700;
 }
-textarea {
+textarea.notes {
   margin-top: 0.5em;
   padding: 0.5em;
   font-size: 1em;
   border-radius: 8px;
-  border: 1px solid #3a7ca5;
+  background-color: #1D2E28;
+  border: 1px solid #3399ff;
+  color: #ffffff;
   resize: vertical;
 }
-button {
+button.mark-done {
   margin-top: 0.8em;
   padding: 0.5em;
-  background-color: #2e8540;
-  color: white;
+  background-color: #18392B;
+  color: #ffffff;
   border: none;
   border-radius: 8px;
   cursor: pointer;
+}
+button.mark-done:hover {
+  box-shadow: 0 0 8px #0F5132;
 }
 .toolbar {
   display: flex;
@@ -67,6 +71,15 @@ button {
   margin-bottom: 1em;
   align-items: center;
   flex-wrap: wrap;
+}
+
+.toggle-label,
+.sort-select {
+  color: #0A5C36;
+}
+
+.toggle-input:checked + .toggle-slider {
+  background-color: #14452F;
 }
 
 .password-overlay {


### PR DESCRIPTION
## Summary
- restyle Beneath the Greenlight page with darker green theme
- add classes to controls for new color rules
- add styling hooks to generated devotion cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f76aa254c832c804a2fc6702a5636