### PR TITLE
Update Add Activity modal styling and close behavior

### DIFF
--- a/greenlight/css/style.css
+++ b/greenlight/css/style.css
@@ -290,7 +290,11 @@ h1 {
 
 #entry-select-modal .modal-content {
   font-family: 'Poppins', sans-serif;
-  max-width: 420px;
+  max-width: 600px;
+  padding: 24px;
+  background: linear-gradient(145deg, #0A5C36, #0F5132);
+  border: 1px solid #18392B;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
 }
 
 .modal-subtext {
@@ -303,29 +307,44 @@ h1 {
 #entry-options {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-  gap: 0.5rem;
+  gap: 12px;
   margin: 1rem 0;
 }
 
-.pill-btn {
+
+#entry-select-modal .pill-btn {
   border: none;
-  background-color: var(--accent-color);
-  color: #fff;
+  background-color: #14452F;
+  color: #ffffff;
+  font-weight: 600;
   padding: 0.6rem 1rem;
-  border-radius: 999px;
+  border-radius: 6px;
   cursor: pointer;
   font-size: 0.9rem;
+  margin-bottom: 12px;
 }
 
-.full-width-btn {
+#entry-select-modal .pill-btn:hover {
+  background-color: #0A5C36;
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.4);
+}
+
+#entry-select-modal .full-width-btn {
   width: 100%;
-  background-color: var(--accent-color);
-  color: #fff;
+  background-color: #14452F;
+  color: #ffffff;
+  font-weight: 600;
   border: none;
   padding: 0.6rem 0;
-  border-radius: 999px;
+  border-radius: 6px;
   cursor: pointer;
   font-size: 1rem;
+  margin-bottom: 12px;
+}
+
+#entry-select-modal .full-width-btn:hover {
+  background-color: #0A5C36;
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.4);
 }
 
 .close-btn:hover {

--- a/greenlight/index.html
+++ b/greenlight/index.html
@@ -44,7 +44,7 @@
 
   <div id="entry-select-modal" class="modal hidden" role="dialog" aria-modal="true">
     <div class="modal-content entry-modal">
-      <button class="close-btn" onclick="closeModal(this)">✕</button>
+      <button class="close-btn" onclick="window.location.href='/greenlight/'">✕</button>
       <h2>Add Activity</h2>
       <p class="modal-subtext">Choose a shared task, ritual, or activity to track.</p>
       <div id="entry-options">


### PR DESCRIPTION
## Summary
- restyle Add Activity modal in Beneath the Greenlight
- enlarge modal and update buttons to green theme
- add close button linking back to `/greenlight/`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870a0821478832c8e2646dd51503f0b