### PR TITLE
Fix roles page PDF styling

### DIFF
--- a/your-roles.html
+++ b/your-roles.html
@@ -24,7 +24,7 @@
 
   <script type="module">
     import { calculateRoleScores } from './js/calculateRoleScores.js';
-    import { initTheme } from './js/theme.js';
+    import { initTheme, applyPrintStyles } from './js/theme.js';
     initTheme();
 
     function flattenSurvey(survey) {
@@ -72,6 +72,8 @@
       const target = document.getElementById('comparison-chart');
       if (!target) return;
 
+      applyPrintStyles();
+
       const opt = {
         margin: 0.5,
         filename: 'kink_comparison.pdf',
@@ -79,7 +81,7 @@
         html2canvas: {
           scale: 2,
           useCORS: true,
-          backgroundColor: '#111'
+          backgroundColor: '#000'
         },
         jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' }
       };


### PR DESCRIPTION
## Summary
- import `applyPrintStyles` on the roles page
- apply PDF print styling and use darker background before calling `html2pdf`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687be4a35238832c8e0dc00ed9c6c744