### PR TITLE
Implement partner notes and shared scheduler pages

### DIFF
--- a/greenlight/duck.svg
+++ b/greenlight/duck.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <ellipse cx="50" cy="60" rx="35" ry="20" fill="#0a8833" />
+  <circle cx="70" cy="35" r="15" fill="#0caa44" />
+  <polygon points="78,35 95,40 78,45" fill="#ffd23f" />
+</svg>

--- a/greenlight/index.html
+++ b/greenlight/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Beneath the Greenlight</title>
   <link rel="manifest" href="manifest.json">
+  <link rel="icon" type="image/svg+xml" href="duck.svg">
   <meta name="theme-color" content="#0F5132">
   <link href="https://fonts.googleapis.com/css2?family=Lexend+Deca&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/style.css">

--- a/greenlight/js/script.js
+++ b/greenlight/js/script.js
@@ -86,10 +86,10 @@ function load() {
     partnerTz.value = tz;
   }
   cleanupDeleted();
-  render();
-  renderUndo();
-  renderNotes();
-  updateSchedule();
+  if (container) render();
+  if (undoContainer && undoList) renderUndo();
+  if (notesList) renderNotes();
+  if (localTime && partnerTz) updateSchedule();
 }
 
 // Card Creation
@@ -306,6 +306,7 @@ function cleanupDeleted() {
 }
 
 function renderUndo() {
+  if (!undoContainer || !undoList) return;
   cleanupDeleted();
   undoList.innerHTML = '';
   if (deletedCards.length === 0) {
@@ -329,6 +330,7 @@ function renderUndo() {
 
 // Render All Cards
 function render() {
+  if (!container) return;
   container.innerHTML = '';
   cards.forEach(card => {
     const el = createCard(card);
@@ -358,6 +360,7 @@ function saveNotes() {
 }
 
 function renderNotes() {
+  if (!notesList) return;
   notesList.innerHTML = '';
   partnerNotes.forEach((n, idx) => {
     const li = document.createElement('li');
@@ -392,7 +395,9 @@ function renderNotes() {
 }
 
 function toggleMenu() {
-  menu.classList.toggle('open');
+  if (menu) {
+    menu.classList.toggle('open');
+  }
 }
 
 function toggleDarkMode() {
@@ -417,62 +422,70 @@ function updateSchedule() {
 }
 
 // Listeners
-addBtn.addEventListener('click', () => {
-  modal.classList.remove('hidden');
-  modalTitle.value = '';
-  modalEstimate.value = '';
-  modalYoutube.value = '';
-  modalType.value = 'due';
-});
-
-saveCardBtn.addEventListener('click', () => {
-  addCard({
-    title: modalTitle.value,
-    dueHours: Number(modalEstimate.value) || 24,
-    type: modalType.value,
-    estimate: Number(modalEstimate.value) || 0,
-    youtube: modalYoutube.value
+if (addBtn) {
+  addBtn.addEventListener('click', () => {
+    modal.classList.remove('hidden');
+    modalTitle.value = '';
+    modalEstimate.value = '';
+    modalYoutube.value = '';
+    modalType.value = 'due';
   });
-  modal.classList.add('hidden');
-});
+}
 
-cancelCardBtn.addEventListener('click', () => {
-  modal.classList.add('hidden');
-});
-localTime.addEventListener('input', updateSchedule);
-partnerTz.addEventListener('input', updateSchedule);
+if (saveCardBtn) {
+  saveCardBtn.addEventListener('click', () => {
+    addCard({
+      title: modalTitle.value,
+      dueHours: Number(modalEstimate.value) || 24,
+      type: modalType.value,
+      estimate: Number(modalEstimate.value) || 0,
+      youtube: modalYoutube.value
+    });
+    modal.classList.add('hidden');
+  });
+}
+
+if (cancelCardBtn) {
+  cancelCardBtn.addEventListener('click', () => {
+    modal.classList.add('hidden');
+  });
+}
+if (localTime) localTime.addEventListener('input', updateSchedule);
+if (partnerTz) partnerTz.addEventListener('input', updateSchedule);
 window.addEventListener('load', () => {
   localStorage.removeItem('greenlight-categories');
   load();
 });
-menuBtn.addEventListener('click', toggleMenu);
-closeMenuBtn.addEventListener('click', toggleMenu);
-darkToggle.addEventListener('click', toggleDarkMode);
-menuNotes.addEventListener('click', () => {
-  notesSection.classList.toggle('hidden');
+if (menuBtn) menuBtn.addEventListener('click', toggleMenu);
+if (closeMenuBtn) closeMenuBtn.addEventListener('click', toggleMenu);
+if (darkToggle) darkToggle.addEventListener('click', toggleDarkMode);
+if (menuNotes) menuNotes.addEventListener('click', () => {
+  if (notesSection) notesSection.classList.toggle('hidden');
   toggleMenu();
 });
-menuRecent.addEventListener('click', () => {
-  undoContainer.classList.toggle('hidden');
+if (menuRecent) menuRecent.addEventListener('click', () => {
+  if (undoContainer) undoContainer.classList.toggle('hidden');
   toggleMenu();
 });
-menuSettings.addEventListener('click', () => {
-  settingsSection.classList.toggle('hidden');
+if (menuSettings) menuSettings.addEventListener('click', () => {
+  if (settingsSection) settingsSection.classList.toggle('hidden');
   toggleMenu();
 });
-saveNoteBtn.addEventListener('click', () => {
-  if (noteText.value.trim()) {
-    partnerNotes.push({
-      text: noteText.value,
-      initials: noteInitials.value,
-      time: Date.now()
-    });
-    noteText.value = '';
-    noteInitials.value = '';
-    saveNotes();
-    renderNotes();
-  }
-});
+if (saveNoteBtn) {
+  saveNoteBtn.addEventListener('click', () => {
+    if (noteText.value.trim()) {
+      partnerNotes.push({
+        text: noteText.value,
+        initials: noteInitials.value,
+        time: Date.now()
+      });
+      noteText.value = '';
+      noteInitials.value = '';
+      saveNotes();
+      renderNotes();
+    }
+  });
+}
 
 // Global audio memo
 if (globalRecordBtn && globalPlayBtn) {

--- a/greenlight/manifest.json
+++ b/greenlight/manifest.json
@@ -3,6 +3,13 @@
   "short_name": "Greenlight",
   "start_url": "./index.html",
   "display": "standalone",
-  "background_color": "#f2f7f4",
-  "theme_color": "#225533"
+  "background_color": "#0F5132",
+  "theme_color": "#0F5132",
+  "icons": [
+    {
+      "src": "duck.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
 }

--- a/greenlight/partner-notes/index.html
+++ b/greenlight/partner-notes/index.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Partner Notes - Beneath the Greenlight</title>
+  <link rel="manifest" href="../manifest.json">
+  <link rel="icon" type="image/svg+xml" href="../duck.svg">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <header>
+    <a href="../index.html" aria-label="Back">←</a>
+    <h1>Partner Notes</h1>
+    <button id="dark-mode-toggle" aria-label="Toggle Dark Mode">🌓</button>
+  </header>
+  <section id="partner-notes">
+    <ul id="notes-list"></ul>
+    <input id="note-initials" placeholder="Initials">
+    <textarea id="note-text" placeholder="Write a note"></textarea>
+    <button id="save-note">Save Note</button>
+  </section>
+  <script src="../js/script.js"></script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => navigator.serviceWorker.register('../sw.js'));
+    }
+  </script>
+</body>
+</html>

--- a/greenlight/shared-scheduler/index.html
+++ b/greenlight/shared-scheduler/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Shared Scheduler - Beneath the Greenlight</title>
+  <link rel="manifest" href="../manifest.json">
+  <link rel="icon" type="image/svg+xml" href="../duck.svg">
+  <link rel="stylesheet" href="../css/style.css">
+</head>
+<body>
+  <header>
+    <a href="../index.html" aria-label="Back">←</a>
+    <h1>Shared Scheduler</h1>
+    <button id="dark-mode-toggle" aria-label="Toggle Dark Mode">🌓</button>
+  </header>
+  <section id="settings-section">
+    <div id="scheduler">
+      <h3>Shared Moment Scheduler</h3>
+      <label>Local time <input type="datetime-local" id="local-time"></label>
+      <label>Partner time zone
+        <select id="partner-tz">
+          <option value="UTC">UTC</option>
+          <option value="America/Los_Angeles">America/Los_Angeles</option>
+          <option value="America/New_York">America/New_York</option>
+          <option value="Europe/London">Europe/London</option>
+          <option value="Europe/Berlin">Europe/Berlin</option>
+          <option value="Asia/Tokyo">Asia/Tokyo</option>
+          <option value="Australia/Sydney">Australia/Sydney</option>
+        </select>
+      </label>
+      <p id="your-time"></p>
+      <p id="partner-time"></p>
+    </div>
+  </section>
+  <script src="../js/script.js"></script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => navigator.serviceWorker.register('../sw.js'));
+    }
+  </script>
+</body>
+</html>

--- a/greenlight/sw.js
+++ b/greenlight/sw.js
@@ -2,9 +2,12 @@ const CACHE = 'greenlight-v2';
 const FILES = [
   './',
   './index.html',
+  './partner-notes/index.html',
+  './shared-scheduler/index.html',
   './css/style.css',
   './js/script.js',
-  './manifest.json'
+  './manifest.json',
+  './duck.svg'
 ];
 self.addEventListener('install', e => {
   e.waitUntil(caches.open(CACHE).then(c => c.addAll(FILES)));


### PR DESCRIPTION
## Summary
- add green duck icon and reference it in manifest and index
- make JS robust to partial pages
- create Partner Notes and Shared Scheduler pages with their own routes
- include new pages and assets in service worker cache

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68705df06e58832caa8c849dd28122dc