### PR TITLE
Implement export options

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -25,10 +25,12 @@
           <input type="file" id="fileB" hidden />
         </label>
       </div>
-      <div class="button-container">
-        <button id="downloadResults" class="compatibility-button">
-          Download Data
-        </button>
+      <div class="button-container export-buttons">
+        <button id="pngBtn" class="compatibility-button">Download as PNG</button>
+        <button id="htmlBtn" class="compatibility-button">Export as HTML</button>
+        <button id="mdBtn" class="compatibility-button">Export Markdown</button>
+        <button id="csvBtn" class="compatibility-button">Export CSV</button>
+        <button id="jsonBtn" class="compatibility-button">Save JSON Backup</button>
       </div>
     </div>
     <div id="comparisonResult"></div>
@@ -38,6 +40,7 @@
     <div class="print-footer"></div>
   </div>
   <script src="js/template-survey.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
   <script type="module" src="js/compatibilityPage.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add PNG, HTML, Markdown, CSV and JSON export buttons on the compatibility page
- implement the export logic in `compatibilityPage.js`
- include the html2canvas library for screenshot exports

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688499926558832c82b3bed411f514c4