### PR TITLE
Add advanced Greenlight tracker features

### DIFF
--- a/greenlight/README.md
+++ b/greenlight/README.md
@@ -22,6 +22,9 @@ A private, local-submissive memory tracker and devotion log.
 - Add YouTube links with thumbnail preview
 - Record or upload voice memos for each card
 - Customizable label for video links (defaults to "YouTube Video")
+- Mark complete counter
+- Partner notes with initials and timestamp
+- Dual timezone shared moment scheduler
 
 ## Setup
 

--- a/greenlight/css/style.css
+++ b/greenlight/css/style.css
@@ -5,12 +5,6 @@ body {
   color: #ffffff;
 }
 
-#form-container {
-  max-width: 600px;
-  margin: 0 auto;
-  padding: 20px;
-}
-
 input,
 select,
 textarea {
@@ -29,26 +23,18 @@ h1 {
   margin: 0;
 }
 
-#main-content {
+#cards-container {
   padding: 1rem;
 }
 
-.category-card,
-.category-form {
+.card {
   background-color: #14452F;
   padding: 1rem;
   border-radius: 1rem;
   margin-bottom: 1rem;
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
 }
 
-.category-card {
-  justify-content: space-between;
-}
-
-#add-category-btn {
+#add-card {
   position: fixed;
   bottom: 30px;
   right: 30px;
@@ -62,28 +48,11 @@ h1 {
   box-shadow: 0 0 10px #14452F;
 }
 
-#preset-menu {
-  position: fixed;
-  bottom: 100px;
-  right: 30px;
-  background-color: #14452F;
-  padding: 0.5rem;
-  border-radius: 1rem;
-  box-shadow: 0 0 10px #000;
-  display: none;
+#scheduler {
+  padding: 1rem;
 }
 
-#preset-menu button {
+#scheduler label {
   display: block;
-  width: 100%;
-  margin: 0.25rem 0;
-  background-color: #0A5C36;
-  color: white;
-  border: none;
-  padding: 0.5rem;
-  border-radius: 0.5rem;
-}
-
-.hidden {
-  display: none;
+  margin-bottom: 0.5rem;
 }

--- a/greenlight/index.html
+++ b/greenlight/index.html
@@ -4,30 +4,31 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Beneath the Greenlight</title>
-  <link rel="stylesheet" href="/greenlight/css/style.css">
+  <link rel="manifest" href="manifest.json">
+  <meta name="theme-color" content="#225533">
+  <link rel="apple-touch-icon" href="icon-192.png">
+  <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
   <header>
     <h1>🌿 Beneath the Greenlight</h1>
   </header>
-    <main id="main-content">
-      <div id="completed-cards-container">
-        <!-- Only completed cards show up here -->
-      </div>
-      <div id="form-container">
-        <div id="card-form-area" style="display: none;"></div>
-      </div>
-      <div id="preset-menu" class="hidden">
-        <button class="preset-option">Braiding</button>
-        <button class="preset-option">Reading</button>
-        <button class="preset-option">Videos to Watch</button>
-        <button class="preset-option">Service &amp; Protocol</button>
-        <button class="preset-option">Tasks Today</button>
-        <button class="preset-option">Shibari Practice</button>
-        <button id="custom-option">Custom</button>
-      </div>
-      <button id="add-category-btn">＋</button>
-    </main>
-  <script src="/greenlight/js/script.js"></script>
+  <main>
+    <div id="cards-container"></div>
+    <button id="add-card">＋</button>
+
+    <section id="scheduler">
+      <h2>Shared Moment Scheduler</h2>
+      <label>Local time <input type="datetime-local" id="local-time"></label>
+      <label>Partner UTC offset <input type="number" id="partner-offset" value="0"></label>
+      <p id="partner-time"></p>
+    </section>
+  </main>
+  <script src="js/script.js"></script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => navigator.serviceWorker.register('sw.js'));
+    }
+  </script>
 </body>
 </html>

--- a/greenlight/js/script.js
+++ b/greenlight/js/script.js
@@ -1,108 +1,205 @@
-const completedContainer = document.getElementById('completed-cards-container');
-const formArea = document.getElementById('card-form-area');
-const addBtn = document.getElementById('add-category-btn');
-const presetMenu = document.getElementById('preset-menu');
-const presetButtons = document.querySelectorAll('#preset-menu .preset-option');
-const customOption = document.getElementById('custom-option');
+const container = document.getElementById('cards-container');
+const addBtn = document.getElementById('add-card');
+const localTime = document.getElementById('local-time');
+const partnerOffset = document.getElementById('partner-offset');
+const partnerTime = document.getElementById('partner-time');
 
-const STORAGE_KEY = 'greenlight-categories';
-let categories = [];
+const STORAGE_KEY = 'greenlight-cards';
+let cards = [];
 
 function save() {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify(categories));
-}
-
-function createForm(cat) {
-  const div = document.createElement('div');
-  div.className = 'category-form';
-
-  const input = document.createElement('input');
-  input.type = 'text';
-  input.placeholder = 'Category name';
-  input.value = cat.name;
-  input.oninput = () => {
-    cat.name = input.value;
-    save();
-  };
-
-  const label = document.createElement('label');
-  label.textContent = 'Completed ';
-  const checkbox = document.createElement('input');
-  checkbox.type = 'checkbox';
-  checkbox.checked = cat.completed;
-  checkbox.onchange = () => {
-    cat.completed = checkbox.checked;
-    save();
-    render();
-  };
-  label.appendChild(checkbox);
-
-  div.appendChild(input);
-  div.appendChild(label);
-
-  return div;
-}
-
-function createCard(cat) {
-  const div = document.createElement('div');
-  div.className = 'category-card';
-  div.textContent = cat.name;
-  return div;
-}
-
-function render() {
-  completedContainer.innerHTML = '';
-  formArea.innerHTML = '';
-  categories.forEach(cat => {
-    if (cat.completed) {
-      completedContainer.appendChild(createCard(cat));
-    } else {
-      formArea.appendChild(createForm(cat));
-    }
-  });
-  formArea.style.display = categories.some(c => !c.completed) ? 'block' : 'none';
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(cards));
 }
 
 function load() {
   const data = localStorage.getItem(STORAGE_KEY);
   if (data) {
-    try {
-      categories = JSON.parse(data);
-    } catch {
-      categories = [];
-    }
+    try { cards = JSON.parse(data); } catch { cards = []; }
   }
   render();
 }
 
-function addCategory(name = '') {
-  const cat = { id: Date.now(), name, completed: false };
-  categories.push(cat);
+function formatElapsed(hours) {
+  const h = Math.floor(Math.abs(hours));
+  const m = Math.floor((Math.abs(hours) - h) * 60);
+  return `${h}h ${m}m`;
+}
+
+function createCard(card) {
+  const div = document.createElement('div');
+  div.className = 'card';
+
+  const title = document.createElement('input');
+  title.value = card.title;
+  title.placeholder = 'Title';
+  title.oninput = () => { card.title = title.value; save(); };
+
+  const due = document.createElement('input');
+  due.type = 'number';
+  due.min = '1';
+  due.value = card.dueHours;
+  due.onchange = () => { card.dueHours = Number(due.value); save(); updateTime(); };
+
+  const timeInfo = document.createElement('div');
+
+  const markBtn = document.createElement('button');
+  markBtn.textContent = 'Mark Complete';
+  markBtn.onclick = () => {
+    card.lastDone = Date.now();
+    card.count = (card.count || 0) + 1;
+    save();
+    updateTime();
+  };
+
+  const countSpan = document.createElement('span');
+
+  const yt = document.createElement('input');
+  yt.type = 'url';
+  yt.placeholder = 'YouTube link';
+  yt.value = card.youtube || '';
+  yt.oninput = () => { card.youtube = yt.value; save(); link.href = yt.value; };
+
+  const link = document.createElement('a');
+  link.textContent = 'Open Video';
+  link.target = '_blank';
+  link.href = card.youtube || '#';
+
+  // notes
+  const notesList = document.createElement('ul');
+  const noteInput = document.createElement('input');
+  noteInput.placeholder = 'Add note';
+  const initialsInput = document.createElement('input');
+  initialsInput.placeholder = 'Initials';
+  const addNote = document.createElement('button');
+  addNote.textContent = 'Add Note';
+  addNote.onclick = () => {
+    if (noteInput.value.trim()) {
+      const note = {
+        text: noteInput.value,
+        initials: initialsInput.value,
+        time: Date.now()
+      };
+      card.notes.push(note);
+      noteInput.value = '';
+      initialsInput.value = '';
+      save();
+      render();
+    }
+  };
+
+  // voice recording
+  let recorder, audioURL;
+  const recBtn = document.createElement('button');
+  recBtn.textContent = 'Record';
+  const playBtn = document.createElement('button');
+  playBtn.textContent = 'Play';
+  playBtn.disabled = true;
+  recBtn.onclick = async () => {
+    if (!recorder) {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      recorder = new MediaRecorder(stream);
+      const chunks = [];
+      recorder.ondataavailable = e => chunks.push(e.data);
+      recorder.onstop = () => {
+        const blob = new Blob(chunks, { type: 'audio/webm' });
+        const reader = new FileReader();
+        reader.onload = () => {
+          card.audio = reader.result;
+          save();
+          playBtn.disabled = false;
+        };
+        reader.readAsDataURL(blob);
+      };
+      recorder.start();
+      recBtn.textContent = 'Stop';
+    } else {
+      recorder.stop();
+      recorder = null;
+      recBtn.textContent = 'Record';
+    }
+  };
+  playBtn.onclick = () => {
+    if (card.audio) {
+      const audio = new Audio(card.audio);
+      audio.play();
+    }
+  };
+  if (card.audio) playBtn.disabled = false;
+
+  function updateTime() {
+    if (card.lastDone) {
+      const hours = (Date.now() - card.lastDone) / 3600000;
+      const remaining = card.dueHours - hours;
+      if (remaining > 0) {
+        timeInfo.textContent = 'Due in ' + formatElapsed(remaining);
+      } else {
+        timeInfo.textContent = 'Last done ' + formatElapsed(hours) + ' ago';
+      }
+    } else {
+      timeInfo.textContent = 'Not completed yet';
+    }
+    countSpan.textContent = `Completed ${card.count || 0}`;
+  }
+
+  updateTime();
+  setInterval(updateTime, 60000);
+
+  div.appendChild(title);
+  div.appendChild(due);
+  div.appendChild(timeInfo);
+  div.appendChild(markBtn);
+  div.appendChild(countSpan);
+  div.appendChild(yt);
+  div.appendChild(link);
+  div.appendChild(recBtn);
+  div.appendChild(playBtn);
+  div.appendChild(notesList);
+  card.notes.forEach(n => {
+    const li = document.createElement('li');
+    const d = new Date(n.time);
+    li.textContent = `${d.toLocaleString()} ${n.initials}: ${n.text}`;
+    notesList.appendChild(li);
+  });
+  div.appendChild(noteInput);
+  div.appendChild(initialsInput);
+  div.appendChild(addNote);
+
+  return div;
+}
+
+function render() {
+  container.innerHTML = '';
+  cards.forEach(card => container.appendChild(createCard(card)));
+}
+
+function addCard(title = '') {
+  cards.push({
+    id: Date.now(),
+    title,
+    dueHours: 24,
+    lastDone: null,
+    youtube: '',
+    notes: [],
+    count: 0,
+    audio: null
+  });
   save();
   render();
-  formArea.style.display = 'block';
 }
 
-addBtn.addEventListener('click', () => {
-  presetMenu.classList.toggle('hidden');
-});
+addBtn.addEventListener('click', () => addCard());
 
-presetButtons.forEach(btn => {
-  btn.addEventListener('click', () => {
-    addCategory(btn.textContent);
-    presetMenu.classList.add('hidden');
-  });
-});
+localTime.addEventListener('input', updateSchedule);
+partnerOffset.addEventListener('input', updateSchedule);
 
-customOption.addEventListener('click', () => {
-  addCategory();
-  presetMenu.classList.add('hidden');
-});
-
-document.addEventListener('click', (e) => {
-  if (!presetMenu.contains(e.target) && e.target !== addBtn) {
-    presetMenu.classList.add('hidden');
-  }
-});
+function updateSchedule() {
+  const date = new Date(localTime.value);
+  if (isNaN(date)) { partnerTime.textContent = ''; return; }
+  const localOff = -date.getTimezoneOffset() / 60;
+  const partnerOff = Number(partnerOffset.value || 0);
+  const utc = date.getTime() - localOff * 3600000;
+  const pDate = new Date(utc + partnerOff * 3600000);
+  partnerTime.textContent = 'Partner time: ' + pDate.toLocaleString();
+}
 
 window.addEventListener('load', load);

--- a/greenlight/sw.js
+++ b/greenlight/sw.js
@@ -1,0 +1,15 @@
+const CACHE = 'greenlight-v1';
+const FILES = [
+  './',
+  './index.html',
+  './css/style.css',
+  './js/script.js',
+  './manifest.json',
+  './icon-192.png'
+];
+self.addEventListener('install', e => {
+  e.waitUntil(caches.open(CACHE).then(c => c.addAll(FILES)));
+});
+self.addEventListener('fetch', e => {
+  e.respondWith(caches.match(e.request).then(r => r || fetch(e.request)));
+});


### PR DESCRIPTION
## Summary
- overhaul `/greenlight` to support editable ritual cards
- store card data in LocalStorage with completion tracking
- add voice memo recording/playback and note taking
- include dual timezone scheduler for shared moments
- add PWA support with service worker

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68701a00e200832cb963f174c9b35a83