### PR TITLE
Fix compatibility report print styles

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1911,9 +1911,8 @@ body {
   .page-break {
     page-break-after: always !important;
   }
-}
-
-#compatibility-report * {
-  font-size: 11px !important;
-  color: #111111 !important;
+  #compatibility-report * {
+    font-size: 11px !important;
+    color: #111111 !important;
+  }
 }


### PR DESCRIPTION
## Summary
- move `#compatibility-report` dark mode override into the `@media print` block

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882b715abe8832ca1dde8adc2e99f4c