### PR TITLE
Adjust export table width

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2318,6 +2318,13 @@ body {
   text-align: center;
 }
 
+/* Ensure exported results table spans full width */
+.exporting .results-table {
+  margin: 0; /* Remove auto margins */
+  width: 100%; /* Use full width of wrapper */
+  max-width: none; /* Remove max-width constraint */
+}
+
 /* Loading spinner displayed during PDF generation */
 .loading-overlay {
   position: fixed;


### PR DESCRIPTION
## Summary
- ensure `.results-table` uses full width when exporting PDFs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6886c5e2b8d4832c90585ac03bb9d05c