### PR TITLE
Improve voice notes modal UX

### DIFF
--- a/greenlight/css/style.css
+++ b/greenlight/css/style.css
@@ -143,13 +143,18 @@ h1 {
   cursor: pointer;
 }
 
-#menu .voice-memos {
-  cursor: default;
-  flex-direction: column;
-  align-items: flex-start;
-}
 
 #close-menu {
+  background: none;
+  border: none;
+  color: var(--text-color);
+  font-size: 1.2rem;
+  position: absolute;
+  top: 10px;
+  right: 10px;
+}
+
+.close-modal {
   background: none;
   border: none;
   color: var(--text-color);
@@ -190,22 +195,6 @@ h1 {
   min-width: 120px; /* consistent size */
 }
 
-.voice-memos, .export-btn {
-  margin-top: 0.5rem;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.5rem;
-}
-.voice-memos button,
-.export-btn button {
-  background-color: #1d3127;
-  color: white;
-  padding: 0.4rem 0.8rem;
-  border-radius: 8px;
-  font-size: 0.9rem;
-  border: none;
-}
 
 .modal {
   position: fixed;
@@ -238,4 +227,26 @@ h1 {
   padding: 0.4rem 0.8rem;
   border-radius: 0.5rem;
   margin-right: 0.5rem;
+}
+
+#voice-controls,
+#voice-load {
+  display: flex;
+  gap: 0.5rem;
+  margin: 0.5rem 0;
+}
+
+#voice-list li {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+#voice-list button {
+  background-color: var(--accent-color);
+  color: white;
+  border: none;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.5rem;
 }

--- a/greenlight/index.html
+++ b/greenlight/index.html
@@ -39,45 +39,76 @@
     </div>
   </div>
 
-  <!-- Undo Deleted Cards -->
-  <div id="undo-container" class="hidden">
-    <h2>Recently Deleted</h2>
-    <div id="undo-list"></div>
+  <!-- Recently Deleted Modal -->
+  <div id="undo-modal" class="modal hidden" role="dialog" aria-modal="true">
+    <div class="modal-content">
+      <button class="close-modal" id="close-undo">×</button>
+      <h2>Recently Deleted</h2>
+      <div id="undo-list"></div>
+    </div>
   </div>
 
-  <!-- Settings Section -->
-  <section id="settings-section" class="hidden">
-    <h2>Settings</h2>
-    <div id="scheduler">
-      <h3>Shared Moment Scheduler</h3>
-      <label>Local time <input type="datetime-local" id="local-time"></label>
-      <label>Partner time zone
-        <select id="partner-tz">
-          <option value="UTC">UTC</option>
-          <option value="America/Los_Angeles">America/Los_Angeles</option>
-          <option value="America/New_York">America/New_York</option>
-          <option value="Europe/London">Europe/London</option>
-          <option value="Europe/Berlin">Europe/Berlin</option>
-          <option value="Asia/Tokyo">Asia/Tokyo</option>
-          <option value="Australia/Sydney">Australia/Sydney</option>
-        </select>
-      </label>
-      <p id="your-time"></p>
-      <p id="partner-time"></p>
+  <!-- Settings Modal -->
+  <div id="settings-modal" class="modal hidden" role="dialog" aria-modal="true">
+    <div class="modal-content">
+      <button class="close-modal" id="close-settings">×</button>
+      <h2>Settings</h2>
+      <div id="scheduler">
+        <h3>Shared Moment Scheduler</h3>
+        <label>Local time <input type="datetime-local" id="local-time"></label>
+        <label>Partner time zone
+          <select id="partner-tz">
+            <option value="UTC">UTC</option>
+            <option value="America/Los_Angeles">America/Los_Angeles</option>
+            <option value="America/New_York">America/New_York</option>
+            <option value="Europe/London">Europe/London</option>
+            <option value="Europe/Berlin">Europe/Berlin</option>
+            <option value="Asia/Tokyo">Asia/Tokyo</option>
+            <option value="Australia/Sydney">Australia/Sydney</option>
+          </select>
+        </label>
+        <p id="your-time"></p>
+        <p id="partner-time"></p>
+      </div>
     </div>
-  </section>
+  </div>
 
-  <!-- Partner Notes Section -->
-  <section id="partner-notes" class="hidden">
-    <h2>Partner Notes</h2>
-    <ul id="notes-list"></ul>
-    <input id="note-initials" placeholder="Initials">
-    <textarea id="note-text" placeholder="Write a note"></textarea>
-    <button id="save-note">Save Note</button>
-  </section>
+  <!-- Partner Notes Modal -->
+  <div id="notes-modal" class="modal hidden" role="dialog" aria-modal="true">
+    <div class="modal-content">
+      <button class="close-modal" id="close-notes">×</button>
+      <h2>Partner Notes</h2>
+      <ul id="notes-list"></ul>
+      <input id="note-initials" placeholder="Initials">
+      <textarea id="note-text" placeholder="Write a note"></textarea>
+      <button id="save-note">Save Note</button>
+    </div>
+  </div>
 
-  <div class="export-btn">
-    <button id="export-json">Export Data</button>
+  <!-- Voice Notes Modal -->
+  <div id="voice-modal" class="modal hidden" role="dialog" aria-modal="true">
+    <div class="modal-content">
+      <button class="close-modal" id="close-voice">×</button>
+      <h2>Voice Notes</h2>
+      <div id="voice-controls">
+        <button id="voice-record">Record</button>
+        <input id="voice-label" placeholder="Label (optional)">
+        <button id="voice-save">Save</button>
+      </div>
+      <div id="voice-load">
+        <input id="voice-file" type="file" accept=".webm,.mp3,.wav">
+      </div>
+      <ul id="voice-list"></ul>
+    </div>
+  </div>
+
+  <!-- About Modal -->
+  <div id="about-modal" class="modal hidden" role="dialog" aria-modal="true">
+    <div class="modal-content">
+      <button class="close-modal" id="close-about">×</button>
+      <h2>About</h2>
+      <p>Beneath the Greenlight helps you track shared moments and notes.</p>
+    </div>
   </div>
 
   <!-- Slide-out Menu -->
@@ -86,10 +117,7 @@
     <ul>
       <li id="menu-recent">Recently Deleted</li>
       <li id="menu-notes">Partner Notes</li>
-      <li class="voice-memos">
-        <button id="global-record">Record Memo</button>
-        <button id="global-play" disabled>Play Memo</button>
-      </li>
+      <li id="menu-voice">Voice Notes</li>
       <li id="menu-settings">Settings</li>
       <li id="menu-about">About</li>
     </ul>


### PR DESCRIPTION
## Summary
- redesign Beneath the Greenlight's sidebar behavior
- add modal popups for Recently Deleted, Partner Notes, Settings, About, and new Voice Notes
- store voice notes in localStorage and list them with play/delete
- remove old export and voice memo buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68706c0a33fc832cbf99940da3e559cc