### PR TITLE
Cleanup Greenlight HTML and startup

### DIFF
--- a/greenlight/index.html
+++ b/greenlight/index.html
@@ -20,31 +20,10 @@
   <div id="cards-container"></div>
   <button id="add-card">＋</button>
 
-  <!-- Completed Cards Area -->
-  <div id="completed-cards-container">
-    <!-- Only completed cards show up here -->
-  </div>
-
-  <!-- Card Form Area -->
-  <div id="form-container">
-    <div id="card-form-area" style="display: none;"></div>
-  </div>
-
   <!-- Undo Deleted Cards -->
   <div id="undo-container" class="hidden">
     <h2>Recently Deleted</h2>
     <div id="undo-list"></div>
-  </div>
-
-  <!-- Preset Menu -->
-  <div id="preset-menu" class="hidden">
-    <button class="preset-option">Braiding</button>
-    <button class="preset-option">Reading</button>
-    <button class="preset-option">Videos to Watch</button>
-    <button class="preset-option">Service &amp; Protocol</button>
-    <button class="preset-option">Tasks Today</button>
-    <button class="preset-option">Shibari Practice</button>
-    <button id="custom-option">Custom</button>
   </div>
 
   <!-- Settings Section -->

--- a/greenlight/js/script.js
+++ b/greenlight/js/script.js
@@ -343,7 +343,10 @@ function updateSchedule() {
 addBtn.addEventListener('click', () => addCard());
 localTime.addEventListener('input', updateSchedule);
 partnerTz.addEventListener('input', updateSchedule);
-window.addEventListener('load', load);
+window.addEventListener('load', () => {
+  localStorage.removeItem('greenlight-categories');
+  load();
+});
 menuBtn.addEventListener('click', toggleMenu);
 closeMenuBtn.addEventListener('click', toggleMenu);
 darkToggle.addEventListener('click', toggleDarkMode);


### PR DESCRIPTION
## Summary
- remove old containers and preset menu from greenlight UI
- clean up load listener to drop legacy key

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687036518508832c9050fd652a467e5a