### PR TITLE
Ensure pure black PDF background

### DIFF
--- a/js/auto-pdf.js
+++ b/js/auto-pdf.js
@@ -8,7 +8,8 @@ const opt = {
   html2canvas: {
     scale: 2,
     useCORS: true,
-    backgroundColor: '#121212' // make sure canvas background is dark!
+    // ensure the captured canvas is pure black
+    backgroundColor: '#000000'
   },
   jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' }
 };
@@ -22,13 +23,13 @@ document.querySelectorAll('button').forEach(btn => {
 const style = document.createElement('style');
 style.innerHTML = `
   body {
-    background-color: #121212 !important;
+    background-color: #000000 !important;
     color: #f0f0f0 !important;
     font-family: 'Arial', sans-serif;
   }
 
   #results {
-    background-color: #121212 !important;
+    background-color: #000000 !important;
     padding: 2rem;
   }
 

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -258,7 +258,8 @@ async function generateComparisonPDF() {
 
   const pageWidth = pdf.internal.pageSize.getWidth();
   const pageHeight = pdf.internal.pageSize.getHeight();
-  pdf.setFillColor(18, 18, 18);
+  // fill the first page background with pure black
+  pdf.setFillColor(0, 0, 0);
   pdf.rect(0, 0, pageWidth, pageHeight, 'F');
 
   const opt = {
@@ -275,7 +276,8 @@ async function generateComparisonPDF() {
   const totalPages = pdf.internal.getNumberOfPages();
   for (let i = 1; i <= totalPages; i++) {
     pdf.setPage(i);
-    pdf.setFillColor(18, 18, 18);
+    // ensure each page background is pure black
+    pdf.setFillColor(0, 0, 0);
     pdf.rect(0, 0, pageWidth, pageHeight, 'F');
   }
 


### PR DESCRIPTION
## Summary
- fix html2canvas background color for auto PDF export
- update style injection colors to pure black
- set pdf background fill to black when exporting comparison results

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6885b61439d0832c87656a934e4ae9b4