### PR TITLE
Center PDF output with margins

### DIFF
--- a/js/auto-pdf.js
+++ b/js/auto-pdf.js
@@ -1,7 +1,7 @@
 const exportToPDF = () => {
   const element = document.getElementById('pdf-container');
   const opt = {
-    margin: 0,
+    margin: 0.5,
     filename: 'Kink_Compatibility_Report.pdf',
     image: { type: 'jpeg', quality: 1 },
     html2canvas: {

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -275,7 +275,7 @@ async function generateComparisonPDF() {
   pdf.rect(0, 0, width, height, 'F');
 
   const opt = {
-    margin: 0,
+    margin: 40,
     filename: 'kink-compatibility-results.pdf',
     image: { type: 'jpeg', quality: 0.98 },
     html2canvas: {

--- a/js/script.js
+++ b/js/script.js
@@ -896,7 +896,7 @@ function downloadPDF() {
   element.classList.add('pdf-wrapper');
 
   const opt = {
-    margin: [0, 0, 0, 0],
+    margin: 40,
     filename: 'kink-compatibility-results.pdf',
     image: { type: 'jpeg', quality: 1 },
     html2canvas: {


### PR DESCRIPTION
## Summary
- center PDFs by adding margins to export options

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886886c2688832c85b95aca46e040fa