### PR TITLE
Refine PDF export styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1931,7 +1931,7 @@ body {
 @media print {
   body,
   html {
-    background-color: #000 !important;
+    background-color: var(--bg-color, #000) !important;
     color: var(--text-color, inherit) !important;
     -webkit-print-color-adjust: exact !important;
     print-color-adjust: exact !important;
@@ -2223,12 +2223,12 @@ body {
     align-items: center;
     background-color: var(--panel-color, #1e1e2f);
     color: inherit;
-    padding: 0.25rem 0.5rem;
-    margin: 0.2rem 0;
+    padding: 0.15rem 0.4rem;
+    margin: 0.15rem 0;
     border-radius: 4px;
-    font-size: 0.7rem;
+    font-size: 0.65rem;
     height: auto;
-    min-height: 1.4rem;
+    min-height: 1.2rem;
   }
 
   .kink-label {
@@ -2369,6 +2369,10 @@ body {
     page-break-before: avoid;
     page-break-after: avoid;
     page-break-inside: avoid;
+  }
+  #export-target {
+    margin-left: auto !important;
+    margin-right: auto !important;
   }
 }
 

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -262,13 +262,17 @@ async function generateComparisonPDF() {
   element.style.paddingBottom = '100px';
 
   const jsPDF = await loadJsPDF();
-  const pdf = new jsPDF({ unit: 'in', format: 'letter', orientation: 'portrait' });
+  const width = element.scrollWidth;
+  const height = element.scrollHeight;
+  const pdf = new jsPDF({
+    unit: 'px',
+    format: [width, height],
+    orientation: 'portrait'
+  });
 
-  const pageWidth = pdf.internal.pageSize.getWidth();
-  const pageHeight = pdf.internal.pageSize.getHeight();
   // fill the first page background with pure black
   pdf.setFillColor(0, 0, 0);
-  pdf.rect(0, 0, pageWidth, pageHeight, 'F');
+  pdf.rect(0, 0, width, height, 'F');
 
   const opt = {
     margin: 0,
@@ -280,8 +284,8 @@ async function generateComparisonPDF() {
       backgroundColor: '#000000',
       scrollX: 0,
       scrollY: 0,
-      windowWidth: element.scrollWidth,
-      windowHeight: element.scrollHeight,
+      windowWidth: width,
+      windowHeight: height,
       logging: false,
       allowTaint: true,
       crossOrigin: 'anonymous'
@@ -297,7 +301,7 @@ async function generateComparisonPDF() {
     pdf.setPage(i);
     // ensure each page background is pure black
     pdf.setFillColor(0, 0, 0);
-    pdf.rect(0, 0, pageWidth, pageHeight, 'F');
+    pdf.rect(0, 0, width, height, 'F');
   }
 
   await worker.save();
@@ -571,7 +575,9 @@ function exportJSON() {
 document.addEventListener('DOMContentLoaded', () => {
   initTheme();
   loadSavedSurvey();
-  const btn = document.getElementById('download-pdf');
+  const btns = document.querySelectorAll('#download-pdf');
+  btns.forEach((b, i) => { if (i > 0) b.remove(); });
+  const btn = btns[0];
   if (btn) {
     btn.addEventListener('click', async function () {
       const spinner = document.getElementById('loading-spinner');


### PR DESCRIPTION
## Summary
- adjust PDF page sizing to remove margins and center content
- shrink comparison cards for more compact layout
- ensure black background and centered export area
- de-duplicate `Download PDF` buttons at runtime

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885e6b4f530832cbb9af4b2525b2250