### PR TITLE
Add manual PDF download option

### DIFF
--- a/auto-pdf.html
+++ b/auto-pdf.html
@@ -9,6 +9,7 @@
   <script src="js/auto-pdf.js" defer></script>
 </head>
 <body>
+  <button class="manual-export" onclick="downloadPDF()">Download Results as PDF</button>
   <div id="results">
     <!-- Compatibility results go here -->
   </div>

--- a/css/auto-pdf.css
+++ b/css/auto-pdf.css
@@ -20,8 +20,18 @@ body {
 }
 
 /* === 3. Hide Buttons === */
-button,
-.download-btn,
-.manual-export {
+button:not(.manual-export),
+.download-btn {
   display: none !important;
+}
+
+.manual-export {
+  display: block;
+  margin: 1rem auto;
+  padding: 0.5rem 1rem;
+  background-color: #333;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
 }

--- a/js/auto-pdf.js
+++ b/js/auto-pdf.js
@@ -67,6 +67,12 @@ style.innerHTML = `
 `;
 document.head.appendChild(style);
 
-// EXECUTE EXPORT
-html2pdf().set(opt).from(element).save();
+function downloadPDF() {
+  html2pdf().set(opt).from(element).save();
+}
+
+window.downloadPDF = downloadPDF;
+
+// EXECUTE EXPORT AUTOMATICALLY
+downloadPDF();
 


### PR DESCRIPTION
## Summary
- allow manual PDF export from auto-pdf page
- keep automatic export but expose `downloadPDF()`
- show manual download button and style it

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688550a63574832ca16ebde6ee1600a9