### PR TITLE
Add Blue Sky theme

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -179,6 +179,11 @@ body.theme-blue #mainCategoryList button.active {
   color: #fff;
   border: 1px solid #003377;
 }
+body.theme-blue-sky #mainCategoryList button.active {
+  background-color: #99c9f2;
+  color: #002244;
+  border: 1px solid #99c9f2;
+}
 body.theme-echoes-beyond #mainCategoryList button.active {
   background-color: #334863;
   color: #fca311;
@@ -263,6 +268,11 @@ body.theme-blue .category-panel {
   background-color: #002244;
   color: #fff;
   border-right-color: #003366;
+}
+body.theme-blue-sky .category-panel {
+  background-color: #cde6ff;
+  color: #002244;
+  border-right-color: #99c9f2;
 }
 body.theme-echoes-beyond .category-panel {
   background-color: #1b263b;
@@ -356,6 +366,14 @@ body.theme-blue .tab {
 body.theme-blue .tab.active {
   background-color: #0055aa;
   border: 1px solid #003377;
+}
+body.theme-blue-sky .tab {
+  background-color: #cde6ff;
+  color: #002244;
+}
+body.theme-blue-sky .tab.active {
+  background-color: #99c9f2;
+  border: 1px solid #99c9f2;
 }
 body.theme-echoes-beyond .tab {
   background-color: #2b314c;
@@ -454,6 +472,11 @@ body.theme-blue #categoryContainer button.active {
   color: #fff;
   border: 1px solid #003377;
 }
+body.theme-blue-sky #categoryContainer button.active {
+  background-color: #99c9f2;
+  color: #002244;
+  border: 1px solid #99c9f2;
+}
 body.theme-echoes-beyond #categoryContainer button.active {
   background-color: #334863;
   color: #fca311;
@@ -490,6 +513,10 @@ body.light-mode #comparisonResult {
 body.theme-blue #comparisonResult {
   background-color: #002244;
   color: #fff;
+}
+body.theme-blue-sky #comparisonResult {
+  background-color: #cde6ff;
+  color: #002244;
 }
 body.theme-echoes-beyond #comparisonResult {
   background-color: #1b263b;
@@ -760,6 +787,10 @@ body.light-mode .expandable-panel summary {
 body.theme-blue .expandable-panel summary {
   background-color: #003366;
   color: #fff;
+}
+body.theme-blue-sky .expandable-panel summary {
+  background-color: #cde6ff;
+  color: #002244;
 }
 body.theme-echoes-beyond .expandable-panel summary {
   background-color: #2b314c;
@@ -1156,6 +1187,10 @@ body.light-mode .progress-bar {
 body.theme-blue .progress-container,
 body.theme-blue .progress-bar {
   background-color: #001933;
+}
+body.theme-blue-sky .progress-container,
+body.theme-blue-sky .progress-bar {
+  background-color: #e6f2ff;
 }
 body.theme-echoes-beyond .progress-container,
 body.theme-echoes-beyond .progress-bar {

--- a/css/theme.css
+++ b/css/theme.css
@@ -40,6 +40,16 @@
   --progress-fill-color: #0055aa;
 }
 
+.theme-blue-sky {
+  --bg-color: #e6f2ff;
+  --panel-color: #cde6ff;
+  --text-color: #002244;
+  --button-bg: #99c9f2;
+  --button-text: #002244;
+  --button-hover-bg: #b5d8ff;
+  --progress-fill-color: #99c9f2;
+}
+
 .theme-echoes-beyond {
   --bg-color: #14213d;
   --panel-color: #1b263b;

--- a/data-tools.html
+++ b/data-tools.html
@@ -16,6 +16,7 @@
       <option value="dark-mode">Dark</option>
       <option value="light-mode">Light Forest</option>
       <option value="theme-blue">Blue</option>
+      <option value="theme-blue-sky">Blue Sky</option>
       <option value="theme-echoes-beyond">Echoes Beyond</option>
       <option value="theme-love-notes-lipstick">Love Notes & Lipstick</option>
       <option value="theme-rainbow">Rainbow</option>

--- a/index.html
+++ b/index.html
@@ -21,6 +21,7 @@
       <option value="dark-mode">Dark</option>
       <option value="light-mode">Light Forest</option>
       <option value="theme-blue">Blue</option>
+      <option value="theme-blue-sky">Blue Sky</option>
       <option value="theme-echoes-beyond">Echoes Beyond</option>
       <option value="theme-love-notes-lipstick">Love Notes & Lipstick</option>
       <option value="theme-rainbow">Rainbow</option>

--- a/js/theme.js
+++ b/js/theme.js
@@ -34,6 +34,22 @@ export function applyThemeFontStyles(theme) {
       dropdownText: '#f2f2f2',
       borderColor: '#444'
     },
+    'theme-blue': {
+      fontColor: '#ffffff',
+      bgColor: '#001933',
+      fontFamily: 'Helvetica, sans-serif',
+      dropdownBg: '#002244',
+      dropdownText: '#ffffff',
+      borderColor: '#003366'
+    },
+    'theme-blue-sky': {
+      fontColor: '#002244',
+      bgColor: '#e6f2ff',
+      fontFamily: 'Helvetica, sans-serif',
+      dropdownBg: '#cde6ff',
+      dropdownText: '#002244',
+      borderColor: '#99c9f2'
+    },
     'theme-echoes-beyond': {
       fontColor: '#d0ffd0',
       bgColor: '#0f1b0f',

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -22,6 +22,7 @@
       <option value="dark-mode">Dark</option>
       <option value="light-mode">Light Forest</option>
       <option value="theme-blue">Blue</option>
+      <option value="theme-blue-sky">Blue Sky</option>
       <option value="theme-echoes-beyond">Echoes Beyond</option>
       <option value="theme-love-notes-lipstick">Love Notes & Lipstick</option>
       <option value="theme-rainbow">Rainbow</option>


### PR DESCRIPTION
## Summary
- add `theme-blue-sky` color variables
- style survey components for the new theme
- register new theme in JS
- expose the option in survey pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874296808d0832c84bfaf3616866618