### PR TITLE
Add compact result card layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2114,3 +2114,44 @@ body {
   color: #aaa;
 }
 
+/* Compact result card layout */
+.result-card {
+  background-color: #2e2e2e;
+  border-radius: 6px;
+  padding: 12px 16px;
+  margin-bottom: 12px;
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.3);
+  color: #f1f1f1;
+}
+
+.result-header {
+  display: flex;
+  justify-content: space-between;
+  font-weight: bold;
+  margin-bottom: 8px;
+  font-size: 14px;
+}
+
+.result-row.compact {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 13px;
+  margin: 4px 0;
+}
+
+.result-bar {
+  flex: 1;
+  margin-left: 10px;
+  height: 12px;
+  background-color: #444;
+  border-radius: 4px;
+  position: relative;
+}
+
+.result-bar-fill {
+  height: 100%;
+  border-radius: 4px;
+  background-color: #00cc66;
+}
+

--- a/your-roles.html
+++ b/your-roles.html
@@ -55,7 +55,7 @@
 
     function renderResultRow(roleName, score, tooltipText) {
       const row = document.createElement('div');
-      row.className = 'result-row';
+      row.className = 'result-row compact';
       row.innerHTML = `
         <div class="percentage">${score}%</div>
         <div class="bar-container" title="${tooltipText || ''}">
@@ -125,7 +125,14 @@
           chart.id = 'comparison-chart';
           chart.className = 'pdf-export-area';
           scores.forEach(s => {
-            chart.appendChild(renderResultRow(s.name, s.percent));
+            const card = document.createElement('div');
+            card.className = 'result-card';
+            const header = document.createElement('div');
+            header.className = 'result-header';
+            header.innerHTML = `<span>${titleCase(s.name)}</span><span>⭐</span>`;
+            card.appendChild(header);
+            card.appendChild(renderResultRow(s.name, s.percent));
+            chart.appendChild(card);
           });
           container.appendChild(chart);
           setTimeout(() => {


### PR DESCRIPTION
## Summary
- style result card elements in CSS
- create result card wrappers in your-roles.html for each role

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6885553c6fa4832c9b9ddd460c8acd17