### PR TITLE
Fix PDF export styling

### DIFF
--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -234,7 +234,7 @@ async function generateComparisonPDF() {
     margin: 0.5,
     filename: `compatibility-${ts}.pdf`,
     image: { type: 'jpeg', quality: 0.98 },
-    html2canvas: { scale: 2, useCORS: true, backgroundColor: '#000' },
+    html2canvas: { scale: 2, useCORS: true, backgroundColor: '#fff' },
     jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' }
   };
   if (window.html2pdf) {

--- a/js/theme.js
+++ b/js/theme.js
@@ -103,8 +103,8 @@ export function applyPrintStyles() {
   style.innerHTML = `
     @media print {
       body {
-        background: #000 !important;
-        color: #fff !important;
+        background: #fff !important;
+        color: #000 !important;
         font-family: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
         letter-spacing: 0.3px;
       }
@@ -113,15 +113,15 @@ export function applyPrintStyles() {
         max-width: 900px;
         margin: auto;
         padding: 20px;
-        background-color: #000 !important;
-        color: #fff !important;
+        background-color: #fff !important;
+        color: #000 !important;
         border-radius: 10px;
         font-size: 14px;
       }
 
       .col-labels,
       .col-labels .col-label {
-        color: #fff !important;
+        color: #000 !important;
       }
 
       .category-header {
@@ -195,13 +195,14 @@ export function applyPrintStyles() {
         width: 60px;
         font-weight: bold;
         text-align: right;
+        color: #000 !important;
       }
       .percentage.green { color: #00FF88 !important; }
       .percentage.yellow { color: #FFD700 !important; }
       .percentage.red { color: #FF4C4C !important; }
       .role {
         flex: 1.5;
-        color: #fff !important;
+        color: #000 !important;
       }
       .bar-container {
         flex: 2;

--- a/your-roles.html
+++ b/your-roles.html
@@ -81,7 +81,7 @@
         html2canvas: {
           scale: 2,
           useCORS: true,
-          backgroundColor: '#000'
+          backgroundColor: '#fff'
         },
         jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' }
       };


### PR DESCRIPTION
## Summary
- use white background for printed PDFs
- tweak print color styles for readability
- ensure generated PDFs use white background

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687bec81d734832c910d542fdaa6f2a9