### PR TITLE
Add persistent ritual timers

### DIFF
--- a/greenlight/script.js
+++ b/greenlight/script.js
@@ -1,52 +1,159 @@
-document.getElementById('addBtn').onclick = () => {
-  document.getElementById('modal').classList.remove('hidden');
-};
-document.getElementById('closeModal').onclick = () => {
-  document.getElementById('modal').classList.add('hidden');
-};
-
+const addBtn = document.getElementById('addBtn');
+const closeModal = document.getElementById('closeModal');
 const content = document.getElementById('content');
 const presetButtons = document.querySelectorAll('.preset-buttons button');
 const customBtn = document.getElementById('customBtn');
+const modal = document.getElementById('modal');
 
-function addRitual(name = "New Ritual") {
-  const card = document.createElement('div');
-  card.className = 'ritual-card';
+const STORAGE_KEY = 'greenlight-cards';
+let cards = [];
+
+addBtn.onclick = () => modal.classList.remove('hidden');
+closeModal.onclick = () => modal.classList.add('hidden');
+
+function parseDuration(str) {
+  if (!str) return 0;
+  let total = 0;
+  const regex = /(\d+)\s*([smhd])/gi;
+  let m;
+  while ((m = regex.exec(str))) {
+    const val = parseInt(m[1]);
+    const unit = m[2].toLowerCase();
+    if (unit === 's') total += val * 1000;
+    if (unit === 'm') total += val * 60 * 1000;
+    if (unit === 'h') total += val * 60 * 60 * 1000;
+    if (unit === 'd') total += val * 24 * 60 * 60 * 1000;
+  }
+  return total;
+}
+
+function formatTime(ms) {
+  const sec = Math.max(0, Math.floor(ms / 1000));
+  const d = Math.floor(sec / 86400);
+  const h = Math.floor((sec % 86400) / 3600);
+  const m = Math.floor((sec % 3600) / 60);
+  const s = sec % 60;
+  const parts = [];
+  if (d) parts.push(`${d}d`);
+  if (d || h) parts.push(`${h}h`);
+  if (d || h || m) parts.push(`${m}m`);
+  parts.push(`${s}s`);
+  return parts.join(' ');
+}
+
+function saveCards() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(cards));
+}
+
+function createCard(card) {
+  const el = document.createElement('div');
+  el.className = 'ritual-card';
+  el.dataset.id = card.id;
 
   const title = document.createElement('input');
   title.className = 'ritual-title';
-  title.value = name;
+  title.value = card.title;
+  title.oninput = () => {
+    card.title = title.value;
+    saveCards();
+  };
 
-  const timerType = document.createElement('select');
-  timerType.className = 'ritual-type';
-  const option1 = document.createElement('option');
-  option1.value = 'left';
-  option1.textContent = 'Time Left';
-  const option2 = document.createElement('option');
-  option2.value = 'since';
-  option2.textContent = 'Time Since';
-  timerType.appendChild(option1);
-  timerType.appendChild(option2);
+  const typeSel = document.createElement('select');
+  typeSel.className = 'ritual-type';
+  typeSel.innerHTML = `<option value="left">Time Left</option><option value="since">Time Since</option>`;
+  typeSel.value = card.timerType;
+  typeSel.onchange = () => {
+    card.timerType = typeSel.value;
+    saveCards();
+  };
 
   const timerInput = document.createElement('input');
   timerInput.className = 'ritual-timer';
   timerInput.placeholder = 'e.g., 30m, 2h';
+  timerInput.value = card.inputText || '';
+  timerInput.onchange = () => {
+    card.inputText = timerInput.value;
+    card.duration = parseDuration(timerInput.value);
+    saveCards();
+  };
 
-  card.appendChild(title);
-  card.appendChild(timerType);
-  card.appendChild(timerInput);
-  content.appendChild(card);
+  const timerDisplay = document.createElement('div');
+  timerDisplay.className = 'timer-display';
+
+  const complete = document.createElement('input');
+  complete.type = 'checkbox';
+  complete.className = 'complete-box';
+  complete.onchange = () => {
+    if (complete.checked) {
+      card.lastCompleted = Date.now();
+      saveCards();
+      complete.checked = false;
+    }
+  };
+
+  el.appendChild(title);
+  el.appendChild(typeSel);
+  el.appendChild(timerInput);
+  el.appendChild(timerDisplay);
+  el.appendChild(complete);
+  content.appendChild(el);
+
+  function update() {
+    const now = Date.now();
+    let diff = 0;
+    if (card.timerType === 'left') {
+      diff = card.duration - (now - card.lastCompleted);
+    } else {
+      diff = now - card.lastCompleted;
+    }
+    timerDisplay.textContent = formatTime(diff);
+  }
+  update();
+  setInterval(update, 1000);
+}
+
+function addRitual(name = 'New Ritual') {
+  const card = {
+    id: Date.now(),
+    title: name,
+    timerType: 'left',
+    inputText: '',
+    duration: 0,
+    lastCompleted: Date.now()
+  };
+  cards.push(card);
+  saveCards();
+  createCard(card);
   document.querySelector('.empty-state').style.display = 'none';
 }
 
-presetButtons.forEach(button => {
-  button.addEventListener('click', () => {
-    addRitual(button.textContent);
-    document.getElementById('modal').classList.add('hidden');
+presetButtons.forEach(btn => {
+  btn.addEventListener('click', () => {
+    addRitual(btn.textContent);
+    modal.classList.add('hidden');
   });
 });
 
 customBtn.onclick = () => {
   addRitual();
-  document.getElementById('modal').classList.add('hidden');
+  modal.classList.add('hidden');
 };
+
+function loadCards() {
+  const data = localStorage.getItem(STORAGE_KEY);
+  if (data) {
+    try {
+      cards = JSON.parse(data);
+    } catch (e) {
+      cards = [];
+    }
+  }
+  if (!cards.length) {
+    document.querySelector('.empty-state').style.display = 'block';
+  } else {
+    document.querySelector('.empty-state').style.display = 'none';
+  }
+  cards.forEach(createCard);
+}
+
+window.addEventListener('load', loadCards);

--- a/greenlight/style.css
+++ b/greenlight/style.css
@@ -89,3 +89,7 @@ h1 {
   border: none;
   width: 100%;
 }
+
+.timer-display { text-align: center; font-weight: bold; }
+.complete-box { align-self: flex-start; }
+


### PR DESCRIPTION
## Summary
- make rituals store in localStorage
- show animated timers that count up or down
- add completion checkbox to restart timer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ff9c69468832cb6eee12eec41df5f