### PR TITLE
Fix PDF export padding

### DIFF
--- a/css/auto-pdf.css
+++ b/css/auto-pdf.css
@@ -18,15 +18,15 @@ body {
   background-color: #000;
   display: flex;
   justify-content: center;
-  padding: 40px;
+  padding: 0;
   width: 100%;
 }
 
 #compatibility-wrapper {
   background-color: #111;
   width: 100%;
-  max-width: 1000px;
-  padding: 20px;
+  max-width: none;
+  padding: 0;
   text-align: left;
   box-sizing: border-box;
 }

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -260,7 +260,7 @@ async function generateComparisonPDF() {
   container.style.margin = '0 auto';
   container.style.padding = '0';
   container.style.background = '#000';
-  container.style.paddingBottom = '100px';
+  container.style.paddingBottom = '0';
 
   const jsPDF = await loadJsPDF();
   const width = element.scrollWidth;


### PR DESCRIPTION
## Summary
- allow PDF content to fill full width
- remove extra bottom padding in PDF export script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886b2c03f78832ca7ee8939cd593aca