### PR TITLE
Improve dark mode styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -9,20 +9,20 @@ body {
 
 html,
 body {
-  background-color: #000000;
-  color: #ffffff;
-  font-family: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+  background-color: #0f0f0f;
+  color: #f0f0f0;
+  font-family: 'Inter', 'Open Sans', system-ui, sans-serif;
 }
 
 .card,
 .category-box,
 .survey-section,
 .result-card {
-  background-color: rgba(30, 40, 60, 0.9) !important;
-  color: #ffffff !important;
-  border: none !important;
-  padding: 1rem;
-  margin-bottom: 1rem;
+  background-color: rgba(30, 30, 47, 0.95) !important;
+  color: #f0f0f0 !important;
+  border: 1px solid rgba(255, 255, 255, 0.15) !important;
+  padding: 16px;
+  margin-bottom: 20px;
   border-radius: 8px;
 }
 
@@ -46,12 +46,13 @@ body {
 
 /* Default theme variables */
 :root {
-  --bg-color: #1a1a1a;
-  --panel-color: #292b3d;
-  --text-color: #ffffff;
+  --bg-color: #0f0f0f;
+  --panel-color: #1e1e2f;
+  --text-color: #f0f0f0;
   --button-bg: #444;
   --button-text: #ffffff;
   --button-hover-bg: #666;
+  --progress-fill-color: #00c853;
 }
 .category-panel {
   position: fixed;
@@ -1047,21 +1048,22 @@ body.light-mode .static-rating-legend {
 }
 
 .section-header:nth-of-type(odd) {
-  color: #ff875f;
+  color: #6ee07f;
 }
 
 .section-header:nth-of-type(even) {
-  color: #8fd3f4;
+  color: #ff6666;
 }
 
 .section-header {
   font-size: 1.3rem;
   margin: 24px 0 12px;
-  border-bottom: 2px solid #444;
+  border-bottom: 1px solid #444;
   padding-bottom: 4px;
   text-align: center;
   margin-left: auto;
   margin-right: auto;
+  font-weight: 700;
 }
 
 .section-divider {
@@ -1199,8 +1201,9 @@ body.light-mode .static-rating-legend {
   width: 80%;
   max-width: 300px;
   margin: 20px auto;
-  background-color: #2b2b2b;
+  background-color: #333;
   border-radius: 10px;
+  border: 1px solid #444;
   height: 26px; /* keep progress bar text from being clipped */
   overflow: hidden;
 }
@@ -1213,12 +1216,13 @@ body.light-mode .static-rating-legend {
 .progress-bar {
   width: 100%;
   height: 100%;
-  background-color: #2c2c2c;
+  background-color: #333;
   border-radius: 12px;
   padding: 4px 10px;
   font-size: 1rem;
   display: inline-block;
   overflow: hidden;
+  box-shadow: inset 0 0 4px rgba(0, 0, 0, 0.5);
 }
 .progress-bar-text {
   color: #ffffff;
@@ -1227,7 +1231,7 @@ body.light-mode .static-rating-legend {
 .progress-fill {
   height: 100%;
   width: 0;
-  background-color: var(--progress-fill-color, #4caf50);
+  background-color: var(--progress-fill-color, #00c853);
   transition: width 0.4s ease;
   border-radius: 10px 0 0 10px;
 }

--- a/css/theme.css
+++ b/css/theme.css
@@ -1,11 +1,11 @@
 :root {
-  --bg-color: #1a1a1a;
-  --panel-color: #292b3d;
-  --text-color: #ffffff;
+  --bg-color: #0f0f0f;
+  --panel-color: #1e1e2f;
+  --text-color: #f0f0f0;
   --button-bg: #444;
   --button-text: #ffffff;
   --button-hover-bg: #666;
-  --progress-fill-color: #00cc66;
+  --progress-fill-color: #00c853;
 }
 
 .theme-lightforest,
@@ -21,13 +21,13 @@
 
 .theme-darkviolet,
 .dark-mode {
-  --bg-color: #000000;
-  --panel-color: #292b3d;
+  --bg-color: #0f0f0f;
+  --panel-color: #1e1e2f;
   --text-color: #f0f0f0;
   --button-bg: #7c5fe9;
   --button-text: #ffffff;
   --button-hover-bg: #9b84ff;
-  --progress-fill-color: #7c5fe9;
+  --progress-fill-color: #00c853;
 }
 
 .theme-blue {

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -253,7 +253,15 @@ async function generateComparisonPDF() {
   if (!pdfContainer) return;
 
   pdfContainer.classList.add('pdf-export');
-  await html2pdf().from(pdfContainer).save();
+  await html2pdf()
+    .set({
+      margin: 0,
+      filename: 'survey.pdf',
+      pagebreak: { mode: ['avoid-all'] },
+      html2canvas: { backgroundColor: '#0f0f0f', useCORS: true }
+    })
+    .from(pdfContainer)
+    .save();
   pdfContainer.classList.remove('pdf-export');
 }
 

--- a/your-roles.html
+++ b/your-roles.html
@@ -74,7 +74,15 @@
       if (!pdfContainer) return;
 
       pdfContainer.classList.add('pdf-export');
-      html2pdf().from(pdfContainer).save();
+      html2pdf()
+        .set({
+          margin: 0,
+          filename: 'survey.pdf',
+          pagebreak: { mode: ['avoid-all'] },
+          html2canvas: { backgroundColor: '#0f0f0f', useCORS: true }
+        })
+        .from(pdfContainer)
+        .save();
       pdfContainer.classList.remove('pdf-export');
     }
 


### PR DESCRIPTION
## Summary
- refine global dark theme styling
- ensure exported PDFs use same dark background

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688476bcaf18832cbccd47560bc50ae2