### PR TITLE
Update PDF print styles

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1859,7 +1859,7 @@ body {
 @media print {
   body {
     background-color: #ffffff !important;
-    color: #111111 !important;
+    color: #000000 !important;
     font-family: 'Segoe UI', 'Helvetica Neue', sans-serif !important;
     font-size: 11px !important;
     -webkit-print-color-adjust: exact !important;
@@ -1867,24 +1867,28 @@ body {
   }
 
   .category {
-    color: #cc0000 !important;
+    color: #b00020 !important;
     font-weight: bold !important;
-    font-size: 14px !important;
+    font-size: 16px !important;
+    margin-top: 12px;
   }
 
   .item-label {
-    color: #111111 !important;
-    font-size: 11px !important;
+    color: #333333 !important;
+    font-size: 14px !important;
   }
 
+  .match-bar,
   .score-bar {
     background-color: #e0e0e0 !important;
-    border-radius: 4px !important;
+    border-radius: 5px !important;
     overflow: hidden !important;
+    height: 10px !important;
   }
 
+  .match-bar-fill,
   .bar-fill {
-    background-color: #008000 !important;
+    background-color: #00c853 !important;
     height: 12px !important;
   }
 
@@ -1893,11 +1897,15 @@ body {
   }
 
   .star-match {
-    color: #FFD700 !important;
+    color: #ffb300 !important;
   }
 
   .red-flag {
-    color: #FF0000 !important;
+    color: #d32f2f !important;
+  }
+
+  .score-flag-mismatch {
+    color: #fbc02d !important;
   }
 
   .page-break {

--- a/js/theme.js
+++ b/js/theme.js
@@ -96,48 +96,64 @@ export function applyThemeColors(theme) {
   document.body.style.backgroundColor = selected.bgColor;
 }
 
+export const pdfStyles = `
+  @media print {
+    :root {
+      --bg-color: #ffffff !important;
+      --text-color: #000000 !important;
+      --panel-color: #f9f9f9 !important;
+    }
+
+    html, body {
+      background: #ffffff !important;
+      color: #000000 !important;
+      font-family: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+      letter-spacing: 0.3px;
+      -webkit-print-color-adjust: exact !important;
+      print-color-adjust: exact !important;
+    }
+
+    .category-title {
+      font-size: 16px !important;
+      font-weight: bold !important;
+      color: #b00020 !important; /* deep red */
+      margin-top: 12px;
+    }
+
+    .item-label {
+      font-size: 14px;
+      color: #333333 !important;
+    }
+
+    .match-bar {
+      height: 10px !important;
+      border-radius: 5px;
+      background-color: #e0e0e0 !important;
+    }
+
+    .match-bar-fill {
+      background-color: #00c853 !important; /* bright green */
+    }
+
+    .score-flag-high {
+      color: #ffb300 !important; /* gold */
+    }
+
+    .score-flag-low {
+      color: #d32f2f !important; /* red */
+    }
+
+    .score-flag-mismatch {
+      color: #fbc02d !important; /* yellow */
+    }
+  }
+`;
+
 export function applyPrintStyles() {
   if (document.getElementById('pdf-print-style')) return;
   const style = document.createElement('style');
   style.id = 'pdf-print-style';
-  style.innerHTML = `
-@media print {
-  :root {
-    --bg-color: #ffffff !important;
-    --text-color: #111111 !important;
-    --panel-color: #f2f2f2 !important;
-  }
-
-  html, body {
-    background: #ffffff !important;
-    color: #111111 !important;
-    font-family: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
-    letter-spacing: 0.3px;
-    -webkit-print-color-adjust: exact !important;
-    print-color-adjust: exact !important;
-  }
-
-  .category-title {
-    font-weight: bold !important;
-    color: #cc0000 !important;
-  }
-
-  .match-label {
-    color: #008000 !important;
-  }
-
-  .score-flag-high {
-    color: #FFD700 !important;
-  }
-
-  .score-flag-low {
-    color: #FF0000 !important;
-  }
-
-  .score-flag-mismatch {
-    color: #FFCC00 !important;
-  }
-}
+  style.textContent = pdfStyles + `
 
 
       #comparison-chart {


### PR DESCRIPTION
## Summary
- implement a dedicated `pdfStyles` constant for print-friendly colors
- update `applyPrintStyles` to use the constant
- tweak stylesheet print rules for light PDF output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882b282bb94832cb271ede7f9e64c8e