### PR TITLE
Update favicon paths

### DIFF
--- a/greenlight/index.html
+++ b/greenlight/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Beneath the Greenlight</title>
   <link rel="manifest" href="manifest.json">
-  <link rel="icon" type="image/svg+xml" href="duck.svg">
+  <link rel="icon" type="image/png" href="greenlightduck.png">
   <meta name="theme-color" content="#0F5132">
   <link href="https://fonts.googleapis.com/css2?family=Lexend+Deca&display=swap" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">

--- a/greenlight/manifest.json
+++ b/greenlight/manifest.json
@@ -7,9 +7,9 @@
   "theme_color": "#0F5132",
   "icons": [
     {
-      "src": "duck.svg",
+      "src": "greenlightduck.png",
       "sizes": "any",
-      "type": "image/svg+xml"
+      "type": "image/png"
     }
   ]
 }

--- a/greenlight/partner-notes/index.html
+++ b/greenlight/partner-notes/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Partner Notes - Beneath the Greenlight</title>
   <link rel="manifest" href="../manifest.json">
-  <link rel="icon" type="image/svg+xml" href="../duck.svg">
+  <link rel="icon" type="image/png" href="../greenlightduck.png">
   <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>

--- a/greenlight/shared-scheduler/index.html
+++ b/greenlight/shared-scheduler/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Shared Scheduler - Beneath the Greenlight</title>
   <link rel="manifest" href="../manifest.json">
-  <link rel="icon" type="image/svg+xml" href="../duck.svg">
+  <link rel="icon" type="image/png" href="../greenlightduck.png">
   <link rel="stylesheet" href="../css/style.css">
 </head>
 <body>

--- a/greenlight/sw.js
+++ b/greenlight/sw.js
@@ -8,7 +8,7 @@ const FILES = [
   './css/style.css',
   './js/script.js',
   './manifest.json',
-  './duck.svg'
+  './greenlightduck.png'
 ];
 self.addEventListener('install', e => {
   self.skipWaiting();


### PR DESCRIPTION
## Summary
- use PNG favicon in Greenlight HTML pages
- update manifest and service worker paths

## Testing
- `npm test`
- `grep -R "duck.svg" greenlight`

------
https://chatgpt.com/codex/tasks/task_e_6870b32d1910832c82aaad27672efbc8