### PR TITLE
Add compatibility PDF download wrapper

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -26,10 +26,13 @@
         </label>
       </div>
     </div>
-    <div id="comparisonResult"></div>
-    <div id="export-target" class="pdf-container print-wrapper">
-      <div id="compatibility-report" class="pdf-export-area"></div>
-      <div id="print-card-list" class="print-only"></div>
+    <button id="download-pdf" class="btn-download">Download PDF</button>
+    <div id="pdf-export-wrapper">
+      <div id="comparisonResult"></div>
+      <div id="export-target" class="pdf-container print-wrapper">
+        <div id="compatibility-report" class="pdf-export-area"></div>
+        <div id="print-card-list" class="print-only"></div>
+      </div>
     </div>
     <div class="print-footer"></div>
   </div>

--- a/css/style.css
+++ b/css/style.css
@@ -2305,3 +2305,31 @@ body {
   text-align: center;
 }
 
+@media print {
+  * {
+    margin: 0 !important;
+    padding: 0 !important;
+    box-shadow: none !important;
+  }
+
+  html,
+  body {
+    background: #121212 !important;
+    color: #ffffff !important;
+    width: 100% !important;
+    height: 100% !important;
+    overflow: hidden;
+    font-family: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif !important;
+  }
+
+  #pdf-export-wrapper {
+    margin: 0 auto !important;
+    padding: 0 !important;
+    background-color: #121212 !important;
+    width: 100% !important;
+    page-break-before: avoid;
+    page-break-after: avoid;
+    page-break-inside: avoid;
+  }
+}
+

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -251,7 +251,7 @@ async function generateComparisonPDF() {
   document.body.classList.add('exporting');
   const mode = document.body.classList.contains('light-mode') ? 'light' : 'dark';
   applyPrintStyles(mode);
-  const element = document.getElementById('export-target');
+  const element = document.getElementById('pdf-export-wrapper');
   if (!element) return;
   window.scrollTo(0, 0);
 
@@ -459,9 +459,6 @@ function updateComparison() {
     });
   }
 
-  setTimeout(() => {
-    generateComparisonPDF();
-  }, 0);
 }
 
 const fileAInput = document.getElementById('fileA');
@@ -495,7 +492,7 @@ function downloadBlob(blob, filename) {
 }
 
 async function exportPNG() {
-  const element = document.getElementById('export-target');
+  const element = document.getElementById('pdf-export-wrapper');
   if (!element) return;
   const canvas = await html2canvas(element, {
     backgroundColor: '#000000',
@@ -509,7 +506,7 @@ async function exportPNG() {
 }
 
 function exportHTML() {
-  const element = document.getElementById('export-target');
+  const element = document.getElementById('pdf-export-wrapper');
   if (!element) return;
   const html = `<!DOCTYPE html><html><head><meta charset="UTF-8"><title>Kink Survey Results</title></head><body>${element.innerHTML}</body></html>`;
   const blob = new Blob([html], { type: 'text/html' });
@@ -571,4 +568,20 @@ function exportJSON() {
 document.addEventListener('DOMContentLoaded', () => {
   initTheme();
   loadSavedSurvey();
+  const btn = document.getElementById('download-pdf');
+  if (btn) {
+    btn.addEventListener('click', function () {
+      const element = document.getElementById('pdf-export-wrapper');
+      html2pdf()
+        .from(element)
+        .set({
+          margin: 0,
+          filename: 'kink_compatibility_comparison.pdf',
+          image: { type: 'jpeg', quality: 1 },
+          html2canvas: { scale: 2, useCORS: true },
+          jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' }
+        })
+        .save();
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- wrap comparison section in `#pdf-export-wrapper`
- add Download PDF button on compatibility page
- update JS to export from the new wrapper and attach button handler
- add print rules for wrapper in CSS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885d7a17d48832ca58b292a9f531404