### PR TITLE
Remove PDF export padding

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1936,9 +1936,13 @@ body {
   .pdf-container {
     background-color: transparent !important;
     color: inherit !important;
-    padding: 20px;
+    padding: 0;
     font-family: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
     border: 1px solid rgba(255, 255, 255, 0.15);
+  }
+
+  .print-wrapper {
+    padding: 0 !important;
   }
 
   .card,
@@ -2188,10 +2192,14 @@ body {
 
   .pdf-container {
     width: 100%;
-    padding: 0.5rem;
+    padding: 0;
     background-color: transparent;
     color: inherit;
     font-family: sans-serif;
+  }
+
+  .print-wrapper {
+    padding: 0 !important;
   }
 
   .category-header {


### PR DESCRIPTION
## Summary
- eliminate padding from `.pdf-container` and `.print-wrapper` when exporting to PDF

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6885c70a3b7c832cb92b5ba0c8522bea