### PR TITLE
Fix script path for greenlight menu

### DIFF
--- a/greenlight/index.html
+++ b/greenlight/index.html
@@ -151,7 +151,7 @@
       </div>
 
 
-<script src="/greenlight/js/script.js"></script>
+<script src="js/script.js"></script>
 <script>
   if ('serviceWorker' in navigator) {
     window.addEventListener('load', () => navigator.serviceWorker.register('sw.js'));


### PR DESCRIPTION
## Summary
- fix script path so greenlight's side menu works when loaded from `/greenlight/index.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870a5c961d4832c9ec9fce7dca92a6e