### PR TITLE
Add timezone dropdowns

### DIFF
--- a/greenlight/index.html
+++ b/greenlight/index.html
@@ -96,13 +96,13 @@
         <h3>Shared Moment Scheduler</h3>
         <label id="local-time-label"><span id="local-time-text">Local date</span> <input type="date" id="local-time"></label>
         <label>Your time zone
-          <input id="your-tz" placeholder="e.g., America/Chicago">
+          <select id="your-tz"></select>
         </label>
         <label>Your country
           <select id="your-country"></select>
         </label>
         <label>Partner time zone
-          <input id="partner-tz" placeholder="e.g., America/New_York">
+          <select id="partner-tz"></select>
         </label>
         <label>Partner country
           <select id="partner-country"></select>

--- a/greenlight/js/script.js
+++ b/greenlight/js/script.js
@@ -124,7 +124,21 @@ document.addEventListener('DOMContentLoaded', () => {
   renderCards();
   loadNotes();
   renderNotes();
+  populateTimeZones(yourTz);
+  populateTimeZones(partnerTz);
 });
+
+function populateTimeZones(selectElement) {
+  if (!selectElement || typeof Intl.supportedValuesOf !== 'function') return;
+  const zones = Intl.supportedValuesOf('timeZone');
+  selectElement.innerHTML = '<option value="">Select time zone</option>';
+  zones.forEach(zone => {
+    const option = document.createElement('option');
+    option.value = zone;
+    option.textContent = zone;
+    selectElement.appendChild(option);
+  });
+}
 
 // Country list for dropdowns
 const COUNTRIES = [

--- a/greenlight/shared-scheduler/index.html
+++ b/greenlight/shared-scheduler/index.html
@@ -19,13 +19,13 @@
       <h3>Shared Moment Scheduler</h3>
       <label id="local-time-label"><span id="local-time-text">Local date</span> <input type="date" id="local-time"></label>
       <label>Your time zone
-        <input id="your-tz" placeholder="e.g., America/Chicago">
+        <select id="your-tz"></select>
       </label>
       <label>Your country
         <select id="your-country"></select>
       </label>
       <label>Partner time zone
-        <input id="partner-tz" placeholder="e.g., America/New_York">
+        <select id="partner-tz"></select>
       </label>
       <label>Partner country
         <select id="partner-country"></select>


### PR DESCRIPTION
## Summary
- change scheduler inputs to `<select>` elements for time zones
- populate time zone dropdowns with all IANA values via JS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871640cc79c832c8162b74a99c7db0e