### PR TITLE
Update result card styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2114,44 +2114,88 @@ body {
   color: #aaa;
 }
 
-/* Compact result card layout */
+/* Slimmed-down result card for compatibility results */
 .result-card {
-  background-color: #2e2e2e;
+  background-color: #1e1e1e; /* softer black for dark mode */
   border-radius: 6px;
-  padding: 12px 16px;
-  margin-bottom: 12px;
-  box-shadow: 0 0 6px rgba(0, 0, 0, 0.3);
-  color: #f1f1f1;
+  padding: 6px 12px;
+  margin-bottom: 8px;
+  font-size: 12px;
+  box-shadow: 0 0 3px rgba(0,0,0,0.2);
+  color: #f0f0f0;
+  max-width: 100%;
 }
 
+/* Header Row (Kink | Partner A | Partner B) */
 .result-header {
   display: flex;
   justify-content: space-between;
-  font-weight: bold;
-  margin-bottom: 8px;
-  font-size: 14px;
+  align-items: center;
+  font-weight: 600;
+  margin-bottom: 4px;
+  font-size: 12px;
+  color: #fff;
 }
 
-.result-row.compact {
+/* Body of each row (kink label + 2 bars) */
+.result-row {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  font-size: 13px;
-  margin: 4px 0;
+  gap: 12px;
+  margin: 2px 0;
+  font-size: 11px;
+  flex-wrap: wrap;
 }
 
+/* Kink Label */
+.kink-label {
+  flex: 1;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Bar Containers */
 .result-bar {
   flex: 1;
-  margin-left: 10px;
-  height: 12px;
   background-color: #444;
-  border-radius: 4px;
+  height: 10px;
+  border-radius: 3px;
   position: relative;
 }
 
+/* Green Fill */
 .result-bar-fill {
-  height: 100%;
-  border-radius: 4px;
   background-color: #00cc66;
+  height: 100%;
+  border-radius: 3px;
+}
+
+/* Percentage Text */
+.percentage-label {
+  font-size: 10px;
+  text-align: right;
+  color: #ccc;
+  margin-left: 4px;
+}
+
+/* PDF-specific override (white background only for print/export) */
+@media print {
+  body {
+    background: white !important;
+    color: black !important;
+  }
+  .result-card {
+    background-color: white !important;
+    color: black !important;
+    box-shadow: none !important;
+  }
+  .result-bar {
+    background-color: #ddd !important;
+  }
+  .result-bar-fill {
+    background-color: #4caf50 !important;
+  }
 }
 


### PR DESCRIPTION
## Summary
- tweak the result card CSS used on compatibility results

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68856b892e68832cb718745055aadfe6