### PR TITLE
Implement export options

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -26,9 +26,7 @@
         </label>
       </div>
       <div class="button-container">
-        <button id="downloadResults" class="compatibility-button">
-          Download Data
-        </button>
+        <button id="pngBtn" class="compatibility-button">Download as PNG</button>
       </div>
     </div>
     <div id="comparisonResult"></div>
@@ -38,6 +36,7 @@
     <div class="print-footer"></div>
   </div>
   <script src="js/template-survey.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
   <script type="module" src="js/compatibilityPage.js"></script>
 </body>
 </html>

--- a/compatibility.html
+++ b/compatibility.html
@@ -25,8 +25,12 @@
           <input type="file" id="fileB" hidden />
         </label>
       </div>
-      <div class="button-container">
+      <div class="button-container export-buttons">
         <button id="pngBtn" class="compatibility-button">Download as PNG</button>
+        <button id="htmlBtn" class="compatibility-button">Export as HTML</button>
+        <button id="mdBtn" class="compatibility-button">Export Markdown</button>
+        <button id="csvBtn" class="compatibility-button">Export CSV</button>
+        <button id="jsonBtn" class="compatibility-button">Save JSON Backup</button>
       </div>
     </div>
     <div id="comparisonResult"></div>

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -321,7 +321,7 @@ function loadFileB(file) {
 function updateComparison() {
   const container = document.getElementById('compatibility-report');
   const msg = document.getElementById('comparisonResult');
-  const dlBtn = document.getElementById('downloadResults');
+  const dlBtn = document.getElementById('pngBtn');
   if (!surveyA || !surveyB) {
     msg.textContent = surveyA || surveyB ? 'Please upload both surveys to compare.' : '';
     container.innerHTML = '';
@@ -414,19 +414,21 @@ if (fileBInput) {
 
 
 
-const downloadBtn = document.getElementById('downloadResults');
-if (downloadBtn) {
-  downloadBtn.addEventListener('click', async () => {
-    if (!surveyA || !surveyB) {
-      alert('Please upload both surveys first.');
-      return;
-    }
-    if (!lastResult) {
-      lastResult = buildKinkBreakdown(surveyA, surveyB);
-    }
-    await generateComparisonPDF();
+async function exportPNG() {
+  const element = document.getElementById('print-area');
+  if (!element) return;
+  const canvas = await html2canvas(element, {
+    backgroundColor: '#000000',
+    scale: 2,
+    useCORS: true
   });
+  const link = document.createElement('a');
+  link.download = 'kink-survey.png';
+  link.href = canvas.toDataURL('image/png');
+  link.click();
 }
+
+document.getElementById('pngBtn')?.addEventListener('click', exportPNG);
 
 document.addEventListener('DOMContentLoaded', () => {
   initTheme();

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -414,6 +414,19 @@ if (fileBInput) {
 
 
 
+function downloadBlob(blob, filename) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.style.display = 'none';
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  setTimeout(() => {
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }, 0);
+}
 async function exportPNG() {
   const element = document.getElementById('print-area');
   if (!element) return;
@@ -428,7 +441,71 @@ async function exportPNG() {
   link.click();
 }
 
+function exportHTML() {
+  const element = document.getElementById('print-area');
+  if (!element) return;
+  const html = `<!DOCTYPE html><html><head><meta charset="UTF-8"><title>Kink Survey Results</title></head><body>${element.innerHTML}</body></html>`;
+  const blob = new Blob([html], { type: 'text/html' });
+  downloadBlob(blob, 'kink-survey.html');
+}
+
+function exportMarkdown() {
+  if (!lastResult) {
+    if (!surveyA || !surveyB) {
+      alert('Please upload both surveys first.');
+      return;
+    }
+    lastResult = buildKinkBreakdown(surveyA, surveyB);
+  }
+  const lines = ['# Kink Compatibility Results'];
+  for (const [cat, items] of Object.entries(lastResult)) {
+    lines.push(`\n## ${cat}`);
+    items.forEach(it => {
+      const a = maxRating(it.you);
+      const b = maxRating(it.partner);
+      lines.push(`- **${it.name}** - You: ${formatRating(a)} | Partner: ${formatRating(b)}`);
+    });
+  }
+  const blob = new Blob([lines.join('\n')], { type: 'text/markdown' });
+  downloadBlob(blob, 'kink-survey.md');
+}
+
+function exportCSV() {
+  if (!lastResult) {
+    if (!surveyA || !surveyB) {
+      alert('Please upload both surveys first.');
+      return;
+    }
+    lastResult = buildKinkBreakdown(surveyA, surveyB);
+  }
+  const rows = [['Category', 'Item', 'Partner A', 'Partner B']];
+  Object.entries(lastResult).forEach(([cat, list]) => {
+    list.forEach(it => {
+      rows.push([cat, it.name, maxRating(it.you) ?? '', maxRating(it.partner) ?? '']);
+    });
+  });
+  const csv = rows.map(r => r.map(v => `"${String(v).replace(/"/g, '""')}"`).join(',')).join('\n');
+  const blob = new Blob([csv], { type: 'text/csv' });
+  downloadBlob(blob, 'kink-survey.csv');
+}
+
+function exportJSON() {
+  if (!lastResult) {
+    if (!surveyA || !surveyB) {
+      alert('Please upload both surveys first.');
+      return;
+    }
+    lastResult = buildKinkBreakdown(surveyA, surveyB);
+  }
+  const blob = new Blob([JSON.stringify(lastResult, null, 2)], { type: 'application/json' });
+  downloadBlob(blob, 'kink-survey.json');
+}
+
 document.getElementById('pngBtn')?.addEventListener('click', exportPNG);
+document.getElementById('htmlBtn')?.addEventListener('click', exportHTML);
+document.getElementById('mdBtn')?.addEventListener('click', exportMarkdown);
+document.getElementById('csvBtn')?.addEventListener('click', exportCSV);
+document.getElementById('jsonBtn')?.addEventListener('click', exportJSON);
 
 document.addEventListener('DOMContentLoaded', () => {
   initTheme();


### PR DESCRIPTION
## Summary
- add PNG, HTML, Markdown, CSV and JSON export buttons on the compatibility page
- implement the export logic in `compatibilityPage.js`
- include the html2canvas library for screenshot exports

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688499926558832c82b3bed411f514c4