### PR TITLE
Update compatibility visuals to new design

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -9,7 +9,7 @@ body {
 
 /* Default theme variables */
 :root {
-  --bg-color: #1a1a2e;
+  --bg-color: #000000;
   --panel-color: #292b3d;
   --text-color: #f0f0f0;
   --button-bg: #444;
@@ -1764,7 +1764,7 @@ body {
 }
 /* Compatibility page refined layout */
 #compare-page {
-  font-family: 'Inter', 'Segoe UI', Arial, sans-serif;
+  font-family: 'Segoe UI', Arial, sans-serif;
   max-width: 850px;
   margin: 20px auto;
   color: var(--text-color);
@@ -1772,9 +1772,10 @@ body {
 
 .col-labels {
   display: flex;
-  font-weight: 500;
+  font-weight: 700;
   font-size: 16px;
   margin-bottom: 4px;
+  color: #f0f0f0;
 }
 .col-labels .label-col {
   flex: 2;
@@ -1782,6 +1783,7 @@ body {
 .col-labels .col-label {
   flex: 1;
   text-align: center;
+  color: inherit;
 }
 
 .category-header {
@@ -1832,7 +1834,7 @@ body {
   font-size: 12px;
   text-align: center;
   pointer-events: none;
-  color: #000;
+  color: #fff;
 }
 .compare-icons {
   width: 40px;

--- a/css/theme.css
+++ b/css/theme.css
@@ -1,5 +1,5 @@
 :root {
-  --bg-color: #1a1a2e;
+  --bg-color: #000000;
   --panel-color: #292b3d;
   --text-color: #f0f0f0;
   --button-bg: #444;
@@ -21,7 +21,7 @@
 
 .theme-darkviolet,
 .dark-mode {
-  --bg-color: #1a1a2e;
+  --bg-color: #000000;
   --panel-color: #292b3d;
   --text-color: #f0f0f0;
   --button-bg: #7c5fe9;

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -41,6 +41,11 @@ function barFillColor(percent) {
   return '#FF4C4C';
 }
 
+function barTextColor(percent) {
+  if (percent === null) return '#ffffff';
+  return percent >= 60 ? '#000000' : '#ffffff';
+}
+
 function avgPercent(a, b) {
   const av = (a ?? 0) + (b ?? 0);
   return av / 2;
@@ -55,7 +60,7 @@ function makeBar(percent) {
   outer.appendChild(fill);
   const text = document.createElement('span');
   text.className = 'partner-text';
-  text.style.color = barFillColor(percent ?? 0);
+  text.style.color = barTextColor(percent);
   text.textContent = percent === null ? '-' : percent + '%';
   outer.appendChild(text);
   return outer;
@@ -305,8 +310,8 @@ async function generateComparisonPDF(breakdown) {
     doc.rect(x, yPos, barLength, 5, 'F');
     doc.setDrawColor(255, 255, 255);
     doc.rect(x, yPos, width, 5);
-    const [r, g, b] = colorForPercent(percent);
-    doc.setTextColor(r, g, b);
+    const textColor = percent >= 60 ? [0, 0, 0] : [255, 255, 255];
+    doc.setTextColor(...textColor);
     doc.setFontSize(9);
     addText(`${percent}%`, x + width / 2, yPos + 3.5, { align: 'center' });
     doc.setTextColor(255, 255, 255);
@@ -408,6 +413,8 @@ async function generateComparisonPDF(breakdown) {
       }
     });
 
+    doc.setDrawColor(255, 255, 255);
+    doc.line(margin, y, pageWidth - margin, y);
     y += 6;
   });
 

--- a/js/theme.js
+++ b/js/theme.js
@@ -103,9 +103,9 @@ export function applyPrintStyles() {
   style.innerHTML = `
     @media print {
       body {
-        background: #111 !important;
+        background: #000 !important;
         color: white !important;
-        font-family: 'Inter', 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+        font-family: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
         letter-spacing: 0.3px;
       }
 


### PR DESCRIPTION
## Summary
- switch base and dark theme backgrounds to pure black
- tweak compatibility page fonts and label styles
- adjust bar text color logic for better contrast
- draw divider lines in exported PDF
- use black background in print styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b468b2c80832c97ccea0f79688852