### PR TITLE
Enlarge partner notes text box

### DIFF
--- a/greenlight/js/script.js
+++ b/greenlight/js/script.js
@@ -54,7 +54,7 @@ const style = document.createElement('style');
 style.textContent = `
   #note-text {
     width: 100%;
-    height: 120px;
+    height: 200px;
     font-size: 1rem;
     padding: 12px;
     border-radius: 8px;


### PR DESCRIPTION
## Summary
- enlarge the partner notes text area height so it's easier to write longer entries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6870ca819630832cbb6a5d0483967d73