### PR TITLE
Restore export and tighten menu

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1096,7 +1096,7 @@ body.light-mode .static-rating-legend {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  min-height: 50vh;
+  min-height: auto;
 }
 
 /* Progress bar styles */

--- a/index.html
+++ b/index.html
@@ -201,6 +201,7 @@
   <div class="button-group">
     <!-- Top two buttons -->
     <button id="newSurveyBtn" class="survey-button">Start New Survey</button>
+    <button id="downloadBtn" class="survey-button">Export My Data</button>
 
     <!-- Spacer -->
     <div class="section-spacing"></div>


### PR DESCRIPTION
## Summary
- reintroduce Export My Data button on the home page
- remove large gap around menu

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686f7f4b819c832ca826f7ac0f9bb091