### PR TITLE
Add final dark theme and pdf export fixes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1973,30 +1973,36 @@ body {
   }
 }
 html, body {
-  background-color: #000000 !important;
-  color: #ffffff !important;
+  background-color: #000 !important;
+  color: #fff !important;
+  font-family: 'Segoe UI', sans-serif;
   margin: 0;
   padding: 0;
-  font-family: 'Segoe UI', sans-serif;
 }
 
-.card, .kink-category, .print-wrapper {
-  background-color: #0a0a0a !important;
+#app,
+.print-wrapper,
+.card,
+.kink-category,
+.section {
+  background-color: #111 !important;
+  color: #fff !important;
   border: 1px solid #333 !important;
   box-shadow: none !important;
-  color: #ffffff !important;
 }
 
-h1, h2, h3, h4, h5 {
-  color: #00ffb7 !important;
+.section-header,
+.category-header {
+  color: #ff4444 !important;
+  font-weight: 600;
 }
 
-.section-header {
-  color: #ff5555 !important;
-}
-
-.item-label, .partner-label, p, span, li {
-  color: #ffffff !important;
+.item-label,
+.partner-label,
+span,
+p,
+li {
+  color: #f0f0f0 !important;
 }
 
 .progress-bar-container {
@@ -2007,7 +2013,25 @@ h1, h2, h3, h4, h5 {
   background-color: #00e676 !important;
 }
 
-[class*="dark"], [class*="theme"], .theme-dark {
-  background-color: #000000 !important;
-  color: #ffffff !important;
+table,
+tr,
+td,
+th {
+  background-color: #111 !important;
+  color: #fff !important;
 }
+
+hr {
+  border-color: #333 !important;
+}
+
+::-webkit-scrollbar {
+  width: 0px;
+  background: transparent;
+}
+
+[class*="dark"], [class*="theme"], .theme-dark {
+  background-color: #000 !important;
+  color: #fff !important;
+}
+

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -249,23 +249,23 @@ function buildKinkBreakdown(surveyA, surveyB) {
 
 async function generateComparisonPDF() {
   applyPrintStyles();
-  const element = document.getElementById('print-area');
+  const element = document.getElementById("print-area");
   if (!element) return;
 
   element.classList.add('pdf-export');
   await html2pdf()
     .set({
       margin: 0,
-      filename: 'kink-compatibility.pdf',
+      filename: "survey.pdf",
       html2canvas: {
-        backgroundColor: '#000000',
         scale: 2,
+        backgroundColor: "#000000",
         useCORS: true
       },
       jsPDF: {
-        unit: 'in',
-        format: 'letter',
-        orientation: 'portrait'
+        unit: "in",
+        format: "letter",
+        orientation: "portrait"
       },
       pagebreak: { mode: ['avoid-all'] }
     })

--- a/your-roles.html
+++ b/your-roles.html
@@ -70,23 +70,23 @@
 
     function exportPDFFromVisibleStyledContent() {
       applyPrintStyles();
-      const element = document.getElementById('print-area');
+      const element = document.getElementById("print-area");
       if (!element) return;
 
       element.classList.add('pdf-export');
       html2pdf()
         .set({
           margin: 0,
-          filename: 'kink-compatibility.pdf',
+          filename: "survey.pdf",
           html2canvas: {
-            backgroundColor: '#000000',
             scale: 2,
+            backgroundColor: "#000000",
             useCORS: true
           },
           jsPDF: {
-            unit: 'in',
-            format: 'letter',
-            orientation: 'portrait'
+            unit: "in",
+            format: "letter",
+            orientation: "portrait"
           },
           pagebreak: { mode: ['avoid-all'] }
         })


### PR DESCRIPTION
## Summary
- update dark mode styling in `css/style.css`
- standardize html2pdf export options in `your-roles.html` and `js/compatibilityPage.js`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68848d253acc832c86d99e17a9ab1bda