### PR TITLE
Enable dark PDF theme

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -32,7 +32,7 @@
       </div>
     </div>
     <div id="comparisonResult"></div>
-    <div class="pdf-container print-wrapper">
+    <div id="print-area" class="pdf-container print-wrapper">
       <div id="compatibility-report" class="pdf-export-area"></div>
     </div>
     <div class="print-footer"></div>

--- a/css/style.css
+++ b/css/style.css
@@ -1972,3 +1972,42 @@ body {
     background-color: #444 !important;
   }
 }
+html, body {
+  background-color: #000000 !important;
+  color: #ffffff !important;
+  margin: 0;
+  padding: 0;
+  font-family: 'Segoe UI', sans-serif;
+}
+
+.card, .kink-category, .print-wrapper {
+  background-color: #0a0a0a !important;
+  border: 1px solid #333 !important;
+  box-shadow: none !important;
+  color: #ffffff !important;
+}
+
+h1, h2, h3, h4, h5 {
+  color: #00ffb7 !important;
+}
+
+.section-header {
+  color: #ff5555 !important;
+}
+
+.item-label, .partner-label, p, span, li {
+  color: #ffffff !important;
+}
+
+.progress-bar-container {
+  background-color: #222 !important;
+}
+
+.progress-bar-fill {
+  background-color: #00e676 !important;
+}
+
+[class*="dark"], [class*="theme"], .theme-dark {
+  background-color: #000000 !important;
+  color: #ffffff !important;
+}

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -249,20 +249,29 @@ function buildKinkBreakdown(surveyA, surveyB) {
 
 async function generateComparisonPDF() {
   applyPrintStyles();
-  const pdfContainer = document.querySelector('.pdf-container');
-  if (!pdfContainer) return;
+  const element = document.getElementById('print-area');
+  if (!element) return;
 
-  pdfContainer.classList.add('pdf-export');
+  element.classList.add('pdf-export');
   await html2pdf()
     .set({
       margin: 0,
-      filename: 'survey.pdf',
-      pagebreak: { mode: ['avoid-all'] },
-      html2canvas: { backgroundColor: '#0f0f0f', useCORS: true, scale: 2 }
+      filename: 'kink-compatibility.pdf',
+      html2canvas: {
+        backgroundColor: '#000000',
+        scale: 2,
+        useCORS: true
+      },
+      jsPDF: {
+        unit: 'in',
+        format: 'letter',
+        orientation: 'portrait'
+      },
+      pagebreak: { mode: ['avoid-all'] }
     })
-    .from(pdfContainer)
+    .from(element)
     .save();
-  pdfContainer.classList.remove('pdf-export');
+  element.classList.remove('pdf-export');
 }
 
 function loadFileA(file) {

--- a/your-roles.html
+++ b/your-roles.html
@@ -17,7 +17,7 @@
       <input type="file" id="roleFile" hidden />
     </label>
 
-    <div id="rolesOutput" class="pdf-container print-wrapper result-container"></div>
+    <div id="print-area" class="pdf-container print-wrapper result-container"></div>
   </div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
@@ -70,20 +70,29 @@
 
     function exportPDFFromVisibleStyledContent() {
       applyPrintStyles();
-      const pdfContainer = document.querySelector('.pdf-container');
-      if (!pdfContainer) return;
+      const element = document.getElementById('print-area');
+      if (!element) return;
 
-      pdfContainer.classList.add('pdf-export');
+      element.classList.add('pdf-export');
       html2pdf()
         .set({
           margin: 0,
-          filename: 'survey.pdf',
-          pagebreak: { mode: ['avoid-all'] },
-          html2canvas: { backgroundColor: '#0f0f0f', useCORS: true, scale: 2 }
+          filename: 'kink-compatibility.pdf',
+          html2canvas: {
+            backgroundColor: '#000000',
+            scale: 2,
+            useCORS: true
+          },
+          jsPDF: {
+            unit: 'in',
+            format: 'letter',
+            orientation: 'portrait'
+          },
+          pagebreak: { mode: ['avoid-all'] }
         })
-        .from(pdfContainer)
+        .from(element)
         .save();
-      pdfContainer.classList.remove('pdf-export');
+      element.classList.remove('pdf-export');
     }
 
     document.getElementById('roleFile').addEventListener('change', e => {
@@ -95,7 +104,7 @@
           const parsed = JSON.parse(ev.target.result);
           const survey = parsed.survey || parsed;
           const scores = calculateRoleScores({ all: flattenSurvey(survey) });
-          const container = document.getElementById('rolesOutput');
+          const container = document.getElementById('print-area');
           if (!scores.length) {
             container.textContent = 'No role data found.';
             return;
@@ -125,7 +134,7 @@
           btn.setAttribute('onclick', 'exportPDFFromVisibleStyledContent()');
           container.appendChild(btn);
         } catch (err) {
-          document.getElementById('rolesOutput').textContent = 'Invalid file.';
+          document.getElementById('print-area').textContent = 'Invalid file.';
         }
       };
       reader.readAsText(file);


### PR DESCRIPTION
## Summary
- apply new black theme overrides and high contrast colours in CSS
- update html2pdf options to use print-area element
- give print-area id for compatibility report and role lists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68848b18c454832c9d1f4c56a2d3a4ac