### PR TITLE
Fix missing closing tag in Greenlight about modal

### DIFF
--- a/greenlight/index.html
+++ b/greenlight/index.html
@@ -149,7 +149,7 @@
         <h2>About</h2>
         <p>Beneath the Greenlight helps you track shared moments and notes.</p>
       </div>
-
+    </div>
 
 <script src="js/script.js"></script>
 <script>


### PR DESCRIPTION
## Summary
- close the `about-modal` div in `greenlight/index.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870c1f1def0832c947caa9810fe7039