### PR TITLE
Implement category deletion with undo

### DIFF
--- a/greenlight/css/style.css
+++ b/greenlight/css/style.css
@@ -87,3 +87,29 @@ h1 {
 .hidden {
   display: none;
 }
+
+#undo-container {
+  max-width: 600px;
+  margin: 20px auto;
+}
+
+.undo-item {
+  background-color: #623221;
+  padding: 0.5rem 1rem;
+  border-radius: 1rem;
+  margin-bottom: 0.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.category-card button,
+.category-form button,
+.undo-item button {
+  margin-left: auto;
+  background-color: #d9534f;
+  color: white;
+  border: none;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.5rem;
+}

--- a/greenlight/index.html
+++ b/greenlight/index.html
@@ -14,14 +14,18 @@
       <div id="completed-cards-container">
         <!-- Only completed cards show up here -->
       </div>
-      <div id="form-container">
-        <div id="card-form-area" style="display: none;"></div>
-      </div>
-      <div id="preset-menu" class="hidden">
-        <button class="preset-option">Braiding</button>
-        <button class="preset-option">Reading</button>
-        <button class="preset-option">Videos to Watch</button>
-        <button class="preset-option">Service &amp; Protocol</button>
+        <div id="form-container">
+          <div id="card-form-area" style="display: none;"></div>
+        </div>
+        <div id="undo-container" class="hidden">
+          <h2>Recently Deleted</h2>
+          <div id="undo-list"></div>
+        </div>
+        <div id="preset-menu" class="hidden">
+          <button class="preset-option">Braiding</button>
+          <button class="preset-option">Reading</button>
+          <button class="preset-option">Videos to Watch</button>
+          <button class="preset-option">Service &amp; Protocol</button>
         <button class="preset-option">Tasks Today</button>
         <button class="preset-option">Shibari Practice</button>
         <button id="custom-option">Custom</button>


### PR DESCRIPTION
## Summary
- support deleting categories in Greenlight tool
- provide an undo list for 24‑hour restoration
- style undo area and delete buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687017594d78832c99c7d5758c7f9a37