### PR TITLE
Fix PDF export styling

### DIFF
--- a/your-roles.html
+++ b/your-roles.html
@@ -69,14 +69,15 @@
     }
 
     function downloadResults() {
-      const element = document.getElementById('rolesOutput');
+      const chart = document.getElementById('comparison-chart');
+      if (!chart) return;
       const opt = {
         margin: 0.5,
         filename: 'TalkKink_Compatibility_Report.pdf',
-        html2canvas: { scale: 2 },
+        html2canvas: { scale: 2, useCORS: true },
         jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' }
       };
-      html2pdf().set(opt).from(element).save();
+      html2pdf().set(opt).from(chart).save();
     }
 
     document.getElementById('roleFile').addEventListener('change', e => {


### PR DESCRIPTION
## Summary
- export the same comparison chart HTML to PDF

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68756eb2c5f8832c9ac0859efde46d2d