### PR TITLE
Fix PDF dark theme

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -32,7 +32,7 @@
       </div>
     </div>
     <div id="comparisonResult"></div>
-    <div id="compare-page"></div>
+    <div id="compare-page" class="pdf-export-area"></div>
   </div>
   <script src="js/template-survey.js"></script>
   <script type="module" src="js/compatibilityPage.js"></script>

--- a/js/theme.js
+++ b/js/theme.js
@@ -244,11 +244,35 @@ export function applyPrintStyles() {
       }
 
       @media print {
+        body, .pdf-export-area {
+          background-color: #111 !important;
+          color: #e0e0e0 !important;
+          -webkit-print-color-adjust: exact;
+        }
+
+        .discord-button, .dark-button {
+          background-color: #000 !important;
+          color: #fff !important;
+          border: 1px solid #333;
+          padding: 0.5rem 1rem;
+          border-radius: 6px;
+        }
+
+        .category-wrapper {
+          background-color: #1a1a1a !important;
+          color: #f5f5f5 !important;
+          border: 1px solid #333;
+          padding: 1rem;
+          border-radius: 6px;
+          margin-bottom: 1rem;
+        }
+
         .page-break {
           display: block;
           height: 0;
           page-break-before: always;
           break-before: page;
+          page-break-after: always;
         }
       }
     }

--- a/your-roles.html
+++ b/your-roles.html
@@ -117,6 +117,7 @@
           container.appendChild(title);
           const chart = document.createElement('div');
           chart.id = 'comparison-chart';
+          chart.className = 'pdf-export-area';
           scores.forEach(s => {
             chart.appendChild(renderResultRow(s.name, s.percent));
           });


### PR DESCRIPTION
## Summary
- ensure compatibility result PDF uses `.pdf-export-area` for dark print styling
- apply print-friendly dark theme styles in `applyPrintStyles`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881ac7756a0832c8e115e421a7760f6