### PR TITLE
Add comparison chart layout for role results

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1691,3 +1691,52 @@ body {
   text-align: right;
   color: var(--text-color);
 }
+
+/* ===== Comparison Chart ===== */
+#comparison-chart {
+  margin-top: 20px;
+}
+
+.result-row {
+  display: grid;
+  grid-template-columns: 60px 1fr 150px auto;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.result-row .percentage {
+  text-align: right;
+  font-weight: bold;
+}
+
+.result-row .bar {
+  height: 6px;
+  background-color: #ddd;
+  position: relative;
+  border-radius: 3px;
+}
+
+.result-row .bar::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  height: 100%;
+  width: var(--bar-width);
+  background-color: #00cc44;
+  border-radius: 3px;
+}
+
+.result-row .role {
+  font-weight: 500;
+}
+
+.result-row .more-info a {
+  color: #0066cc;
+  text-decoration: none;
+}
+
+.result-row .more-info a:hover {
+  text-decoration: underline;
+}

--- a/your-roles.html
+++ b/your-roles.html
@@ -45,15 +45,32 @@
 
     function createEntry(name, percent) {
       const row = document.createElement('div');
-      row.className = 'result-entry';
-      const label = document.createElement('div');
-      label.className = 'label';
-      label.textContent = titleCase(name);
-      const score = document.createElement('div');
-      score.className = 'score';
-      score.textContent = `${percent}%`;
-      row.appendChild(label);
-      row.appendChild(score);
+      row.className = 'result-row';
+      row.dataset.score = percent;
+      row.style.setProperty('--bar-width', `${percent}%`);
+
+      const pct = document.createElement('div');
+      pct.className = 'percentage';
+      pct.textContent = `${percent}%`;
+
+      const bar = document.createElement('div');
+      bar.className = 'bar';
+
+      const role = document.createElement('div');
+      role.className = 'role';
+      role.textContent = titleCase(name);
+
+      const info = document.createElement('div');
+      info.className = 'more-info';
+      const link = document.createElement('a');
+      link.href = '#';
+      link.textContent = 'More info';
+      info.appendChild(link);
+
+      row.appendChild(pct);
+      row.appendChild(bar);
+      row.appendChild(role);
+      row.appendChild(info);
       return row;
     }
 
@@ -94,9 +111,12 @@
           title.className = 'result-section-title';
           title.textContent = 'Your Survey Summary';
           container.appendChild(title);
+          const chart = document.createElement('div');
+          chart.id = 'comparison-chart';
           scores.forEach(s => {
-            container.appendChild(createEntry(s.name, s.percent));
+            chart.appendChild(createEntry(s.name, s.percent));
           });
+          container.appendChild(chart);
           const btn = document.createElement('button');
           btn.className = 'download-btn';
           btn.textContent = 'Download PDF';


### PR DESCRIPTION
## Summary
- implement a progress bar style chart for role compatibility
- render chart rows dynamically in `your-roles.html`
- style comparison chart elements in CSS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68755f538efc832c9c494ac08b69911c