### PR TITLE
Fix menu and add card functionality

### DIFF
--- a/greenlight/js/script.js
+++ b/greenlight/js/script.js
@@ -69,6 +69,43 @@ let voiceNotes = [];
 let recorder;
 let recordedData;
 
+// --------------------------- UI Handlers ---------------------------
+// Persist and toggle light/dark mode
+const savedMode = localStorage.getItem(MODE_KEY);
+if (savedMode === 'light') {
+  document.body.classList.add('light-mode');
+}
+if (darkToggle) {
+  darkToggle.addEventListener('click', () => {
+    const isLight = document.body.classList.toggle('light-mode');
+    localStorage.setItem(MODE_KEY, isLight ? 'light' : 'dark');
+  });
+}
+
+// Slide-out menu open/close
+if (menuBtn) {
+  menuBtn.addEventListener('click', () => {
+    menu.classList.add('open');
+  });
+}
+
+if (closeMenuBtn) {
+  closeMenuBtn.addEventListener('click', () => {
+    menu.classList.remove('open');
+  });
+}
+
+function openMenuModal(modalEl) {
+  menu.classList.remove('open');
+  openModal(modalEl);
+}
+
+if (menuNotes) menuNotes.addEventListener('click', () => openMenuModal(notesModal));
+if (menuRecent) menuRecent.addEventListener('click', () => openMenuModal(undoModal));
+if (menuSettings) menuSettings.addEventListener('click', () => openMenuModal(settingsModal));
+if (menuAbout) menuAbout.addEventListener('click', () => openMenuModal(aboutModal));
+if (menuVoice) menuVoice.addEventListener('click', () => openMenuModal(voiceModal));
+
 // Country list for dropdowns
 const COUNTRIES = [
   "Afghanistan","Albania","Algeria","Andorra","Angola","Antigua and Barbuda",


### PR DESCRIPTION
## Summary
- hook up menu button and close controls
- open appropriate modals from the slide-out menu
- toggle light/dark mode and remember setting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870a33a0c40832cbbd411435795adba