### PR TITLE
Add transparency callout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1137,6 +1137,17 @@ body.light-mode .static-rating-legend {
   color: inherit;
 }
 
+/* Callout section below the banner */
+.callout-section {
+  max-width: 800px;
+  margin: 20px auto;
+  padding: 16px;
+  background-color: var(--panel-color);
+  border: 1px solid var(--button-bg);
+  border-radius: 6px;
+  color: inherit;
+}
+
 /* Centered menu container for main buttons */
 .menu-container {
   display: flex;

--- a/index.html
+++ b/index.html
@@ -14,6 +14,35 @@
     💡 “After completing the survey, click ‘Export My List’ to download your answers. You can then view or compare your data by uploading it. Your data is never saved — everything happens on your device.”
   </p>
 
+  <section class="callout-section">
+    <h2>Call for Transparency and Accountability</h2>
+    <p>What they did wasn’t just removal. It was erasure. No warning, no explanation, no accountability. Just gone. Like I never mattered. Like all the effort, time, and care I gave held no weight once I was no longer convenient. That kind of harm isn’t just about being kicked out. It’s about being treated as disposable.</p>
+    <p>This wasn’t conflict resolution. This was control. A decision made behind closed doors to get rid of someone instead of talking to them. That causes real emotional damage. It tells people that if they’re not useful, they’re replaceable. That they can be discarded without dignity, without process, without respect.</p>
+    <p>I’m calling for change because no one else should be treated like that. There needs to be transparency about what was done, why it was done, and when. If you’re removing people from a community, you need to be honest and accountable about it. You need to own the choices and the impact.</p>
+    <p>They also need to understand that people can be part of more than one space. That doesn’t make them disloyal or unsafe. It makes them human. The refusal to accept that, and the punishment of people for simply existing in more than one place, is rooted in fear and control—not in safety or care.</p>
+    <p>By restricting freedom of expression and making participation conditional on obedience, they’ve crossed into authoritarian behavior. That’s not community. That’s power-hoarding.</p>
+    <p>So no, I’m not here just asking to come back. I’m demanding an apology. On Reddit. On Discord. In the spaces where the harm was done. This is about the principle. About being treated with basic humanity. About refusing to be erased. I’m not going away until they learn that they can’t do this to people and expect silence in return.</p>
+    <details class="expandable-panel">
+      <summary>🚨 Things That Need to Change</summary>
+      <div class="panel-content">
+        <ul>
+          <li><strong>Transparent Removal Process</strong> Members should not be removed without notice, discussion, or explanation. Kicking someone out in silence causes emotional harm and erases their contributions.</li>
+          <li><strong>Public Accountability</strong> Actions taken in public spaces (like Reddit or Discord) need public acknowledgment and apology. Harm shouldn’t be hidden.</li>
+          <li><strong>Direct Apologies to Affected Users</strong> A personal apology should be issued to anyone who was removed unfairly. Public apologies should also be made on:<br>Reddit (where harm was done)<br>BratLife Discord (where removal occurred)</li>
+          <li><strong>A Clear, Written Policy on Server Tags</strong> People shouldn’t be punished simply for wearing a different server’s tag, especially when it doesn’t break any rules. The policy should be written, accessible, and fair.</li>
+          <li><strong>Respect for Multi-Community Participation</strong> Being in more than one server or space shouldn’t be treated as disloyalty. Healthy communities respect autonomy and freedom of association.</li>
+          <li><strong>Avoid Closed-Door Decisions</strong> Removal or disciplinary actions should include conversation, context, and an option to respond—not silent bans based on assumption or internal bias.</li>
+          <li><strong>End Authoritarian Moderation Tactics</strong> Participation shouldn’t depend on obedience or conformity. Open conversation and differing opinions should be allowed without fear of punishment.</li>
+          <li><strong>Appeals and Review System</strong> Members should have a way to appeal removals or decisions made by mods. Right now, there is no process—just silence.</li>
+          <li><strong>Stop Using Power as a Weapon</strong> Removing someone should never be used to protect reputation or avoid discomfort. It must be used only when safety is truly at stake.</li>
+          <li><strong>Clarity Between Safety vs Control</strong> Moderation should be about community safety, not personal control or fear. Decisions should reflect actual harm—not speculation or power plays.</li>
+          <li><strong>Respect for Emotional Labor</strong> People who give time, effort, and care to a server deserve acknowledgment, not erasure. Even if someone leaves or disagrees, their contributions still matter.</li>
+        </ul>
+      </div>
+    </details>
+    <p><em>BratLife has already been added to one Discord hub’s shared ban list due to this removal.</em></p>
+  </section>
+
   <!-- Theme Selector -->
   <div id="themeControl">
     <label for="themeSelector">🎨 Select Theme:</label>

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -15,6 +15,35 @@
     💡 “After completing the survey, click ‘Export My List’ to download your answers. You can then view or compare your data by uploading it. Your data is never saved — everything happens on your device.”
   </p>
 
+  <section class="callout-section">
+    <h2>Call for Transparency and Accountability</h2>
+    <p>What they did wasn’t just removal. It was erasure. No warning, no explanation, no accountability. Just gone. Like I never mattered. Like all the effort, time, and care I gave held no weight once I was no longer convenient. That kind of harm isn’t just about being kicked out. It’s about being treated as disposable.</p>
+    <p>This wasn’t conflict resolution. This was control. A decision made behind closed doors to get rid of someone instead of talking to them. That causes real emotional damage. It tells people that if they’re not useful, they’re replaceable. That they can be discarded without dignity, without process, without respect.</p>
+    <p>I’m calling for change because no one else should be treated like that. There needs to be transparency about what was done, why it was done, and when. If you’re removing people from a community, you need to be honest and accountable about it. You need to own the choices and the impact.</p>
+    <p>They also need to understand that people can be part of more than one space. That doesn’t make them disloyal or unsafe. It makes them human. The refusal to accept that, and the punishment of people for simply existing in more than one place, is rooted in fear and control—not in safety or care.</p>
+    <p>By restricting freedom of expression and making participation conditional on obedience, they’ve crossed into authoritarian behavior. That’s not community. That’s power-hoarding.</p>
+    <p>So no, I’m not here just asking to come back. I’m demanding an apology. On Reddit. On Discord. In the spaces where the harm was done. This is about the principle. About being treated with basic humanity. About refusing to be erased. I’m not going away until they learn that they can’t do this to people and expect silence in return.</p>
+    <details class="expandable-panel">
+      <summary>🚨 Things That Need to Change</summary>
+      <div class="panel-content">
+        <ul>
+          <li><strong>Transparent Removal Process</strong> Members should not be removed without notice, discussion, or explanation. Kicking someone out in silence causes emotional harm and erases their contributions.</li>
+          <li><strong>Public Accountability</strong> Actions taken in public spaces (like Reddit or Discord) need public acknowledgment and apology. Harm shouldn’t be hidden.</li>
+          <li><strong>Direct Apologies to Affected Users</strong> A personal apology should be issued to anyone who was removed unfairly. Public apologies should also be made on:<br>Reddit (where harm was done)<br>BratLife Discord (where removal occurred)</li>
+          <li><strong>A Clear, Written Policy on Server Tags</strong> People shouldn’t be punished simply for wearing a different server’s tag, especially when it doesn’t break any rules. The policy should be written, accessible, and fair.</li>
+          <li><strong>Respect for Multi-Community Participation</strong> Being in more than one server or space shouldn’t be treated as disloyalty. Healthy communities respect autonomy and freedom of association.</li>
+          <li><strong>Avoid Closed-Door Decisions</strong> Removal or disciplinary actions should include conversation, context, and an option to respond—not silent bans based on assumption or internal bias.</li>
+          <li><strong>End Authoritarian Moderation Tactics</strong> Participation shouldn’t depend on obedience or conformity. Open conversation and differing opinions should be allowed without fear of punishment.</li>
+          <li><strong>Appeals and Review System</strong> Members should have a way to appeal removals or decisions made by mods. Right now, there is no process—just silence.</li>
+          <li><strong>Stop Using Power as a Weapon</strong> Removing someone should never be used to protect reputation or avoid discomfort. It must be used only when safety is truly at stake.</li>
+          <li><strong>Clarity Between Safety vs Control</strong> Moderation should be about community safety, not personal control or fear. Decisions should reflect actual harm—not speculation or power plays.</li>
+          <li><strong>Respect for Emotional Labor</strong> People who give time, effort, and care to a server deserve acknowledgment, not erasure. Even if someone leaves or disagrees, their contributions still matter.</li>
+        </ul>
+      </div>
+    </details>
+    <p><em>BratLife has already been added to one Discord hub’s shared ban list due to this removal.</em></p>
+  </section>
+
   <!-- Theme Selector -->
   <div id="themeControl">
     <label for="themeSelector">🎨 Select Theme:</label>


### PR DESCRIPTION
## Summary
- display new "Call for Transparency and Accountability" section after the banner on survey pages
- style the section using `.callout-section`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688424af1ae4832ca9ea554bfdaa34b7