### PR TITLE
Improve survey theme styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1333,8 +1333,10 @@ body.light-mode .scrollable-panel::-webkit-scrollbar-track {
 /* ===== TALK KINK SURVEY LAYOUT FIX (DESKTOP + MOBILE) ===== */
 /* Applies ONLY to survey content — does not affect Greenlight */
 
-#survey-section {
-  transition: color 0.3s ease, font-family 0.3s ease;
+#survey-section,
+#survey-section * {
+  transition: color 0.3s ease, background-color 0.3s ease,
+    font-family 0.3s ease, border-color 0.3s ease;
 }
 
 #survey-section .category-row {
@@ -1362,6 +1364,13 @@ body.light-mode .scrollable-panel::-webkit-scrollbar-track {
   max-width: 150px;
   flex: 1 1 35%;
   margin-left: 0;
+}
+
+#survey-section select {
+  padding: 6px;
+  border-radius: 4px;
+  border: 1px solid #aaa;
+  appearance: none;
 }
 
 /* ===== RESPONSIVE TWEAKS ===== */

--- a/js/theme.js
+++ b/js/theme.js
@@ -20,15 +20,27 @@ export function applyThemeFontStyles(theme) {
   const themeStyles = {
     'light-mode': {
       fontColor: '#111',
-      fontFamily: 'Arial, sans-serif'
+      bgColor: '#ffffff',
+      fontFamily: 'Arial, sans-serif',
+      dropdownBg: '#fff',
+      dropdownText: '#111',
+      borderColor: '#ccc'
     },
     'dark-mode': {
-      fontColor: '#eee',
-      fontFamily: 'Helvetica, sans-serif'
+      fontColor: '#f2f2f2',
+      bgColor: '#121212',
+      fontFamily: 'Helvetica, sans-serif',
+      dropdownBg: '#1f1f1f',
+      dropdownText: '#f2f2f2',
+      borderColor: '#444'
     },
     'theme-echoes-beyond': {
-      fontColor: '#e0ffe0',
-      fontFamily: '"Courier New", monospace'
+      fontColor: '#d0ffd0',
+      bgColor: '#0f1b0f',
+      fontFamily: '"Courier New", monospace',
+      dropdownBg: '#1e2e1e',
+      dropdownText: '#d0ffd0',
+      borderColor: '#355935'
     }
   };
 
@@ -36,7 +48,19 @@ export function applyThemeFontStyles(theme) {
 
   if (surveyContent) {
     surveyContent.style.color = selected.fontColor;
+    surveyContent.style.backgroundColor = selected.bgColor;
     surveyContent.style.fontFamily = selected.fontFamily;
+
+    surveyContent.querySelectorAll('*').forEach(el => {
+      el.style.color = selected.fontColor;
+      el.style.fontFamily = selected.fontFamily;
+    });
+
+    surveyContent.querySelectorAll('select').forEach(select => {
+      select.style.backgroundColor = selected.dropdownBg;
+      select.style.color = selected.dropdownText;
+      select.style.borderColor = selected.borderColor;
+    });
   }
 
   if (categoryPanel) {


### PR DESCRIPTION
## Summary
- add smoother transition effects for survey section and its elements
- style survey dropdowns to match dynamic themes
- update theme configuration to control fonts, colors, and dropdown styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68740c8257c8832cbb3ee0d0f0ba2469