### PR TITLE
Implement shared calendar

### DIFF
--- a/greenlight/calendar.html
+++ b/greenlight/calendar.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Shared Calendar - Beneath the Greenlight</title>
+  <link rel="manifest" href="manifest.json">
+  <link rel="icon" type="image/png" href="greenlightduck.png">
+  <link rel="stylesheet" href="css/style.css">
+  <link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.9/index.global.min.css" rel="stylesheet">
+</head>
+<body>
+  <header>
+    <a id="close-calendar" href="/greenlight/" aria-label="Back">↩️</a>
+    <h1>Shared Calendar</h1>
+    <button id="dark-mode-toggle" aria-label="Toggle Dark Mode">🌓</button>
+  </header>
+  <div id="calendar-controls">
+    <div id="tz-info">
+      <span id="your-display"></span>
+      <span id="partner-display"></span>
+    </div>
+    <select id="tz-toggle">
+      <option value="your">Your Time</option>
+      <option value="partner">Partner Time</option>
+    </select>
+    <button id="add-event">Add Event</button>
+    <button id="export-events">Export</button>
+    <button id="import-events">Import</button>
+    <input type="file" id="import-file" accept="application/json" class="hidden">
+  </div>
+  <div id="calendar"></div>
+
+  <div id="event-modal" class="modal hidden" role="dialog" aria-modal="true">
+    <div class="modal-content modal-box">
+      <button class="close-modal" onclick="closeModal(this)">×</button>
+      <label>Event Title <input id="event-title" required></label>
+      <label>Start <input type="datetime-local" id="event-start" required></label>
+      <label>End <input type="datetime-local" id="event-end" required></label>
+      <label>Label (optional) <input id="event-label"></label>
+      <label>Visibility
+        <select id="event-visibility">
+          <option value="busy">Busy</option>
+          <option value="free">Free</option>
+          <option value="tentative">Tentative</option>
+        </select>
+      </label>
+      <label>Initials <input id="event-initials" required></label>
+      <div>
+        <button id="save-event">Save</button>
+        <button id="delete-event" class="hidden">Delete</button>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.9/index.global.min.js"></script>
+  <script src="js/calendar.js"></script>
+  <script src="js/script.js"></script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => navigator.serviceWorker.register('sw.js'));
+    }
+  </script>
+</body>
+</html>

--- a/greenlight/css/style.css
+++ b/greenlight/css/style.css
@@ -358,3 +358,21 @@ h1 {
 .close-btn:hover {
   color: var(--accent-color);
 }
+
+/* Shared calendar page */
+#calendar-controls {
+  padding: 1rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+#calendar {
+  padding: 1rem;
+}
+#tz-info {
+  flex-basis: 100%;
+}
+#event-modal .modal-content {
+  min-height: 500px;
+}

--- a/greenlight/js/calendar.js
+++ b/greenlight/js/calendar.js
@@ -1,0 +1,161 @@
+const STORAGE_KEY = 'greenlight-shared-calendar';
+let events = [];
+let calendar;
+let editingEvent = null;
+
+function loadEvents() {
+  try {
+    return JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+  } catch (e) {
+    return [];
+  }
+}
+
+function saveEvents() {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(events));
+}
+
+function formatTZ(tz) {
+  const date = new Date();
+  const parts = date.toLocaleString('en-US', { timeZone: tz, timeZoneName: 'short' }).split(' ');
+  const abbr = parts.pop();
+  const offset = -new Date(date.toLocaleString('en-US', { timeZone: tz })).getTimezoneOffset() / 60;
+  const sign = offset >= 0 ? '+' : '';
+  return `${abbr} (UTC${sign}${offset})`;
+}
+
+function updateTZDisplay(yourTz, partnerTz) {
+  document.getElementById('your-display').textContent = `Your Time: ${formatTZ(yourTz)}`;
+  document.getElementById('partner-display').textContent = `Their Time: ${formatTZ(partnerTz)}`;
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const yourTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const partnerTz = localStorage.getItem('greenlight-tz') || yourTz;
+  updateTZDisplay(yourTz, partnerTz);
+
+  events = loadEvents();
+
+  const calendarEl = document.getElementById('calendar');
+  calendar = new FullCalendar.Calendar(calendarEl, {
+    timeZone: yourTz,
+    initialView: 'dayGridMonth',
+    headerToolbar: {
+      left: 'prev,next today',
+      center: 'title',
+      right: 'dayGridMonth,timeGridWeek,timeGridDay'
+    },
+    events,
+    editable: true,
+    eventClick: info => openEditModal(info.event)
+  });
+  calendar.render();
+
+  document.getElementById('tz-toggle').addEventListener('change', e => {
+    const tz = e.target.value === 'partner' ? partnerTz : yourTz;
+    calendar.setOption('timeZone', tz);
+  });
+
+  document.getElementById('add-event').addEventListener('click', () => {
+    editingEvent = null;
+    document.getElementById('event-title').value = '';
+    document.getElementById('event-start').value = '';
+    document.getElementById('event-end').value = '';
+    document.getElementById('event-label').value = '';
+    document.getElementById('event-visibility').value = 'busy';
+    document.getElementById('event-initials').value = '';
+    document.getElementById('delete-event').classList.add('hidden');
+    openModal(document.getElementById('event-modal'));
+  });
+
+  document.getElementById('export-events').addEventListener('click', () => {
+    const blob = new Blob([JSON.stringify(events, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'greenlight-calendar.json';
+    a.click();
+    URL.revokeObjectURL(url);
+  });
+
+  const importFile = document.getElementById('import-file');
+  document.getElementById('import-events').addEventListener('click', () => importFile.click());
+  importFile.addEventListener('change', () => {
+    const file = importFile.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        const data = JSON.parse(reader.result);
+        if (Array.isArray(data)) {
+          events = data;
+          saveEvents();
+          calendar.removeAllEvents();
+          calendar.addEventSource(events);
+        }
+      } catch (err) {
+        alert('Invalid file');
+      }
+    };
+    reader.readAsText(file);
+  });
+
+  document.getElementById('save-event').addEventListener('click', () => {
+    const title = document.getElementById('event-title').value.trim();
+    const start = document.getElementById('event-start').value;
+    const end = document.getElementById('event-end').value;
+    const label = document.getElementById('event-label').value.trim();
+    const visibility = document.getElementById('event-visibility').value;
+    const initials = document.getElementById('event-initials').value.trim();
+    if (!title || !start || !end || !initials) {
+      alert('Please complete required fields');
+      return;
+    }
+    const eventData = {
+      id: editingEvent ? editingEvent.id : Date.now(),
+      title,
+      start: new Date(start).toISOString(),
+      end: new Date(end).toISOString(),
+      label,
+      addedBy: initials,
+      visibility
+    };
+    if (editingEvent) {
+      const idx = events.findIndex(e => e.id === editingEvent.id);
+      if (idx > -1) events[idx] = eventData;
+      editingEvent.setProp('title', title);
+      editingEvent.setStart(eventData.start);
+      editingEvent.setEnd(eventData.end);
+      editingEvent.setExtendedProp('label', label);
+      editingEvent.setExtendedProp('addedBy', initials);
+      editingEvent.setExtendedProp('visibility', visibility);
+    } else {
+      events.push(eventData);
+      calendar.addEvent(eventData);
+    }
+    saveEvents();
+    closeModal(document.getElementById('save-event'));
+  });
+
+  document.getElementById('delete-event').addEventListener('click', () => {
+    if (!editingEvent) return;
+    if (confirm('Delete this event?')) {
+      events = events.filter(e => e.id !== editingEvent.id);
+      editingEvent.remove();
+      saveEvents();
+      closeModal(document.getElementById('delete-event'));
+    }
+  });
+});
+
+function openEditModal(event) {
+  editingEvent = event;
+  document.getElementById('event-title').value = event.title;
+  document.getElementById('event-start').value = event.startStr.replace('Z', '');
+  document.getElementById('event-end').value = event.endStr ? event.endStr.replace('Z', '') : '';
+  document.getElementById('event-label').value = event.extendedProps.label || '';
+  document.getElementById('event-visibility').value = event.extendedProps.visibility || 'busy';
+  document.getElementById('event-initials').value = event.extendedProps.addedBy || '';
+  document.getElementById('delete-event').classList.remove('hidden');
+  openModal(document.getElementById('event-modal'));
+}

--- a/greenlight/js/script.js
+++ b/greenlight/js/script.js
@@ -159,6 +159,10 @@ if (addBtn) {
 // Add card when a preset option is chosen
 document.querySelectorAll('#entry-options .add-option').forEach(btn => {
   btn.addEventListener('click', () => {
+    if (btn.dataset.type === 'calendar') {
+      window.location.href = 'calendar.html';
+      return;
+    }
     addCard({ title: btn.textContent, label: btn.dataset.type || '' });
     hideModal(entryModal);
   });

--- a/index.html
+++ b/index.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="refresh" content="0; url=/greenlight/">
-  <link rel="canonical" href="/greenlight/">
+  <meta http-equiv="refresh" content="0; url=https://www.talkkink.org/greenlight/">
+  <link rel="canonical" href="https://www.talkkink.org/greenlight/">
   <title>Redirecting...</title>
 </head>
 <body>
-  <p>Redirecting to <a href="/greenlight/">https://www.talkkink.org/greenlight/</a>...</p>
+  <p>Redirecting to <a href="https://www.talkkink.org/greenlight/">https://www.talkkink.org/greenlight/</a>...</p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- redirect root to the Greenlight homepage with absolute URL
- create a new calendar page powered by FullCalendar
- manage events in `localStorage`
- add calendar controls and modal for adding/editing events
- hook "Shared Calendar" option to open the calendar page
- style the new calendar view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870bc2dad2c832ca83237f286c546a6