### PR TITLE
Enhance Greenlight desktop layout

### DIFF
--- a/greenlight/css/style.css
+++ b/greenlight/css/style.css
@@ -113,14 +113,19 @@ h1 {
 
 #menu {
   position: fixed;
-  top: 0;
-  left: 0;
+  top: 60px;
+  left: -220px;
   width: 200px;
-  height: 100%;
+  height: calc(100% - 60px);
   background-color: var(--card-bg);
   color: var(--text-color);
   padding: 1rem;
   box-shadow: 2px 0 10px rgba(0,0,0,0.5);
+  transition: left 0.3s ease;
+}
+
+#menu.open {
+  left: 0;
 }
 
 #menu ul {

--- a/greenlight/index.html
+++ b/greenlight/index.html
@@ -47,15 +47,45 @@
     <button id="custom-option">Custom</button>
   </div>
 
-  <!-- Add Custom Category -->
-  <button id="add-category-btn">＋</button>
-
-  <!-- Shared Moment Scheduler -->
-  <section id="scheduler">
-    <h2>Shared Moment Scheduler</h2>
-    <label>Local time <input type="datetime-local" id="local-time"></label>
-    <label>Partner UTC offset <input type="number" id="partner-offset" value="0"></label>
-    <p id="partner-time"></p>
+  <!-- Settings Section -->
+  <section id="settings-section" class="hidden">
+    <h2>Settings</h2>
+    <div id="scheduler">
+      <h3>Shared Moment Scheduler</h3>
+      <label>Local time <input type="datetime-local" id="local-time"></label>
+      <label>Partner time zone
+        <select id="partner-offset">
+          <option value="-12">UTC-12:00</option>
+          <option value="-11">UTC-11:00</option>
+          <option value="-10">UTC-10:00</option>
+          <option value="-9">UTC-09:00</option>
+          <option value="-8">UTC-08:00</option>
+          <option value="-7">UTC-07:00</option>
+          <option value="-6">UTC-06:00</option>
+          <option value="-5">UTC-05:00</option>
+          <option value="-4">UTC-04:00</option>
+          <option value="-3">UTC-03:00</option>
+          <option value="-2">UTC-02:00</option>
+          <option value="-1">UTC-01:00</option>
+          <option value="0" selected>UTC+00:00</option>
+          <option value="1">UTC+01:00</option>
+          <option value="2">UTC+02:00</option>
+          <option value="3">UTC+03:00</option>
+          <option value="4">UTC+04:00</option>
+          <option value="5">UTC+05:00</option>
+          <option value="6">UTC+06:00</option>
+          <option value="7">UTC+07:00</option>
+          <option value="8">UTC+08:00</option>
+          <option value="9">UTC+09:00</option>
+          <option value="10">UTC+10:00</option>
+          <option value="11">UTC+11:00</option>
+          <option value="12">UTC+12:00</option>
+          <option value="13">UTC+13:00</option>
+          <option value="14">UTC+14:00</option>
+        </select>
+      </label>
+      <p id="partner-time"></p>
+    </div>
   </section>
 
   <!-- Partner Notes Section -->
@@ -68,7 +98,7 @@
   </section>
 
   <!-- Slide-out Menu -->
-  <nav id="menu" class="hidden">
+  <nav id="menu">
     <ul>
       <li id="menu-recent">Recently Deleted</li>
       <li id="menu-notes">Partner Notes</li>

--- a/greenlight/js/script.js
+++ b/greenlight/js/script.js
@@ -1,6 +1,6 @@
 // DOM Elements
 const container = document.getElementById('cards-container');
-const addBtn = document.getElementById('add-card') || document.getElementById('add-category-btn');
+const addBtn = document.getElementById('add-card');
 const localTime = document.getElementById('local-time');
 const partnerOffset = document.getElementById('partner-offset');
 const partnerTime = document.getElementById('partner-time');
@@ -15,6 +15,8 @@ const noteText = document.getElementById('note-text');
 const saveNoteBtn = document.getElementById('save-note');
 const menuNotes = document.getElementById('menu-notes');
 const menuRecent = document.getElementById('menu-recent');
+const menuSettings = document.getElementById('menu-settings');
+const settingsSection = document.getElementById('settings-section');
 const darkToggle = document.getElementById('dark-mode-toggle');
 
 // Storage Keys
@@ -308,7 +310,7 @@ function renderNotes() {
 }
 
 function toggleMenu() {
-  menu.classList.toggle('hidden');
+  menu.classList.toggle('open');
 }
 
 function toggleDarkMode() {
@@ -344,6 +346,10 @@ menuNotes.addEventListener('click', () => {
 });
 menuRecent.addEventListener('click', () => {
   undoContainer.classList.toggle('hidden');
+  toggleMenu();
+});
+menuSettings.addEventListener('click', () => {
+  settingsSection.classList.toggle('hidden');
   toggleMenu();
 });
 saveNoteBtn.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- add settings panel with timezone selector
- remove extra plus button
- slide menu open and closed
- start menu below header

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68702e70f7ac832c9e5ab378f9b8b8d8