### PR TITLE
Fix export button visibility and table spacing

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2,7 +2,7 @@
 body {
   margin: 0;
   padding: 0;
-  font-family: Arial, sans-serif;
+  font-family: 'Segoe UI', Arial, sans-serif;
   background-color: var(--bg-color);
   color: var(--text-color);
 }
@@ -1167,13 +1167,14 @@ body.theme-rainbow .progress-bar {
 .kink-table {
   width: 100%;
   border-collapse: collapse;
-  margin: 10px 0;
+  margin: 6px 0;
+  font-size: 0.9rem;
 }
 
 .kink-table th,
 .kink-table td {
   border: 1px solid #666;
-  padding: 4px 6px;
+  padding: 2px 4px;
   text-align: center;
 }
 

--- a/js/script.js
+++ b/js/script.js
@@ -469,6 +469,7 @@ beginSurveyBtn.addEventListener('click', () => {
   categoryOverlay.style.display = 'none';
   if (categoryOrder.length) {
     buildPanelLayout();
+    if (downloadBtn) downloadBtn.style.display = 'block';
   }
 });
 


### PR DESCRIPTION
## Summary
- show export button when the survey begins
- use Segoe UI as the base font
- tighten kink table layout for better readability

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f7c64de74832c864984a48d2ddd05