### PR TITLE
Restore talkkink.org redirect

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Talk Kink GitHub Pages
 
 This repository hosts the static files for the Talk Kink website.
-Visiting https://www.talkkink.org/ now shows a landing page with links to
-the available tools, including the `/greenlight/` app.
+Visiting https://www.talkkink.org/ now automatically loads the
+`/greenlight/` tool.
 
 ## DNS Configuration
 
@@ -33,7 +33,7 @@ After the DNS records resolve, go to the repository’s **Settings** → **Pages
 
 The website is built from the following files in this repository:
 
-- `index.html` (landing page linking to `/greenlight/` and other tools)
+- `index.html` (redirects to `/greenlight/`)
 - `css/style.css`
 - `js/script.js`
 - `template-survey.json`

--- a/index.html
+++ b/index.html
@@ -1,21 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Talk Kink</title>
-  <link rel="stylesheet" href="css/style.css" />
-  <link rel="stylesheet" href="css/theme.css" />
+  <meta charset="UTF-8">
+  <meta http-equiv="refresh" content="0; url=https://www.talkkink.org/greenlight/">
+  <link rel="canonical" href="https://www.talkkink.org/greenlight/">
+  <title>Redirecting...</title>
 </head>
-<body class="dark-mode">
-  <div class="scroll-container scrollable-panel">
-    <h1>Talk Kink</h1>
-    <p>Welcome to the Talk Kink tools. Choose where to go:</p>
-    <div class="button-container">
-      <button class="survey-button" onclick="location.href='greenlight/'">Beneath the Greenlight</button>
-      <button class="survey-button" onclick="location.href='kinks/'">Kink Interest Survey</button>
-      <button class="survey-button" onclick="location.href='data-tools.html'">Data Tools</button>
-    </div>
-  </div>
+<body>
+  <p>Redirecting to <a href="https://www.talkkink.org/greenlight/">https://www.talkkink.org/greenlight/</a>...</p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- revert `Stop redirecting homepage` to restore talkkink.org redirect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871e2d9385c832c9cc7db1856a6e998