### PR TITLE
Update Greenlight ritual cards

### DIFF
--- a/greenlight/index.html
+++ b/greenlight/index.html
@@ -1,50 +1,33 @@
-
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Beneath the Greenlight</title>
-  <link rel="stylesheet" href="style.css" />
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
   <header>
     <h1>🌿 Beneath the Greenlight</h1>
   </header>
   <main id="content">
-    <p class="empty-state">No memories yet. Tap the + button to start recording.</p>
+    <p class="empty-state">No rituals yet. Tap the + button to begin.</p>
   </main>
   <button id="addBtn">+</button>
 
   <div id="modal" class="hidden">
     <div class="modal-content">
-      <h2>Add Memory</h2>
-      <p>Popular Memories</p>
+      <h2>Add Ritual</h2>
+      <p>Popular Rituals</p>
       <div class="preset-buttons">
-        <button data-title="Braiding">Braiding</button>
-        <button data-title="Service">Service</button>
-        <button data-title="Reading">Reading</button>
-        <button data-title="Gratefulness">Gratefulness</button>
-        <button data-title="Aftercare">Aftercare</button>
-        <button data-title="Quiet Time">Quiet Time</button>
+        <button>Braiding</button>
+        <button>Service</button>
+        <button>Reading</button>
+        <button>Gratefulness</button>
+        <button>Aftercare</button>
+        <button>Quiet Time</button>
       </div>
-      <form id="ritualForm">
-        <input id="ritualTitle" placeholder="Title" />
-        <input id="ritualCategory" placeholder="Category" list="categoryOptions" />
-        <textarea id="ritualNotes" placeholder="Notes"></textarea>
-        <input id="ritualVideo" type="url" placeholder="Video URL" />
-        <input id="ritualVideoLabel" placeholder="Video Label" value="YouTube Video" />
-        <input id="ritualFiles" type="file" accept="image/*,audio/*" multiple />
-        <button type="submit" id="saveRitualBtn">Save Memory</button>
-      </form>
-      <datalist id="categoryOptions">
-        <option value="Braiding"></option>
-        <option value="Service"></option>
-        <option value="Reading"></option>
-        <option value="Gratefulness"></option>
-        <option value="Aftercare"></option>
-        <option value="Quiet Time"></option>
-      </datalist>
+      <button id="customBtn">Custom Ritual</button>
       <button id="closeModal">×</button>
     </div>
   </div>

--- a/greenlight/script.js
+++ b/greenlight/script.js
@@ -1,132 +1,52 @@
+document.getElementById('addBtn').onclick = () => {
+  document.getElementById('modal').classList.remove('hidden');
+};
+document.getElementById('closeModal').onclick = () => {
+  document.getElementById('modal').classList.add('hidden');
+};
+
 const content = document.getElementById('content');
-const addBtn = document.getElementById('addBtn');
-const modal = document.getElementById('modal');
-const closeModal = document.getElementById('closeModal');
-const form = document.getElementById('ritualForm');
-const titleInput = document.getElementById('ritualTitle');
-const notesInput = document.getElementById('ritualNotes');
-const videoInput = document.getElementById('ritualVideo');
-const videoLabelInput = document.getElementById('ritualVideoLabel');
-const categoryInput = document.getElementById('ritualCategory');
-const fileInput = document.getElementById('ritualFiles');
 const presetButtons = document.querySelectorAll('.preset-buttons button');
+const customBtn = document.getElementById('customBtn');
 
-let rituals = JSON.parse(localStorage.getItem('rituals') || '[]');
+function addRitual(name = "New Ritual") {
+  const card = document.createElement('div');
+  card.className = 'ritual-card';
 
-function save() {
-  localStorage.setItem('rituals', JSON.stringify(rituals));
+  const title = document.createElement('input');
+  title.className = 'ritual-title';
+  title.value = name;
+
+  const timerType = document.createElement('select');
+  timerType.className = 'ritual-type';
+  const option1 = document.createElement('option');
+  option1.value = 'left';
+  option1.textContent = 'Time Left';
+  const option2 = document.createElement('option');
+  option2.value = 'since';
+  option2.textContent = 'Time Since';
+  timerType.appendChild(option1);
+  timerType.appendChild(option2);
+
+  const timerInput = document.createElement('input');
+  timerInput.className = 'ritual-timer';
+  timerInput.placeholder = 'e.g., 30m, 2h';
+
+  card.appendChild(title);
+  card.appendChild(timerType);
+  card.appendChild(timerInput);
+  content.appendChild(card);
+  document.querySelector('.empty-state').style.display = 'none';
 }
 
-function fileToDataUrl(file) {
-  return new Promise(resolve => {
-    const reader = new FileReader();
-    reader.onload = () => resolve(reader.result);
-    reader.readAsDataURL(file);
-  });
-}
-
-async function render() {
-  content.innerHTML = '';
-  if (rituals.length === 0) {
-    content.innerHTML = '<p class="empty-state">No rituals yet. Tap the + button to begin your devotion.</p>';
-    return;
-  }
-  const categories = {};
-  rituals.forEach((ritual, index) => {
-    const cat = ritual.category || 'Uncategorized';
-    if (!categories[cat]) categories[cat] = [];
-    categories[cat].push({ ritual, index });
-  });
-
-  for (const cat of Object.keys(categories)) {
-    const header = document.createElement('h2');
-    header.textContent = cat;
-    header.className = 'category-header';
-    content.appendChild(header);
-
-    for (const { ritual, index } of categories[cat]) {
-      const card = document.createElement('div');
-      card.className = 'card';
-      const h = document.createElement('h3');
-      h.textContent = ritual.title;
-      card.appendChild(h);
-      if (ritual.notes) {
-        const p = document.createElement('p');
-        p.textContent = ritual.notes;
-        card.appendChild(p);
-      }
-      if (ritual.video) {
-        const a = document.createElement('a');
-        a.href = ritual.video;
-        a.target = '_blank';
-        a.textContent = ritual.videoLabel || 'YouTube Video';
-        a.className = 'video-link';
-        card.appendChild(a);
-      }
-      if (ritual.files && ritual.files.length) {
-        const attach = document.createElement('div');
-        attach.className = 'attachments';
-        for (const f of ritual.files) {
-          if (f.type.startsWith('image/')) {
-            const img = document.createElement('img');
-            img.src = f.data;
-            attach.appendChild(img);
-          } else if (f.type.startsWith('audio/')) {
-            const audio = document.createElement('audio');
-            audio.controls = true;
-            audio.src = f.data;
-            attach.appendChild(audio);
-          }
-        }
-        card.appendChild(attach);
-      }
-      const del = document.createElement('button');
-      del.textContent = 'Delete';
-      del.className = 'delete-btn';
-      del.onclick = () => {
-        rituals.splice(index, 1);
-        save();
-        render();
-      };
-      card.appendChild(del);
-      content.appendChild(card);
-    }
-  }
-}
-
-form.addEventListener('submit', async (e) => {
-  e.preventDefault();
-  const files = fileInput.files;
-  const attachments = [];
-  for (const file of files) {
-    const data = await fileToDataUrl(file);
-    attachments.push({ type: file.type, data });
-  }
-  rituals.push({
-    title: titleInput.value.trim() || 'Untitled',
-    notes: notesInput.value.trim(),
-    video: videoInput.value.trim(),
-    videoLabel: videoLabelInput.value.trim() || 'YouTube Video',
-    category: categoryInput.value.trim(),
-    files: attachments
-  });
-  save();
-  render();
-  form.reset();
-  modal.classList.add('hidden');
-});
-
-presetButtons.forEach(btn => {
-  btn.addEventListener('click', () => {
-    titleInput.value = btn.dataset.title || btn.textContent;
+presetButtons.forEach(button => {
+  button.addEventListener('click', () => {
+    addRitual(button.textContent);
+    document.getElementById('modal').classList.add('hidden');
   });
 });
 
-addBtn.onclick = () => {
-  modal.classList.remove('hidden');
+customBtn.onclick = () => {
+  addRitual();
+  document.getElementById('modal').classList.add('hidden');
 };
-closeModal.onclick = () => {
-  modal.classList.add('hidden');
-};
-
-render();

--- a/greenlight/style.css
+++ b/greenlight/style.css
@@ -1,4 +1,3 @@
-
 body {
   margin: 0;
   font-family: 'Segoe UI', sans-serif;
@@ -12,7 +11,6 @@ header {
 }
 h1 {
   margin: 0;
-  color: #ffffff;
 }
 #content {
   padding: 2rem;
@@ -38,11 +36,6 @@ h1 {
 #modal.hidden {
   display: none;
 }
-
-.category-header {
-  margin-top: 2rem;
-  color: #2a9fd6;
-}
 #modal {
   position: fixed;
   top: 0; left: 0; right: 0; bottom: 0;
@@ -56,16 +49,14 @@ h1 {
   padding: 2rem;
   border-radius: 1rem;
   width: 80%;
-  max-width: 500px;
+  max-width: 400px;
   position: relative;
 }
 .modal-content h2 {
   margin-top: 0;
 }
-.modal-content p {
-  margin-bottom: 0.5rem;
-}
-.preset-buttons button {
+.preset-buttons button,
+#customBtn {
   background-color: #0A5C36;
   color: white;
   border: none;
@@ -82,43 +73,19 @@ h1 {
   font-size: 1.5rem;
   border: none;
 }
-
-form#ritualForm {
-  display: flex;
-  flex-direction: column;
-  margin-top: 1rem;
-}
-form#ritualForm input,
-form#ritualForm textarea {
-  margin-bottom: 0.5rem;
-  padding: 0.5rem;
-  border-radius: 0.5rem;
-  border: none;
-}
-form#ritualForm button {
-  background-color: #2a9fd6;
-  border: none;
-  padding: 0.6rem 1.2rem;
-  border-radius: 1rem;
-  color: #fff;
-  font-weight: bold;
-}
-
-.card {
+.ritual-card {
   background-color: #14452F;
   padding: 1rem;
   border-radius: 1rem;
   margin-bottom: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 }
-.card h3 {
-  margin-top: 0;
-}
-.attachments img {
-  max-width: 100px;
-  margin-right: 0.5rem;
+.ritual-card input,
+.ritual-card select {
+  padding: 0.5rem;
   border-radius: 0.5rem;
-}
-.attachments audio {
-  display: block;
-  margin-top: 0.5rem;
+  border: none;
+  width: 100%;
 }


### PR DESCRIPTION
## Summary
- simplify Greenlight interface
- allow adding basic ritual cards with editable name, timer type and manual timer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ff6f72cac832c884ee882e3ba8360