### PR TITLE
Improve role result bars

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1554,11 +1554,9 @@ body {
 /*  Compatibility Comparison Updates                  */
 /* -------------------------------------------------- */
 
-/* 🔧 REMOVE EXISTING COMPATIBILITY BARS */
+/* Compatibility comparison cleanup */
 .compatibility-bar,
-.compare-bar,
-.bar-container,
-.bar-fill {
+.compare-bar {
   display: none !important;
 }
 
@@ -1694,49 +1692,73 @@ body {
 
 /* ===== Comparison Chart ===== */
 #comparison-chart {
-  margin-top: 20px;
+  background-color: #111;
+  color: white;
+  font-family: Arial, sans-serif;
+  padding: 24px;
+  border-radius: 12px;
+  max-width: 850px;
+  margin: 40px auto;
+  box-shadow: 0 0 20px rgba(0, 0, 0, 0.6);
 }
 
 .result-row {
-  display: grid;
-  grid-template-columns: 60px 1fr 150px auto;
+  display: flex;
   align-items: center;
-  gap: 8px;
-  margin-bottom: 8px;
+  padding: 6px 0;
+  gap: 12px;
+  border-bottom: 1px solid #2a2a2a;
 }
 
-.result-row .percentage {
-  text-align: right;
+.result-row:last-child {
+  border-bottom: none;
+}
+
+.percentage {
+  width: 60px;
   font-weight: bold;
+  text-align: right;
+  color: white;
 }
 
-.result-row .bar {
-  height: 6px;
-  background-color: #ddd;
+.role {
+  flex: 1.5;
+  color: white;
+}
+
+.bar-container {
+  flex: 2;
+  background: #222;
+  height: 10px;
+  border-radius: 5px;
+  overflow: hidden;
   position: relative;
-  border-radius: 3px;
 }
 
-.result-row .bar::before {
-  content: '';
+.bar-fill {
+  height: 100%;
   position: absolute;
   left: 0;
   top: 0;
-  height: 100%;
-  width: var(--bar-width);
-  background-color: #00cc44;
-  border-radius: 3px;
+  border-radius: 5px;
 }
 
-.result-row .role {
-  font-weight: 500;
+.more-info {
+  flex-shrink: 0;
+  font-size: 0.85rem;
+  color: #ccc;
 }
 
-.result-row .more-info a {
-  color: #0066cc;
-  text-decoration: none;
-}
-
-.result-row .more-info a:hover {
-  text-decoration: underline;
+@media (max-width: 600px) {
+  #comparison-chart {
+    padding: 16px;
+    margin: 20px 10px;
+  }
+  .percentage {
+    width: 45px;
+    font-size: 0.8rem;
+  }
+  .more-info {
+    font-size: 0.75rem;
+  }
 }

--- a/your-roles.html
+++ b/your-roles.html
@@ -43,34 +43,28 @@
       return str.replace(/\b\w/g, c => c.toUpperCase());
     }
 
-    function createEntry(name, percent) {
+    function getBarColor(score) {
+      if (score >= 95) return '#00cc00';
+      if (score >= 85) return '#33cc33';
+      if (score >= 70) return '#66cc33';
+      if (score >= 55) return '#cccc33';
+      if (score >= 40) return '#ff9933';
+      if (score >= 20) return '#ff6633';
+      if (score > 0) return '#cc0033';
+      return '#990000';
+    }
+
+    function renderResultRow(roleName, score, tooltipText) {
       const row = document.createElement('div');
       row.className = 'result-row';
-      row.dataset.score = percent;
-      row.style.setProperty('--bar-width', `${percent}%`);
-
-      const pct = document.createElement('div');
-      pct.className = 'percentage';
-      pct.textContent = `${percent}%`;
-
-      const bar = document.createElement('div');
-      bar.className = 'bar';
-
-      const role = document.createElement('div');
-      role.className = 'role';
-      role.textContent = titleCase(name);
-
-      const info = document.createElement('div');
-      info.className = 'more-info';
-      const link = document.createElement('a');
-      link.href = '#';
-      link.textContent = 'More info';
-      info.appendChild(link);
-
-      row.appendChild(pct);
-      row.appendChild(bar);
-      row.appendChild(role);
-      row.appendChild(info);
+      row.innerHTML = `
+        <div class="percentage">${score}%</div>
+        <div class="bar-container" title="${tooltipText || ''}">
+          <div class="bar-fill" style="width: ${score}%; background-color: ${getBarColor(score)};"></div>
+        </div>
+        <div class="role">${titleCase(roleName)}</div>
+        <div class="more-info"><a href="#">More info</a></div>
+      `;
       return row;
     }
 
@@ -114,7 +108,7 @@
           const chart = document.createElement('div');
           chart.id = 'comparison-chart';
           scores.forEach(s => {
-            chart.appendChild(createEntry(s.name, s.percent));
+            chart.appendChild(renderResultRow(s.name, s.percent));
           });
           container.appendChild(chart);
           const btn = document.createElement('button');


### PR DESCRIPTION
## Summary
- overhaul progress bars for role matches
- expose `getBarColor()` and `renderResultRow()` helpers
- clean up CSS and add responsive tweaks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687566dd8d58832cad2a24139771d401