### PR TITLE
Center PDF export content

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2284,3 +2284,24 @@ body {
   }
 }
 
+/* Center exported content only during PDF generation */
+.exporting #export-target {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  width: 800px;
+  max-width: 90vw;
+  margin: 0 auto;
+}
+
+.exporting #export-target h1,
+.exporting #export-target h2,
+.exporting #export-target h3,
+.exporting #export-target h4,
+.exporting #export-target h5,
+.exporting #export-target h6 {
+  text-align: center;
+}
+

--- a/js/auto-pdf.js
+++ b/js/auto-pdf.js
@@ -114,10 +114,13 @@ style.innerHTML = `
 document.head.appendChild(style);
 
 function downloadPDF() {
+  document.body.classList.add('exporting');
   window.scrollTo(0, 0);
   opt.html2canvas.windowWidth = content.scrollWidth;
   opt.html2canvas.windowHeight = content.scrollHeight;
-  html2pdf().set(opt).from(content).save();
+  html2pdf().set(opt).from(content).save().then(() => {
+    document.body.classList.remove('exporting');
+  });
 }
 
 window.downloadPDF = downloadPDF;

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -248,6 +248,7 @@ function buildKinkBreakdown(surveyA, surveyB) {
 }
 
 async function generateComparisonPDF() {
+  document.body.classList.add('exporting');
   const mode = document.body.classList.contains('light-mode') ? 'light' : 'dark';
   applyPrintStyles(mode);
   const element = document.getElementById('export-target');
@@ -255,7 +256,7 @@ async function generateComparisonPDF() {
   window.scrollTo(0, 0);
 
   // ensure the export container has no margin or padding and a black background
-  element.style.margin = '0';
+  element.style.margin = '0 auto';
   element.style.padding = '0';
   element.style.background = '#000';
   element.style.paddingBottom = '100px';
@@ -297,6 +298,7 @@ async function generateComparisonPDF() {
   }
 
   await worker.save();
+  document.body.classList.remove('exporting');
 }
 
 function loadFileA(file) {

--- a/js/script.js
+++ b/js/script.js
@@ -858,6 +858,7 @@ if (downloadBtn) downloadBtn.addEventListener('click', exportSurvey);
 
 function downloadPDF() {
   document.body.classList.add('dark-mode');
+  document.body.classList.add('exporting');
   applyPrintStyles('dark');
 
   const element = document.getElementById('export-target') || document.getElementById('surveyContainer');
@@ -914,7 +915,9 @@ function downloadPDF() {
     },
   };
 
-  html2pdf().set(opt).from(element).save();
+  html2pdf().set(opt).from(element).save().then(() => {
+    document.body.classList.remove('exporting');
+  });
 }
 
 

--- a/your-roles.html
+++ b/your-roles.html
@@ -76,6 +76,7 @@
       // Force background color for PDF rendering
       element.style.backgroundColor = "#000"; // pure black background
 
+      document.body.classList.add('exporting');
       element.classList.add('pdf-export');
       html2pdf()
         .set({
@@ -91,7 +92,10 @@
           pagebreak: { mode: ['avoid-all'] }
         })
         .from(element)
-        .save();
+        .save()
+        .then(() => {
+          document.body.classList.remove('exporting');
+        });
       element.classList.remove('pdf-export');
       element.style.backgroundColor = "";
     }


### PR DESCRIPTION
## Summary
- center exported content via `.exporting` class
- toggle `.exporting` when generating PDF

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885d5bf3680832c80c6dd08ed14db3d