### PR TITLE
Apply dark theme across site and PDF output

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -18,18 +18,19 @@ body {
 .category-box,
 .survey-section,
 .result-card {
-  background-color: rgba(30, 30, 47, 0.95) !important;
+  background-color: #1a1a1a !important;
   color: #f0f0f0 !important;
-  border: 1px solid rgba(255, 255, 255, 0.15) !important;
+  border: 1px solid #333 !important;
+  box-shadow: none !important;
   padding: 16px;
-  margin-bottom: 20px;
+  margin-bottom: 16px;
   border-radius: 8px;
 }
 
 .bar-label,
 .item-label,
 .item-name {
-  color: #e0e0e0 !important;
+  color: #a0f2b4 !important;
 }
 
 .match-bar {
@@ -240,10 +241,10 @@ body.theme-rainbow #mainCategoryList button.active {
 
 /* Theme Styling */
 body.dark-mode {
-  background-color: #121212;
-  color: #e0e0e0;
+  background-color: #0f0f0f;
+  color: #f0f0f0;
   --panel-color: #1e1e2f;
-  --text-color: #e0e0e0;
+  --text-color: #f0f0f0;
   --button-bg: #7c5fe9;
   --button-text: #ffffff;
   --button-hover-bg: #9b84ff;
@@ -1047,27 +1048,20 @@ body.light-mode .static-rating-legend {
   pointer-events: none;
 }
 
-.section-header:nth-of-type(odd) {
-  color: #6ee07f;
-}
-
-.section-header:nth-of-type(even) {
-  color: #ff6666;
-}
-
 .section-header {
   font-size: 1.3rem;
   margin: 24px 0 12px;
-  border-bottom: 1px solid #444;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.15);
   padding-bottom: 4px;
   text-align: center;
   margin-left: auto;
   margin-right: auto;
   font-weight: 700;
+  color: #ff5c5c;
 }
 
 .section-divider {
-  border-top: 1px solid #333;
+  border-top: 1px solid rgba(255, 255, 255, 0.15);
   margin: 24px 0;
 }
 
@@ -1201,9 +1195,9 @@ body.light-mode .static-rating-legend {
   width: 80%;
   max-width: 300px;
   margin: 20px auto;
-  background-color: #333;
-  border-radius: 10px;
-  border: 1px solid #444;
+  background-color: #444;
+  border-radius: 4px;
+  border: 1px solid #333;
   height: 26px; /* keep progress bar text from being clipped */
   overflow: hidden;
 }
@@ -1216,8 +1210,8 @@ body.light-mode .static-rating-legend {
 .progress-bar {
   width: 100%;
   height: 100%;
-  background-color: #333;
-  border-radius: 12px;
+  background-color: #444;
+  border-radius: 4px;
   padding: 4px 10px;
   font-size: 1rem;
   display: inline-block;
@@ -1233,13 +1227,13 @@ body.light-mode .static-rating-legend {
   width: 0;
   background-color: var(--progress-fill-color, #00c853);
   transition: width 0.4s ease;
-  border-radius: 10px 0 0 10px;
+  border-radius: 4px 0 0 4px;
 }
 
 /* Match progress bar background to theme */
 body.dark-mode .progress-container,
 body.dark-mode .progress-bar {
-  background-color: #121212;
+  background-color: #444;
 }
 body.light-mode .progress-container,
 body.light-mode .progress-bar {
@@ -1636,23 +1630,24 @@ body {
 .result-container,
 .pdf-container {
   position: relative;
-  background-color: var(--panel-color, var(--bg-color, #000));
-  color: var(--text-color, #222);
+  background-color: #0f0f0f;
+  color: #f0f0f0;
   font-family: 'Segoe UI', Arial, 'Helvetica Neue', sans-serif;
   max-width: 900px;
   margin: 40px auto;
   padding: 30px;
   border-radius: 10px;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+  box-shadow: none;
+  border: 1px solid rgba(255, 255, 255, 0.15);
 }
 
 .result-section-title {
   font-size: 20px;
   font-weight: 600;
-  border-bottom: 2px solid #bbb;
+  border-bottom: 2px solid rgba(255, 255, 255, 0.15);
   margin-bottom: 18px;
   padding-bottom: 6px;
-  color: var(--text-color, #111);
+  color: #f0f0f0;
 }
 
 .result-entry {
@@ -1660,9 +1655,9 @@ body {
   justify-content: space-between;
   padding: 10px 14px;
   margin-bottom: 6px;
-  background-color: var(--bg-color, #fff);
+  background-color: #1a1a1a;
   border-radius: 6px;
-  border: 1px solid #ddd;
+  border: 1px solid rgba(255, 255, 255, 0.15);
 }
 .result-entry .label {
   flex: 2;
@@ -1917,46 +1912,48 @@ body {
 @media print {
   body,
   html {
-    background-color: #0a0a0a !important;
-    color: #ffffff !important;
+    background-color: #0f0f0f !important;
+    color: #f0f0f0 !important;
     -webkit-print-color-adjust: exact !important;
     print-color-adjust: exact !important;
   }
 
   .pdf-container {
-    background-color: #000000 !important;
-    color: #ffffff !important;
+    background-color: #0f0f0f !important;
+    color: #f0f0f0 !important;
     padding: 20px;
     font-family: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+    border: 1px solid rgba(255, 255, 255, 0.15);
   }
 
   .card,
   .category-box,
   .result-card {
-    background-color: rgba(30, 40, 60, 0.9) !important;
-    color: #ffffff !important;
-    border: none !important;
+    background-color: #1a1a1a !important;
+    color: #f0f0f0 !important;
+    border: 1px solid #333 !important;
+    box-shadow: none !important;
   }
 
   .match-bar {
-    background-color: #00cc88 !important;
+    background-color: #444 !important;
   }
 
   .item-label {
-    color: #ffffff !important;
+    color: #c0ffc7 !important;
   }
 
   .pdf-container h2,
   .pdf-container h3,
   .pdf-container .category-title {
-    color: #00c8ff !important;
+    color: #ff5c5c !important;
   }
 
   .pdf-container .bar-label {
-    color: #ffffff !important;
+    color: #a0f2b4 !important;
   }
 
   .pdf-container .match-bar {
-    background-color: #00ff7f !important;
+    background-color: #444 !important;
   }
 }


### PR DESCRIPTION
## Summary
- tweak container backgrounds and text colors for consistent dark mode
- style progress bars and section headers for PDF export
- enforce dark PDF background with updated print styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688479fe842c832c88406d15eb345d14