### PR TITLE
Fix survey start on landing page

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -490,7 +490,15 @@ beginSurveyBtn.addEventListener('click', () => {
   currentCategory = categoryOrder[0] || null;
   categoryOverlay.style.display = 'none';
   if (categoryOrder.length) {
-    buildPanelLayout();
+    // When the page includes a panel container, show the expandable layout.
+    // Otherwise fall back to the guided mode view starting with the first
+    // selected category.
+    if (panelContainer) {
+      buildPanelLayout();
+    } else if (currentCategory) {
+      showKinks(currentCategory);
+      updateProgress();
+    }
     if (downloadBtn) downloadBtn.style.display = 'block';
   }
 });


### PR DESCRIPTION
## Summary
- update `beginSurveyBtn` handler to show the guided survey when the landing
  page lacks a panel container

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6871ef2e6ba4832cbd68ca07a7a0381b