### PR TITLE
Improve survey JSON parsing

### DIFF
--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -19,6 +19,20 @@ const RATING_LABELS = {
   5: 'Love / Core Interest'
 };
 
+function parseSurveyJSON(text) {
+  const clean = text.replace(/^\uFEFF/, '').trim();
+  try {
+    return JSON.parse(clean);
+  } catch {
+    const first = clean.indexOf('{');
+    const last = clean.lastIndexOf('}');
+    if (first !== -1 && last !== -1 && first < last) {
+      return JSON.parse(clean.slice(first, last + 1));
+    }
+    throw new Error('Invalid JSON');
+  }
+}
+
 function formatRating(val) {
   return val === null || val === undefined
     ? '-'
@@ -263,16 +277,14 @@ function loadFileA(file) {
   const reader = new FileReader();
   reader.onload = ev => {
     try {
-      const text = ev.target.result
-        .replace(/^\uFEFF/, '')
-        .trim();
-      const parsed = JSON.parse(text);
+      const parsed = parseSurveyJSON(ev.target.result);
       surveyA = normalizeSurveyFormat(parsed.survey || parsed);
       mergeSurveyWithTemplate(surveyA, window.templateSurvey);
       normalizeRatings(surveyA);
       filterGeneralOptions(surveyA);
       updateComparison();
-    } catch {
+    } catch (err) {
+      console.warn('Failed to load Survey A:', err);
       alert('Invalid JSON for Survey A.');
     }
   };
@@ -287,16 +299,14 @@ function loadFileB(file) {
   const reader = new FileReader();
   reader.onload = ev => {
     try {
-      const text = ev.target.result
-        .replace(/^\uFEFF/, '')
-        .trim();
-      const parsed = JSON.parse(text);
+      const parsed = parseSurveyJSON(ev.target.result);
       surveyB = normalizeSurveyFormat(parsed.survey || parsed);
       mergeSurveyWithTemplate(surveyB, window.templateSurvey);
       normalizeRatings(surveyB);
       filterGeneralOptions(surveyB);
       updateComparison();
-    } catch {
+    } catch (err) {
+      console.warn('Failed to load Survey B:', err);
       alert('Invalid JSON for Survey B.');
     }
   };

--- a/js/script.js
+++ b/js/script.js
@@ -39,6 +39,20 @@ const HIGH_INTENSITY_CATEGORY = 'High-Intensity Kinks (SSC-Aware)';
 const HIGH_INTENSITY_WARNING =
   'The High-Intensity Kinks category includes intense but SSC-aware kink options that require strong negotiation, emotional readiness, and safe aftercare. Only explore if you feel prepared.';
 
+function parseSurveyJSON(text) {
+  const clean = text.replace(/^\uFEFF/, '').trim();
+  try {
+    return JSON.parse(clean);
+  } catch {
+    const first = clean.indexOf('{');
+    const last = clean.lastIndexOf('}');
+    if (first !== -1 && last !== -1 && first < last) {
+      return JSON.parse(clean.slice(first, last + 1));
+    }
+    throw new Error('Invalid JSON');
+  }
+}
+
 
 function applyAnimation(el, cls) {
   el.classList.add(cls);
@@ -533,10 +547,7 @@ function loadSurveyAFile(file) {
   const reader = new FileReader();
   reader.onload = ev => {
     try {
-      const text = ev.target.result
-        .replace(/^\uFEFF/, '')
-        .trim();
-      const parsed = JSON.parse(text);
+      const parsed = parseSurveyJSON(ev.target.result);
       surveyA = normalizeSurveyFormat(parsed.survey || parsed);
       mergeSurveyWithTemplate(surveyA, window.templateSurvey);
       normalizeRatings(surveyA);
@@ -579,15 +590,13 @@ if (fileBInput) {
     const reader = new FileReader();
     reader.onload = ev => {
       try {
-        const text = ev.target.result
-          .replace(/^\uFEFF/, '')
-          .trim();
-        const parsed = JSON.parse(text);
+        const parsed = parseSurveyJSON(ev.target.result);
         surveyB = normalizeSurveyFormat(parsed.survey || parsed);
         mergeSurveyWithTemplate(surveyB, window.templateSurvey);
         normalizeRatings(surveyB);
         filterGeneralOptions(surveyB);
-      } catch {
+      } catch (err) {
+        console.warn('Failed to load Survey B:', err);
         alert('Invalid JSON for Survey B.');
       }
     };
@@ -880,16 +889,14 @@ if (compareBtn) compareBtn.addEventListener('click', () => {
     const reader = new FileReader();
     reader.onload = ev => {
       try {
-        const text = ev.target.result
-          .replace(/^\uFEFF/, '')
-          .trim();
-        const parsed = JSON.parse(text);
+        const parsed = parseSurveyJSON(ev.target.result);
         surveyB = normalizeSurveyFormat(parsed.survey || parsed);
         mergeSurveyWithTemplate(surveyB, window.templateSurvey);
         normalizeRatings(surveyB);
         filterGeneralOptions(surveyB);
         runComparison();
-      } catch {
+      } catch (err) {
+        console.warn('Failed to load Survey B:', err);
         alert('Invalid JSON for Survey B.');
       }
     };


### PR DESCRIPTION
## Summary
- add `parseSurveyJSON` helper to handle stray text and BOM
- log detailed errors when survey JSON fails to load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6881c1386f04832c93389f561b4a9a36