### PR TITLE
Improve PDF styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1924,6 +1924,10 @@ body {
 
 .page-break { display: none; }
 
+@page {
+  margin: 0;
+}
+
 @media print {
   body,
   html {

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -578,8 +578,13 @@ document.addEventListener('DOMContentLoaded', () => {
           margin: 0,
           filename: 'kink_compatibility_comparison.pdf',
           image: { type: 'jpeg', quality: 1 },
-          html2canvas: { scale: 2, useCORS: true },
-          jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' }
+          html2canvas: {
+            scale: 2,
+            useCORS: true,
+            backgroundColor: '#000'
+          },
+          jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' },
+          pagebreak: { mode: ['avoid-all'] }
         })
         .save();
     });


### PR DESCRIPTION
## Summary
- keep PDF pages flush by adding `@page` rule
- export compatibility results with black background and page break handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885d92b7838832c913a681146aa4dbc