### PR TITLE
Remove recording option in greenlight

### DIFF
--- a/greenlight/README.md
+++ b/greenlight/README.md
@@ -20,7 +20,7 @@ A private, local-submissive memory tracker and devotion log.
 - Data saved privately in browser (no account needed)
 - Categorize memories on the main screen
 - Add YouTube links with thumbnail preview
-- Record voice memos for each card
+- Load voice memos for each card
 - Customizable label for video links (defaults to "YouTube Video")
 
 ## Setup

--- a/greenlight/script.js
+++ b/greenlight/script.js
@@ -129,12 +129,11 @@ function createCard(card) {
 
   updateThumb();
 
-  const recordBtn = document.createElement('button');
-  recordBtn.textContent = 'Record';
+  const audioInput = document.createElement('input');
+  audioInput.type = 'file';
+  audioInput.accept = 'audio/*';
   const audioList = document.createElement('div');
   audioList.className = 'audio-list';
-  let recorder;
-  let chunks = [];
 
   function addAudio(url) {
     const audio = document.createElement('audio');
@@ -149,30 +148,18 @@ function createCard(card) {
     card.audios = [];
   }
 
-  recordBtn.onclick = async () => {
-    if (!recorder) {
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-      recorder = new MediaRecorder(stream);
-      recorder.ondataavailable = e => chunks.push(e.data);
-      recorder.onstop = () => {
-        const blob = new Blob(chunks, { type: 'audio/webm' });
-        const url = URL.createObjectURL(blob);
-        addAudio(url);
-        const reader = new FileReader();
-        reader.onload = () => {
-          card.audios.push(reader.result);
-          saveCards();
-        };
-        reader.readAsDataURL(blob);
-        chunks = [];
-        recorder = null;
-        recordBtn.textContent = 'Record';
-      };
-      recorder.start();
-      recordBtn.textContent = 'Stop';
-    } else {
-      recorder.stop();
-    }
+  audioInput.onchange = () => {
+    const file = audioInput.files[0];
+    if (!file) return;
+    const url = URL.createObjectURL(file);
+    addAudio(url);
+    const reader = new FileReader();
+    reader.onload = () => {
+      card.audios.push(reader.result);
+      saveCards();
+    };
+    reader.readAsDataURL(file);
+    audioInput.value = '';
   };
 
   el.appendChild(title);
@@ -183,7 +170,7 @@ function createCard(card) {
   el.appendChild(complete);
   el.appendChild(ytInput);
   el.appendChild(ytPreviewLink);
-  el.appendChild(recordBtn);
+  el.appendChild(audioInput);
   el.appendChild(audioList);
   content.appendChild(el);
 


### PR DESCRIPTION
## Summary
- swap the record button for an audio upload input on rituals
- update docs to mention uploading voice memos instead of recording

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687003bb2f0c832c8318c53322478f31