### PR TITLE
Improve PDF dark mode styling

### DIFF
--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -235,7 +235,7 @@ async function generateComparisonPDF() {
     margin: 0.5,
     filename: `compatibility-${ts}.pdf`,
     image: { type: 'jpeg', quality: 0.98 },
-    html2canvas: { scale: 2, useCORS: true, backgroundColor: '#000000' },
+    html2canvas: { scale: 2, useCORS: true, backgroundColor: '#1a1a1a' },
     jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' }
   };
   if (window.html2pdf) {

--- a/js/theme.js
+++ b/js/theme.js
@@ -101,26 +101,26 @@ export function applyPrintStyles() {
   const style = document.createElement('style');
   style.id = 'pdf-print-style';
   style.innerHTML = `
-    @media print {
-      :root {
-        --bg-color: #000000 !important;
-        --text-color: #ffffff !important;
-      }
+      @media print {
+        :root {
+          --bg-color: #1a1a1a !important;
+          --text-color: #ffffff !important;
+        }
 
-      html,
-      body {
-        background: #000000 !important;
-        color: #ffffff !important;
-        -webkit-print-color-adjust: exact;
-        font-family: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
-        letter-spacing: 0.3px;
-      }
+        html,
+        body {
+          background: #1a1a1a !important;
+          color: #ffffff !important;
+          -webkit-print-color-adjust: exact;
+          font-family: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+          letter-spacing: 0.3px;
+        }
 
       #comparison-chart {
         max-width: 900px;
         margin: auto;
         padding: 20px;
-        background-color: var(--bg-color, #000) !important;
+        background-color: var(--bg-color, #1a1a1a) !important;
         color: var(--text-color, #fff) !important;
         border-radius: 10px;
         font-size: 16px;

--- a/your-roles.html
+++ b/your-roles.html
@@ -78,11 +78,11 @@
         margin: 0.5,
         filename: 'kink_comparison.pdf',
         image: { type: 'jpeg', quality: 0.98 },
-        html2canvas: {
-          scale: 2,
-          useCORS: true,
-          backgroundColor: '#000000'
-        },
+          html2canvas: {
+            scale: 2,
+            useCORS: true,
+            backgroundColor: '#1a1a1a'
+          },
         jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' }
       };
 


### PR DESCRIPTION
## Summary
- adjust `applyPrintStyles` to use dark gray background
- update pdf export to use dark gray for html2canvas

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d2d96a20c832cb8dfcb3f7e0f6f9e