### PR TITLE
Fix modal close actions

### DIFF
--- a/greenlight/index.html
+++ b/greenlight/index.html
@@ -11,15 +11,32 @@
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
+  <div id="main-page">
   <header>
     <button id="menu-btn" aria-label="Menu">☰</button>
     <h1>🌿 Beneath the Greenlight</h1>
     <button id="dark-mode-toggle" aria-label="Toggle Dark Mode">🌓</button>
   </header>
-<main id="main-content">
-  <!-- Active Cards Section -->
-  <div id="cards-container"></div>
-  <button id="add-card">＋</button>
+  <main id="main-content">
+    <!-- Active Cards Section -->
+    <div id="cards-container"></div>
+    <button id="add-card">＋</button>
+
+
+  <!-- Slide-out Menu -->
+  <nav id="menu">
+    <button id="close-menu" aria-label="Close">×</button>
+    <ul>
+      <li id="menu-recent">Recently Deleted</li>
+      <li id="menu-notes">Partner Notes</li>
+      <li id="menu-voice">Voice Notes</li>
+      <li id="menu-settings">Settings</li>
+      <li id="menu-about">About</li>
+    </ul>
+
+  </nav>
+</main>
+  </div>
 
   <div id="new-card-modal" class="modal hidden" role="dialog" aria-modal="true">
     <div class="modal-content modal-box">
@@ -111,19 +128,6 @@
       <p>Beneath the Greenlight helps you track shared moments and notes.</p>
     </div>
   </div>
-
-  <!-- Slide-out Menu -->
-  <nav id="menu">
-    <button id="close-menu" aria-label="Close">×</button>
-    <ul>
-      <li id="menu-recent">Recently Deleted</li>
-      <li id="menu-notes">Partner Notes</li>
-      <li id="menu-voice">Voice Notes</li>
-      <li id="menu-settings">Settings</li>
-      <li id="menu-about">About</li>
-    </ul>
-  </nav>
-</main>
 
 <script src="/greenlight/js/script.js"></script>
 <script>

--- a/greenlight/js/script.js
+++ b/greenlight/js/script.js
@@ -427,11 +427,11 @@ function updateSchedule() {
 // Listeners
 if (addBtn) {
   addBtn.addEventListener('click', () => {
-    modal.classList.remove('hidden');
     modalTitle.value = '';
     modalEstimate.value = '';
     modalYoutube.value = '';
     modalType.value = 'due';
+    openModal(modal);
   });
 }
 
@@ -444,13 +444,13 @@ if (saveCardBtn) {
       estimate: Number(modalEstimate.value) || 0,
       youtube: modalYoutube.value
     });
-    modal.classList.add('hidden');
+    closeModal(saveCardBtn);
   });
 }
 
 if (cancelCardBtn) {
   cancelCardBtn.addEventListener('click', () => {
-    modal.classList.add('hidden');
+    closeModal(cancelCardBtn);
   });
 }
 if (localTime) localTime.addEventListener('input', updateSchedule);
@@ -465,21 +465,35 @@ if (closeMenuBtn) closeMenuBtn.addEventListener('click', toggleMenu);
 if (darkToggle) darkToggle.addEventListener('click', toggleDarkMode);
 function openModal(el) {
   if (el) el.classList.remove('hidden');
+  const mainPage = document.getElementById('main-page');
+  if (mainPage) mainPage.style.display = 'none';
+  const overlay = document.getElementById('modal-overlay');
+  if (overlay) overlay.style.display = 'block';
 }
 function hideModal(el) {
   if (el) el.classList.add('hidden');
 }
 
 function closeModal(button) {
-  const modal =
-    button.closest('.modal-box') || button.closest('.popup-card');
+  const modal = button.closest('.modal-box') || button.closest('.popup-card');
   if (modal) {
     modal.style.display = 'none';
+
+    // Clear inputs
     const inputs = modal.querySelectorAll('input, textarea');
     inputs.forEach(input => (input.value = ''));
   }
+
+  // Hide overlay if present
   const overlay = document.getElementById('modal-overlay');
   if (overlay) overlay.style.display = 'none';
+
+  // Re-show main interface
+  const mainPage = document.getElementById('main-page');
+  if (mainPage) mainPage.style.display = 'block';
+
+  // Optional: reset scroll or focus
+  window.scrollTo(0, 0);
 }
 if (menuNotes) menuNotes.addEventListener('click', () => {
   openModal(notesModal);


### PR DESCRIPTION
## Summary
- update `openModal` and `closeModal` to toggle the main interface
- hide/show main page when adding a card
- move modal markup outside of the main-page container

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687079857a20832c8c63d72332782288