### PR TITLE
Ensure dark theme PDF exports

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -1,6 +1,6 @@
 import { calculateCompatibility } from './compatibility.js';
 import { pruneSurvey } from './pruneSurvey.js';
-import { initTheme, applyThemeColors } from './theme.js';
+import { initTheme, applyThemeColors, applyPrintStyles } from './theme.js';
 
 // ================== Password Protection ==================
 const PASSWORD = 'toopoortosue';
@@ -857,6 +857,8 @@ function exportSurvey() {
 if (downloadBtn) downloadBtn.addEventListener('click', exportSurvey);
 
 function downloadPDF() {
+  document.body.classList.add('dark-mode');
+  applyPrintStyles('dark');
   const element = document.getElementById('surveyContainer');
   if (!element) return;
   const opt = {

--- a/js/theme.js
+++ b/js/theme.js
@@ -124,7 +124,7 @@ export const pdfStyles = `
 
     .item-label {
       font-size: 14px;
-      color: #333333 !important;
+      color: #cccccc !important;
     }
 
     .match-bar {
@@ -255,7 +255,7 @@ export function applyPrintStyles(mode = 'dark') {
         padding-right: 8px;
         font-weight: 500;
         font-size: 14px;
-        color: #333 !important;
+        color: #dddddd !important;
       }
       .compare-label.green { color: #00c853 !important; }
       .compare-label.yellow { color: #fbc02d !important; }


### PR DESCRIPTION
## Summary
- apply dark print styles before generating PDF
- lighten PDF text colors for better contrast

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885b4d7da54832cb598d382b92ada6b