### PR TITLE
Enable automatic PDF export

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -25,12 +25,8 @@
           <input type="file" id="fileB" hidden />
         </label>
       </div>
-      <div class="button-container export-buttons">
-        <button id="pngBtn" class="compatibility-button">Download as PNG</button>
-        <button id="htmlBtn" class="compatibility-button">Export as HTML</button>
-        <button id="mdBtn" class="compatibility-button">Export Markdown</button>
-        <button id="csvBtn" class="compatibility-button">Export CSV</button>
-        <button id="jsonBtn" class="compatibility-button">Save JSON Backup</button>
+      <div id="pdfFallback" class="compatibility-button-container" style="display:none;margin-top:10px;">
+        Having trouble downloading? <button id="downloadPdfFallbackBtn" class="compatibility-button">Click here to download your PDF</button>
       </div>
     </div>
     <div id="comparisonResult"></div>

--- a/index.html
+++ b/index.html
@@ -74,8 +74,11 @@
         </div>
         <div id="finalScreen" class="final-screen" style="display:none">
           <button id="saveSurveyBtn">Save Survey</button>
-          <button id="downloadPdfBtn">Download PDF</button>
           <button id="returnHomeBtn">Return Home</button>
+          <div id="pdfFallback" style="display:none;margin-top:10px;">
+            Having trouble downloading?
+            <button id="downloadPdfFallbackBtn">Click here to download your PDF</button>
+          </div>
         </div>
     </div>
   </div>

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -321,16 +321,16 @@ function loadFileB(file) {
 function updateComparison() {
   const container = document.getElementById('compatibility-report');
   const msg = document.getElementById('comparisonResult');
-  const dlBtn = document.getElementById('pngBtn');
+  const dlBtn = null;
   if (!surveyA || !surveyB) {
     msg.textContent = surveyA || surveyB ? 'Please upload both surveys to compare.' : '';
     container.innerHTML = '';
     lastResult = null;
-    if (dlBtn) dlBtn.style.backgroundColor = '';
+    if (dlBtn) {}
     return;
   }
   msg.textContent = '';
-  if (dlBtn) dlBtn.style.backgroundColor = '#000';
+  if (dlBtn) {}
   const kinkBreakdown = buildKinkBreakdown(surveyA, surveyB);
   lastResult = kinkBreakdown;
   container.innerHTML = '';
@@ -396,6 +396,10 @@ function updateComparison() {
       container.appendChild(br);
     }
   });
+  setTimeout(() => {
+    generateComparisonPDF();
+    setTimeout(showFallback, 5000);
+  }, 0);
 }
 
 const fileAInput = document.getElementById('fileA');
@@ -502,11 +506,14 @@ function exportJSON() {
   downloadBlob(blob, 'kink-survey.json');
 }
 
-document.getElementById('pngBtn')?.addEventListener('click', exportPNG);
-document.getElementById('htmlBtn')?.addEventListener('click', exportHTML);
-document.getElementById('mdBtn')?.addEventListener('click', exportMarkdown);
-document.getElementById('csvBtn')?.addEventListener('click', exportCSV);
-document.getElementById('jsonBtn')?.addEventListener('click', exportJSON);
+function showFallback() {
+  const fb = document.getElementById('pdfFallback');
+  const btn = document.getElementById('downloadPdfFallbackBtn');
+  if (!fb || !btn) return;
+  fb.style.display = 'block';
+  btn.addEventListener('click', generateComparisonPDF);
+}
+
 
 document.addEventListener('DOMContentLoaded', () => {
   initTheme();

--- a/js/script.js
+++ b/js/script.js
@@ -225,7 +225,6 @@ const themeSelector = document.getElementById('themeSelector');
 const categoryDescription = document.getElementById('categoryDescription');
 const newSurveyBtn = document.getElementById('newSurveyBtn');
 const downloadBtn = document.getElementById('downloadBtn');
-const downloadPdfBtn = document.getElementById('downloadPdfBtn');
 const progressBanner = document.getElementById('progressBanner');
 const progressLabel = document.getElementById('progressLabel');
 const progressFill = document.getElementById('progressFill');
@@ -714,6 +713,10 @@ function nextCategory() {
     surveyContainer.style.display = 'none';
     finalScreen.style.display = 'flex';
     progressBanner.style.display = 'none';
+    setTimeout(() => {
+      downloadPDF();
+      setTimeout(showFallback, 5000);
+    }, 0);
   }
   updateProgress();
 }
@@ -883,7 +886,14 @@ function downloadPDF() {
   html2pdf().set(opt).from(element).save();
 }
 
-if (downloadPdfBtn) downloadPdfBtn.addEventListener('click', downloadPDF);
+function showFallback() {
+  const fb = document.getElementById('pdfFallback');
+  const btn = document.getElementById('downloadPdfFallbackBtn');
+  if (!fb || !btn) return;
+  fb.style.display = 'block';
+  btn.addEventListener('click', downloadPDF);
+}
+
 
 // ================== See Our Compatibility ==================
 const compareBtn = document.getElementById('compareBtn');

--- a/kink-list.html
+++ b/kink-list.html
@@ -14,8 +14,9 @@
     <p>Upload your exported survey to view an organised list of your kinks.</p>
     <div class="button-container">
       <button id="uploadButton" class="survey-button">Generate Kink Data</button>
-      <button id="downloadButton" class="survey-button" disabled>Download List</button>
-      <button id="downloadSurveyBtn" class="survey-button" disabled>Download Survey Data</button>
+      <div id="pdfFallback" style="display:none;margin-top:10px;">
+        Having trouble downloading? <button id="downloadPdfFallbackBtn" class="survey-button">Click here to download your PDF</button>
+      </div>
     </div>
   </div>
   <input type="file" id="listFile" hidden />
@@ -75,8 +76,6 @@
       }
 
     const uploadBtn = document.getElementById('uploadButton');
-    const downloadBtn = document.getElementById('downloadButton');
-    const downloadSurveyBtn = document.getElementById('downloadSurveyBtn');
     const fileInput = document.getElementById('listFile');
     let currentSurvey = null;
 
@@ -92,9 +91,8 @@
             const survey = parsed.survey || parsed;
             mergeSurveyWithTemplate(survey, window.templateSurvey);
             currentSurvey = survey;
-            downloadBtn.disabled = false;
-            downloadSurveyBtn.disabled = false;
             showList(survey);
+            setTimeout(triggerAutoPDF, 0);
           } catch {
             document.getElementById('listOutput').textContent = 'Invalid file.';
           }
@@ -102,32 +100,22 @@
       reader.readAsText(file);
     });
 
-    downloadBtn.addEventListener('click', () => {
+
+    function triggerAutoPDF() {
       if (!currentSurvey) return;
       const results = flattenSurvey(currentSurvey);
       const categories = calculateCategoryScores(currentSurvey);
       generateKinkPDF(results, categories);
-    });
+      setTimeout(showFallback, 5000);
+    }
 
-    downloadSurveyBtn.addEventListener('click', () => {
-      if (!currentSurvey) return;
-      const exportObj = { survey: currentSurvey };
-      const blob = new Blob([JSON.stringify(exportObj, null, 2)], {
-        type: 'application/json'
-      });
-      const url = URL.createObjectURL(blob);
-      const link = document.createElement('a');
-      link.style.display = 'none';
-      link.href = url;
-      const ts = new Date().toISOString().replace(/[:.]/g, '-');
-      link.download = `kink-survey-${ts}.json`;
-      document.body.appendChild(link);
-      link.click();
-      setTimeout(() => {
-        document.body.removeChild(link);
-        URL.revokeObjectURL(url);
-      }, 0);
-    });
+    function showFallback() {
+      const fb = document.getElementById('pdfFallback');
+      const btn = document.getElementById('downloadPdfFallbackBtn');
+      if (!fb || !btn) return;
+      fb.style.display = 'block';
+      btn.addEventListener('click', triggerAutoPDF);
+    }
 
     function showList(survey) {
       const container = document.getElementById('listOutput');

--- a/your-roles.html
+++ b/your-roles.html
@@ -18,6 +18,9 @@
     </label>
 
     <div id="print-area" class="pdf-container print-wrapper result-container"></div>
+    <div id="pdfFallback" style="display:none;margin-top:10px;">
+      Having trouble downloading? <button id="downloadPdfFallbackBtn" class="survey-button">Click here to download your PDF</button>
+    </div>
   </div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
@@ -132,17 +135,24 @@
             chart.appendChild(renderResultRow(s.name, s.percent));
           });
           container.appendChild(chart);
-          const btn = document.createElement('button');
-          btn.className = 'download-btn';
-          btn.textContent = 'Download My List';
-          btn.setAttribute('onclick', 'exportPDFFromVisibleStyledContent()');
-          container.appendChild(btn);
+          setTimeout(() => {
+            exportPDFFromVisibleStyledContent();
+            setTimeout(showFallback, 5000);
+          }, 0);
         } catch (err) {
           document.getElementById('print-area').textContent = 'Invalid file.';
         }
       };
       reader.readAsText(file);
     });
+
+    function showFallback() {
+      const fb = document.getElementById('pdfFallback');
+      const btn = document.getElementById('downloadPdfFallbackBtn');
+      if (!fb || !btn) return;
+      fb.style.display = 'block';
+      btn.addEventListener('click', exportPDFFromVisibleStyledContent);
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove manual download buttons from survey and compatibility pages
- automatically download PDFs when results render
- show minimal fallback button if download fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6884ae9885dc832c83b5b8a4e37743b8