### PR TITLE
Add font customization dialog

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -566,6 +566,13 @@ body.theme-rainbow #comparisonResult {
   box-sizing: border-box;
 }
 
+#surveyIntro select {
+  padding: 6px;
+  border-radius: 4px;
+  border: 1px solid #aaa;
+  appearance: none;
+}
+
 #categoryOverlay {
   display: none;
   align-items: center;

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
     </select>
   </div>
 
+
   <div id="progressBanner" class="progress-container" style="display:block">
     <div class="progress-bar">
       <span id="progressLabel" class="progress-bar-text"></span>
@@ -186,6 +187,14 @@
   <div id="surveyIntro" class="overlay">
     <div class="intro-modal">
       <p>Follow the prompts to rate each category in order.</p>
+      <label for="fontSelectorIntro">Font Style:</label>
+      <select id="fontSelectorIntro">
+        <option value="default">Default</option>
+        <option value="'Arial', sans-serif">Arial</option>
+        <option value="'Georgia', serif">Georgia</option>
+        <option value="'Courier New', monospace">Courier New</option>
+        <option value="'Trebuchet MS', sans-serif">Trebuchet MS</option>
+      </select>
       <button id="startSurveyBtn">Start Survey</button>
     </div>
   </div>

--- a/js/script.js
+++ b/js/script.js
@@ -1,6 +1,6 @@
 import { calculateCompatibility } from './compatibility.js';
 import { pruneSurvey } from './pruneSurvey.js';
-import { initTheme, applyThemeFontStyles } from './theme.js';
+import { initTheme, applyThemeFontStyles, applyCustomFont } from './theme.js';
 
 // ================== Password Protection ==================
 const PASSWORD = 'toopoortosue';
@@ -208,6 +208,7 @@ const closeRoleDefinitionsBtn = document.getElementById('closeRoleDefinitionsBtn
 const surveyIntro = document.getElementById('surveyIntro');
 const startSurveyBtn = document.getElementById('startSurveyBtn');
 const themeSelector = document.getElementById('themeSelector');
+const fontSelector = document.getElementById('fontSelectorIntro');
 const categoryDescription = document.getElementById('categoryDescription');
 const newSurveyBtn = document.getElementById('newSurveyBtn');
 const downloadBtn = document.getElementById('downloadBtn');
@@ -420,6 +421,9 @@ function startNewSurvey() {
   if (themeSelector) {
     applyThemeFontStyles(themeSelector.value);
   }
+  if (fontSelector) {
+    applyCustomFont(fontSelector.value);
+  }
 
   categoryOverlay.style.display = 'flex';
   if (panelContainer) panelContainer.style.display = 'none';
@@ -457,6 +461,9 @@ startSurveyBtn.addEventListener('click', () => {
   if (themeSelector) {
     applyThemeFontStyles(themeSelector.value);
   }
+  if (fontSelector) {
+    applyCustomFont(fontSelector.value);
+  }
   startNewSurvey();
 });
 
@@ -493,6 +500,9 @@ if (deselectAllBtn) {
 beginSurveyBtn.addEventListener('click', () => {
   if (themeSelector) {
     applyThemeFontStyles(themeSelector.value);
+  }
+  if (fontSelector) {
+    applyCustomFont(fontSelector.value);
   }
   categoryOrder = Array.from(previewList.querySelectorAll('input[type="checkbox"]'))
     .filter(cb => cb.checked)

--- a/js/theme.js
+++ b/js/theme.js
@@ -1,5 +1,6 @@
 export function initTheme() {
   const themeSelector = document.getElementById('themeSelector');
+  const fontSelector = document.getElementById('fontSelectorIntro');
   const savedTheme = localStorage.getItem('selectedTheme') || 'dark-mode';
   document.body.className = savedTheme;
   applyThemeFontStyles(savedTheme);
@@ -10,6 +11,19 @@ export function initTheme() {
       document.body.className = selectedTheme;
       localStorage.setItem('selectedTheme', selectedTheme);
       applyThemeFontStyles(selectedTheme);
+      const currentFont = fontSelector ? fontSelector.value : null;
+      if (currentFont) applyCustomFont(currentFont);
+    });
+  }
+
+  if (fontSelector) {
+    const savedFont = localStorage.getItem('selectedFont') || 'default';
+    fontSelector.value = savedFont;
+    applyCustomFont(savedFont);
+    fontSelector.addEventListener('change', () => {
+      const selectedFont = fontSelector.value;
+      localStorage.setItem('selectedFont', selectedFont);
+      applyCustomFont(selectedFont);
     });
   }
 }
@@ -66,5 +80,26 @@ export function applyThemeFontStyles(theme) {
   if (categoryPanel) {
     categoryPanel.style.color = selected.fontColor;
     categoryPanel.style.fontFamily = selected.fontFamily;
+  }
+}
+
+export function applyCustomFont(font) {
+  const surveyContent = document.querySelector('#survey-section');
+  const categoryPanel = document.querySelector('#categoryPanel');
+
+  if (font === 'default') {
+    applyThemeFontStyles(document.body.className);
+    return;
+  }
+
+  if (surveyContent) {
+    surveyContent.style.fontFamily = font;
+    surveyContent.querySelectorAll('*').forEach(el => {
+      el.style.fontFamily = font;
+    });
+  }
+
+  if (categoryPanel) {
+    categoryPanel.style.fontFamily = font;
   }
 }

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -28,6 +28,7 @@
     </select>
   </div>
 
+
   <div id="progressBanner" class="progress-container" style="display:block">
     <div class="progress-bar">
       <span id="progressLabel" class="progress-bar-text"></span>
@@ -184,6 +185,14 @@
   <div id="surveyIntro" class="overlay">
     <div class="intro-modal">
       <p>Follow the prompts to rate each category in order.</p>
+      <label for="fontSelectorIntro">Font Style:</label>
+      <select id="fontSelectorIntro">
+        <option value="default">Default</option>
+        <option value="'Arial', sans-serif">Arial</option>
+        <option value="'Georgia', serif">Georgia</option>
+        <option value="'Courier New', monospace">Courier New</option>
+        <option value="'Trebuchet MS', sans-serif">Trebuchet MS</option>
+      </select>
       <button id="startSurveyBtn">Start Survey</button>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- allow choosing a font style when the survey starts
- persist selected font in localStorage
- apply font override via `applyCustomFont`
- style intro dialog select input

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687416434ab4832c9ddab7444ba97dba