### PR TITLE
Fix PDF dark mode rendering for compatibility page

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -32,7 +32,7 @@
       </div>
     </div>
     <div id="comparisonResult"></div>
-    <div id="compare-page" class="pdf-export-area"></div>
+      <div id="compatibility-report" class="pdf-export-area"></div>
   </div>
   <script src="js/template-survey.js"></script>
   <script type="module" src="js/compatibilityPage.js"></script>

--- a/css/style.css
+++ b/css/style.css
@@ -1763,7 +1763,7 @@ body {
   }
 }
 /* Compatibility page refined layout */
-#compare-page {
+#compatibility-report {
   font-family: 'Segoe UI', Arial, sans-serif;
   max-width: 850px;
   margin: 20px auto;
@@ -1857,10 +1857,66 @@ body {
 .page-break { display: none; }
 
 @media print {
+  * {
+    -webkit-print-color-adjust: exact !important;
+    color-adjust: exact !important;
+    print-color-adjust: exact !important;
+  }
+
+  body {
+    background-color: #1a1a1a !important;
+    color: #ffffff !important;
+    font-family: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif !important;
+    font-size: 11px;
+    margin: 20px !important;
+  }
+
+  .category {
+    font-size: 14px;
+    font-weight: bold;
+    color: #ff4444 !important;
+    margin-top: 12px;
+    page-break-before: auto;
+  }
+
+  .item-label {
+    font-weight: normal;
+    color: #ffffff;
+    text-align: left;
+  }
+
+  .score-bar {
+    background: #2a2a2a !important;
+    border-radius: 4px;
+    overflow: hidden;
+    position: relative;
+  }
+
+  .score-bar .bar-fill {
+    background: #00cc66 !important;
+    height: 12px;
+  }
+
+  .zero-match {
+    background: #555555 !important;
+  }
+
+  .star-match {
+    color: #ffcc00 !important;
+  }
+
+  .red-flag {
+    color: #ff4444 !important;
+  }
+
   .page-break {
     display: block;
     height: 0;
-    page-break-before: always;
-    break-before: page;
+    page-break-after: always;
   }
+}
+
+#compatibility-report * {
+  font-size: 11px !important;
+  color: #ffffff !important;
 }

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -235,61 +235,27 @@ function buildKinkBreakdown(surveyA, surveyB) {
 
 async function generateComparisonPDF() {
   applyPrintStyles();
-  const pdfContainer = document.querySelector('.pdf-export-area');
-  if (!pdfContainer) return;
+  const target = document.querySelector('#compatibility-report');
+  if (!target) return;
 
-  const styledClone = pdfContainer.cloneNode(true);
-  styledClone.style.backgroundColor = '#111';
-  styledClone.style.color = '#eee';
-  styledClone.style.padding = '20px';
-  styledClone.style.fontFamily = "'Segoe UI', sans-serif";
-  styledClone.querySelectorAll('.category-wrapper').forEach(el => {
-    el.style.backgroundColor = '#1a1a1a';
-    el.style.color = '#f5f5f5';
-    el.style.border = '1px solid #333';
-    el.style.padding = '1rem';
-    el.style.borderRadius = '6px';
-  });
-  styledClone.querySelectorAll('.discord-button').forEach(btn => {
-    btn.style.backgroundColor = '#000';
-    btn.style.color = '#fff';
-    btn.style.border = '1px solid #333';
-    btn.style.borderRadius = '6px';
-  });
-  styledClone.style.position = 'fixed';
-  styledClone.style.left = '-9999px';
-  document.body.appendChild(styledClone);
+  const opt = {
+    margin: [10, 10],
+    filename: 'TalkKink_Compatibility.pdf',
+    image: { type: 'jpeg', quality: 0.98 },
+    html2canvas: {
+      scale: 2,
+      useCORS: true,
+      backgroundColor: '#1a1a1a'
+    },
+    jsPDF: {
+      unit: 'mm',
+      format: 'a4',
+      orientation: 'portrait'
+    },
+    pagebreak: { mode: ['css', 'legacy'] }
+  };
 
-  let html2canvasFn = window.html2canvas;
-  if (!html2canvasFn) {
-    try {
-      const { default: h2c } = await import('https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js');
-      html2canvasFn = h2c;
-    } catch (err) {
-      console.error('Failed to load html2canvas:', err);
-      document.body.removeChild(styledClone);
-      return;
-    }
-  }
-
-  const canvas = await html2canvasFn(styledClone, { backgroundColor: null, scale: 2 });
-  document.body.removeChild(styledClone);
-  const imgData = canvas.toDataURL('image/png');
-
-  let jsPDF;
-  try {
-    jsPDF = await loadJsPDF();
-  } catch (err) {
-    console.warn('Failed to load jsPDF library:', err);
-    return;
-  }
-
-  const pdf = new jsPDF('p', 'mm', 'a4');
-  const imgProps = pdf.getImageProperties(imgData);
-  const pdfWidth = pdf.internal.pageSize.getWidth();
-  const pdfHeight = (imgProps.height * pdfWidth) / imgProps.width;
-  pdf.addImage(imgData, 'PNG', 0, 0, pdfWidth, pdfHeight);
-  pdf.save('TalkKink_Compatibility.pdf');
+  html2pdf().set(opt).from(target).save();
 }
 
 function loadFileA(file) {
@@ -331,7 +297,7 @@ function loadFileB(file) {
   reader.readAsText(file);
 }
 function updateComparison() {
-  const container = document.getElementById('compare-page');
+  const container = document.getElementById('compatibility-report');
   const msg = document.getElementById('comparisonResult');
   const dlBtn = document.getElementById('downloadResults');
   if (!surveyA || !surveyB) {

--- a/js/kinkCompareBars.js
+++ b/js/kinkCompareBars.js
@@ -30,7 +30,7 @@ function renderKinkSection(title, g, r, n) {
 
 // Example usage
 document.addEventListener('DOMContentLoaded', () => {
-  const el = document.getElementById('compare-page');
+  const el = document.getElementById('compatibility-report');
   if (el) {
     el.innerHTML += renderKinkSection('Nipple clips', 5, 5, 0);
   }


### PR DESCRIPTION
## Summary
- rename report container to `compatibility-report`
- switch PDF export to use html2pdf with improved settings
- add print styling rules for dark mode compatibility report
- update example code to use new container

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6881b6ac813c832ca482e24fd1f5b1a6