### PR TITLE
Improve theme color handling

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -1,6 +1,6 @@
 import { calculateCompatibility } from './compatibility.js';
 import { pruneSurvey } from './pruneSurvey.js';
-import { initTheme, applyThemeFontStyles } from './theme.js';
+import { initTheme, applyThemeColors } from './theme.js';
 
 // ================== Password Protection ==================
 const PASSWORD = 'toopoortosue';
@@ -418,7 +418,7 @@ function startNewSurvey() {
   if (mainNavButtons) mainNavButtons.style.display = 'none';
 
   if (themeSelector) {
-    applyThemeFontStyles(themeSelector.value);
+    applyThemeColors(themeSelector.value);
   }
 
   categoryOverlay.style.display = 'flex';
@@ -455,7 +455,7 @@ startSurveyBtn.addEventListener('click', () => {
   guidedMode = true;
   if (surveyIntro) surveyIntro.style.display = 'none';
   if (themeSelector) {
-    applyThemeFontStyles(themeSelector.value);
+    applyThemeColors(themeSelector.value);
   }
   startNewSurvey();
 });
@@ -492,7 +492,7 @@ if (deselectAllBtn) {
 
 beginSurveyBtn.addEventListener('click', () => {
   if (themeSelector) {
-    applyThemeFontStyles(themeSelector.value);
+    applyThemeColors(themeSelector.value);
   }
   categoryOrder = Array.from(previewList.querySelectorAll('input[type="checkbox"]'))
     .filter(cb => cb.checked)

--- a/js/theme.js
+++ b/js/theme.js
@@ -2,121 +2,96 @@ export function initTheme() {
   const themeSelector = document.getElementById('themeSelector');
   const savedTheme = localStorage.getItem('selectedTheme') || 'dark-mode';
   document.body.className = savedTheme;
-  applyThemeFontStyles(savedTheme);
+  applyThemeColors(savedTheme);
   if (themeSelector) {
     themeSelector.value = savedTheme;
     themeSelector.addEventListener('change', () => {
       const selectedTheme = themeSelector.value;
       document.body.className = selectedTheme;
       localStorage.setItem('selectedTheme', selectedTheme);
-      applyThemeFontStyles(selectedTheme);
+      applyThemeColors(selectedTheme);
     });
   }
 }
 
-export function applyThemeFontStyles(theme) {
+export function applyThemeColors(theme) {
   const surveyContent = document.querySelector('#survey-section');
   const categoryPanel = document.querySelector('#categoryPanel');
   const themeStyles = {
     'light-mode': {
       fontColor: '#111',
       bgColor: '#ffffff',
-      fontFamily: 'Arial, sans-serif',
       inputBg: '#f7f7f7',
       inputText: '#111',
-      borderColor: '#ccc',
-      buttonBg: '#e0e0e0',
-      buttonText: '#111'
+      borderColor: '#ccc'
     },
     'dark-mode': {
       fontColor: '#f2f2f2',
       bgColor: '#121212',
-      fontFamily: 'Helvetica, sans-serif',
       inputBg: '#2a2a2a',
       inputText: '#ffffff',
-      borderColor: '#666',
-      buttonBg: '#333',
-      buttonText: '#f2f2f2'
+      borderColor: '#666'
     },
     'theme-blue': {
       fontColor: '#ffffff',
-      bgColor: '#001933',
-      fontFamily: 'Helvetica, sans-serif',
-      inputBg: '#002244',
+      bgColor: '#2a3b55',
+      inputBg: '#3a4b6b',
       inputText: '#ffffff',
-      borderColor: '#003366',
-      buttonBg: '#0055aa',
-      buttonText: '#ffffff'
+      borderColor: '#4c5d7a'
     },
     'theme-blue-sky': {
       fontColor: '#002244',
       bgColor: '#dfefff',
-      fontFamily: 'Helvetica, sans-serif',
-      inputBg: '#b0d4ff',
+      inputBg: '#c9e0ff',
       inputText: '#002244',
-      borderColor: '#99c9f2',
-      buttonBg: '#99c9f2',
-      buttonText: '#002244'
+      borderColor: '#a9c9e6'
     },
     'theme-echoes-beyond': {
       fontColor: '#ffcc66',
-      bgColor: '#0b1d26',
-      fontFamily: '"Courier New", monospace',
-      inputBg: '#ffb347',
+      bgColor: '#14213d',
+      inputBg: '#f9d7a5',
       inputText: '#003366',
-      borderColor: '#cc7a00',
-      buttonBg: '#0b1d26',
-      buttonText: '#ffcc66'
+      borderColor: '#cc7a00'
     },
     'theme-love-notes-lipstick': {
-      fontColor: '#fff0f5',
-      bgColor: '#2b002b',
-      fontFamily: 'Helvetica, sans-serif',
-      inputBg: '#a64ca6',
-      inputText: '#fff0f5',
-      borderColor: '#d47bd4',
-      buttonBg: '#d47bd4',
-      buttonText: '#2b002b'
+      fontColor: '#ffe0f5',
+      bgColor: '#3b0a3b',
+      inputBg: '#dca0d7',
+      inputText: '#3b0a3b',
+      borderColor: '#c286c2'
     },
     'theme-rainbow': {
-      fontColor: '#ffffff',
-      bgColor: '#000000',
-      fontFamily: 'Helvetica, sans-serif',
-      inputBg: 'linear-gradient(90deg, red, orange, yellow, green, blue, indigo, violet)',
-      inputText: '#ffffff',
-      borderColor: '#ffffff',
-      buttonBg: 'linear-gradient(90deg, red, orange, yellow, green, blue, indigo, violet)',
-      buttonText: '#ffffff'
+      fontColor: '#222',
+      bgColor: '#fff0f5',
+      inputBg: '#f8e6ff',
+      inputText: '#222',
+      borderColor: '#d8b0e6'
     }
   };
 
-  const selected = themeStyles[theme] || themeStyles['dark-mode'];
+  const normalized = (theme || '').toLowerCase().replace(/\s+/g, '-');
+  const selected = themeStyles[normalized] || themeStyles['dark-mode'];
 
   if (surveyContent) {
     surveyContent.style.color = selected.fontColor;
     surveyContent.style.backgroundColor = selected.bgColor;
-    surveyContent.style.fontFamily = selected.fontFamily;
 
     surveyContent.querySelectorAll('*').forEach(el => {
       el.style.color = selected.fontColor;
-      el.style.fontFamily = selected.fontFamily;
     });
 
     surveyContent.querySelectorAll('select, input[type="text"]').forEach(input => {
-      input.style.background = selected.inputBg;
+      input.style.backgroundColor = selected.inputBg;
       input.style.color = selected.inputText;
       input.style.borderColor = selected.borderColor;
-      input.style.boxShadow = '0 1px 2px rgba(0, 0, 0, 0.1)';
-    });
-
-    surveyContent.querySelectorAll('button').forEach(btn => {
-      btn.style.background = selected.buttonBg;
-      btn.style.color = selected.buttonText;
+      input.style.borderRadius = '6px';
+      input.style.boxShadow = '0 2px 4px rgba(0, 0, 0, 0.1)';
     });
   }
 
   if (categoryPanel) {
     categoryPanel.style.color = selected.fontColor;
-    categoryPanel.style.fontFamily = selected.fontFamily;
   }
+
+  document.body.style.backgroundColor = selected.bgColor;
 }


### PR DESCRIPTION
## Summary
- switch to new `applyThemeColors` helper for styling
- use softer pastel colors and remove gradients
- update event handlers to apply theme on survey start and theme change

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68744c60c7b0832c86f55ca7564fbd7b