### PR TITLE
Update quiz layout and data tools buttons

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1016,10 +1016,10 @@ body.light-mode .static-rating-legend {
 }
 /* Communication panel layout adjustments */
 #kinkList .kink-container {
-  margin-bottom: 8px;
+  margin-bottom: 4px;
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 6px;
 }
 
 #kinkList .kink-label {
@@ -1042,10 +1042,10 @@ body.light-mode .static-rating-legend {
 }
 
 .panel-content .kink-container {
-  margin-bottom: 8px;
+  margin-bottom: 4px;
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 6px;
 }
 .panel-content .kink-label {
   flex: 1;

--- a/data-tools.html
+++ b/data-tools.html
@@ -23,10 +23,11 @@
   </div>
 
   <div class="main-nav-buttons" style="margin-top:20px;">
-    <button class="survey-button" onclick="location.href='compatibility.html'">See Our Compatibility</button>
+    <button class="survey-button" onclick="location.href='compatibility.html'">Calculate Results</button>
     <button id="roleDefinitionsBtn" class="survey-button">Role Definitions</button>
     <button class="survey-button" onclick="location.href='your-roles.html'">View Role Results</button>
     <button class="survey-button" onclick="location.href='kink-list.html'">View Kink List</button>
+    <button class="survey-button" onclick="location.href='index.html'">Retake Quiz</button>
   </div>
 
   <div id="roleDefinitionsPanel" class="category-panel scrollable-panel" style="display:none;">


### PR DESCRIPTION
## Summary
- rename compatibility button to **Calculate Results** on data-tools page
- add **Retake Quiz** button for returning to the main survey
- tighten spacing of kink list items so categories and rating scales sit closer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687030c68d8c832c8f7ad37b36e012a0