### PR TITLE
Add entry selection modal for plus button

### DIFF
--- a/greenlight/css/style.css
+++ b/greenlight/css/style.css
@@ -219,6 +219,7 @@ h1 {
   border-radius: 1rem;
   width: 90%;
   max-width: 320px;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.4);
 }
 .modal-content button {
   margin-top: 0.5rem;
@@ -271,4 +272,41 @@ h1 {
   border-radius: 8px;
   background-color: #18392B;
   color: white;
+}
+
+#entry-select-modal .modal-content {
+  font-family: 'Poppins', sans-serif;
+  max-width: 420px;
+}
+
+#entry-options {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.5rem;
+  margin: 1rem 0;
+}
+
+.pill-btn {
+  border: none;
+  background-color: var(--accent-color);
+  color: #fff;
+  padding: 0.6rem 1rem;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.full-width-btn {
+  width: 100%;
+  background-color: var(--accent-color);
+  color: #fff;
+  border: none;
+  padding: 0.6rem 0;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.close-btn:hover {
+  color: var(--accent-color);
 }

--- a/greenlight/index.html
+++ b/greenlight/index.html
@@ -8,6 +8,7 @@
   <link rel="icon" type="image/svg+xml" href="duck.svg">
   <meta name="theme-color" content="#0F5132">
   <link href="https://fonts.googleapis.com/css2?family=Lexend+Deca&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>
@@ -35,7 +36,22 @@
     </ul>
 
   </nav>
-</main>
+  </main>
+  </div>
+
+  <div id="entry-select-modal" class="modal hidden" role="dialog" aria-modal="true">
+    <div class="modal-content entry-modal">
+      <button class="close-btn" onclick="closeModal(this)">✕</button>
+      <h2>Add New Entry</h2>
+      <div id="entry-options">
+        <button class="pill-btn">Shared Activity</button>
+        <button class="pill-btn">Shared Calendar Event</button>
+        <button class="pill-btn">YouTube Video</button>
+        <button class="pill-btn">Learning Exercise</button>
+        <button class="pill-btn">Personal Task</button>
+      </div>
+      <button id="custom-entry-btn" class="full-width-btn">Add Something Custom</button>
+    </div>
   </div>
 
   <div id="new-card-modal" class="modal hidden" role="dialog" aria-modal="true">

--- a/greenlight/js/script.js
+++ b/greenlight/js/script.js
@@ -48,6 +48,8 @@ const modalEstimate = document.getElementById('new-card-estimate');
 const modalYoutube = document.getElementById('new-card-youtube');
 const saveCardBtn = document.getElementById('save-card');
 const cancelCardBtn = document.getElementById('cancel-card');
+const entryModal = document.getElementById('entry-select-modal');
+const customEntryBtn = document.getElementById('custom-entry-btn');
 
 // Storage Keys
 const STORAGE_KEY = 'greenlight-cards';
@@ -473,11 +475,24 @@ function updateSchedule() {
 // Listeners
 if (addBtn) {
   addBtn.addEventListener('click', () => {
+    openModal(entryModal);
+  });
+}
+
+if (customEntryBtn) {
+  customEntryBtn.addEventListener('click', () => {
     modalTitle.value = '';
     modalEstimate.value = '';
     modalYoutube.value = '';
     modalType.value = 'due';
+    hideModal(entryModal);
     openModal(modal);
+  });
+}
+
+if (entryModal) {
+  entryModal.addEventListener('click', e => {
+    if (e.target === entryModal) hideModal(entryModal);
   });
 }
 


### PR DESCRIPTION
## Summary
- add Google Poppins font and modern shadowed modal box
- create new `entry-select-modal` with pill buttons and custom button
- style pill buttons and entry modal
- update script to open new modal from `+` button and allow overlay close

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68709666a288832c8b7a2b5c8976eb2c