### PR TITLE
Fix PDF table overflow

### DIFF
--- a/css/auto-pdf.css
+++ b/css/auto-pdf.css
@@ -25,7 +25,7 @@ body {
 #compatibility-wrapper {
   background-color: #000;
   width: 100%;
-  max-width: 1000px;
+  max-width: 100%;
   margin: 0 auto;
   padding: 20px;
   box-sizing: border-box;
@@ -74,7 +74,7 @@ body.exporting {
   align-items: center;
   justify-content: center;
   width: 100% !important;
-  max-width: 1160px !important;
+  max-width: 100% !important;
   margin: 0 auto !important;
   padding: 0 !important;
   background-color: #000 !important;

--- a/css/style.css
+++ b/css/style.css
@@ -2324,7 +2324,7 @@ body {
 }
 
 .exporting {
-  zoom: 0.9;
+  zoom: 0.8;
 }
 
 .exporting #compatibility-wrapper {
@@ -2483,7 +2483,8 @@ body {
 }
 
 #compatibility-wrapper {
-  width: 1000px;
+  width: 100%;
+  max-width: 1000px;
   background: #000;
   margin: 0 auto;
 }
@@ -2575,7 +2576,7 @@ body {
   justify-content: center;
   text-align: left !important;
   width: 100% !important;
-  max-width: 1160px !important;
+  max-width: 100% !important;
   margin: 0 auto !important;
   padding: 0 !important;
   background: #000 !important;
@@ -2689,7 +2690,7 @@ body {
   justify-content: center;
   text-align: left !important;
   width: 100% !important;
-  max-width: 1160px !important;
+  max-width: 100% !important;
   margin: 0 auto !important;
   padding: 0 !important;
   background: #000 !important;


### PR DESCRIPTION
## Summary
- shrink export zoom to 0.8
- remove fixed widths for export and center pdf content

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888515fa8d0832c9d4e3cd8fc21df44