### PR TITLE
Fix PDF export width

### DIFF
--- a/js/auto-pdf.js
+++ b/js/auto-pdf.js
@@ -1,5 +1,5 @@
 const exportToPDF = () => {
-  const element = document.getElementById('pdf-container');
+  const element = document.getElementById('compatibility-wrapper');
   const width = element.scrollWidth;
   const height = element.scrollHeight;
 

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -251,15 +251,16 @@ async function generateComparisonPDF() {
   document.body.classList.add('exporting');
   const mode = document.body.classList.contains('light-mode') ? 'light' : 'dark';
   applyPrintStyles(mode);
-  const element = document.getElementById('pdf-container');
-  if (!element) return;
+  const container = document.getElementById('pdf-container');
+  const element = document.getElementById('compatibility-wrapper');
+  if (!container || !element) return;
   window.scrollTo(0, 0);
 
   // ensure the export container has no margin or padding and a black background
-  element.style.margin = '0 auto';
-  element.style.padding = '0';
-  element.style.background = '#000';
-  element.style.paddingBottom = '100px';
+  container.style.margin = '0 auto';
+  container.style.padding = '0';
+  container.style.background = '#000';
+  container.style.paddingBottom = '100px';
 
   const jsPDF = await loadJsPDF();
   const width = element.scrollWidth;


### PR DESCRIPTION
## Summary
- use inner `compatibility-wrapper` element for PDF generation
- adjust compatibility page export to compute size from inner container

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886ac28d764832ca28d83e29e54bedd