### PR TITLE
Improve print theme and PDF export

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1873,62 +1873,45 @@ body {
 .page-break { display: none; }
 
 @media print {
-  body {
-    background-color: #fdfcfb !important;
+  body, html {
+    background-color: #e6f0fa !important;
+    color: #1a1a1a !important;
+    font-family: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+    line-height: 1.5;
+    font-size: 12pt !important;
+  }
+
+  .category-header {
+    background-color: #d0e4f5 !important;
     color: #000000 !important;
-    font-family: 'Segoe UI', 'Helvetica Neue', sans-serif !important;
-    font-size: 11px !important;
-    -webkit-print-color-adjust: exact !important;
-    print-color-adjust: exact !important;
+    font-weight: bold;
+    padding: 6px;
+    border-bottom: 1px solid #ccc;
   }
 
-  .category {
-    color: #b00020 !important;
-    font-weight: bold !important;
-    font-size: 16px !important;
-    margin-top: 12px;
+  .kink-row {
+    background-color: #ffffff !important;
+    color: #1a1a1a !important;
+    padding: 4px;
+    border-bottom: 1px solid #dddddd;
   }
 
-  .item-label {
-    color: #333333 !important;
-    font-size: 14px !important;
+  .match-symbols {
+    font-size: 12px;
+    color: #0080ff;
   }
 
-  .match-bar,
-  .score-bar {
-    background-color: #e0e0e0 !important;
-    border-radius: 5px !important;
-    overflow: hidden !important;
-    height: 10px !important;
+  .category-wrapper {
+    border-bottom: 1px solid #4a90e2 !important;
   }
 
-  .match-bar-fill,
-  .bar-fill {
-    background-color: #00c853 !important;
-    height: 12px !important;
+  .icon-star {
+    color: #4a90e2 !important;
   }
 
-  .bar-fill.zero {
-    background-color: #cccccc !important;
-  }
-
-  .star-match {
-    color: #ffb300 !important;
-  }
-
-  .red-flag {
-    color: #d32f2f !important;
-  }
-
-  .score-flag-mismatch {
-    color: #fbc02d !important;
-  }
-
-  .page-break {
-    page-break-after: always !important;
-  }
   #compatibility-report * {
-    font-size: 11px !important;
-    color: #111111 !important;
+    font-size: 12pt !important;
   }
 }

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -253,17 +253,17 @@ async function generateComparisonPDF() {
   if (!target) return;
 
   const opt = {
-    margin: [10, 10],
-    filename: 'TalkKink_Compatibility.pdf',
-    image: { type: 'jpeg', quality: 1 },
+    margin: 0.5,
+    filename: 'kink-compatibility.pdf',
+    image: { type: 'jpeg', quality: 0.98 },
     html2canvas: {
       scale: 2,
       useCORS: true,
-      backgroundColor: '#fdfcfb'
+      backgroundColor: '#e6f0fa'
     },
     jsPDF: {
-      unit: 'mm',
-      format: 'a4',
+      unit: 'in',
+      format: 'letter',
       orientation: 'portrait'
     },
     pagebreak: { mode: ['css', 'legacy'] }

--- a/js/theme.js
+++ b/js/theme.js
@@ -99,7 +99,7 @@ export function applyThemeColors(theme) {
 export const pdfStyles = `
   @media print {
     :root {
-      --bg-color: #fdfcfb !important;
+      --bg-color: #e6f0fa !important;
       --text-color: #000000 !important;
       --panel-color: #f9f9f9 !important;
     }
@@ -108,6 +108,7 @@ export const pdfStyles = `
       background: var(--bg-color) !important;
       color: #000000 !important;
       font-family: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+      font-size: 12pt;
       letter-spacing: 0.3px;
       -webkit-print-color-adjust: exact !important;
       print-color-adjust: exact !important;
@@ -161,7 +162,7 @@ export function applyPrintStyles() {
         max-width: 900px;
         margin: 20px auto;
         padding: 30px;
-        background-color: var(--bg-color, #fdfcfb) !important;
+        background-color: var(--bg-color, #e6f0fa) !important;
         color: var(--text-color, #111111) !important;
         border-radius: 10px;
         font-size: 16px;

--- a/your-roles.html
+++ b/your-roles.html
@@ -76,14 +76,18 @@
 
       const opt = {
         margin: 0.5,
-        filename: 'kink_comparison.pdf',
+        filename: 'kink-compatibility.pdf',
         image: { type: 'jpeg', quality: 0.98 },
-          html2canvas: {
-            scale: 2,
-            useCORS: true,
-            backgroundColor: '#000000'
-          },
-        jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' }
+        html2canvas: {
+          scale: 2,
+          useCORS: true,
+          backgroundColor: '#e6f0fa'
+        },
+        jsPDF: {
+          unit: 'in',
+          format: 'letter',
+          orientation: 'portrait'
+        }
       };
 
       html2pdf().set(opt).from(target).save();


### PR DESCRIPTION
## Summary
- style print layout in light blue theme
- update pdf generation to apply print styles
- adjust default print colors in theme

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68843582c808832c93f3b88dd99f2832