### PR TITLE
Fix form width in Greenlight

### DIFF
--- a/greenlight/css/style.css
+++ b/greenlight/css/style.css
@@ -5,6 +5,20 @@ body {
   color: #ffffff;
 }
 
+#form-container {
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 20px;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
 header {
   background-color: #0F5132;
   padding: 1rem;

--- a/greenlight/index.html
+++ b/greenlight/index.html
@@ -14,7 +14,9 @@
     <div id="completed-cards-container">
       <!-- Only completed cards show up here -->
     </div>
-    <div id="card-form-area" style="display: none;"></div>
+    <div id="form-container">
+      <div id="card-form-area" style="display: none;"></div>
+    </div>
     <button id="add-category-btn">＋</button>
   </main>
   <script src="/greenlight/js/script.js"></script>


### PR DESCRIPTION
## Summary
- wrap the Greenlight form area in a container
- cap form width and inputs in `/greenlight` stylesheets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687010a60ce0832c944707398460b8f7