### PR TITLE
Add YouTube thumbnail preview for cards

### DIFF
--- a/greenlight/css/style.css
+++ b/greenlight/css/style.css
@@ -95,6 +95,10 @@ h1 {
   font-size: 0.85rem;
 }
 
+.card img {
+  transition: transform 0.2s ease;
+}
+
 #add-card {
   position: fixed;
   bottom: 30px;

--- a/greenlight/js/script.js
+++ b/greenlight/js/script.js
@@ -297,6 +297,44 @@ function formatAgo(created) {
   return `${mins}m ago`;
 }
 
+// Extract a YouTube video ID from various URL formats
+function extractYouTubeID(url) {
+  const regex = /(?:youtube\.com\/(?:watch\?v=|shorts\/)|youtu\.be\/)([^#&?]*)/;
+  const match = url.match(regex);
+  return match && match[1].length >= 11 ? match[1].substring(0, 11) : null;
+}
+
+// Insert a YouTube thumbnail preview into the card element
+function renderYouTubeThumbnail(cardElement, videoUrl) {
+  const videoId = extractYouTubeID(videoUrl);
+  if (!videoId) return;
+
+  const thumbnailUrl = `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`;
+  const img = document.createElement('img');
+  img.src = thumbnailUrl;
+  img.alt = 'YouTube Thumbnail';
+  img.style.width = '100%';
+  img.style.borderRadius = '8px';
+  img.style.marginTop = '10px';
+  img.style.transition = 'transform 0.2s ease';
+
+  img.addEventListener('mouseover', () => {
+    img.style.transform = 'scale(1.03)';
+    img.style.cursor = 'pointer';
+  });
+
+  img.addEventListener('mouseout', () => {
+    img.style.transform = 'scale(1)';
+  });
+
+  img.addEventListener('click', () => {
+    window.open(`https://www.youtube.com/watch?v=${videoId}`, '_blank');
+  });
+
+  const noteSection = cardElement.querySelector('.card-notes') || cardElement.lastElementChild;
+  cardElement.insertBefore(img, noteSection);
+}
+
 function createCardElement(card) {
   const div = document.createElement('div');
   div.className = 'card';
@@ -341,12 +379,7 @@ function createCardElement(card) {
   div.appendChild(completeBtn);
 
   if (card.youtube) {
-    const ytBtn = document.createElement('button');
-    ytBtn.textContent = 'Open Video';
-    ytBtn.addEventListener('click', () => {
-      window.open(card.youtube, '_blank');
-    });
-    div.appendChild(ytBtn);
+    renderYouTubeThumbnail(div, card.youtube);
   }
 
   const noteInitial = document.createElement('input');


### PR DESCRIPTION
## Summary
- render a preview image for YouTube links
- extract YouTube ID from URL
- style card thumbnails with a hover effect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871cc6fa0a0832c9c94a7b1fc80b93b