### PR TITLE
Add theme font styling to survey area

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1333,6 +1333,10 @@ body.light-mode .scrollable-panel::-webkit-scrollbar-track {
 /* ===== TALK KINK SURVEY LAYOUT FIX (DESKTOP + MOBILE) ===== */
 /* Applies ONLY to survey content — does not affect Greenlight */
 
+#survey-section {
+  transition: color 0.3s ease, font-family 0.3s ease;
+}
+
 #survey-section .category-row {
   display: flex;
   align-items: flex-start;

--- a/js/script.js
+++ b/js/script.js
@@ -1,6 +1,6 @@
 import { calculateCompatibility } from './compatibility.js';
 import { pruneSurvey } from './pruneSurvey.js';
-import { initTheme } from './theme.js';
+import { initTheme, applyThemeFontStyles } from './theme.js';
 
 // ================== Password Protection ==================
 const PASSWORD = 'toopoortosue';
@@ -207,6 +207,7 @@ const roleDefinitionsBtn = document.getElementById('roleDefinitionsBtn');
 const closeRoleDefinitionsBtn = document.getElementById('closeRoleDefinitionsBtn');
 const surveyIntro = document.getElementById('surveyIntro');
 const startSurveyBtn = document.getElementById('startSurveyBtn');
+const themeSelector = document.getElementById('themeSelector');
 const categoryDescription = document.getElementById('categoryDescription');
 const newSurveyBtn = document.getElementById('newSurveyBtn');
 const downloadBtn = document.getElementById('downloadBtn');
@@ -449,6 +450,9 @@ function startNewSurvey() {
 startSurveyBtn.addEventListener('click', () => {
   guidedMode = true;
   if (surveyIntro) surveyIntro.style.display = 'none';
+  if (themeSelector) {
+    applyThemeFontStyles(themeSelector.value);
+  }
   startNewSurvey();
 });
 

--- a/js/theme.js
+++ b/js/theme.js
@@ -11,3 +11,28 @@ export function initTheme() {
     });
   }
 }
+
+export function applyThemeFontStyles(theme) {
+  const surveyContent = document.querySelector('#survey-section');
+  const themeStyles = {
+    'light-mode': {
+      fontColor: '#111',
+      fontFamily: 'Arial, sans-serif'
+    },
+    'dark-mode': {
+      fontColor: '#eee',
+      fontFamily: 'Helvetica, sans-serif'
+    },
+    'theme-echoes-beyond': {
+      fontColor: '#e0ffe0',
+      fontFamily: '"Courier New", monospace'
+    }
+  };
+
+  const selected = themeStyles[theme] || themeStyles['dark-mode'];
+
+  if (surveyContent) {
+    surveyContent.style.color = selected.fontColor;
+    surveyContent.style.fontFamily = selected.fontFamily;
+  }
+}


### PR DESCRIPTION
## Summary
- add dynamic font application helper in `theme.js`
- trigger new font logic when starting the survey
- make `#survey-section` transition fonts smoothly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873fd7fba34832cab8fa613d31f745c