### PR TITLE
Integrate final PDF export layout

### DIFF
--- a/auto-pdf.html
+++ b/auto-pdf.html
@@ -9,9 +9,16 @@
   <script src="js/auto-pdf.js" defer></script>
 </head>
 <body>
-  <button class="manual-export" onclick="downloadPDF()">Download Results as PDF</button>
-  <div id="export-target">
-    <!-- Compatibility results go here -->
+  <div id="button-section">
+    <button>Upload Your Survey</button>
+    <button>Upload Partner’s Survey</button>
+    <button id="download" type="button">Download PDF</button>
+  </div>
+
+  <div id="pdf-container">
+    <div id="compatibility-wrapper">
+      <!-- Compatibility results go here -->
+    </div>
   </div>
 </body>
 </html>

--- a/css/auto-pdf.css
+++ b/css/auto-pdf.css
@@ -1,37 +1,49 @@
-/* === 1. Page Background and Font === */
 body {
-  background-color: #000000; /* Fully black page background */
-  color: #ffffff;
-  font-family: 'Segoe UI', sans-serif;
-  font-size: 14px;
+  background-color: #000 !important;
+  color: #f1f1f1 !important;
+  margin: 0 !important;
+  padding: 0 !important;
+  font-family: sans-serif;
+}
+
+#button-section {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  padding: 20px;
+}
+
+#pdf-container {
+  background-color: #000;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 40px;
+  min-height: 100vh;
+}
+
+#compatibility-wrapper {
+  background-color: #111;
+  width: 1000px;
+  padding: 20px;
+  text-align: left;
+}
+
+table,
+.compatibility-table {
+  width: 100%;
+  margin: 0 auto;
+}
+
+@page {
   margin: 0;
-  padding: 0;
 }
 
-/* === 2. Centered Survey Layout with Dark Container === */
-#export-target {
-  max-width: 1000px;
-  width: 95%;
-  margin: 2rem auto;
-  padding: 1rem;
-  background-color: #1e1e2f; /* deep navy/purple tone */
-  border-radius: 12px;
-  box-shadow: 0 0 12px rgba(255,255,255,0.1);
-}
-
-/* === 3. Hide Buttons === */
-button:not(.manual-export),
-.download-btn {
-  display: none !important;
-}
-
-.manual-export {
-  display: block;
-  margin: 1rem auto;
-  padding: 0.5rem 1rem;
-  background-color: #333;
-  color: #fff;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
+@media print {
+  body {
+    margin: 0;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
 }

--- a/js/auto-pdf.js
+++ b/js/auto-pdf.js
@@ -1,130 +1,21 @@
-// SETUP DARK PDF EXPORT
-const content = document.getElementById('export-target');
-content.classList.add('pdf-container');
-// provide extra space so the last bar never gets cut off
-content.style.paddingBottom = '100px';
-
-const opt = {
-  margin: [0, 0, 0, 0],
-  filename: 'kink-compatibility-results.pdf',
-  image: { type: 'jpeg', quality: 1 },
-  html2canvas: {
-    scale: 2,
-    useCORS: true,
-    backgroundColor: '#000',
-    scrollY: 0,
-    scrollX: 0,
-    windowWidth: content.scrollWidth,
-    windowHeight: content.scrollHeight
-  },
-  jsPDF: {
-    unit: 'px',
-    format: [content.scrollWidth, content.scrollHeight],
-    orientation: 'portrait'
-  }
+const exportToPDF = () => {
+  const element = document.getElementById('pdf-container');
+  const opt = {
+    margin: 0,
+    filename: 'kink-compatibility-results.pdf',
+    image: { type: 'jpeg', quality: 1 },
+    html2canvas: {
+      scale: 2,
+      useCORS: true,
+      backgroundColor: '#000'
+    },
+    jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' },
+    pagebreak: { mode: ['avoid-all'] }
+  };
+  html2pdf().set(opt).from(element).save();
 };
 
-// CLEAN EXPORT BUTTON (REMOVE "Trouble Downloading")
-document.querySelectorAll('button').forEach(btn => {
-  if (btn.innerText.toLowerCase().includes('trouble')) btn.remove();
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.getElementById('download');
+  if (btn) btn.addEventListener('click', exportToPDF);
 });
-
-// STYLE INJECTION (Print Overrides)
-const printStyle = document.createElement('style');
-printStyle.textContent = `
-  @media print {
-    .pdf-container {
-      background: #000 !important;
-      color: #fff !important;
-      padding: 0 !important;
-      margin: 0 !important;
-      width: 100vw;
-      min-height: 100vh;
-      box-sizing: border-box;
-    }
-
-    html, body {
-      margin: 0 !important;
-      padding: 0 !important;
-      background: #000 !important;
-      height: 100% !important;
-      overflow: hidden !important;
-    }
-
-    * {
-      box-sizing: border-box !important;
-      -webkit-print-color-adjust: exact !important;
-      print-color-adjust: exact !important;
-    }
-  }
-`;
-document.head.appendChild(printStyle);
-
-// STYLE INJECTION (Dark Theme)
-const style = document.createElement('style');
-style.innerHTML = `
-  html, body {
-    margin: 0 !important;
-    padding: 0 !important;
-    background-color: #000000 !important;
-    color: #f0f0f0 !important;
-    font-family: 'Arial', sans-serif;
-    height: 100%;
-    overflow: hidden;
-  }
-
-  #export-target {
-    background-color: #000000 !important;
-    padding: 2rem;
-  }
-
-  table {
-    background-color: #1a1a1a !important;
-    border-collapse: collapse;
-    width: 100%;
-    color: #e0e0e0;
-  }
-
-  th, td {
-    padding: 0.75rem 1rem;
-    text-align: left;
-    border-bottom: 1px solid #333;
-  }
-
-  th {
-    background-color: #111 !important;
-    color: #bbb;
-    font-weight: 600;
-  }
-
-  .bar-container {
-    background: #2a2a2a !important;
-    border-radius: 5px;
-  }
-
-  .bar {
-    height: 12px;
-    border-radius: 5px;
-  }
-
-  .bar.green { background-color: #00e676 !important; }
-  .bar.yellow { background-color: #ffeb3b !important; }
-  .bar.red { background-color: #f44336 !important; }
-`;
-document.head.appendChild(style);
-
-function downloadPDF() {
-  document.body.classList.add('exporting');
-  window.scrollTo(0, 0);
-  opt.html2canvas.windowWidth = content.scrollWidth;
-  opt.html2canvas.windowHeight = content.scrollHeight;
-  html2pdf().set(opt).from(content).save().then(() => {
-    document.body.classList.remove('exporting');
-  });
-}
-
-window.downloadPDF = downloadPDF;
-
-// EXECUTE EXPORT AUTOMATICALLY
-downloadPDF();
-


### PR DESCRIPTION
## Summary
- remove previous `export-sample.html`
- update `auto-pdf.html` with button section and export container
- simplify PDF export logic in `js/auto-pdf.js`
- style the export page with `css/auto-pdf.css`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6885f2e19630832ca306aeec41375845