### PR TITLE
Simplify partner notes form

### DIFF
--- a/greenlight/index.html
+++ b/greenlight/index.html
@@ -119,7 +119,6 @@
       <button class="close-modal" onclick="closeModal(this)">×</button>
       <h2>Partner Notes</h2>
       <ul id="notes-list"></ul>
-      <input id="note-initials" placeholder="Initials">
       <textarea id="note-text" placeholder="Write a note"></textarea>
       <button id="save-note">Save Note</button>
     </div>

--- a/greenlight/js/script.js
+++ b/greenlight/js/script.js
@@ -16,7 +16,6 @@ const menuBtn = document.getElementById('menu-btn');
 const menu = document.getElementById('menu');
 const notesModal = document.getElementById('notes-modal');
 const notesList = document.getElementById('notes-list');
-const noteInitials = document.getElementById('note-initials');
 const noteText = document.getElementById('note-text');
 const saveNoteBtn = document.getElementById('save-note');
 const menuNotes = document.getElementById('menu-notes');

--- a/greenlight/partner-notes/index.html
+++ b/greenlight/partner-notes/index.html
@@ -16,7 +16,6 @@
   </header>
   <section id="partner-notes">
     <ul id="notes-list"></ul>
-    <input id="note-initials" placeholder="Initials">
     <textarea id="note-text" placeholder="Write a note"></textarea>
     <button id="save-note">Save Note</button>
   </section>


### PR DESCRIPTION
## Summary
- remove initials input from partner notes modal
- update standalone partner notes page
- drop `noteInitials` DOM reference

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6870c5ef1bcc832cb0d3c3902e759073