### PR TITLE
Adjust progress banner height

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1112,7 +1112,7 @@ body.light-mode .static-rating-legend {
   margin: 20px auto;
   background-color: #2b2b2b;
   border-radius: 10px;
-  height: 18px;
+  height: 26px; /* keep progress bar text from being clipped */
   overflow: hidden;
 }
 .progress-label {


### PR DESCRIPTION
## Summary
- adjust `.progress-container` height so progress text isn't clipped

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872b621ecb0832cb38639299450bad9