### PR TITLE
Preserve dark theme in generated PDFs

### DIFF
--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -230,11 +230,12 @@ async function generateComparisonPDF() {
   const target = document.getElementById('compare-page');
   if (!target) return;
   const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  const bgColor = getComputedStyle(document.body).backgroundColor;
   const opt = {
     margin: 0.5,
     filename: `compatibility-${ts}.pdf`,
     image: { type: 'jpeg', quality: 0.98 },
-    html2canvas: { scale: 2, useCORS: true, backgroundColor: '#fff' },
+    html2canvas: { scale: 2, useCORS: true, backgroundColor: bgColor },
     jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' }
   };
   if (window.html2pdf) {

--- a/js/theme.js
+++ b/js/theme.js
@@ -103,8 +103,8 @@ export function applyPrintStyles() {
   style.innerHTML = `
     @media print {
       body {
-        background: #fff !important;
-        color: #000 !important;
+        background: var(--bg-color, #000) !important;
+        color: var(--text-color, #fff) !important;
         font-family: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
         letter-spacing: 0.3px;
       }
@@ -113,15 +113,15 @@ export function applyPrintStyles() {
         max-width: 900px;
         margin: auto;
         padding: 20px;
-        background-color: #fff !important;
-        color: #000 !important;
+        background-color: var(--bg-color, #000) !important;
+        color: var(--text-color, #fff) !important;
         border-radius: 10px;
         font-size: 14px;
       }
 
       .col-labels,
       .col-labels .col-label {
-        color: #000 !important;
+        color: var(--text-color, #fff) !important;
       }
 
       .category-header {
@@ -195,14 +195,14 @@ export function applyPrintStyles() {
         width: 60px;
         font-weight: bold;
         text-align: right;
-        color: #000 !important;
+        color: var(--text-color, #fff) !important;
       }
       .percentage.green { color: #00FF88 !important; }
       .percentage.yellow { color: #FFD700 !important; }
       .percentage.red { color: #FF4C4C !important; }
       .role {
         flex: 1.5;
-        color: #000 !important;
+        color: var(--text-color, #fff) !important;
       }
       .bar-container {
         flex: 2;

--- a/your-roles.html
+++ b/your-roles.html
@@ -74,6 +74,7 @@
 
       applyPrintStyles();
 
+      const bgColor = getComputedStyle(document.body).backgroundColor;
       const opt = {
         margin: 0.5,
         filename: 'kink_comparison.pdf',
@@ -81,7 +82,7 @@
         html2canvas: {
           scale: 2,
           useCORS: true,
-          backgroundColor: '#fff'
+          backgroundColor: bgColor
         },
         jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' }
       };


### PR DESCRIPTION
## Summary
- keep body styling when printing PDF so background and font colors match the selected theme
- use current theme background when exporting PDFs from compatibility and roles pages

## Testing
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_687bf31eadb4832cbc5b4c8c9d84605c