### PR TITLE
Fix add button visibility and update PWA cache

### DIFF
--- a/greenlight/css/style.css
+++ b/greenlight/css/style.css
@@ -100,8 +100,10 @@ h1 {
   bottom: 30px;
   right: 30px;
   background-color: var(--accent-color);
-  color: white;
-  border: none;
+  color: var(--bg-color);
+  border: 2px solid var(--text-color);
+  cursor: pointer;
+  z-index: 20;
   font-size: 2rem;
   width: 60px;
   height: 60px;

--- a/greenlight/sw.js
+++ b/greenlight/sw.js
@@ -1,5 +1,5 @@
 // Bump the cache name to force clients to fetch the latest assets
-const CACHE = 'greenlight-v5';
+const CACHE = 'greenlight-v6';
 const FILES = [
   './',
   './index.html',


### PR DESCRIPTION
## Summary
- tweak the `#add-card` button styling so it stands out
- bump service worker cache to force clients to fetch updated assets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870c390ec7c832c9f679c3005f2c61d