### PR TITLE
Fix PDF print layout

### DIFF
--- a/css/auto-pdf.css
+++ b/css/auto-pdf.css
@@ -260,3 +260,34 @@ body.exporting {
     size: auto;
   }
 }
+
+/* Print-specific layout fixes for PDF export */
+@media print {
+  .compatibility-wrapper {
+    display: table;
+    margin: 0 auto;
+    transform: scale(0.9);
+    transform-origin: top center;
+  }
+
+  .results-table {
+    width: 100%;
+    max-width: none;
+  }
+
+  th, td {
+    white-space: normal;
+    word-wrap: break-word;
+  }
+
+  @page {
+    size: A4;
+    margin: 0;
+  }
+
+  body {
+    margin: 0;
+    padding: 0;
+    background: #000;
+  }
+}

--- a/css/style.css
+++ b/css/style.css
@@ -2771,3 +2771,33 @@ body {
     display: none !important;
   }
 }
+/* Print-specific layout fixes for PDF export */
+@media print {
+  .compatibility-wrapper {
+    display: table;
+    margin: 0 auto;
+    transform: scale(0.9);
+    transform-origin: top center;
+  }
+
+  .results-table {
+    width: 100%;
+    max-width: none;
+  }
+
+  th, td {
+    white-space: normal;
+    word-wrap: break-word;
+  }
+
+  @page {
+    size: A4;
+    margin: 0;
+  }
+
+  body {
+    margin: 0;
+    padding: 0;
+    background: #000;
+  }
+}


### PR DESCRIPTION
## Summary
- tweak `@media print` in main stylesheet and `auto-pdf.css`
  - center compatibility table and shrink to fit
  - remove page margins and background borders
  - ensure table width and text wrapping for PDF

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688859156a6c832c8d4e3e4e8e6e324b