### PR TITLE
Improve fixed-size PDF export

### DIFF
--- a/auto-pdf.html
+++ b/auto-pdf.html
@@ -9,24 +9,26 @@
   <script src="js/auto-pdf.js" defer></script>
 </head>
 <body>
+  <!-- ✅ BUTTONS AT THE TOP -->
   <div id="button-section">
     <button>Upload Your Survey</button>
     <button>Upload Partner’s Survey</button>
     <button onclick="exportToPDF()">Download PDF</button>
   </div>
 
+  <!-- ✅ COMPATIBILITY RESULTS WRAPPER -->
   <div id="pdf-container">
     <div id="compatibility-wrapper">
-      <table class="compatibility-table">
+      <!-- Your compatibility table goes here -->
+      <table>
         <thead>
           <tr><th>Kink</th><th>Partner A</th><th>Partner B</th></tr>
         </thead>
         <tbody>
-          <tr><td>Activity 1</td><td>100%</td><td>100%</td></tr>
-          <tr><td>Activity 2</td><td>100%</td><td>100%</td></tr>
-          <tr><td>Activity 3</td><td>100%</td><td>100%</td></tr>
-          <tr><td>Activity 4</td><td>40%</td><td>40%</td></tr>
-          <!-- add more rows as needed -->
+          <tr><td>Nipple clips</td><td>100%</td><td>100%</td></tr>
+          <tr><td>CBT</td><td>100%</td><td>100%</td></tr>
+          <tr><td>Hair pulling</td><td>100%</td><td>100%</td></tr>
+          <tr><td>Clit weights</td><td>40%</td><td>40%</td></tr>
         </tbody>
       </table>
     </div>

--- a/css/auto-pdf.css
+++ b/css/auto-pdf.css
@@ -24,17 +24,20 @@ body {
 
 #compatibility-wrapper {
   background-color: #111;
-  width: 100%;
-  max-width: 980px; /* reduced from 1000px to prevent edge clipping */
+  width: 1000px; /* fixed width for consistency */
   padding: 20px;
-  text-align: left;
   box-sizing: border-box;
 }
 
-table,
-.compatibility-table {
+table {
   width: 100%;
   margin: 0 auto;
+  border-collapse: collapse;
+}
+
+th, td {
+  padding: 10px;
+  text-align: left;
 }
 
 @page {

--- a/js/auto-pdf.js
+++ b/js/auto-pdf.js
@@ -1,6 +1,6 @@
 const exportToPDF = () => {
-  const element = document.getElementById('pdf-container');
-  const width = element.scrollWidth;
+  const element = document.getElementById('compatibility-wrapper');
+  const width = element.offsetWidth;
   const height = element.scrollHeight;
 
   const opt = {
@@ -18,7 +18,7 @@ const exportToPDF = () => {
     },
     jsPDF: {
       unit: 'px',
-      format: [width + 10, height], // add buffer to avoid cutoff
+      format: [width, height],
       orientation: 'portrait'
     },
     pagebreak: {


### PR DESCRIPTION
## Summary
- ensure compatibility wrapper table matches exact demo markup
- enforce consistent styling for the PDF export page
- size PDF output using pixel dimensions for exact rendering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886bbc4af60832cbd9138e7867d08c2