### PR TITLE
Add category preset menu in Greenlight

### DIFF
--- a/greenlight/css/style.css
+++ b/greenlight/css/style.css
@@ -61,3 +61,29 @@ h1 {
   border-radius: 50%;
   box-shadow: 0 0 10px #14452F;
 }
+
+#preset-menu {
+  position: fixed;
+  bottom: 100px;
+  right: 30px;
+  background-color: #14452F;
+  padding: 0.5rem;
+  border-radius: 1rem;
+  box-shadow: 0 0 10px #000;
+  display: none;
+}
+
+#preset-menu button {
+  display: block;
+  width: 100%;
+  margin: 0.25rem 0;
+  background-color: #0A5C36;
+  color: white;
+  border: none;
+  padding: 0.5rem;
+  border-radius: 0.5rem;
+}
+
+.hidden {
+  display: none;
+}

--- a/greenlight/index.html
+++ b/greenlight/index.html
@@ -10,15 +10,24 @@
   <header>
     <h1>🌿 Beneath the Greenlight</h1>
   </header>
-  <main id="main-content">
-    <div id="completed-cards-container">
-      <!-- Only completed cards show up here -->
-    </div>
-    <div id="form-container">
-      <div id="card-form-area" style="display: none;"></div>
-    </div>
-    <button id="add-category-btn">＋</button>
-  </main>
+    <main id="main-content">
+      <div id="completed-cards-container">
+        <!-- Only completed cards show up here -->
+      </div>
+      <div id="form-container">
+        <div id="card-form-area" style="display: none;"></div>
+      </div>
+      <div id="preset-menu" class="hidden">
+        <button class="preset-option">Braiding</button>
+        <button class="preset-option">Reading</button>
+        <button class="preset-option">Videos to Watch</button>
+        <button class="preset-option">Service &amp; Protocol</button>
+        <button class="preset-option">Tasks Today</button>
+        <button class="preset-option">Shibari Practice</button>
+        <button id="custom-option">Custom</button>
+      </div>
+      <button id="add-category-btn">＋</button>
+    </main>
   <script src="/greenlight/js/script.js"></script>
 </body>
 </html>

--- a/greenlight/js/script.js
+++ b/greenlight/js/script.js
@@ -1,6 +1,9 @@
 const completedContainer = document.getElementById('completed-cards-container');
 const formArea = document.getElementById('card-form-area');
 const addBtn = document.getElementById('add-category-btn');
+const presetMenu = document.getElementById('preset-menu');
+const presetButtons = document.querySelectorAll('#preset-menu .preset-option');
+const customOption = document.getElementById('custom-option');
 
 const STORAGE_KEY = 'greenlight-categories';
 let categories = [];
@@ -72,12 +75,34 @@ function load() {
   render();
 }
 
-addBtn.addEventListener('click', () => {
-  const cat = { id: Date.now(), name: '', completed: false };
+function addCategory(name = '') {
+  const cat = { id: Date.now(), name, completed: false };
   categories.push(cat);
   save();
   render();
   formArea.style.display = 'block';
+}
+
+addBtn.addEventListener('click', () => {
+  presetMenu.classList.toggle('hidden');
+});
+
+presetButtons.forEach(btn => {
+  btn.addEventListener('click', () => {
+    addCategory(btn.textContent);
+    presetMenu.classList.add('hidden');
+  });
+});
+
+customOption.addEventListener('click', () => {
+  addCategory();
+  presetMenu.classList.add('hidden');
+});
+
+document.addEventListener('click', (e) => {
+  if (!presetMenu.contains(e.target) && e.target !== addBtn) {
+    presetMenu.classList.add('hidden');
+  }
 });
 
 window.addEventListener('load', load);


### PR DESCRIPTION
## Summary
- show quick-add preset categories when tapping the ＋ button
- style the preset menu as a small popup above the button
- wire up buttons to add selected categories

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68701204bce0832caf89ab8bf11c998f