### PR TITLE
Set black background for generated PDFs

### DIFF
--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -235,7 +235,7 @@ async function generateComparisonPDF() {
     margin: 0.5,
     filename: `compatibility-${ts}.pdf`,
     image: { type: 'jpeg', quality: 0.98 },
-    html2canvas: { scale: 2, useCORS: true, backgroundColor: '#1a1a1a' },
+    html2canvas: { scale: 2, useCORS: true, backgroundColor: '#000000' },
     jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' }
   };
   if (window.html2pdf) {
@@ -287,13 +287,16 @@ function loadFileB(file) {
 function updateComparison() {
   const container = document.getElementById('compare-page');
   const msg = document.getElementById('comparisonResult');
+  const dlBtn = document.getElementById('downloadResults');
   if (!surveyA || !surveyB) {
     msg.textContent = surveyA || surveyB ? 'Please upload both surveys to compare.' : '';
     container.innerHTML = '';
     lastResult = null;
+    if (dlBtn) dlBtn.style.backgroundColor = '';
     return;
   }
   msg.textContent = '';
+  if (dlBtn) dlBtn.style.backgroundColor = '#000';
   const kinkBreakdown = buildKinkBreakdown(surveyA, surveyB);
   lastResult = kinkBreakdown;
   container.innerHTML = '';

--- a/js/theme.js
+++ b/js/theme.js
@@ -103,14 +103,14 @@ export function applyPrintStyles() {
   style.innerHTML = `
 @media print {
   :root {
-    --bg-color: #1a1a1a !important;
+    --bg-color: #000000 !important;
     --text-color: #ffffff !important;
-    --panel-color: #1a1a1a !important;
+    --panel-color: #000000 !important;
   }
 
   html,
   body {
-    background: #1a1a1a !important;
+    background: #000000 !important;
     color: #ffffff !important;
     -webkit-print-color-adjust: exact;
     font-family: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
@@ -123,7 +123,7 @@ export function applyPrintStyles() {
         max-width: 900px;
         margin: auto;
         padding: 20px;
-        background-color: var(--bg-color, #1a1a1a) !important;
+        background-color: var(--bg-color, #000000) !important;
         color: var(--text-color, #fff) !important;
         border-radius: 10px;
         font-size: 16px;

--- a/your-roles.html
+++ b/your-roles.html
@@ -81,7 +81,7 @@
           html2canvas: {
             scale: 2,
             useCORS: true,
-            backgroundColor: '#1a1a1a'
+            backgroundColor: '#000000'
           },
         jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' }
       };


### PR DESCRIPTION
## Summary
- darken PDF output background
- highlight the compatibility download button after results are ready

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d3d2096e8832c90c1f4ee8fb8b635