### PR TITLE
Fix PDF export width

### DIFF
--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -276,7 +276,7 @@ async function generateComparisonPDF() {
   pdf.rect(0, 0, width, height, 'F');
 
   const opt = {
-    margin: 40,
+    margin: 0,
     filename: 'kink-compatibility-results.pdf',
     image: { type: 'jpeg', quality: 0.98 },
     html2canvas: {


### PR DESCRIPTION
## Summary
- remove the 40px margin when generating comparison PDFs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886b082786c832cb2b135981fe2a366