### PR TITLE
Update PDF export to use compatibility wrapper

### DIFF
--- a/css/auto-pdf.css
+++ b/css/auto-pdf.css
@@ -208,8 +208,8 @@ body.exporting {
     padding: 0 !important;
     width: 100% !important;
     max-width: 100% !important;
-    text-align: center;
-    overflow: hidden !important;
+    text-align: left;
+    overflow: hidden;
   }
 
   .results-table {

--- a/js/auto-pdf.js
+++ b/js/auto-pdf.js
@@ -1,5 +1,5 @@
 const exportToPDF = () => {
-  const element = document.getElementById('pdf-container');
+  const element = document.getElementById('compatibility-wrapper');
   document.body.classList.add('exporting');
 
   const opt = {


### PR DESCRIPTION
## Summary
- use the `compatibility-wrapper` element when generating PDF
- adjust print styles so export content is left-aligned

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688815a1f670832ca313f9d171ba031a