### PR TITLE
Add credits modal on homepage

### DIFF
--- a/greenlight/css/style.css
+++ b/greenlight/css/style.css
@@ -77,6 +77,18 @@ h1 {
   box-shadow: 0 0 10px #14452F;
 }
 
+#credits-btn {
+  position: fixed;
+  bottom: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: none;
+  border: none;
+  color: var(--text-color);
+  font-size: 0.9rem;
+  cursor: pointer;
+}
+
 #scheduler {
   padding: 1rem;
 }

--- a/greenlight/index.html
+++ b/greenlight/index.html
@@ -122,13 +122,29 @@
   </div>
 
   <!-- About Modal -->
-  <div id="about-modal" class="modal hidden" role="dialog" aria-modal="true">
-    <div class="modal-content modal-box">
-      <button class="close-btn" onclick="closeModal(this)">✕</button>
-      <h2>About</h2>
-      <p>Beneath the Greenlight helps you track shared moments and notes.</p>
+    <div id="about-modal" class="modal hidden" role="dialog" aria-modal="true">
+      <div class="modal-content modal-box">
+        <button class="close-btn" onclick="closeModal(this)">✕</button>
+        <h2>About</h2>
+        <p>Beneath the Greenlight helps you track shared moments and notes.</p>
+      </div>
     </div>
-  </div>
+
+    <button id="credits-btn">Credits</button>
+
+    <div id="credits-modal" class="modal hidden" role="dialog" aria-modal="true">
+      <div class="modal-content modal-box">
+        <button class="close-btn" onclick="closeModal(this)">✕</button>
+        <h2>Credits</h2>
+        <p>Development Team:</p>
+        <ul>
+          <li>ducksy</li>
+          <li>sidelight</li>
+          <li>renTheduck</li>
+          <li>Vyrex</li>
+        </ul>
+      </div>
+    </div>
 
 <script src="/greenlight/js/script.js"></script>
 <script>

--- a/greenlight/js/script.js
+++ b/greenlight/js/script.js
@@ -39,6 +39,8 @@ const closeNotesBtn = document.getElementById('close-notes');
 const closeSettingsBtn = document.getElementById('close-settings');
 const closeAboutBtn = document.getElementById('close-about');
 const closeVoiceBtn = document.getElementById('close-voice');
+const creditsBtn = document.getElementById('credits-btn');
+const creditsModal = document.getElementById('credits-modal');
 const modal = document.getElementById('new-card-modal');
 const modalTitle = document.getElementById('new-card-title');
 const modalType = document.getElementById('new-card-type');
@@ -552,6 +554,7 @@ if (menuVoice) menuVoice.addEventListener('click', () => {
   openModal(voiceModal);
   toggleMenu();
 });
+if (creditsBtn) creditsBtn.addEventListener('click', () => openModal(creditsModal));
 if (closeUndoBtn) closeUndoBtn.addEventListener('click', () => hideModal(undoModal));
 if (closeNotesBtn) closeNotesBtn.addEventListener('click', () => hideModal(notesModal));
 if (closeSettingsBtn) closeSettingsBtn.addEventListener('click', () => hideModal(settingsModal));


### PR DESCRIPTION
## Summary
- include a new **Credits** text button on the homepage
- implement credits modal with names of the developers
- style the credits button at the bottom center
- hook up modal open behavior in JS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687091094488832c9679c1e54d6bad5f