### PR TITLE
Add data tools page redirect after export

### DIFF
--- a/data-tools.html
+++ b/data-tools.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Talk Kink Tools</title>
+  <link rel="stylesheet" href="css/style.css" />
+  <link rel="stylesheet" href="css/theme.css" />
+</head>
+<body class="dark-mode">
+  <h1>What would you like to do next?</h1>
+
+  <div id="themeControl">
+    <label for="themeSelector">🎨 Select Theme:</label>
+    <select id="themeSelector">
+      <option value="dark-mode">Dark</option>
+      <option value="light-mode">Light Forest</option>
+      <option value="theme-blue">Blue</option>
+      <option value="theme-echoes-beyond">Echoes Beyond</option>
+      <option value="theme-love-notes-lipstick">Love Notes & Lipstick</option>
+      <option value="theme-rainbow">Rainbow</option>
+    </select>
+  </div>
+
+  <div class="main-nav-buttons" style="margin-top:20px;">
+    <button class="survey-button" onclick="location.href='compatibility.html'">See Our Compatibility</button>
+    <button id="roleDefinitionsBtn" class="survey-button">Role Definitions</button>
+    <button class="survey-button" onclick="location.href='your-roles.html'">View Role Results</button>
+    <button class="survey-button" onclick="location.href='kink-list.html'">View Kink List</button>
+  </div>
+
+  <div id="roleDefinitionsPanel" class="category-panel scrollable-panel" style="display:none;">
+    <button id="closeRoleDefinitionsBtn">✖</button>
+    <h2>Role Definitions</h2>
+    <h3 class="section-header">Dominant / Giver Roles</h3>
+    <div class="role-card">
+      <h4>Sadist</h4>
+      <p>Enjoys inflicting consensual pain or discomfort.</p>
+    </div>
+    <div class="role-card">
+      <h4>Emotional Sadist</h4>
+      <p>Derives satisfaction from creating emotional intensity, psychological pressure, or vulnerability.</p>
+    </div>
+    <div class="role-card">
+      <h4>Primal (Hunter)</h4>
+      <p>Relies on instinct and presence to dominate; enjoys pursuit and overpowering prey.</p>
+    </div>
+    <div class="role-card">
+      <h4>Emotional Primal</h4>
+      <p>Dominates through emotional overwhelm, intense gaze, and intuitive connection.</p>
+    </div>
+    <div class="role-card">
+      <h4>Owner</h4>
+      <p>Exercises structured control over a submissive’s body, behavior, or schedule.</p>
+    </div>
+    <div class="role-card">
+      <h4>Handler</h4>
+      <p>Guides, trains, or controls another person, often in petplay or performance roles.</p>
+    </div>
+    <div class="role-card">
+      <h4>Caregiver</h4>
+      <p>Provides emotional support, nurturing, and structure to a submissive or little.</p>
+    </div>
+    <div class="role-card">
+      <h4>Service Top</h4>
+      <p>Offers structured acts (like impact or discipline) with the partner's benefit in mind.</p>
+    </div>
+    <div class="role-card">
+      <h4>Mindfuck Dominant / Manipulator</h4>
+      <p>Uses confusion, contradiction, or emotional baiting to disorient and control.</p>
+    </div>
+    <div class="role-card">
+      <h4>Objectifier / Dehumanizer</h4>
+      <p>Strips status or individuality from a partner to enforce obedience or role identity.</p>
+    </div>
+    <div class="section-divider"></div>
+    <h3 class="section-header">Submissive / Receiver Roles</h3>
+    <div class="role-card">
+      <h4>Masochist</h4>
+      <p>Enjoys receiving consensual pain or intense sensation.</p>
+    </div>
+    <div class="role-card">
+      <h4>Emotional Masochist</h4>
+      <p>Aroused by emotional exposure, degradation, shame, or psychological tension.</p>
+    </div>
+    <div class="role-card">
+      <h4>Prey</h4>
+      <p>Eroticizes being hunted, stalked, or overwhelmed.</p>
+    </div>
+    <div class="role-card">
+      <h4>Emotional Prey</h4>
+      <p>Draws pleasure from being emotionally pursued, seen, or broken open.</p>
+    </div>
+    <div class="role-card">
+      <h4>Pet</h4>
+      <p>Adopts a non-verbal, obedient, or animal-like role for comfort, submission, or training.</p>
+    </div>
+    <div class="role-card">
+      <h4>Little</h4>
+      <p>Regresses into a childlike or youthful headspace under a caregiver’s guidance.</p>
+    </div>
+    <div class="role-card">
+      <h4>Service Submissive</h4>
+      <p>Gains fulfillment through helpfulness, obedience, and daily rituals.</p>
+    </div>
+    <div class="role-card">
+      <h4>Brat</h4>
+      <p>Defies, teases, or resists as a way to provoke control or prove interest.</p>
+    </div>
+    <div class="role-card">
+      <h4>Internal Conflict Sub</h4>
+      <p>Submits through internal struggle, self-denial, or shame; obedience is hard-earned.</p>
+    </div>
+    <div class="role-card">
+      <h4>Performance Sub</h4>
+      <p>Aroused by being watched, judged, or evaluated during service or submission.</p>
+    </div>
+    <div class="role-card">
+      <h4>Mindfuck Enthusiast / Manipulation Sub</h4>
+      <p>Derives excitement from confusion, mental destabilization, or loss of control.</p>
+    </div>
+  </div>
+  <div id="roleDefinitionsOverlay" class="overlay"></div>
+
+  <script type="module">
+    import { initTheme } from './js/theme.js';
+    initTheme();
+
+    const panel = document.getElementById('roleDefinitionsPanel');
+    const overlay = document.getElementById('roleDefinitionsOverlay');
+    const showPanel = () => {
+      panel.style.display = 'block';
+      overlay.style.display = 'block';
+      if (window.innerWidth <= 768) panel.classList.add('visible');
+    };
+    const hidePanel = () => {
+      panel.classList.remove('visible');
+      panel.style.display = 'none';
+      overlay.style.display = 'none';
+    };
+    document.getElementById('roleDefinitionsBtn').addEventListener('click', showPanel);
+    document.getElementById('closeRoleDefinitionsBtn').addEventListener('click', hidePanel);
+    overlay.addEventListener('click', hidePanel);
+  </script>
+</body>
+</html>

--- a/js/script.js
+++ b/js/script.js
@@ -774,6 +774,10 @@ function exportSurvey() {
   } catch (err) {
     console.warn('Failed to save survey to localStorage:', err);
   }
+  // After exporting, send the user to the data tools page
+  setTimeout(() => {
+    window.location.href = '/data-tools.html';
+  }, 0);
 }
 
 if (downloadBtn) downloadBtn.addEventListener('click', exportSurvey);


### PR DESCRIPTION
## Summary
- create `data-tools.html` with navigation links to compatibility, role results, and kink list along with role definitions overlay
- send users to the new page from `exportSurvey()` after JSON export

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870113a32ac832cbbd2b248cdfc96b1