### PR TITLE
Fix print layout alignment

### DIFF
--- a/css/auto-pdf.css
+++ b/css/auto-pdf.css
@@ -208,14 +208,17 @@ body.exporting {
 
   .compatibility-wrapper,
   #compatibility-wrapper {
+    display: table;
+    margin: 0 auto !important;
     background-color: #000 !important;
     color: #fff !important;
-    margin: 0 auto !important;
     padding: 0 !important;
     width: 100% !important;
     max-width: 100% !important;
     text-align: left;
     overflow: hidden;
+    transform: scale(0.85);
+    transform-origin: top center;
   }
 
   .results-table {
@@ -248,6 +251,8 @@ body.exporting {
     font-size: 1.2em;
     text-align: center;
     border-bottom: 1px solid #333;
+    word-wrap: break-word;
+    white-space: normal;
   }
 
   @page {

--- a/css/style.css
+++ b/css/style.css
@@ -2466,8 +2466,10 @@ body {
     page-break-inside: avoid;
   }
   #compatibility-wrapper {
-    margin-left: auto !important;
-    margin-right: auto !important;
+    display: table;
+    margin: 0 auto !important;
+    transform: scale(0.85);
+    transform-origin: top center;
   }
 }
 
@@ -2608,9 +2610,9 @@ body {
     overflow: visible !important;
   }
   #compatibility-wrapper {
-    margin-left: auto !important;
-    margin-right: auto !important;
-    transform: scale(0.9);
+    display: table;
+    margin: 0 auto !important;
+    transform: scale(0.85);
     transform-origin: top center;
   }
 
@@ -2625,6 +2627,20 @@ body {
     white-space: normal !important;
     word-wrap: break-word !important;
     overflow-wrap: break-word !important;
+  }
+
+  .category-header {
+    word-wrap: break-word;
+    white-space: normal;
+  }
+
+  @page {
+    margin: 0;
+  }
+
+  body {
+    margin: 0;
+    padding: 0;
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure compatibility PDF layout centers and scales correctly
- avoid overflow by shrinking to 85%
- wrap long category headers during print

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688856998028832ca1614e5428e52c82