### PR TITLE
Improve PDF styling

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -33,6 +33,7 @@
     </div>
     <div id="comparisonResult"></div>
       <div id="compatibility-report" class="pdf-export-area"></div>
+    <div class="print-footer"></div>
   </div>
   <script src="js/template-survey.js"></script>
   <script type="module" src="js/compatibilityPage.js"></script>

--- a/css/style.css
+++ b/css/style.css
@@ -1794,6 +1794,11 @@ body {
   padding: 4px 0;
   margin: 12px 0 4px;
 }
+.category-wrapper {
+  margin-bottom: 24px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid #ddd;
+}
 .category-header.green { color: #00cc66; }
 .category-header.yellow { color: #ffcc00; }
 .category-header.red { color: #ff4444; }
@@ -1858,7 +1863,7 @@ body {
 
 @media print {
   body {
-    background-color: #ffffff !important;
+    background-color: #fdfcfb !important;
     color: #000000 !important;
     font-family: 'Segoe UI', 'Helvetica Neue', sans-serif !important;
     font-size: 11px !important;

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -259,7 +259,7 @@ async function generateComparisonPDF() {
     html2canvas: {
       scale: 2,
       useCORS: true,
-      backgroundColor: '#1a1a1a'
+      backgroundColor: '#fdfcfb'
     },
     jsPDF: {
       unit: 'mm',
@@ -349,6 +349,7 @@ function updateComparison() {
 
   sortedCats.forEach(({cat, list, max}) => {
     const section = document.createElement('div');
+    section.className = 'category-wrapper';
     const header = document.createElement('div');
     header.className = 'category-header ' + colorClass(max);
     header.textContent = cat;

--- a/js/theme.js
+++ b/js/theme.js
@@ -175,7 +175,7 @@ export function applyPrintStyles() {
       .category-header {
         font-size: 18px;
         font-weight: bold;
-        margin-top: 24px;
+        margin: 24px 0 8px;
         padding-top: 8px;
         color: #b00020 !important;
       }
@@ -277,6 +277,27 @@ export function applyPrintStyles() {
         flex-shrink: 0;
         font-size: 12px;
         color: #ccc !important;
+      }
+
+      .category-wrapper {
+        margin-bottom: 24px;
+        padding-bottom: 20px;
+        border-bottom: 1px solid #ddd;
+      }
+
+      .print-footer {
+        position: fixed;
+        bottom: 10px;
+        left: 0;
+        right: 0;
+        text-align: center;
+        font-size: 12px;
+        color: #666;
+      }
+
+      @media print {
+        body { counter-reset: page; }
+        .print-footer:after { content: counter(page); }
       }
 
       .page-break {


### PR DESCRIPTION
## Summary
- apply a lighter background color when printing
- wrap category sections with a new `category-wrapper` class
- update PDF generator to use the soft background
- add footer element for page numbers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882fa9ec96c832cadd2728685e591a9