### PR TITLE
Set black background for generated PDFs

### DIFF
--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -230,12 +230,11 @@ async function generateComparisonPDF() {
   const target = document.getElementById('compare-page');
   if (!target) return;
   const ts = new Date().toISOString().replace(/[:.]/g, '-');
-  const bgColor = getComputedStyle(document.body).backgroundColor;
   const opt = {
     margin: 0.5,
     filename: `compatibility-${ts}.pdf`,
     image: { type: 'jpeg', quality: 0.98 },
-    html2canvas: { scale: 2, useCORS: true, backgroundColor: bgColor },
+    html2canvas: { scale: 2, useCORS: true, backgroundColor: '#000000' },
     jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' }
   };
   if (window.html2pdf) {

--- a/your-roles.html
+++ b/your-roles.html
@@ -74,7 +74,6 @@
 
       applyPrintStyles();
 
-      const bgColor = getComputedStyle(document.body).backgroundColor;
       const opt = {
         margin: 0.5,
         filename: 'kink_comparison.pdf',
@@ -82,7 +81,7 @@
         html2canvas: {
           scale: 2,
           useCORS: true,
-          backgroundColor: bgColor
+          backgroundColor: '#000000'
         },
         jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' }
       };


### PR DESCRIPTION
## Summary
- ensure PDFs use pure black background rather than the current theme color

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c52584164832c97ae1b66b59f5cba