### PR TITLE
Fix export wrapper layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2299,14 +2299,8 @@ body {
 
 /* Center exported content only during PDF generation */
 .exporting #compatibility-wrapper {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  width: 800px;
-  max-width: 90vw;
-  margin: 0 auto;
+  display: block; /* Revert to block layout */
+  text-align: left; /* Ensure text aligns left */
 }
 
 .exporting #compatibility-wrapper h1,


### PR DESCRIPTION
## Summary
- revert export layout to block style and left text alignment

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6886c5ed21b0832c9ba6d01cae0dd241