### PR TITLE
Add PDF page break support

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1853,3 +1853,14 @@ body {
 .icon-red-flag { color: #e60000; }
 .icon-yellow-flag { color: #f1c40f; }
 
+
+.page-break { display: none; }
+
+@media print {
+  .page-break {
+    display: block;
+    height: 0;
+    page-break-before: always;
+    break-before: page;
+  }
+}

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -3,6 +3,11 @@ import { initTheme, applyPrintStyles } from './theme.js';
 let surveyA = null;
 let surveyB = null;
 let lastResult = null;
+const PAGE_BREAK_CATEGORIES = new Set([
+  'Communication',
+  'Service',
+  'Impact Play'
+]);
 const RATING_LABELS = {
   0: 'Hard No',
   1: 'Dislike / Haven\u2019t Considered',
@@ -236,7 +241,8 @@ async function generateComparisonPDF() {
     filename: `compatibility-${ts}.pdf`,
     image: { type: 'jpeg', quality: 0.98 },
     html2canvas: { scale: 2, useCORS: true, backgroundColor: '#000000' },
-    jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' }
+    jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' },
+    pagebreak: { mode: ['avoid-all', 'css'], before: '.page-break' }
   };
   if (window.html2pdf) {
     window.html2pdf().set(opt).from(target).save();
@@ -355,6 +361,11 @@ function updateComparison() {
     });
 
     container.appendChild(section);
+    if (PAGE_BREAK_CATEGORIES.has(cat)) {
+      const br = document.createElement('div');
+      br.className = 'page-break';
+      container.appendChild(br);
+    }
   });
 }
 

--- a/js/theme.js
+++ b/js/theme.js
@@ -238,6 +238,19 @@ export function applyPrintStyles() {
         font-size: 12px;
         color: #ccc !important;
       }
+
+      .page-break {
+        display: none;
+      }
+
+      @media print {
+        .page-break {
+          display: block;
+          height: 0;
+          page-break-before: always;
+          break-before: page;
+        }
+      }
     }
   `;
   document.head.appendChild(style);


### PR DESCRIPTION
## Summary
- add `.page-break` CSS for print-only page breaks
- include page break styles in injected print CSS
- let `generateComparisonPDF` honor manual page breaks
- insert page breaks after select categories

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881a586e68c832cb565c67e6deff0fa