### PR TITLE
Add universal close button for Greenlight modals

### DIFF
--- a/greenlight/css/style.css
+++ b/greenlight/css/style.css
@@ -250,3 +250,24 @@ h1 {
   padding: 0.25rem 0.5rem;
   border-radius: 0.5rem;
 }
+
+.close-btn {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  background: transparent;
+  border: none;
+  font-size: 20px;
+  color: white;
+  cursor: pointer;
+  z-index: 10;
+}
+
+.modal-box,
+.popup-card {
+  position: relative;
+  padding: 1rem;
+  border-radius: 8px;
+  background-color: #18392B;
+  color: white;
+}

--- a/greenlight/index.html
+++ b/greenlight/index.html
@@ -22,7 +22,8 @@
   <button id="add-card">＋</button>
 
   <div id="new-card-modal" class="modal hidden" role="dialog" aria-modal="true">
-    <div class="modal-content">
+    <div class="modal-content modal-box">
+      <button class="close-btn" onclick="closeModal(this)">✕</button>
       <label>Name <input id="new-card-title" type="text"></label>
       <label>Timer type
         <select id="new-card-type">
@@ -41,8 +42,8 @@
 
   <!-- Recently Deleted Modal -->
   <div id="undo-modal" class="modal hidden" role="dialog" aria-modal="true">
-    <div class="modal-content">
-      <button class="close-modal" id="close-undo">×</button>
+    <div class="modal-content modal-box">
+      <button class="close-btn" onclick="closeModal(this)">✕</button>
       <h2>Recently Deleted</h2>
       <div id="undo-list"></div>
     </div>
@@ -50,8 +51,8 @@
 
   <!-- Settings Modal -->
   <div id="settings-modal" class="modal hidden" role="dialog" aria-modal="true">
-    <div class="modal-content">
-      <button class="close-modal" id="close-settings">×</button>
+    <div class="modal-content modal-box">
+      <button class="close-btn" onclick="closeModal(this)">✕</button>
       <h2>Settings</h2>
       <div id="scheduler">
         <h3>Shared Moment Scheduler</h3>
@@ -75,8 +76,8 @@
 
   <!-- Partner Notes Modal -->
   <div id="notes-modal" class="modal hidden" role="dialog" aria-modal="true">
-    <div class="modal-content">
-      <button class="close-modal" id="close-notes">×</button>
+    <div class="modal-content modal-box">
+      <button class="close-btn" onclick="closeModal(this)">✕</button>
       <h2>Partner Notes</h2>
       <ul id="notes-list"></ul>
       <input id="note-initials" placeholder="Initials">
@@ -87,8 +88,8 @@
 
   <!-- Voice Notes Modal -->
   <div id="voice-modal" class="modal hidden" role="dialog" aria-modal="true">
-    <div class="modal-content">
-      <button class="close-modal" id="close-voice">×</button>
+    <div class="modal-content modal-box">
+      <button class="close-btn" onclick="closeModal(this)">✕</button>
       <h2>Voice Notes</h2>
       <div id="voice-controls">
         <button id="voice-record">Record</button>
@@ -104,8 +105,8 @@
 
   <!-- About Modal -->
   <div id="about-modal" class="modal hidden" role="dialog" aria-modal="true">
-    <div class="modal-content">
-      <button class="close-modal" id="close-about">×</button>
+    <div class="modal-content modal-box">
+      <button class="close-btn" onclick="closeModal(this)">✕</button>
       <h2>About</h2>
       <p>Beneath the Greenlight helps you track shared moments and notes.</p>
     </div>

--- a/greenlight/js/script.js
+++ b/greenlight/js/script.js
@@ -466,8 +466,20 @@ if (darkToggle) darkToggle.addEventListener('click', toggleDarkMode);
 function openModal(el) {
   if (el) el.classList.remove('hidden');
 }
-function closeModal(el) {
+function hideModal(el) {
   if (el) el.classList.add('hidden');
+}
+
+function closeModal(button) {
+  const modal =
+    button.closest('.modal-box') || button.closest('.popup-card');
+  if (modal) {
+    modal.style.display = 'none';
+    const inputs = modal.querySelectorAll('input, textarea');
+    inputs.forEach(input => (input.value = ''));
+  }
+  const overlay = document.getElementById('modal-overlay');
+  if (overlay) overlay.style.display = 'none';
 }
 if (menuNotes) menuNotes.addEventListener('click', () => {
   openModal(notesModal);
@@ -489,11 +501,11 @@ if (menuVoice) menuVoice.addEventListener('click', () => {
   openModal(voiceModal);
   toggleMenu();
 });
-if (closeUndoBtn) closeUndoBtn.addEventListener('click', () => closeModal(undoModal));
-if (closeNotesBtn) closeNotesBtn.addEventListener('click', () => closeModal(notesModal));
-if (closeSettingsBtn) closeSettingsBtn.addEventListener('click', () => closeModal(settingsModal));
-if (closeAboutBtn) closeAboutBtn.addEventListener('click', () => closeModal(aboutModal));
-if (closeVoiceBtn) closeVoiceBtn.addEventListener('click', () => closeModal(voiceModal));
+if (closeUndoBtn) closeUndoBtn.addEventListener('click', () => hideModal(undoModal));
+if (closeNotesBtn) closeNotesBtn.addEventListener('click', () => hideModal(notesModal));
+if (closeSettingsBtn) closeSettingsBtn.addEventListener('click', () => hideModal(settingsModal));
+if (closeAboutBtn) closeAboutBtn.addEventListener('click', () => hideModal(aboutModal));
+if (closeVoiceBtn) closeVoiceBtn.addEventListener('click', () => hideModal(voiceModal));
 if (saveNoteBtn) {
   saveNoteBtn.addEventListener('click', () => {
     if (noteText.value.trim()) {


### PR DESCRIPTION
## Summary
- add universal `✕` close buttons to Beneath the Greenlight modals
- style the new `.close-btn` and `.modal-box` classes
- implement `closeModal` helper in Greenlight script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870751b8e68832cb2d68d0afcec5efd