### PR TITLE
Ensure dark mode PDF export

### DIFF
--- a/js/theme.js
+++ b/js/theme.js
@@ -102,9 +102,16 @@ export function applyPrintStyles() {
   style.id = 'pdf-print-style';
   style.innerHTML = `
     @media print {
+      :root {
+        --bg-color: #000000 !important;
+        --text-color: #ffffff !important;
+      }
+
+      html,
       body {
-        background: var(--bg-color, #000) !important;
-        color: var(--text-color, #fff) !important;
+        background: #000000 !important;
+        color: #ffffff !important;
+        -webkit-print-color-adjust: exact;
         font-family: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
         letter-spacing: 0.3px;
       }

--- a/kink-list.html
+++ b/kink-list.html
@@ -206,6 +206,10 @@
       }
       const doc = new jsPDF();
       const pageWidth = doc.internal.pageSize.getWidth();
+      const pageHeight = doc.internal.pageSize.getHeight();
+      doc.setFillColor(0, 0, 0);
+      doc.rect(0, 0, pageWidth, pageHeight, 'F');
+      doc.setTextColor(255, 255, 255);
       let y = 20;
 
       doc.setFont('helvetica', 'bold');


### PR DESCRIPTION
## Summary
- force black background and white text when printing/exporting PDF
- draw black background and white text in PDF generation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c0945691c832cb0691079ca62cb7d