### PR TITLE
Ensure dark background for compatibility PDF export

### DIFF
--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -252,21 +252,31 @@ async function generateComparisonPDF() {
   const element = document.querySelector('.pdf-container');
   if (!element) return;
 
-  const opt = {
-    margin: 0,
-    filename: 'kink-compatibility-results.pdf',
-    image: { type: 'jpeg', quality: 0.98 },
-    html2canvas: { scale: 2, useCORS: true, backgroundColor: '#000000' },
-    jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' }
-  };
-
-  const worker = html2pdf().set(opt).from(element).toPdf();
-  const pdf = await worker.get('pdf');
+  const jsPDF = await loadJsPDF();
+  const pdf = new jsPDF({ unit: 'in', format: 'letter', orientation: 'portrait' });
 
   const pageWidth = pdf.internal.pageSize.getWidth();
   const pageHeight = pdf.internal.pageSize.getHeight();
   pdf.setFillColor(18, 18, 18);
   pdf.rect(0, 0, pageWidth, pageHeight, 'F');
+
+  const opt = {
+    margin: 0,
+    filename: 'kink-compatibility-results.pdf',
+    image: { type: 'jpeg', quality: 0.98 },
+    html2canvas: { scale: 2, useCORS: true, backgroundColor: '#000000' },
+    jsPDF: pdf
+  };
+
+  const worker = html2pdf().set(opt).from(element).toPdf();
+  await worker.get('pdf');
+
+  const totalPages = pdf.internal.getNumberOfPages();
+  for (let i = 1; i <= totalPages; i++) {
+    pdf.setPage(i);
+    pdf.setFillColor(18, 18, 18);
+    pdf.rect(0, 0, pageWidth, pageHeight, 'F');
+  }
 
   await worker.save();
 }


### PR DESCRIPTION
## Summary
- generateComparisonPDF now creates a jsPDF instance via `loadJsPDF` before rendering
- pre-fill page 1 with a dark rectangle and pass the instance to `html2pdf`
- after rendering, fill every page with the dark rectangle

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885acf0db08832cb138519d0b4bb25e