### PR TITLE
Update greenlight to use 'memory' wording

### DIFF
--- a/greenlight/README.md
+++ b/greenlight/README.md
@@ -1,6 +1,6 @@
 # Beneath the Greenlight
 
-A private, local-submissive ritual tracker and devotion log.
+A private, local-submissive memory tracker and devotion log.
 
 ## Features
 - 6 editable devotion cards:

--- a/greenlight/index.html
+++ b/greenlight/index.html
@@ -12,14 +12,14 @@
     <h1>🌿 Beneath the Greenlight</h1>
   </header>
   <main id="content">
-    <p class="empty-state">No rituals yet. Tap the + button to begin your devotion.</p>
+    <p class="empty-state">No memories yet. Tap the + button to start recording.</p>
   </main>
   <button id="addBtn">+</button>
 
   <div id="modal" class="hidden">
     <div class="modal-content">
-      <h2>Add Ritual</h2>
-      <p>Popular Rituals</p>
+      <h2>Add Memory</h2>
+      <p>Popular Memories</p>
       <div class="preset-buttons">
         <button data-title="Braiding">Braiding</button>
         <button data-title="Service">Service</button>
@@ -33,7 +33,7 @@
         <textarea id="ritualNotes" placeholder="Notes"></textarea>
         <input id="ritualVideo" type="url" placeholder="Video URL" />
         <input id="ritualFiles" type="file" accept="image/*,audio/*" multiple />
-        <button type="submit" id="saveRitualBtn">Save Ritual</button>
+        <button type="submit" id="saveRitualBtn">Save Memory</button>
       </form>
       <button id="closeModal">×</button>
     </div>


### PR DESCRIPTION
## Summary
- use "memory" wording instead of "ritual" in greenlight UI
- update greenlight README description

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686f836de0cc832ca504799729043e0a