### PR TITLE
Update progress bar to follow theme colors

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1138,7 +1138,7 @@ body.light-mode .static-rating-legend {
 .progress-fill {
   height: 100%;
   width: 0;
-  background-color: #4caf50;
+  background-color: var(--progress-fill-color, #4caf50);
   transition: width 0.4s ease;
   border-radius: 10px 0 0 10px;
 }

--- a/css/theme.css
+++ b/css/theme.css
@@ -5,6 +5,7 @@
   --button-bg: #444;
   --button-text: #ffffff;
   --button-hover-bg: #666;
+  --progress-fill-color: #4caf50;
 }
 
 .theme-lightforest,
@@ -15,6 +16,7 @@
   --button-bg: #558c75;
   --button-text: #ffffff;
   --button-hover-bg: #446d60;
+  --progress-fill-color: #558c75;
 }
 
 .theme-darkviolet,
@@ -25,6 +27,7 @@
   --button-bg: #7c5fe9;
   --button-text: #ffffff;
   --button-hover-bg: #9b84ff;
+  --progress-fill-color: #7c5fe9;
 }
 
 .theme-blue {
@@ -34,6 +37,7 @@
   --button-bg: #0055aa;
   --button-text: #ffffff;
   --button-hover-bg: #003377;
+  --progress-fill-color: #0055aa;
 }
 
 .theme-echoes-beyond {
@@ -43,6 +47,7 @@
   --button-bg: #334863;
   --button-text: #fca311;
   --button-hover-bg: #1f3352;
+  --progress-fill-color: #334863;
 }
 
 .theme-love-notes-lipstick {
@@ -52,6 +57,7 @@
   --button-bg: #ff6bd6;
   --button-text: #311847;
   --button-hover-bg: #c44fb0;
+  --progress-fill-color: #ff6bd6;
 }
 
 .theme-rainbow {
@@ -61,4 +67,5 @@
   --button-bg: rgba(255, 255, 255, 0.9);
   --button-text: #000000;
   --button-hover-bg: rgba(255, 255, 255, 0.7);
+  --progress-fill-color: #603636;
 }


### PR DESCRIPTION
## Summary
- add new CSS variable `--progress-fill-color` with theme-specific values
- use that variable for the progress bar fill so it matches the selected theme

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68740319de18832c9320effae99a0831