### PR TITLE
Fix PDF export centering

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -27,9 +27,9 @@
       </div>
     </div>
     <div id="loading-spinner" class="loading-overlay"><div class="spinner"></div></div>
-    <div id="pdf-export-wrapper">
-      <div id="comparisonResult"></div>
-      <div id="export-target" class="pdf-container print-wrapper">
+    <div id="pdf-container">
+      <div id="compatibility-wrapper">
+        <div id="comparisonResult"></div>
         <div id="compatibility-report" class="pdf-export-area"></div>
         <div id="print-card-list" class="print-only"></div>
       </div>

--- a/css/style.css
+++ b/css/style.css
@@ -2049,7 +2049,7 @@ body {
   font-family: 'Segoe UI', sans-serif;
 }
 
-#export-target {
+#compatibility-wrapper {
   background-color: #000000 !important;
   color: #f5f5f5;
   padding: 1rem;
@@ -2292,7 +2292,7 @@ body {
 }
 
 /* Center exported content only during PDF generation */
-.exporting #export-target {
+.exporting #compatibility-wrapper {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -2303,12 +2303,12 @@ body {
   margin: 0 auto;
 }
 
-.exporting #export-target h1,
-.exporting #export-target h2,
-.exporting #export-target h3,
-.exporting #export-target h4,
-.exporting #export-target h5,
-.exporting #export-target h6 {
+.exporting #compatibility-wrapper h1,
+.exporting #compatibility-wrapper h2,
+.exporting #compatibility-wrapper h3,
+.exporting #compatibility-wrapper h4,
+.exporting #compatibility-wrapper h5,
+.exporting #compatibility-wrapper h6 {
   text-align: center;
 }
 
@@ -2366,7 +2366,7 @@ body {
     font-family: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif !important;
   }
 
-  #pdf-export-wrapper {
+  #pdf-container {
     margin: 0 auto !important;
     padding: 0 !important;
     background-color: #121212 !important;
@@ -2377,9 +2377,42 @@ body {
     page-break-after: avoid;
     page-break-inside: avoid;
   }
-  #export-target {
+  #compatibility-wrapper {
     margin-left: auto !important;
     margin-right: auto !important;
+  }
+}
+
+/* Centered PDF export containers */
+#pdf-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  background: #000;
+  margin: 0;
+  padding: 0;
+  min-height: 100vh;
+}
+
+#compatibility-wrapper {
+  width: 1000px;
+  background: #000;
+  margin: 0 auto;
+}
+
+@media print {
+  body, #pdf-container, #compatibility-wrapper {
+    background: #000 !important;
+    color: #fff !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    -webkit-print-color-adjust: exact !important;
+    print-color-adjust: exact !important;
+  }
+  #compatibility-wrapper {
+    page-break-before: avoid;
+    page-break-after: avoid;
+    page-break-inside: avoid;
   }
 }
 

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -251,7 +251,7 @@ async function generateComparisonPDF() {
   document.body.classList.add('exporting');
   const mode = document.body.classList.contains('light-mode') ? 'light' : 'dark';
   applyPrintStyles(mode);
-  const element = document.getElementById('pdf-export-wrapper');
+  const element = document.getElementById('pdf-container');
   if (!element) return;
   window.scrollTo(0, 0);
 
@@ -290,6 +290,7 @@ async function generateComparisonPDF() {
       allowTaint: true,
       crossOrigin: 'anonymous'
     },
+    pagebreak: { mode: ['avoid-all'] },
     jsPDF: pdf
   };
 
@@ -499,7 +500,7 @@ function downloadBlob(blob, filename) {
 }
 
 async function exportPNG() {
-  const element = document.getElementById('pdf-export-wrapper');
+  const element = document.getElementById('pdf-container');
   if (!element) return;
   const canvas = await html2canvas(element, {
     backgroundColor: '#000000',
@@ -513,7 +514,7 @@ async function exportPNG() {
 }
 
 function exportHTML() {
-  const element = document.getElementById('pdf-export-wrapper');
+  const element = document.getElementById('pdf-container');
   if (!element) return;
   const html = `<!DOCTYPE html><html><head><meta charset="UTF-8"><title>Kink Survey Results</title></head><body>${element.innerHTML}</body></html>`;
   const blob = new Blob([html], { type: 'text/html' });

--- a/js/theme.js
+++ b/js/theme.js
@@ -105,7 +105,7 @@ export const pdfStyles = `
       --panel-color: #292b3d !important;
     }
 
-    html, body, #export-target {
+    html, body, #compatibility-wrapper {
       background: var(--bg-color) !important;
       color: var(--text-color) !important;
       margin: 0 !important;
@@ -116,12 +116,12 @@ export const pdfStyles = `
       -webkit-print-color-adjust: exact !important;
       print-color-adjust: exact !important;
     }
-    #export-target {
+    #compatibility-wrapper {
       width: 100vw;
       min-height: 100vh;
       padding-bottom: 100px;
     }
-    #export-target * {
+    #compatibility-wrapper * {
       box-sizing: border-box !important;
     }
 
@@ -170,7 +170,7 @@ export const lightPdfStyles = `
       --panel-color: #f0f0f0 !important;
     }
 
-    html, body, #export-target {
+    html, body, #compatibility-wrapper {
       background: var(--bg-color) !important;
       color: var(--text-color) !important;
       margin: 0 !important;
@@ -181,12 +181,12 @@ export const lightPdfStyles = `
       -webkit-print-color-adjust: exact !important;
       print-color-adjust: exact !important;
     }
-    #export-target {
+    #compatibility-wrapper {
       width: 100vw;
       min-height: 100vh;
       padding-bottom: 100px;
     }
-    #export-target * {
+    #compatibility-wrapper * {
       box-sizing: border-box !important;
     }
 
@@ -454,7 +454,7 @@ export function applyPrintStyles(mode = 'dark') {
       }
 
       @media print {
-        body, #export-target, .pdf-export-area {
+        body, #compatibility-wrapper, .pdf-export-area {
           background-color: var(--bg-color, #000000) !important;
           color: var(--text-color, #ffffff) !important;
           -webkit-print-color-adjust: exact;


### PR DESCRIPTION
## Summary
- center compatibility export with new `pdf-container` and `compatibility-wrapper`
- update CSS to keep background black and center layout
- point PDF export to the new container and avoid page breaks
- update print styles for new wrapper names

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885edc872ec832cb9e127c66328b7f4