### PR TITLE
Remove fallback button and update PDF exports

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -25,9 +25,6 @@
           <input type="file" id="fileB" hidden />
         </label>
       </div>
-      <div id="pdfFallback" class="compatibility-button-container" style="display:none;margin-top:10px;">
-        Having trouble downloading? <button id="downloadPdfFallbackBtn" class="compatibility-button">Click here to download your PDF</button>
-      </div>
     </div>
     <div id="comparisonResult"></div>
     <div id="print-area" class="pdf-container print-wrapper">

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -259,17 +259,14 @@ async function generateComparisonPDF() {
   await html2pdf()
     .set({
       margin: 0,
-      filename: "survey.pdf",
+      filename: 'kink-compatibility-results.pdf',
+      image: { type: 'jpeg', quality: 1 },
       html2canvas: {
         scale: 2,
-        backgroundColor: "#000000",
+        backgroundColor: '#111',
         useCORS: true
       },
-      jsPDF: {
-        unit: "in",
-        format: "letter",
-        orientation: "portrait"
-      },
+      jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' },
       pagebreak: { mode: ['avoid-all'] }
     })
     .from(element)
@@ -380,9 +377,7 @@ function updateComparison() {
   table.appendChild(tbody);
   container.appendChild(table);
   setTimeout(() => {
-    generateComparisonPDF();
-    setTimeout(showFallback, 5000);
-  }, 0);
+    generateComparisonPDF();  }, 0);
 }
 
 const fileAInput = document.getElementById('fileA');
@@ -488,15 +483,6 @@ function exportJSON() {
   const blob = new Blob([JSON.stringify(lastResult, null, 2)], { type: 'application/json' });
   downloadBlob(blob, 'kink-survey.json');
 }
-
-function showFallback() {
-  const fb = document.getElementById('pdfFallback');
-  const btn = document.getElementById('downloadPdfFallbackBtn');
-  if (!fb || !btn) return;
-  fb.style.display = 'block';
-  btn.addEventListener('click', generateComparisonPDF);
-}
-
 
 document.addEventListener('DOMContentLoaded', () => {
   initTheme();

--- a/kink-list.html
+++ b/kink-list.html
@@ -13,11 +13,7 @@
     <h2>Your Kink List</h2>
     <p>Upload your exported survey to view an organised list of your kinks.</p>
     <div class="button-container">
-      <button id="uploadButton" class="survey-button">Generate Kink Data</button>
-      <div id="pdfFallback" style="display:none;margin-top:10px;">
-        Having trouble downloading? <button id="downloadPdfFallbackBtn" class="survey-button">Click here to download your PDF</button>
-      </div>
-    </div>
+      <button id="uploadButton" class="survey-button">Generate Kink Data</button>    </div>
   </div>
   <input type="file" id="listFile" hidden />
 
@@ -105,18 +101,7 @@
       if (!currentSurvey) return;
       const results = flattenSurvey(currentSurvey);
       const categories = calculateCategoryScores(currentSurvey);
-      generateKinkPDF(results, categories);
-      setTimeout(showFallback, 5000);
-    }
-
-    function showFallback() {
-      const fb = document.getElementById('pdfFallback');
-      const btn = document.getElementById('downloadPdfFallbackBtn');
-      if (!fb || !btn) return;
-      fb.style.display = 'block';
-      btn.addEventListener('click', triggerAutoPDF);
-    }
-
+      generateKinkPDF(results, categories);    }
     function showList(survey) {
       const container = document.getElementById('listOutput');
       container.innerHTML = '';
@@ -260,7 +245,7 @@
         }
       });
 
-      doc.save('kink-results.pdf');
+      doc.save('kink-compatibility-results.pdf');
     }
   </script>
 </body>

--- a/your-roles.html
+++ b/your-roles.html
@@ -17,11 +17,7 @@
       <input type="file" id="roleFile" hidden />
     </label>
 
-    <div id="print-area" class="pdf-container print-wrapper result-container"></div>
-    <div id="pdfFallback" style="display:none;margin-top:10px;">
-      Having trouble downloading? <button id="downloadPdfFallbackBtn" class="survey-button">Click here to download your PDF</button>
-    </div>
-  </div>
+    <div id="print-area" class="pdf-container print-wrapper result-container"></div>  </div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
 
@@ -83,17 +79,14 @@
       html2pdf()
         .set({
           margin: 0,
-          filename: "survey.pdf",
+          filename: 'kink-compatibility-results.pdf',
+          image: { type: 'jpeg', quality: 1 },
           html2canvas: {
             scale: 2,
-            backgroundColor: "#000000",
+            backgroundColor: '#111',
             useCORS: true
           },
-          jsPDF: {
-            unit: "in",
-            format: "letter",
-            orientation: "portrait"
-          },
+          jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' },
           pagebreak: { mode: ['avoid-all'] }
         })
         .from(element)
@@ -136,23 +129,12 @@
           });
           container.appendChild(chart);
           setTimeout(() => {
-            exportPDFFromVisibleStyledContent();
-            setTimeout(showFallback, 5000);
-          }, 0);
+            exportPDFFromVisibleStyledContent();          }, 0);
         } catch (err) {
           document.getElementById('print-area').textContent = 'Invalid file.';
         }
       };
       reader.readAsText(file);
-    });
-
-    function showFallback() {
-      const fb = document.getElementById('pdfFallback');
-      const btn = document.getElementById('downloadPdfFallbackBtn');
-      if (!fb || !btn) return;
-      fb.style.display = 'block';
-      btn.addEventListener('click', exportPDFFromVisibleStyledContent);
-    }
-  </script>
+    });  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- drop obsolete fallback buttons
- simplify scripts after removing fallback logic
- export PDFs in dark theme with improved filename

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688532512718832ca05cee66b90d1e87