### PR TITLE
Add video and media attachments to ritual tracker

### DIFF
--- a/greenlight/index.html
+++ b/greenlight/index.html
@@ -21,14 +21,20 @@
       <h2>Add Ritual</h2>
       <p>Popular Rituals</p>
       <div class="preset-buttons">
-        <button>Braiding</button>
-        <button>Service</button>
-        <button>Reading</button>
-        <button>Gratefulness</button>
-        <button>Aftercare</button>
-        <button>Quiet Time</button>
+        <button data-title="Braiding">Braiding</button>
+        <button data-title="Service">Service</button>
+        <button data-title="Reading">Reading</button>
+        <button data-title="Gratefulness">Gratefulness</button>
+        <button data-title="Aftercare">Aftercare</button>
+        <button data-title="Quiet Time">Quiet Time</button>
       </div>
-      <button id="customBtn">Add Custom Ritual</button>
+      <form id="ritualForm">
+        <input id="ritualTitle" placeholder="Title" />
+        <textarea id="ritualNotes" placeholder="Notes"></textarea>
+        <input id="ritualVideo" type="url" placeholder="Video URL" />
+        <input id="ritualFiles" type="file" accept="image/*,audio/*" multiple />
+        <button type="submit" id="saveRitualBtn">Save Ritual</button>
+      </form>
       <button id="closeModal">×</button>
     </div>
   </div>

--- a/greenlight/script.js
+++ b/greenlight/script.js
@@ -1,7 +1,114 @@
+const content = document.getElementById('content');
+const addBtn = document.getElementById('addBtn');
+const modal = document.getElementById('modal');
+const closeModal = document.getElementById('closeModal');
+const form = document.getElementById('ritualForm');
+const titleInput = document.getElementById('ritualTitle');
+const notesInput = document.getElementById('ritualNotes');
+const videoInput = document.getElementById('ritualVideo');
+const fileInput = document.getElementById('ritualFiles');
+const presetButtons = document.querySelectorAll('.preset-buttons button');
 
-document.getElementById('addBtn').onclick = () => {
-  document.getElementById('modal').classList.remove('hidden');
+let rituals = JSON.parse(localStorage.getItem('rituals') || '[]');
+
+function save() {
+  localStorage.setItem('rituals', JSON.stringify(rituals));
+}
+
+function fileToDataUrl(file) {
+  return new Promise(resolve => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.readAsDataURL(file);
+  });
+}
+
+async function render() {
+  content.innerHTML = '';
+  if (rituals.length === 0) {
+    content.innerHTML = '<p class="empty-state">No rituals yet. Tap the + button to begin your devotion.</p>';
+    return;
+  }
+  for (const [index, ritual] of rituals.entries()) {
+    const card = document.createElement('div');
+    card.className = 'card';
+    const h = document.createElement('h3');
+    h.textContent = ritual.title;
+    card.appendChild(h);
+    if (ritual.notes) {
+      const p = document.createElement('p');
+      p.textContent = ritual.notes;
+      card.appendChild(p);
+    }
+    if (ritual.video) {
+      const a = document.createElement('a');
+      a.href = ritual.video;
+      a.target = '_blank';
+      a.textContent = 'Watch Video';
+      a.className = 'video-link';
+      card.appendChild(a);
+    }
+    if (ritual.files && ritual.files.length) {
+      const attach = document.createElement('div');
+      attach.className = 'attachments';
+      for (const f of ritual.files) {
+        if (f.type.startsWith('image/')) {
+          const img = document.createElement('img');
+          img.src = f.data;
+          attach.appendChild(img);
+        } else if (f.type.startsWith('audio/')) {
+          const audio = document.createElement('audio');
+          audio.controls = true;
+          audio.src = f.data;
+          attach.appendChild(audio);
+        }
+      }
+      card.appendChild(attach);
+    }
+    const del = document.createElement('button');
+    del.textContent = 'Delete';
+    del.className = 'delete-btn';
+    del.onclick = () => {
+      rituals.splice(index, 1);
+      save();
+      render();
+    };
+    card.appendChild(del);
+    content.appendChild(card);
+  }
+}
+
+form.addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const files = fileInput.files;
+  const attachments = [];
+  for (const file of files) {
+    const data = await fileToDataUrl(file);
+    attachments.push({ type: file.type, data });
+  }
+  rituals.push({
+    title: titleInput.value.trim() || 'Untitled',
+    notes: notesInput.value.trim(),
+    video: videoInput.value.trim(),
+    files: attachments
+  });
+  save();
+  render();
+  form.reset();
+  modal.classList.add('hidden');
+});
+
+presetButtons.forEach(btn => {
+  btn.addEventListener('click', () => {
+    titleInput.value = btn.dataset.title || btn.textContent;
+  });
+});
+
+addBtn.onclick = () => {
+  modal.classList.remove('hidden');
 };
-document.getElementById('closeModal').onclick = () => {
-  document.getElementById('modal').classList.add('hidden');
+closeModal.onclick = () => {
+  modal.classList.add('hidden');
 };
+
+render();

--- a/greenlight/style.css
+++ b/greenlight/style.css
@@ -68,15 +68,6 @@ h1 {
   padding: 0.6rem 1rem;
   border-radius: 1rem;
 }
-#customBtn {
-  background-color: #2a9fd6;
-  border: none;
-  margin-top: 1rem;
-  padding: 0.6rem 1.2rem;
-  border-radius: 1rem;
-  color: #fff;
-  font-weight: bold;
-}
 #closeModal {
   position: absolute;
   top: 1rem;
@@ -85,4 +76,44 @@ h1 {
   color: white;
   font-size: 1.5rem;
   border: none;
+}
+
+form#ritualForm {
+  display: flex;
+  flex-direction: column;
+  margin-top: 1rem;
+}
+form#ritualForm input,
+form#ritualForm textarea {
+  margin-bottom: 0.5rem;
+  padding: 0.5rem;
+  border-radius: 0.5rem;
+  border: none;
+}
+form#ritualForm button {
+  background-color: #2a9fd6;
+  border: none;
+  padding: 0.6rem 1.2rem;
+  border-radius: 1rem;
+  color: #fff;
+  font-weight: bold;
+}
+
+.card {
+  background-color: #14452F;
+  padding: 1rem;
+  border-radius: 1rem;
+  margin-bottom: 1rem;
+}
+.card h3 {
+  margin-top: 0;
+}
+.attachments img {
+  max-width: 100px;
+  margin-right: 0.5rem;
+  border-radius: 0.5rem;
+}
+.attachments audio {
+  display: block;
+  margin-top: 0.5rem;
 }


### PR DESCRIPTION
## Summary
- extend Greenlight modal with form fields for title, notes, video link, and media upload
- style new form and ritual cards
- implement localStorage logic to save rituals, including YouTube links and image/audio attachments

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f7f92f8f8832c9bc2765e90a4331c