### PR TITLE
Implement dark-mode PDF export

### DIFF
--- a/auto-pdf.html
+++ b/auto-pdf.html
@@ -9,7 +9,7 @@
   <script src="js/auto-pdf.js" defer></script>
 </head>
 <body>
-  <div id="comparison-container">
+  <div id="results">
     <!-- Compatibility results go here -->
   </div>
 </body>

--- a/css/auto-pdf.css
+++ b/css/auto-pdf.css
@@ -9,7 +9,7 @@ body {
 }
 
 /* === 2. Centered Survey Layout with Dark Container === */
-#comparison-container {
+#results {
   max-width: 1000px;
   width: 95%;
   margin: 2rem auto;

--- a/js/auto-pdf.js
+++ b/js/auto-pdf.js
@@ -1,23 +1,72 @@
-/* === 4. PDF Export with Matching Background === */
-function generatePDF() {
-  html2pdf()
-    .set({
-      margin: 0,
-      filename: `kink-compatibility-${new Date().toISOString().slice(0,10)}.pdf`,
-      html2canvas: {
-        scale: 2,
-        useCORS: true,
-        backgroundColor: '#1e1e2f' // matches container background
-      },
-      jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' }
-    })
-    .from(document.getElementById('comparison-container'))
-    .save();
-}
+// SETUP DARK PDF EXPORT
+const element = document.getElementById('results'); // main results container
 
-/* === 5. Auto-generate PDF on Page Load === */
-window.addEventListener('load', () => {
-  setTimeout(() => {
-    generatePDF();
-  }, 1000);
+const opt = {
+  margin: 0,
+  filename: 'kink-compatibility-results.pdf',
+  image: { type: 'jpeg', quality: 1 },
+  html2canvas: {
+    scale: 2,
+    useCORS: true,
+    backgroundColor: '#121212' // make sure canvas background is dark!
+  },
+  jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' }
+};
+
+// CLEAN EXPORT BUTTON (REMOVE "Trouble Downloading")
+document.querySelectorAll('button').forEach(btn => {
+  if (btn.innerText.toLowerCase().includes('trouble')) btn.remove();
 });
+
+// STYLE INJECTION (Dark Theme)
+const style = document.createElement('style');
+style.innerHTML = `
+  body {
+    background-color: #121212 !important;
+    color: #f0f0f0 !important;
+    font-family: 'Arial', sans-serif;
+  }
+
+  #results {
+    background-color: #121212 !important;
+    padding: 2rem;
+  }
+
+  table {
+    background-color: #1a1a1a !important;
+    border-collapse: collapse;
+    width: 100%;
+    color: #e0e0e0;
+  }
+
+  th, td {
+    padding: 0.75rem 1rem;
+    text-align: left;
+    border-bottom: 1px solid #333;
+  }
+
+  th {
+    background-color: #111 !important;
+    color: #bbb;
+    font-weight: 600;
+  }
+
+  .bar-container {
+    background: #2a2a2a !important;
+    border-radius: 5px;
+  }
+
+  .bar {
+    height: 12px;
+    border-radius: 5px;
+  }
+
+  .bar.green { background-color: #00e676 !important; }
+  .bar.yellow { background-color: #ffeb3b !important; }
+  .bar.red { background-color: #f44336 !important; }
+`;
+document.head.appendChild(style);
+
+// EXECUTE EXPORT
+html2pdf().set(opt).from(element).save();
+


### PR DESCRIPTION
## Summary
- update auto-pdf tool to use a `results` container
- inject dark styles and export PDF with html2pdf

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68854e441c68832c969b147c20a4a378