### PR TITLE
Fix PDF export dark background

### DIFF
--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -256,7 +256,7 @@ async function generateComparisonPDF() {
     margin: 0.5,
     filename: 'kink-compatibility-results.pdf',
     image: { type: 'jpeg', quality: 0.98 },
-    html2canvas: { scale: 2, useCORS: true, backgroundColor: '#ffffff' },
+    html2canvas: { scale: 2, useCORS: true, backgroundColor: '#000000' },
     jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' }
   };
   await html2pdf().set(opt).from(element).save();


### PR DESCRIPTION
## Summary
- update the PDF export option so `generateComparisonPDF()` uses a dark background

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885a2a63f70832c8aed6b9232eaf5fa