### PR TITLE
Fix PDF export layout

### DIFF
--- a/css/auto-pdf.css
+++ b/css/auto-pdf.css
@@ -51,3 +51,58 @@ th, td {
     print-color-adjust: exact;
   }
 }
+
+/* === EXPORT FIXES FOR PDF === */
+.exporting body {
+  margin: 0;
+  padding: 0;
+  background: #000 !important;
+  color: #fff !important;
+}
+
+/* Wrap the table container and center it */
+.exporting .compatibility-wrapper {
+  display: flex !important;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: left !important;
+  width: 100% !important;
+  max-width: 1160px !important;
+  margin: 0 auto !important;
+  padding: 0 !important;
+  background: #000 !important;
+}
+
+/* Make the section headers black */
+.exporting .category-header {
+  background-color: #000 !important;
+  color: #f00 !important; /* Change to #fff for white text if preferred */
+}
+
+/* Ensure full table width and text wrapping */
+.exporting .results-table {
+  width: 100% !important;
+  margin: 0 auto !important;
+  table-layout: fixed;
+  border-collapse: collapse;
+  word-wrap: break-word;
+}
+
+/* Wrap long text in all table cells */
+.exporting .results-table th,
+.exporting .results-table td {
+  white-space: normal !important;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  page-break-inside: avoid;
+  break-inside: avoid;
+  padding: 6px 8px;
+}
+
+/* Hide nav and other UI during print/export */
+@media print {
+  nav, header, footer, .no-print {
+    display: none !important;
+  }
+}

--- a/css/style.css
+++ b/css/style.css
@@ -2547,7 +2547,7 @@ body {
 }
 /* If using a PDF generator like wkhtmltopdf, enable print media styles (e.g., use the --print-media-type flag):contentReference[oaicite:7]{index=7} */
 
-/* === PDF EXPORT FIXES === */
+/* === EXPORT FIXES FOR PDF === */
 .exporting body {
   margin: 0;
   padding: 0;
@@ -2583,12 +2583,13 @@ body {
   overflow-wrap: break-word;
   page-break-inside: avoid;
   break-inside: avoid;
+  padding: 6px 8px;
 }
 
-/* Remove dark blue header if any */
+/* Make the section headers black */
 .exporting .category-header {
-  background: transparent !important;
-  color: #f00;
+  background-color: #000 !important;
+  color: #f00 !important; /* Change to #fff for white text if preferred */
 }
 
 /* Hide non-essential export elements */


### PR DESCRIPTION
## Summary
- tweak `.exporting` styles in `css/style.css` to keep table centered and headers black
- append the export styles to `css/auto-pdf.css`
- keep existing scripts using `document.body.classList.add('exporting')` before pdf creation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6887df6e9cac832cbd6fa2d412332b3c