### PR TITLE
Update service worker cache

### DIFF
--- a/greenlight/sw.js
+++ b/greenlight/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'greenlight-v1';
+const CACHE = 'greenlight-v2';
 const FILES = [
   './',
   './index.html',
@@ -8,6 +8,13 @@ const FILES = [
 ];
 self.addEventListener('install', e => {
   e.waitUntil(caches.open(CACHE).then(c => c.addAll(FILES)));
+});
+self.addEventListener('activate', e => {
+  e.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(k => k !== CACHE).map(k => caches.delete(k)))
+    )
+  );
 });
 self.addEventListener('fetch', e => {
   e.respondWith(caches.match(e.request).then(r => r || fetch(e.request)));


### PR DESCRIPTION
## Summary
- bump the Greenlight cache name to `v2`
- clean up old caches when the service worker activates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687059b39f68832cb888e80b4815b8f1