### PR TITLE
Fix PDF background color

### DIFF
--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -252,6 +252,9 @@ async function generateComparisonPDF() {
   const element = document.getElementById("print-area");
   if (!element) return;
 
+  // Force background color for PDF rendering
+  element.style.backgroundColor = "#111"; // or "#000" for pure black
+
   element.classList.add('pdf-export');
   await html2pdf()
     .set({
@@ -272,6 +275,7 @@ async function generateComparisonPDF() {
     .from(element)
     .save();
   element.classList.remove('pdf-export');
+  element.style.backgroundColor = "";
 }
 
 function loadFileA(file) {

--- a/your-roles.html
+++ b/your-roles.html
@@ -73,6 +73,9 @@
       const element = document.getElementById("print-area");
       if (!element) return;
 
+      // Force background color for PDF rendering
+      element.style.backgroundColor = "#111"; // or "#000" for pure black
+
       element.classList.add('pdf-export');
       html2pdf()
         .set({
@@ -93,6 +96,7 @@
         .from(element)
         .save();
       element.classList.remove('pdf-export');
+      element.style.backgroundColor = "";
     }
 
     document.getElementById('roleFile').addEventListener('change', e => {


### PR DESCRIPTION
## Summary
- enforce background color before exporting PDFs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68848edc7c40832ca0de100cfe1bbe85