### PR TITLE
Add table example and refine auto-pdf export

### DIFF
--- a/auto-pdf.html
+++ b/auto-pdf.html
@@ -17,7 +17,18 @@
 
   <div id="pdf-container">
     <div id="compatibility-wrapper">
-      <!-- Compatibility results go here -->
+      <table class="compatibility-table">
+        <thead>
+          <tr><th>Kink</th><th>Partner A</th><th>Partner B</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Nipple clips</td><td>100%</td><td>100%</td></tr>
+          <tr><td>CBT</td><td>100%</td><td>100%</td></tr>
+          <tr><td>Hair pulling</td><td>100%</td><td>100%</td></tr>
+          <tr><td>Clit weights</td><td>40%</td><td>40%</td></tr>
+          <!-- add more rows as needed -->
+        </tbody>
+      </table>
     </div>
   </div>
 </body>

--- a/js/auto-pdf.js
+++ b/js/auto-pdf.js
@@ -1,20 +1,24 @@
 const exportToPDF = () => {
   const element = document.getElementById('pdf-container');
+  const width = element.scrollWidth;
+  const height = element.scrollHeight;
+
   const opt = {
     margin: 0,
     filename: 'Kink_Compatibility_Report.pdf',
     image: { type: 'jpeg', quality: 1 },
     html2canvas: {
-      scale: 4,
+      scale: 2,
       useCORS: true,
       backgroundColor: '#000',
       scrollY: 0,
-      windowWidth: document.documentElement.scrollWidth,
-      windowHeight: document.documentElement.scrollHeight
+      width,
+      windowWidth: width,
+      windowHeight: height
     },
     jsPDF: {
       unit: 'px',
-      format: [document.documentElement.scrollWidth, document.documentElement.scrollHeight],
+      format: [width, height],
       orientation: 'portrait'
     },
     pagebreak: {


### PR DESCRIPTION
## Summary
- include a simple compatibility table in `auto-pdf.html`
- tweak `js/auto-pdf.js` so dimensions come from the container element
- drop the unused `sample-compatibility.html`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6886a8d8af80832cb345dd0af7e168c6