### PR TITLE
Add light mode PDF option

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,18 @@ stub now opens the browser's print dialog so you can choose **Save as PDF** if t
 library fails to load. Run a local web server and select **Download Data** again
 to download the PDF automatically.
 
+#### Light PDF Mode
+
+PDF exports default to a dark color scheme. Pass `'light'` to `applyPrintStyles()`
+before exporting if you prefer a white background:
+
+```javascript
+applyPrintStyles('light');
+```
+
+Pages will read the current theme and call this automatically when the body
+has the `light-mode` class.
+
 ## Automated Tests
 
 Run the test suite with Node's built-in runner:

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -248,7 +248,8 @@ function buildKinkBreakdown(surveyA, surveyB) {
 }
 
 async function generateComparisonPDF() {
-  applyPrintStyles();
+  const mode = document.body.classList.contains('light-mode') ? 'light' : 'dark';
+  applyPrintStyles(mode);
   const element = document.querySelector('.pdf-container');
   if (!element) return;
 

--- a/js/theme.js
+++ b/js/theme.js
@@ -152,11 +152,67 @@ export const pdfStyles = `
   }
 `;
 
-export function applyPrintStyles() {
+export const lightPdfStyles = `
+  @media print {
+    :root {
+      --bg-color: #ffffff !important;
+      --text-color: #000000 !important;
+      --panel-color: #f0f0f0 !important;
+    }
+
+    html, body {
+      background: var(--bg-color) !important;
+      color: var(--text-color) !important;
+      font-family: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
+      font-size: 13px;
+      letter-spacing: 0.3px;
+      -webkit-print-color-adjust: exact !important;
+      print-color-adjust: exact !important;
+    }
+
+    .category-title {
+      font-size: 18px !important;
+      font-weight: bold !important;
+      color: #b00020 !important; /* deep red */
+      margin-top: 20px;
+    }
+
+    .item-label {
+      font-size: 14px;
+      color: #333333 !important;
+    }
+
+    .match-bar {
+      height: 12px !important;
+      border-radius: 6px;
+      background-color: #e0e0e0 !important;
+      box-shadow: none !important;
+    }
+
+    .match-bar-fill {
+      background-color: #00c853 !important; /* bright green */
+    }
+
+    .score-flag-high {
+      color: #ffb300 !important; /* gold */
+    }
+
+    .score-flag-low {
+      color: #d32f2f !important; /* red */
+    }
+
+    .score-flag-mismatch {
+      color: #fbc02d !important; /* yellow */
+    }
+  }
+`;
+
+export function applyPrintStyles(mode = 'dark') {
   if (document.getElementById('pdf-print-style')) return;
   const style = document.createElement('style');
   style.id = 'pdf-print-style';
-  style.textContent = pdfStyles + `
+  const base = mode === 'light' ? lightPdfStyles : pdfStyles;
+  style.textContent = base + `
 
 
       #comparison-chart {

--- a/kink-list.html
+++ b/kink-list.html
@@ -169,7 +169,8 @@
     }
 
     async function generateKinkPDF(results, categories) {
-      applyPrintStyles();
+      const mode = document.body.classList.contains('light-mode') ? 'light' : 'dark';
+      applyPrintStyles(mode);
       let jsPDF;
       try {
         jsPDF = await loadJsPDF();

--- a/your-roles.html
+++ b/your-roles.html
@@ -68,7 +68,8 @@
     }
 
     function exportPDFFromVisibleStyledContent() {
-      applyPrintStyles();
+      const mode = document.body.classList.contains('light-mode') ? 'light' : 'dark';
+      applyPrintStyles(mode);
       const element = document.getElementById("print-area");
       if (!element) return;
 


### PR DESCRIPTION
## Summary
- add `lightPdfStyles` to theme.js
- allow passing `mode` to `applyPrintStyles`
- detect current page theme when exporting PDFs
- document light PDF mode in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885b280192c832ca1f0b7278852786d