### PR TITLE
Fix PDF print scaling

### DIFF
--- a/css/auto-pdf.css
+++ b/css/auto-pdf.css
@@ -283,7 +283,7 @@ body.exporting {
     max-width: 100%;
     display: flex;
     justify-content: center; /* Center the table horizontally */
-    transform: scale(0.88) translateX(20px); /* Shift right */
+    transform: none;
     transform-origin: top center;
   }
 

--- a/css/style.css
+++ b/css/style.css
@@ -2624,7 +2624,7 @@ body {
     max-width: 100%;
     display: flex;
     justify-content: center; /* Center the table horizontally */
-    transform: scale(0.88) translateX(20px); /* Shift right */
+    transform: none;
     transform-origin: top center;
   }
 


### PR DESCRIPTION
## Summary
- stop scaling the compatibility wrapper when printing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6888669d2020832c9c03365af7bfad15