### PR TITLE
Add icon to PWA manifest

### DIFF
--- a/greenlight/manifest.json
+++ b/greenlight/manifest.json
@@ -4,5 +4,12 @@
   "start_url": "/greenlight/",
   "display": "standalone",
   "background_color": "#0F5132",
+  "icons": [
+    {
+      "src": "greenlightduck.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
+  ]
 
 }


### PR DESCRIPTION
## Summary
- add `greenlightduck.png` as the PWA icon in `manifest.json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870b8765cb0832c8c5cb8174c5f6cae