### PR TITLE
Add editable categories to Greenlight cards

### DIFF
--- a/greenlight/index.html
+++ b/greenlight/index.html
@@ -31,6 +31,14 @@
       <button id="closeModal">×</button>
     </div>
   </div>
+  <datalist id="categoryOptions">
+    <option value="Braiding"></option>
+    <option value="Reading"></option>
+    <option value="Videos to Watch"></option>
+    <option value="Service &amp; Protocol"></option>
+    <option value="Tasks Today"></option>
+    <option value="Shibari Practice"></option>
+  </datalist>
 
   <script src="script.js"></script>
 </body>

--- a/greenlight/script.js
+++ b/greenlight/script.js
@@ -65,6 +65,16 @@ function createCard(card) {
     saveCards();
   };
 
+  const categoryInput = document.createElement('input');
+  categoryInput.className = 'ritual-category';
+  categoryInput.placeholder = 'Category';
+  categoryInput.setAttribute('list', 'categoryOptions');
+  categoryInput.value = card.category || '';
+  categoryInput.oninput = () => {
+    card.category = categoryInput.value;
+    saveCards();
+  };
+
   const typeSel = document.createElement('select');
   typeSel.className = 'ritual-type';
   typeSel.innerHTML = `<option value="left">Time Left</option><option value="since">Time Since</option>`;
@@ -191,6 +201,7 @@ function createCard(card) {
   };
 
   el.appendChild(title);
+  el.appendChild(categoryInput);
   el.appendChild(typeSel);
   el.appendChild(timerInput);
   el.appendChild(timerDisplay);
@@ -225,7 +236,8 @@ function addRitual(name = 'New Ritual') {
     duration: 0,
     lastCompleted: Date.now(),
     youtubeLink: '',
-    audios: []
+    audios: [],
+    category: ''
   };
   cards.push(card);
   saveCards();


### PR DESCRIPTION
## Summary
- allow specifying a category per ritual card in *Greenlight*
- provide default category options in `index.html`
- restore original category list from documentation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686ffdd86f2c832c9fb3af9af701d91b