### PR TITLE
Fix homepage buttons by removing stray snippet

### DIFF
--- a/greenlight/js/script.js
+++ b/greenlight/js/script.js
@@ -193,14 +193,6 @@ function createCard(card) {
   // ... rest of createCard logic stays the same
 }
 
-// ✅ Use image thumbnails for YouTube if valid
-if (vid) {
-  thumbnail.src = `https://img.youtube.com/vi/${vid}/0.jpg`;
-  thumbnail.alt = 'YouTube thumbnail';
-  thumbnail.style.height = '80px';
-  thumbnail.style.borderRadius = '8px';
-}
-
 
 // ---- Minimal Helpers and Card Logic ----
 function openModal(modal) {


### PR DESCRIPTION
## Summary
- remove invalid thumbnail snippet from `greenlight/js/script.js`

This stray block referenced undefined variables and caused the homepage script to crash, preventing any button actions from working. Removing it restores event listeners.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68709c6fa15c832ca759d6b8b30a9b74