### PR TITLE
Update scheduler UI with timezone and country inputs

### DIFF
--- a/greenlight/index.html
+++ b/greenlight/index.html
@@ -73,17 +73,12 @@
       <h2>Settings</h2>
       <div id="scheduler">
         <h3>Shared Moment Scheduler</h3>
-        <label id="local-time-label"><span id="local-time-text">Local time</span> <input type="datetime-local" id="local-time"></label>
+        <label id="local-time-label"><span id="local-time-text">Local date</span> <input type="date" id="local-time"></label>
         <label>Partner time zone
-          <select id="partner-tz">
-            <option value="UTC">UTC</option>
-            <option value="America/Los_Angeles">America/Los_Angeles</option>
-            <option value="America/New_York">America/New_York</option>
-            <option value="Europe/London">Europe/London</option>
-            <option value="Europe/Berlin">Europe/Berlin</option>
-            <option value="Asia/Tokyo">Asia/Tokyo</option>
-            <option value="Australia/Sydney">Australia/Sydney</option>
-          </select>
+          <input id="partner-tz" placeholder="e.g., America/New_York">
+        </label>
+        <label>Partner country
+          <input id="partner-country" placeholder="Country">
         </label>
         <p id="your-time"></p>
         <p id="partner-time"></p>

--- a/greenlight/js/script.js
+++ b/greenlight/js/script.js
@@ -5,6 +5,7 @@ const localTime = document.getElementById('local-time');
 const localTimeLabel = document.getElementById('local-time-label');
 const localTimeText = document.getElementById('local-time-text');
 const partnerTz = document.getElementById('partner-tz');
+const partnerCountry = document.getElementById('partner-country');
 const partnerTime = document.getElementById('partner-time');
 const yourTimeDisplay = document.getElementById('your-time');
 const undoModal = document.getElementById('undo-modal');
@@ -50,6 +51,7 @@ const DELETED_KEY = 'greenlight-deleted';
 const NOTES_KEY = 'greenlight-notes';
 const MODE_KEY = 'greenlight-mode';
 const TZ_KEY = 'greenlight-tz';
+const COUNTRY_KEY = 'greenlight-country';
 
 // State
 let cards = [];
@@ -94,6 +96,10 @@ function load() {
   if (tz && partnerTz) {
     partnerTz.value = tz;
   }
+  const country = localStorage.getItem(COUNTRY_KEY);
+  if (country && partnerCountry) {
+    partnerCountry.value = country;
+  }
   cleanupDeleted();
   if (container) render();
   if (undoList) renderUndo();
@@ -101,10 +107,10 @@ function load() {
   if (localTime && partnerTz) {
     if (!localTime.value) {
       const now = new Date();
-      localTime.value = now.toISOString().slice(0, 16);
+      localTime.value = now.toISOString().slice(0, 10);
       if (localTimeText) {
         const tzName = Intl.DateTimeFormat().resolvedOptions().timeZone;
-        localTimeText.textContent = `Local time (${tzName})`;
+        localTimeText.textContent = `Local date (${tzName})`;
       }
     }
     updateSchedule();
@@ -380,19 +386,22 @@ function toggleDarkMode() {
 
 // Scheduler
 function updateSchedule() {
-  const date = new Date(localTime.value);
-  if (isNaN(date)) {
+  const dateVal = localTime.value;
+  const date = new Date(dateVal);
+  if (!dateVal || isNaN(date)) {
     yourTimeDisplay.textContent = '';
     partnerTime.textContent = '';
     return;
   }
-  const tz = partnerTz.value || 'UTC';
-  const pString = date.toLocaleString([], { timeZone: tz });
+  const tz = partnerTz.value.trim() || 'UTC';
+  const country = partnerCountry ? partnerCountry.value.trim() : '';
   const localTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
-  const yourString = date.toLocaleString([], { timeZoneName: 'short' });
-  yourTimeDisplay.textContent = `Your Time (${localTz}): ${yourString}`;
-  partnerTime.textContent = `Their Time (${tz}): ${pString}`;
+  const yourDate = date.toLocaleDateString([], { timeZone: localTz });
+  const partnerDate = date.toLocaleDateString([], { timeZone: tz });
+  yourTimeDisplay.textContent = `Your Date (${localTz}): ${yourDate}`;
+  partnerTime.textContent = `Their Date (${tz}${country ? ', ' + country : ''}): ${partnerDate}`;
   localStorage.setItem(TZ_KEY, tz);
+  if (partnerCountry) localStorage.setItem(COUNTRY_KEY, country);
 }
 
 // Listeners
@@ -426,6 +435,7 @@ if (cancelCardBtn) {
 }
 if (localTime) localTime.addEventListener('input', updateSchedule);
 if (partnerTz) partnerTz.addEventListener('input', updateSchedule);
+if (partnerCountry) partnerCountry.addEventListener('input', updateSchedule);
 window.addEventListener('load', () => {
   localStorage.removeItem('greenlight-categories');
   load();

--- a/greenlight/shared-scheduler/index.html
+++ b/greenlight/shared-scheduler/index.html
@@ -17,17 +17,12 @@
   <section id="settings-section">
     <div id="scheduler">
       <h3>Shared Moment Scheduler</h3>
-      <label id="local-time-label"><span id="local-time-text">Local time</span> <input type="datetime-local" id="local-time"></label>
+      <label id="local-time-label"><span id="local-time-text">Local date</span> <input type="date" id="local-time"></label>
       <label>Partner time zone
-        <select id="partner-tz">
-          <option value="UTC">UTC</option>
-          <option value="America/Los_Angeles">America/Los_Angeles</option>
-          <option value="America/New_York">America/New_York</option>
-          <option value="Europe/London">Europe/London</option>
-          <option value="Europe/Berlin">Europe/Berlin</option>
-          <option value="Asia/Tokyo">Asia/Tokyo</option>
-          <option value="Australia/Sydney">Australia/Sydney</option>
-        </select>
+        <input id="partner-tz" placeholder="e.g., America/New_York">
+      </label>
+      <label>Partner country
+        <input id="partner-country" placeholder="Country">
       </label>
       <p id="your-time"></p>
       <p id="partner-time"></p>


### PR DESCRIPTION
## Summary
- tweak shared moment scheduler fields
- switch local time entry to a date-only picker
- allow entering partner timezone and country
- persist partner timezone and country across reloads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68708aff91f4832c81c1a1d71e5aedb3