### PR TITLE
Refine compatibility results style

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2,16 +2,16 @@
 body {
   margin: 0;
   padding: 0;
-  font-family: 'Segoe UI', Arial, sans-serif;
+  font-family: 'Inter', 'Roboto', 'Helvetica Neue', Arial, sans-serif;
   background-color: var(--bg-color);
   color: var(--text-color);
 }
 
 /* Default theme variables */
 :root {
-  --bg-color: #000000;
+  --bg-color: #1a1a1a;
   --panel-color: #292b3d;
-  --text-color: #f0f0f0;
+  --text-color: #ffffff;
   --button-bg: #444;
   --button-text: #ffffff;
   --button-hover-bg: #666;
@@ -1787,16 +1787,16 @@ body {
 }
 
 .category-header {
-  font-size: 18px;
+  font-size: 20px;
   font-weight: 700;
   text-align: left;
   border-bottom: 1px solid #555;
   padding: 4px 0;
   margin: 12px 0 4px;
 }
-.category-header.green { color: #00FF88; }
-.category-header.yellow { color: #FFD700; }
-.category-header.red { color: #FF4C4C; }
+.category-header.green { color: #00cc66; }
+.category-header.yellow { color: #ffcc00; }
+.category-header.red { color: #ff4444; }
 
 .compare-row {
   display: flex;
@@ -1812,24 +1812,24 @@ body {
   font-weight: 500;
   font-size: 16px;
 }
-.compare-label.green { color: #00FF88; }
-.compare-label.yellow { color: #FFD700; }
-.compare-label.red { color: #FF4C4C; }
+.compare-label.green { color: #00cc66; }
+.compare-label.yellow { color: #ffcc00; }
+.compare-label.red { color: #ff4444; }
 .partner-bar {
   flex: 1;
   position: relative;
   height: 12px;
-  background: #222;
-  border-radius: 6px;
+  background: #2b2b2b;
+  border-radius: 8px;
   margin: 0 6px;
 }
 .partner-fill {
   height: 100%;
-  border-radius: 6px;
+  border-radius: 8px;
 }
-.partner-fill.green { background-color: #00FF88; }
-.partner-fill.yellow { background-color: #FFD700; }
-.partner-fill.red { background-color: #FF4C4C; }
+.partner-fill.green { background-color: #00cc66; box-shadow: 0 0 5px rgba(0,204,102,0.6); }
+.partner-fill.yellow { background-color: #ffcc00; box-shadow: 0 0 5px rgba(255,204,0,0.6); }
+.partner-fill.red { background-color: #ff4444; box-shadow: 0 0 5px rgba(255,68,68,0.6); }
 .partner-text {
   position: absolute;
   top: -2px;
@@ -1846,5 +1846,10 @@ body {
 .compare-icons {
   width: 40px;
   text-align: right;
-  font-size: 14px;
+  font-size: 16px;
 }
+
+.icon-star { color: #ffd700; }
+.icon-red-flag { color: #e60000; }
+.icon-yellow-flag { color: #f1c40f; }
+

--- a/css/theme.css
+++ b/css/theme.css
@@ -1,11 +1,11 @@
 :root {
-  --bg-color: #000000;
+  --bg-color: #1a1a1a;
   --panel-color: #292b3d;
-  --text-color: #f0f0f0;
+  --text-color: #ffffff;
   --button-bg: #444;
   --button-text: #ffffff;
   --button-hover-bg: #666;
-  --progress-fill-color: #4caf50;
+  --progress-fill-color: #00cc66;
 }
 
 .theme-lightforest,

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -35,9 +35,9 @@ function colorClass(percent) {
 }
 
 function barFillColor(percent) {
-  if (percent >= 80) return '#00FF88';
-  if (percent >= 60) return '#FFD700';
-  return '#FF4C4C';
+  if (percent >= 80) return '#00cc66';
+  if (percent >= 60) return '#ffcc00';
+  return '#ff4444';
 }
 
 
@@ -52,6 +52,7 @@ function makeBar(percent) {
   const fill = document.createElement('div');
   fill.className = 'partner-fill ' + colorClass(percent ?? 0);
   fill.style.width = percent === null ? '0%' : percent + '%';
+  fill.style.backgroundColor = barFillColor(percent ?? 0);
   outer.appendChild(fill);
   const text = document.createElement('span');
   text.className = 'partner-text ' + colorClass(percent ?? 0);
@@ -65,19 +66,19 @@ function buildIcons(ratingA, ratingB) {
   const partnerP = toPercent(ratingB);
   const symbols = [];
   if (youP !== null && partnerP !== null && youP >= 90 && partnerP >= 90) {
-    symbols.push('⭐');
+    symbols.push('<span class="icon-star">⭐</span>');
   }
   if (
     (youP !== null && youP <= 30) ||
     (partnerP !== null && partnerP <= 30)
   ) {
-    symbols.push('🚩');
+    symbols.push('<span class="icon-red-flag">🚩</span>');
   }
   if (
     (ratingA === 5 && ratingB !== null && ratingB < 5) ||
     (ratingB === 5 && ratingA !== null && ratingA < 5)
   ) {
-    symbols.push('🟨');
+    symbols.push('<span class="icon-yellow-flag">🟨</span>');
   }
   return symbols.join(' ');
 }
@@ -345,7 +346,7 @@ function updateComparison() {
       row.appendChild(makeBar(partnerP));
       const icons = document.createElement('div');
       icons.className = 'compare-icons';
-      icons.textContent = buildIcons(ratingA, ratingB);
+      icons.innerHTML = buildIcons(ratingA, ratingB);
       row.appendChild(icons);
       section.appendChild(row);
     });


### PR DESCRIPTION
## Summary
- tweak global theme to use dark gray background and brighter text
- update compatibility bars with new colors, rounded edges, and glow
- color icons via CSS and inject them as spans
- use Inter/Roboto font stack across pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c5cda9fac832cb2804a21aeb304eb