### PR TITLE
Enhance plus modal and card features

### DIFF
--- a/greenlight/css/style.css
+++ b/greenlight/css/style.css
@@ -70,6 +70,29 @@ h1 {
   flex-wrap: wrap;
   align-items: center;
   gap: 0.5rem;
+  position: relative;
+}
+
+.card-delete {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  background: transparent;
+  border: none;
+  color: var(--text-color);
+  font-size: 1.2rem;
+  cursor: pointer;
+}
+
+.complete-count {
+  font-size: 0.8rem;
+  opacity: 0.8;
+}
+
+.card-notes {
+  width: 100%;
+  margin-top: 0.5rem;
+  font-size: 0.85rem;
 }
 
 #add-card {

--- a/greenlight/index.html
+++ b/greenlight/index.html
@@ -50,11 +50,11 @@
       <div id="entry-options">
         <button class="pill-btn add-option" data-type="activity">Shared Activity</button>
         <button class="pill-btn add-option" data-type="calendar">Shared Calendar</button>
-        <button class="pill-btn add-option" data-type="youtube">YouTube Link</button>
+        <button class="pill-btn add-option" data-type="youtube">YouTube Video</button>
         <button class="pill-btn add-option" data-type="learning">Learning Exercise</button>
-        <button class="pill-btn add-option" data-type="task">Task to Complete</button>
+        <button class="pill-btn add-option" data-type="task">Task You Need to Complete</button>
+        <button class="pill-btn add-option" data-type="custom">Custom Entry</button>
       </div>
-      <button id="custom-entry-btn" class="full-width-btn">➕ Add Custom</button>
     </div>
   </div>
 

--- a/index.html
+++ b/index.html
@@ -2,8 +2,8 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="refresh" content="0; url=/greenlight/">
-  <link rel="canonical" href="/greenlight/">
+  <meta http-equiv="refresh" content="0; url=https://www.talkkink.org/greenlight/">
+  <link rel="canonical" href="https://www.talkkink.org/greenlight/">
   <title>Redirecting...</title>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- fix redirect homepage URL
- show six options in the add activity modal
- persist cards to localStorage with notes and YouTube links
- allow marking cards complete, deletion and note taking
- add styles for new card elements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870bb83d0cc832c81379588ecbcb476