### PR TITLE
Update service worker cache handling

### DIFF
--- a/greenlight/sw.js
+++ b/greenlight/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'greenlight-v2';
+const CACHE = 'greenlight-v3';
 const FILES = [
   './',
   './index.html',
@@ -10,15 +10,21 @@ const FILES = [
   './duck.svg'
 ];
 self.addEventListener('install', e => {
+  self.skipWaiting();
   e.waitUntil(caches.open(CACHE).then(c => c.addAll(FILES)));
 });
 self.addEventListener('activate', e => {
   e.waitUntil(
-    caches.keys().then(keys =>
-      Promise.all(keys.filter(k => k !== CACHE).map(k => caches.delete(k)))
-    )
+    caches
+      .keys()
+      .then(keys =>
+        Promise.all(keys.filter(k => k !== CACHE).map(k => caches.delete(k)))
+      )
+      .then(() => self.clients.claim())
   );
 });
 self.addEventListener('fetch', e => {
-  e.respondWith(caches.match(e.request).then(r => r || fetch(e.request)));
+  e.respondWith(
+    fetch(e.request).catch(() => caches.match(e.request))
+  );
 });


### PR DESCRIPTION
## Summary
- bump service worker cache name to `greenlight-v3`
- activate new service worker immediately
- claim clients after activation
- use network-first fetch strategy

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870664b3200832ca8028e68cd08481c