### PR TITLE
Fix back button link on compatibility page

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -11,7 +11,7 @@
   <div class="scroll-container scrollable-panel">
     <h1>See Our Compatibility</h1>
     <div class="back-button-container">
-      <button onclick="window.location.href='https://www.talkking.org'">&larr; Back</button>
+      <button onclick="window.location.href='https://www.talkkink.org'">&larr; Back</button>
     </div>
     <div class="compatibility-button-container">
       <div class="button-group">


### PR DESCRIPTION
## Summary
- update the back button on the compatibility page so it links to `www.talkkink.org`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876d8eb5a1c832c962f436eba85a3e3