### PR TITLE
Fix print styling and PDF export options

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2184,41 +2184,13 @@ body {
   margin-left: 4px;
 }
 
-/* PDF-specific override (white background only for print/export) */
 @media print {
-  body {
-    background: white !important;
-    color: black !important;
-  }
-  .result-card {
-    background-color: white !important;
-    color: black !important;
-    box-shadow: none !important;
-  }
-  .result-bar {
-    background-color: #ddd !important;
-  }
-  .result-bar-fill {
-    background-color: #4caf50 !important;
-  }
-  #print-card-list {
-    display: block;
-  }
-  .results-table {
-    display: none;
-  }
-}
-
-@media print {
-  body {
-    background: white !important;
-    color: black;
-  }
 
   .pdf-container {
     width: 100%;
     padding: 0.5rem;
-    background-color: white;
+    background-color: #121212;
+    color: #f1f1f1;
     font-family: sans-serif;
   }
 
@@ -2299,7 +2271,7 @@ body {
 @media print {
   body {
     background: #121212 !important;
-    color: #f1f1f1;
+    color: #f1f1f1 !important;
   }
 }
 

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -253,13 +253,23 @@ async function generateComparisonPDF() {
   if (!element) return;
 
   const opt = {
-    margin: 0.5,
+    margin: 0,
     filename: 'kink-compatibility-results.pdf',
     image: { type: 'jpeg', quality: 0.98 },
     html2canvas: { scale: 2, useCORS: true, backgroundColor: '#000000' },
     jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' }
   };
-  await html2pdf().set(opt).from(element).save();
+
+  const worker = html2pdf().set(opt).from(element).toPdf();
+  const pdf = await worker.get('pdf');
+
+  const pageWidth = pdf.internal.pageSize.getWidth();
+  const pageHeight = pdf.internal.pageSize.getHeight();
+  const barHeight = 0.3;
+  pdf.setFillColor(18, 18, 18);
+  pdf.rect(0, pageHeight - barHeight, pageWidth, barHeight, 'F');
+
+  await worker.save();
 }
 
 function loadFileA(file) {


### PR DESCRIPTION
## Summary
- tweak PDF export so it uses no margins and draws a dark footer bar
- remove old white background print overrides
- make print styles use dark mode colors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6885a68cf718832c93012473304eb355