### PR TITLE
Fix PDF background color in print mode

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1583,7 +1583,7 @@ body {
 /* 🎨 PDF OUTPUT STYLING (MATCH BDSMTest.org Aesthetic) */
 .result-container,
 .pdf-container {
-  background-color: var(--panel-color, #fafafa);
+  background-color: var(--panel-color, var(--bg-color, #000));
   color: var(--text-color, #222);
   font-family: 'Inter', sans-serif;
   max-width: 800px;

--- a/js/theme.js
+++ b/js/theme.js
@@ -105,6 +105,7 @@ export function applyPrintStyles() {
       :root {
         --bg-color: #000000 !important;
         --text-color: #ffffff !important;
+        --panel-color: #000000 !important;
       }
 
       html,


### PR DESCRIPTION
## Summary
- ensure panel color is applied while printing PDFs
- use panel color in `.pdf-container` for proper print background

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c74ee5e40832ca378d207e46e1278