### PR TITLE
Improve PDF print layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1880,7 +1880,7 @@ body {
     -webkit-print-color-adjust: exact;
     print-color-adjust: exact;
     line-height: 1.5;
-    font-size: 12pt !important;
+    font-size: 13px !important;
   }
 
   .category-header {
@@ -1898,13 +1898,20 @@ body {
     border-bottom: 1px solid #dddddd;
   }
 
+  .compare-row {
+    background-color: #ffffff !important;
+  }
+
   .match-symbols {
     font-size: 12px;
     color: #0080ff;
   }
 
   .category-wrapper {
+    background-color: #ffffff !important;
     border-bottom: 1px solid #4a90e2 !important;
+    padding: 6px;
+    margin-bottom: 12px;
   }
 
   .icon-star {
@@ -1912,6 +1919,6 @@ body {
   }
 
   #compatibility-report * {
-    font-size: 12pt !important;
+    font-size: 13px !important;
   }
 }

--- a/js/theme.js
+++ b/js/theme.js
@@ -108,7 +108,7 @@ export const pdfStyles = `
       background: var(--bg-color) !important;
       color: #000000 !important;
       font-family: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
-      font-size: 12pt;
+      font-size: 13px;
       letter-spacing: 0.3px;
       -webkit-print-color-adjust: exact !important;
       print-color-adjust: exact !important;
@@ -130,7 +130,7 @@ export const pdfStyles = `
       height: 12px !important;
       border-radius: 6px;
       background-color: #e0e0e0 !important;
-      box-shadow: inset 0 0 3px rgba(0,0,0,0.15);
+      box-shadow: none !important;
     }
 
     .match-bar-fill {
@@ -190,6 +190,7 @@ export function applyPrintStyles() {
         gap: 10px;
         padding: 6px 0;
         border-bottom: 1px solid #ccc;
+        background-color: #ffffff !important;
       }
 
       .compare-label {
@@ -210,7 +211,7 @@ export function applyPrintStyles() {
         background: #e0e0e0;
         border-radius: 6px;
         margin: 0 6px;
-        box-shadow: inset 0 0 3px rgba(0,0,0,0.15);
+        box-shadow: none !important;
       }
       .partner-fill.green { background-color: #00c853; }
       .partner-fill.yellow { background-color: #fbc02d; }
@@ -282,8 +283,9 @@ export function applyPrintStyles() {
 
       .category-wrapper {
         margin-bottom: 24px;
-        padding-bottom: 20px;
+        padding: 6px;
         border-bottom: 1px solid #ddd;
+        background-color: #ffffff !important;
       }
 
       .print-footer {
@@ -322,7 +324,7 @@ export function applyPrintStyles() {
         }
 
         .category-wrapper {
-          background-color: #f2f2f2 !important;
+          background-color: #ffffff !important;
           color: #111111 !important;
           border: 1px solid #cccccc;
           padding: 1rem;


### PR DESCRIPTION
## Summary
- tweak print CSS with white row backgrounds and spacing
- clean up print styles in theme.js
- adjust body font size for PDF output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68843a15136c832c9c795def9f52e5ce