### PR TITLE
Fix dark PDF export

### DIFF
--- a/auto-pdf.html
+++ b/auto-pdf.html
@@ -10,7 +10,7 @@
 </head>
 <body>
   <button class="manual-export" onclick="downloadPDF()">Download Results as PDF</button>
-  <div id="results">
+  <div id="export-target">
     <!-- Compatibility results go here -->
   </div>
 </body>

--- a/compatibility.html
+++ b/compatibility.html
@@ -27,7 +27,7 @@
       </div>
     </div>
     <div id="comparisonResult"></div>
-    <div id="print-area" class="pdf-container print-wrapper">
+    <div id="export-target" class="pdf-container print-wrapper">
       <div id="compatibility-report" class="pdf-export-area"></div>
       <div id="print-card-list" class="print-only"></div>
     </div>

--- a/css/auto-pdf.css
+++ b/css/auto-pdf.css
@@ -9,7 +9,7 @@ body {
 }
 
 /* === 2. Centered Survey Layout with Dark Container === */
-#results {
+#export-target {
   max-width: 1000px;
   width: 95%;
   margin: 2rem auto;

--- a/css/style.css
+++ b/css/style.css
@@ -2045,7 +2045,7 @@ body {
   font-family: 'Segoe UI', sans-serif;
 }
 
-#print-area {
+#export-target {
   background-color: #000000 !important;
   color: #f5f5f5;
   padding: 1rem;

--- a/js/auto-pdf.js
+++ b/js/auto-pdf.js
@@ -1,8 +1,8 @@
 // SETUP DARK PDF EXPORT
-const content = document.getElementById('results');
+const content = document.getElementById('export-target');
 content.classList.add('pdf-container');
 // provide extra space so the last bar never gets cut off
-content.style.paddingBottom = '64px';
+content.style.paddingBottom = '100px';
 
 const opt = {
   margin: [0, 0, 0, 0],
@@ -73,7 +73,7 @@ style.innerHTML = `
     overflow: hidden;
   }
 
-  #results {
+  #export-target {
     background-color: #000000 !important;
     padding: 2rem;
   }
@@ -114,6 +114,9 @@ style.innerHTML = `
 document.head.appendChild(style);
 
 function downloadPDF() {
+  window.scrollTo(0, 0);
+  opt.html2canvas.windowWidth = content.scrollWidth;
+  opt.html2canvas.windowHeight = content.scrollHeight;
   html2pdf().set(opt).from(content).save();
 }
 

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -250,13 +250,15 @@ function buildKinkBreakdown(surveyA, surveyB) {
 async function generateComparisonPDF() {
   const mode = document.body.classList.contains('light-mode') ? 'light' : 'dark';
   applyPrintStyles(mode);
-  const element = document.getElementById('print-area');
+  const element = document.getElementById('export-target');
   if (!element) return;
+  window.scrollTo(0, 0);
 
   // ensure the export container has no margin or padding and a black background
   element.style.margin = '0';
   element.style.padding = '0';
   element.style.background = '#000';
+  element.style.paddingBottom = '100px';
 
   const jsPDF = await loadJsPDF();
   const pdf = new jsPDF({ unit: 'in', format: 'letter', orientation: 'portrait' });
@@ -491,7 +493,7 @@ function downloadBlob(blob, filename) {
 }
 
 async function exportPNG() {
-  const element = document.getElementById('print-area');
+  const element = document.getElementById('export-target');
   if (!element) return;
   const canvas = await html2canvas(element, {
     backgroundColor: '#000000',
@@ -505,7 +507,7 @@ async function exportPNG() {
 }
 
 function exportHTML() {
-  const element = document.getElementById('print-area');
+  const element = document.getElementById('export-target');
   if (!element) return;
   const html = `<!DOCTYPE html><html><head><meta charset="UTF-8"><title>Kink Survey Results</title></head><body>${element.innerHTML}</body></html>`;
   const blob = new Blob([html], { type: 'text/html' });

--- a/js/script.js
+++ b/js/script.js
@@ -860,8 +860,10 @@ function downloadPDF() {
   document.body.classList.add('dark-mode');
   applyPrintStyles('dark');
 
-  const element = document.getElementById('surveyContainer');
+  const element = document.getElementById('export-target') || document.getElementById('surveyContainer');
   if (!element) return;
+  window.scrollTo(0, 0);
+  element.style.paddingBottom = '100px';
 
   // Inject minimal styles to ensure full-width dark export
   const style = document.createElement('style');

--- a/js/theme.js
+++ b/js/theme.js
@@ -105,14 +105,24 @@ export const pdfStyles = `
       --panel-color: #292b3d !important;
     }
 
-    html, body {
+    html, body, #export-target {
       background: var(--bg-color) !important;
       color: var(--text-color) !important;
+      margin: 0 !important;
+      padding: 0 !important;
       font-family: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
       font-size: 13px;
       letter-spacing: 0.3px;
       -webkit-print-color-adjust: exact !important;
       print-color-adjust: exact !important;
+    }
+    #export-target {
+      width: 100vw;
+      min-height: 100vh;
+      padding-bottom: 100px;
+    }
+    #export-target * {
+      box-sizing: border-box !important;
     }
 
     .category-title {
@@ -160,14 +170,24 @@ export const lightPdfStyles = `
       --panel-color: #f0f0f0 !important;
     }
 
-    html, body {
+    html, body, #export-target {
       background: var(--bg-color) !important;
       color: var(--text-color) !important;
+      margin: 0 !important;
+      padding: 0 !important;
       font-family: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif;
       font-size: 13px;
       letter-spacing: 0.3px;
       -webkit-print-color-adjust: exact !important;
       print-color-adjust: exact !important;
+    }
+    #export-target {
+      width: 100vw;
+      min-height: 100vh;
+      padding-bottom: 100px;
+    }
+    #export-target * {
+      box-sizing: border-box !important;
     }
 
     .category-title {
@@ -434,7 +454,7 @@ export function applyPrintStyles(mode = 'dark') {
       }
 
       @media print {
-        body, .pdf-export-area {
+        body, #export-target, .pdf-export-area {
           background-color: var(--bg-color, #000000) !important;
           color: var(--text-color, #ffffff) !important;
           -webkit-print-color-adjust: exact;

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -55,8 +55,9 @@
   <div class="main-container">
       <div class="content-panel">
         <div id="panelContainer" style="display:none;"></div>
-        <div id="survey-section">
-        <div id="surveyContainer">
+          <div id="survey-section">
+          <div id="export-target">
+          <div id="surveyContainer">
           <div class="export-button-container">
             <button id="downloadBtn" class="survey-button">Export My List</button>
           </div>
@@ -68,8 +69,9 @@
             <button id="skipCategoryBtn">Skip</button>
           </div>
         </div>
-        </div>
-        <div id="finalScreen" class="final-screen" style="display:none">
+          </div>
+          </div>
+          <div id="finalScreen" class="final-screen" style="display:none">
           <button id="saveSurveyBtn">Save Survey</button>
           <button id="returnHomeBtn">Return Home</button>
         </div>

--- a/your-roles.html
+++ b/your-roles.html
@@ -17,7 +17,7 @@
       <input type="file" id="roleFile" hidden />
     </label>
 
-    <div id="print-area" class="pdf-container print-wrapper result-container"></div>  </div>
+    <div id="export-target" class="pdf-container print-wrapper result-container"></div>  </div>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
 
@@ -70,7 +70,7 @@
     function exportPDFFromVisibleStyledContent() {
       const mode = document.body.classList.contains('light-mode') ? 'light' : 'dark';
       applyPrintStyles(mode);
-      const element = document.getElementById("print-area");
+      const element = document.getElementById("export-target");
       if (!element) return;
 
       // Force background color for PDF rendering
@@ -105,7 +105,7 @@
           const parsed = JSON.parse(ev.target.result);
           const survey = parsed.survey || parsed;
           const scores = calculateRoleScores({ all: flattenSurvey(survey) });
-          const container = document.getElementById('print-area');
+          const container = document.getElementById('export-target');
           if (!scores.length) {
             container.textContent = 'No role data found.';
             return;
@@ -139,7 +139,7 @@
           setTimeout(() => {
             exportPDFFromVisibleStyledContent();          }, 0);
         } catch (err) {
-          document.getElementById('print-area').textContent = 'Invalid file.';
+          document.getElementById('export-target').textContent = 'Invalid file.';
         }
       };
       reader.readAsText(file);


### PR DESCRIPTION
## Summary
- rename print container to `export-target` and ensure it wraps exported content
- inject print styles so `export-target` fills the page and uses dark colors
- adjust scripts to scroll to top, size canvas, and pad the bottom before creating PDFs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885d2dec960832c88abbcc74255e8d8