### PR TITLE
Fix auto PDF layout

### DIFF
--- a/css/auto-pdf.css
+++ b/css/auto-pdf.css
@@ -19,12 +19,14 @@ body {
   display: flex;
   justify-content: center;
   width: 100%;
-  padding: 40px;
+  padding: 20px;
 }
 
 #compatibility-wrapper {
   background-color: #000;
-  width: 1200px; /* fixed wide layout */
+  width: 100%;
+  max-width: 1000px;
+  margin: 0 auto;
   padding: 20px;
   box-sizing: border-box;
 }
@@ -33,11 +35,15 @@ table {
   width: 100%;
   margin: 0 auto;
   border-collapse: collapse;
+  table-layout: fixed;
 }
 
 th, td {
-  padding: 10px;
+  padding: 6px;
   text-align: left;
+  white-space: normal;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 @page {

--- a/js/auto-pdf.js
+++ b/js/auto-pdf.js
@@ -7,7 +7,7 @@ const exportToPDF = () => {
     filename: 'Kink_Compatibility_Report.pdf',
     image: { type: 'jpeg', quality: 1 },
     html2canvas: {
-      scale: 2,
+      scale: 1.6,
       useCORS: true,
       backgroundColor: '#000',
       scrollY: 0


### PR DESCRIPTION
## Summary
- center PDF table and let text wrap
- shrink padding and canvas scale to avoid cropping

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68884e3f7ee4832c95dca68dbaf73300