### PR TITLE
Fix PDF download on compatibility page

### DIFF
--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -1,5 +1,17 @@
 import { initTheme } from './theme.js';
 
+let jsPDFLib = null;
+async function loadJsPDF() {
+  if (jsPDFLib) return jsPDFLib;
+  if (window.jspdf && window.jspdf.jsPDF) {
+    jsPDFLib = window.jspdf.jsPDF;
+    return jsPDFLib;
+  }
+  await import('https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js');
+  jsPDFLib = window.jspdf.jsPDF;
+  return jsPDFLib;
+}
+
 let surveyA = null;
 let surveyB = null;
 let lastResult = null;
@@ -162,7 +174,8 @@ function buildKinkBreakdown(surveyA, surveyB) {
   return breakdown;
 }
 
-function generateComparisonPDF(breakdown) {
+async function generateComparisonPDF(breakdown) {
+  const jsPDF = await loadJsPDF();
   const doc = new jsPDF();
   const pageWidth = doc.internal.pageSize.getWidth();
   const margin = 10;
@@ -363,7 +376,7 @@ if (fileBInput) {
 
 const downloadBtn = document.getElementById('downloadResults');
 if (downloadBtn) {
-  downloadBtn.addEventListener('click', () => {
+  downloadBtn.addEventListener('click', async () => {
     if (!surveyA || !surveyB) {
       alert('Please upload both surveys first.');
       return;
@@ -371,7 +384,7 @@ if (downloadBtn) {
     if (!lastResult) {
       lastResult = buildKinkBreakdown(surveyA, surveyB);
     }
-    generateComparisonPDF(lastResult);
+    await generateComparisonPDF(lastResult);
   });
 }
 


### PR DESCRIPTION
## Summary
- dynamically load jsPDF for compatibility page
- call PDF export async when clicking Download Data button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687af3d7538c832ca4e6391eac87b5c9