### PR TITLE
Fix PDF export layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2297,16 +2297,20 @@ body {
   }
 }
 
-/* Center exported content only during PDF generation */
+/* Layout tweaks applied only while generating the PDF */
 .exporting #compatibility-wrapper {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  width: 800px;
-  max-width: 90vw;
-  margin: 0 auto;
+  display: block;
+  width: 1200px;
+  max-width: none;
+  margin: 0;
+  padding: 20px; /* Consistent with auto-pdf.css */
+  text-align: left;
+}
+
+.exporting .results-table {
+  margin: 0;
+  width: 100%;
+  max-width: none;
 }
 
 .exporting #compatibility-wrapper h1,


### PR DESCRIPTION
## Summary
- adjust layout rules for `.exporting` state to match `auto-pdf.css`
- allow results table to expand during export

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6886c5f5ba1c832cbb8e15149541f876