### PR TITLE
Make PDF backgrounds pure black

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1639,7 +1639,7 @@ body {
 .result-container,
 .pdf-container {
   position: relative;
-  background-color: #0f0f0f;
+  background-color: #000000;
   color: #f0f0f0;
   font-family: 'Segoe UI', Arial, 'Helvetica Neue', sans-serif;
   max-width: 900px;
@@ -1652,7 +1652,7 @@ body {
 
 /* Wrapper used for PDF export */
 .print-wrapper {
-  background-color: #0f0f0f;
+  background-color: #000000;
   padding: 20px;
 }
 
@@ -1985,7 +1985,7 @@ html, body {
 .card,
 .kink-category,
 .section {
-  background-color: #111 !important;
+  background-color: #000000 !important;
   color: #fff !important;
   border: 1px solid #333 !important;
   box-shadow: none !important;
@@ -2042,7 +2042,7 @@ body {
 }
 
 #print-area {
-  background-color: #111 !important;
+  background-color: #000000 !important;
   color: #f5f5f5;
   padding: 1rem;
   border-radius: 8px;

--- a/js/script.js
+++ b/js/script.js
@@ -867,7 +867,7 @@ function downloadPDF() {
     image: { type: 'jpeg', quality: 0.98 },
     html2canvas: {
       scale: 4,
-      backgroundColor: null,
+      backgroundColor: '#000',
       useCORS: true,
       logging: true,
       scrollY: 0,
@@ -876,7 +876,7 @@ function downloadPDF() {
     },
     jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' },
   };
-  element.style.backgroundColor = '#0a0a0a';
+  element.style.backgroundColor = '#000';
   element.style.color = '#f0f0f0';
   element.querySelectorAll('*').forEach(el => {
     const computed = getComputedStyle(el);

--- a/your-roles.html
+++ b/your-roles.html
@@ -74,7 +74,7 @@
       if (!element) return;
 
       // Force background color for PDF rendering
-      element.style.backgroundColor = "#111"; // or "#000" for pure black
+      element.style.backgroundColor = "#000"; // pure black background
 
       element.classList.add('pdf-export');
       html2pdf()
@@ -84,7 +84,7 @@
           image: { type: 'jpeg', quality: 1 },
           html2canvas: {
             scale: 2,
-            backgroundColor: '#111',
+            backgroundColor: '#000',
             useCORS: true
           },
           jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' },


### PR DESCRIPTION
## Summary
- tweak styles for PDF export so background is pure `#000`
- force black background when exporting surveys and roles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6885b9fa3290832c837b1e95cc94e47a