### PR TITLE
Add timestamp, YouTube preview and voice memos

### DIFF
--- a/greenlight/README.md
+++ b/greenlight/README.md
@@ -11,6 +11,7 @@ A private, local-submissive memory tracker and devotion log.
   5. Tasks Today
   6. Shibari Practice
 - Tracks last completed and calculates next due
+- Timestamp input for logging when tasks were completed
 - Editable notes per card
 - Drag-and-drop reorder
 - Sort by title or last done
@@ -18,6 +19,8 @@ A private, local-submissive memory tracker and devotion log.
 - Installs as a mobile app (PWA)
 - Data saved privately in browser (no account needed)
 - Categorize memories on the main screen
+- Add YouTube links with thumbnail preview
+- Record voice memos for each card
 - Customizable label for video links (defaults to "YouTube Video")
 
 ## Setup

--- a/greenlight/style.css
+++ b/greenlight/style.css
@@ -92,4 +92,13 @@ h1 {
 
 .timer-display { text-align: center; font-weight: bold; }
 .complete-box { align-self: flex-start; }
+.youtube-thumb {
+  width: 100%;
+  border-radius: 0.5rem;
+  margin-top: 0.5rem;
+}
+.audio-list audio {
+  width: 100%;
+  margin-top: 0.5rem;
+}
 


### PR DESCRIPTION
## Summary
- add a timestamp field so ritual completion time can be entered manually
- support YouTube links with thumbnail preview
- allow recording voice memos per card
- document new features

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ffc013c94832cb689db378a851b57