### PR TITLE
Fix theme-based category highlight

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -646,8 +646,9 @@ body.theme-rainbow #comparisonResult {
 }
 
 .checkbox-item.selected {
-  background-color: #e0e0e0;
-  border-color: #4caf50;
+  background-color: var(--button-hover-bg, #e0e0e0);
+  border-color: var(--progress-fill-color, #4caf50);
+  color: var(--button-text, #fff);
 }
 
 .checkbox-item input {


### PR DESCRIPTION
## Summary
- use theme colors for selected category checkboxes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687412935ed0832cb787c69eeae38143