### PR TITLE
Fix fonts for survey start

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -417,6 +417,10 @@ function startNewSurvey() {
   if (homeBtn) homeBtn.style.display = 'block';
   if (mainNavButtons) mainNavButtons.style.display = 'none';
 
+  if (themeSelector) {
+    applyThemeFontStyles(themeSelector.value);
+  }
+
   categoryOverlay.style.display = 'flex';
   if (panelContainer) panelContainer.style.display = 'none';
   surveyContainer.style.display = 'none';
@@ -487,6 +491,9 @@ if (deselectAllBtn) {
 }
 
 beginSurveyBtn.addEventListener('click', () => {
+  if (themeSelector) {
+    applyThemeFontStyles(themeSelector.value);
+  }
   categoryOrder = Array.from(previewList.querySelectorAll('input[type="checkbox"]'))
     .filter(cb => cb.checked)
     .map(cb => cb.value);

--- a/js/theme.js
+++ b/js/theme.js
@@ -14,6 +14,7 @@ export function initTheme() {
 
 export function applyThemeFontStyles(theme) {
   const surveyContent = document.querySelector('#survey-section');
+  const categoryPanel = document.querySelector('#categoryPanel');
   const themeStyles = {
     'light-mode': {
       fontColor: '#111',
@@ -34,5 +35,10 @@ export function applyThemeFontStyles(theme) {
   if (surveyContent) {
     surveyContent.style.color = selected.fontColor;
     surveyContent.style.fontFamily = selected.fontFamily;
+  }
+
+  if (categoryPanel) {
+    categoryPanel.style.color = selected.fontColor;
+    categoryPanel.style.fontFamily = selected.fontFamily;
   }
 }


### PR DESCRIPTION
## Summary
- apply theme font styles inside `startNewSurvey`
- update `beginSurveyBtn` handler to adjust fonts when categories are confirmed
- extend `applyThemeFontStyles` to also style the category panel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874009bf890832c92b71b4ae7a8e006