### PR TITLE
Refine Greenlight desktop layout and settings

### DIFF
--- a/greenlight/css/style.css
+++ b/greenlight/css/style.css
@@ -19,6 +19,11 @@ body {
   color: var(--text-color);
 }
 
+#main-content {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
 input,
 select,
 textarea {
@@ -136,6 +141,16 @@ h1 {
 #menu li {
   margin-bottom: 1rem;
   cursor: pointer;
+}
+
+#close-menu {
+  background: none;
+  border: none;
+  color: var(--text-color);
+  font-size: 1.2rem;
+  position: absolute;
+  top: 10px;
+  right: 10px;
 }
 
 #partner-notes {

--- a/greenlight/index.html
+++ b/greenlight/index.html
@@ -54,34 +54,14 @@
       <h3>Shared Moment Scheduler</h3>
       <label>Local time <input type="datetime-local" id="local-time"></label>
       <label>Partner time zone
-        <select id="partner-offset">
-          <option value="-12">UTC-12:00</option>
-          <option value="-11">UTC-11:00</option>
-          <option value="-10">UTC-10:00</option>
-          <option value="-9">UTC-09:00</option>
-          <option value="-8">UTC-08:00</option>
-          <option value="-7">UTC-07:00</option>
-          <option value="-6">UTC-06:00</option>
-          <option value="-5">UTC-05:00</option>
-          <option value="-4">UTC-04:00</option>
-          <option value="-3">UTC-03:00</option>
-          <option value="-2">UTC-02:00</option>
-          <option value="-1">UTC-01:00</option>
-          <option value="0" selected>UTC+00:00</option>
-          <option value="1">UTC+01:00</option>
-          <option value="2">UTC+02:00</option>
-          <option value="3">UTC+03:00</option>
-          <option value="4">UTC+04:00</option>
-          <option value="5">UTC+05:00</option>
-          <option value="6">UTC+06:00</option>
-          <option value="7">UTC+07:00</option>
-          <option value="8">UTC+08:00</option>
-          <option value="9">UTC+09:00</option>
-          <option value="10">UTC+10:00</option>
-          <option value="11">UTC+11:00</option>
-          <option value="12">UTC+12:00</option>
-          <option value="13">UTC+13:00</option>
-          <option value="14">UTC+14:00</option>
+        <select id="partner-tz">
+          <option value="UTC">UTC</option>
+          <option value="America/Los_Angeles">America/Los_Angeles</option>
+          <option value="America/New_York">America/New_York</option>
+          <option value="Europe/London">Europe/London</option>
+          <option value="Europe/Berlin">Europe/Berlin</option>
+          <option value="Asia/Tokyo">Asia/Tokyo</option>
+          <option value="Australia/Sydney">Australia/Sydney</option>
         </select>
       </label>
       <p id="partner-time"></p>
@@ -99,6 +79,7 @@
 
   <!-- Slide-out Menu -->
   <nav id="menu">
+    <button id="close-menu" aria-label="Close">×</button>
     <ul>
       <li id="menu-recent">Recently Deleted</li>
       <li id="menu-notes">Partner Notes</li>

--- a/greenlight/js/script.js
+++ b/greenlight/js/script.js
@@ -2,7 +2,7 @@
 const container = document.getElementById('cards-container');
 const addBtn = document.getElementById('add-card');
 const localTime = document.getElementById('local-time');
-const partnerOffset = document.getElementById('partner-offset');
+const partnerTz = document.getElementById('partner-tz');
 const partnerTime = document.getElementById('partner-time');
 const undoContainer = document.getElementById('undo-container');
 const undoList = document.getElementById('undo-list');
@@ -18,12 +18,14 @@ const menuRecent = document.getElementById('menu-recent');
 const menuSettings = document.getElementById('menu-settings');
 const settingsSection = document.getElementById('settings-section');
 const darkToggle = document.getElementById('dark-mode-toggle');
+const closeMenuBtn = document.getElementById('close-menu');
 
 // Storage Keys
 const STORAGE_KEY = 'greenlight-cards';
 const DELETED_KEY = 'greenlight-deleted';
 const NOTES_KEY = 'greenlight-notes';
 const MODE_KEY = 'greenlight-mode';
+const TZ_KEY = 'greenlight-tz';
 
 // State
 let cards = [];
@@ -61,10 +63,15 @@ function load() {
   if (mode === 'light') {
     document.body.classList.add('light-mode');
   }
+  const tz = localStorage.getItem(TZ_KEY);
+  if (tz && partnerTz) {
+    partnerTz.value = tz;
+  }
   cleanupDeleted();
   render();
   renderUndo();
   renderNotes();
+  updateSchedule();
 }
 
 // Card Creation
@@ -326,19 +333,19 @@ function updateSchedule() {
     partnerTime.textContent = '';
     return;
   }
-  const localOff = -date.getTimezoneOffset() / 60;
-  const partnerOff = Number(partnerOffset.value || 0);
-  const utc = date.getTime() - localOff * 3600000;
-  const pDate = new Date(utc + partnerOff * 3600000);
-  partnerTime.textContent = 'Partner time: ' + pDate.toLocaleString();
+  const tz = partnerTz.value || 'UTC';
+  const pString = date.toLocaleString([], { timeZone: tz });
+  partnerTime.textContent = `Partner time (${tz}): ` + pString;
+  localStorage.setItem(TZ_KEY, tz);
 }
 
 // Listeners
 addBtn.addEventListener('click', () => addCard());
 localTime.addEventListener('input', updateSchedule);
-partnerOffset.addEventListener('input', updateSchedule);
+partnerTz.addEventListener('input', updateSchedule);
 window.addEventListener('load', load);
 menuBtn.addEventListener('click', toggleMenu);
+closeMenuBtn.addEventListener('click', toggleMenu);
 darkToggle.addEventListener('click', toggleDarkMode);
 menuNotes.addEventListener('click', () => {
   notesSection.classList.toggle('hidden');


### PR DESCRIPTION
## Summary
- keep mobile layout width on desktop
- add close button to slide-out menu
- convert partner time scheduler to timezone-based select
- adjust script to store timezone preference and hook up new button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870317e6d60832ca24d638bb3de5981