### PR TITLE
Update greenlight modals

### DIFF
--- a/greenlight/css/style.css
+++ b/greenlight/css/style.css
@@ -165,13 +165,14 @@ h1 {
 }
 
 .close-modal {
+  position: absolute;
+  top: 16px;
+  right: 20px;
+  font-size: 1.5rem;
   background: none;
   border: none;
-  color: var(--text-color);
-  font-size: 1.2rem;
-  position: absolute;
-  top: 10px;
-  right: 10px;
+  color: white;
+  cursor: pointer;
 }
 
 #partner-notes {
@@ -224,8 +225,13 @@ h1 {
 
 .modal-content {
   background-color: var(--card-bg);
-  padding: 1rem;
-  border-radius: 1rem;
+  padding: 2rem;
+  min-height: 400px;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  border-radius: 12px;
   width: 90%;
   max-width: 320px;
   box-shadow: 0 2px 10px rgba(0,0,0,0.4);
@@ -235,8 +241,10 @@ h1 {
   background-color: var(--accent-color);
   color: white;
   border: none;
-  padding: 0.4rem 0.8rem;
-  border-radius: 0.5rem;
+  padding: 1rem 1.5rem;
+  font-size: 1rem;
+  border-radius: 12px;
+  height: 60px;
   margin-right: 0.5rem;
 }
 .category-option {

--- a/greenlight/index.html
+++ b/greenlight/index.html
@@ -44,7 +44,7 @@
 
   <div id="entry-select-modal" class="modal hidden" role="dialog" aria-modal="true">
     <div class="modal-content entry-modal">
-      <button class="close-btn" onclick="window.location.href='/greenlight/'">✕</button>
+      <button class="close-modal" onclick="window.location.href='/greenlight/'">×</button>
       <h2>Add Activity</h2>
       <p class="modal-subtext">Choose a shared task, ritual, or activity to track.</p>
       <div id="entry-options">
@@ -60,7 +60,7 @@
 
   <div id="new-card-modal" class="modal hidden" role="dialog" aria-modal="true">
     <div class="modal-content modal-box">
-      <button class="close-btn" onclick="closeModal(this)">✕</button>
+      <button class="close-modal" onclick="closeModal(this)">×</button>
       <label>Name <input id="new-card-title" type="text"></label>
       <label>Custom Label <input id="new-card-label" type="text"></label>
       <label>Timer type
@@ -81,7 +81,7 @@
   <!-- Recently Deleted Modal -->
   <div id="undo-modal" class="modal hidden" role="dialog" aria-modal="true">
     <div class="modal-content modal-box">
-      <button class="close-btn" onclick="closeModal(this)">✕</button>
+      <button class="close-modal" onclick="closeModal(this)">×</button>
       <h2>Recently Deleted</h2>
       <div id="undo-list"></div>
     </div>
@@ -90,7 +90,7 @@
   <!-- Settings Modal -->
   <div id="settings-modal" class="modal hidden" role="dialog" aria-modal="true">
     <div class="modal-content modal-box">
-      <button class="close-btn" onclick="closeModal(this)">✕</button>
+      <button class="close-modal" onclick="closeModal(this)">×</button>
       <h2>Settings</h2>
       <div id="scheduler">
         <h3>Shared Moment Scheduler</h3>
@@ -116,7 +116,7 @@
   <!-- Partner Notes Modal -->
   <div id="notes-modal" class="modal hidden" role="dialog" aria-modal="true">
     <div class="modal-content modal-box">
-      <button class="close-btn" onclick="closeModal(this)">✕</button>
+      <button class="close-modal" onclick="closeModal(this)">×</button>
       <h2>Partner Notes</h2>
       <ul id="notes-list"></ul>
       <input id="note-initials" placeholder="Initials">
@@ -128,7 +128,7 @@
   <!-- Voice Notes Modal -->
   <div id="voice-modal" class="modal hidden" role="dialog" aria-modal="true">
     <div class="modal-content modal-box">
-      <button class="close-btn" onclick="closeModal(this)">✕</button>
+      <button class="close-modal" onclick="closeModal(this)">×</button>
       <h2>Voice Notes</h2>
       <div id="voice-controls">
         <button id="voice-record">Record</button>
@@ -145,7 +145,7 @@
   <!-- About Modal -->
     <div id="about-modal" class="modal hidden" role="dialog" aria-modal="true">
       <div class="modal-content modal-box">
-        <button class="close-btn" onclick="closeModal(this)">✕</button>
+        <button class="close-modal" onclick="closeModal(this)">×</button>
         <h2>About</h2>
         <p>Beneath the Greenlight helps you track shared moments and notes.</p>
       </div>


### PR DESCRIPTION
## Summary
- style `.modal-content` for larger layout and add `.close-modal` rules
- add consistent close button markup in Greenlight modals

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870aa30a174832ca882c24f0d523935