### PR TITLE
Inject print styles when generating PDFs

### DIFF
--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -1,4 +1,4 @@
-import { initTheme } from './theme.js';
+import { initTheme, applyPrintStyles } from './theme.js';
 
 let surveyA = null;
 let surveyB = null;
@@ -163,6 +163,7 @@ function buildKinkBreakdown(surveyA, surveyB) {
 }
 
 async function generateComparisonPDF(breakdown) {
+  applyPrintStyles();
   let jsPDF;
   try {
     await import('https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js');

--- a/js/theme.js
+++ b/js/theme.js
@@ -95,3 +95,82 @@ export function applyThemeColors(theme) {
 
   document.body.style.backgroundColor = selected.bgColor;
 }
+
+export function applyPrintStyles() {
+  if (document.getElementById('pdf-print-style')) return;
+  const style = document.createElement('style');
+  style.id = 'pdf-print-style';
+  style.innerHTML = `
+    @media print {
+      body {
+        background: #111 !important;
+        color: white !important;
+        font-family: Arial, sans-serif;
+      }
+
+      #comparison-chart {
+        max-width: 900px;
+        margin: auto;
+        padding: 20px;
+        background-color: #111 !important;
+        color: white !important;
+        border-radius: 10px;
+        font-size: 14px;
+      }
+
+      .category-title {
+        font-size: 16px;
+        font-weight: bold;
+        margin-top: 20px;
+        color: #44ff88 !important;
+      }
+
+      .result-row {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 4px 0;
+        border-bottom: 1px solid #333;
+      }
+
+      .percentage {
+        width: 60px;
+        font-weight: bold;
+        color: white !important;
+        text-align: right;
+      }
+
+      .role {
+        flex: 1.5;
+        color: white !important;
+      }
+
+      .bar-container {
+        flex: 2;
+        background: #222;
+        border-radius: 4px;
+        height: 10px;
+        position: relative;
+      }
+
+      .bar-fill {
+        height: 100%;
+        border-radius: 4px;
+        position: absolute;
+        left: 0;
+        top: 0;
+      }
+
+      .bar-fill.green { background: #00cc66; }
+      .bar-fill.yellow { background: #e6c300; }
+      .bar-fill.red { background: #cc0033; }
+
+      .more-info {
+        flex-shrink: 0;
+        font-size: 12px;
+        color: #ccc !important;
+      }
+    }
+  `;
+  document.head.appendChild(style);
+}

--- a/kink-list.html
+++ b/kink-list.html
@@ -25,7 +25,7 @@
 
     <script src="js/template-survey.js"></script>
     <script type="module">
-      import { initTheme } from './js/theme.js';
+      import { initTheme, applyPrintStyles } from './js/theme.js';
       import { calculateCategoryScores } from './js/categoryScores.js';
       initTheme();
 
@@ -195,6 +195,7 @@
     }
 
     async function generateKinkPDF(results, categories) {
+      applyPrintStyles();
       let jsPDF;
       try {
         await import('https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js');

--- a/your-roles.html
+++ b/your-roles.html
@@ -24,7 +24,7 @@
 
   <script type="module">
     import { calculateRoleScores } from './js/calculateRoleScores.js';
-    import { initTheme } from './js/theme.js';
+    import { initTheme, applyPrintStyles } from './js/theme.js';
     initTheme();
 
     function flattenSurvey(survey) {
@@ -138,6 +138,7 @@
     function downloadResults() {
       const chart = document.getElementById('comparison-chart');
       if (!chart) return;
+      applyPrintStyles();
       applyComparisonStylesForPDF();
       const opt = {
         margin: 0.5,


### PR DESCRIPTION
## Summary
- add `applyPrintStyles` in `theme.js` for injecting print styles
- import and use `applyPrintStyles` before PDF generation in
  - `kink-list.html`
  - `your-roles.html`
  - `js/compatibilityPage.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876b2e4f8ac832caa2c7f5198194555