### PR TITLE
Remove rating legend from compatibility screen and fix PDF

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -10,16 +10,6 @@
 <body class="dark-mode">
   <div class="scroll-container scrollable-panel">
     <h1>See Our Compatibility</h1>
-    <div class="static-rating-legend">
-      <ul>
-        <li>0 — Hard No</li>
-        <li>1 — Dislike / Haven’t Considered</li>
-        <li>2 — Would Try for Partner</li>
-        <li>3 — Okay / Neutral</li>
-        <li>4 — Like</li>
-        <li>5 — Love / Core Interest</li>
-      </ul>
-    </div>
     <div class="back-button-container">
       <button onclick="window.location.href='/greenlight/'">&larr; Back</button>
     </div>

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -331,9 +331,12 @@ if (fileBInput) {
 const downloadBtn = document.getElementById('downloadResults');
 if (downloadBtn) {
   downloadBtn.addEventListener('click', () => {
-    if (!lastResult) {
-      alert('No results to download.');
+    if (!surveyA || !surveyB) {
+      alert('Please upload both surveys first.');
       return;
+    }
+    if (!lastResult) {
+      lastResult = buildKinkBreakdown(surveyA, surveyB);
     }
     generateComparisonPDF(lastResult);
   });


### PR DESCRIPTION
## Summary
- remove rating legend from `compatibility.html`
- compute results when generating PDF so download button always works

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68733a0986f4832c8e172934eb52a141