### PR TITLE
Add theme selector and new themes

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -79,3 +79,96 @@
   --button-hover-bg: rgba(255, 255, 255, 0.7);
   --progress-fill-color: #603636;
 }
+
+/* New simplified themes */
+.theme-dark {
+  --bg-color: #0d0d0d;
+  --text-color: #f2f2f2;
+  --accent-color: #333;
+  --button-bg: #1a1a1a;
+  --button-text: #f2f2f2;
+  --border-color: #444;
+  --link-color: #66ccff;
+  --hover-bg: #333;
+  --hover-text: #ffffff;
+  --panel-bg: #1a1a1a;
+  --card-bg: #222;
+}
+.theme-lipstick {
+  --bg-color: #1a001f;
+  --text-color: #fceaff;
+  --accent-color: #ff4ecb;
+  --highlight-color: #a200ff;
+  --button-bg: #ff4ecb;
+  --button-text: #1a001f;
+  --border-color: #ff91f0;
+  --link-color: #ffb3ec;
+  --hover-bg: #a200ff;
+  --hover-text: #ffffff;
+  --panel-bg: #300030;
+  --card-bg: #2a002a;
+}
+.theme-forest {
+  --bg-color: #f0f7f1;
+  --text-color: #1d3b1d;
+  --accent-color: #3d6651;
+  --button-bg: #a6d5b5;
+  --button-text: #1d3b1d;
+  --border-color: #81b89b;
+  --link-color: #297c58;
+  --hover-bg: #82c8a0;
+  --hover-text: #fff;
+  --panel-bg: #e6f3ea;
+  --card-bg: #d9efe1;
+}
+
+body.theme-dark {
+  background-color: var(--bg-color);
+  color: var(--text-color);
+}
+body.theme-dark button,
+body.theme-dark .start-button {
+  background-color: var(--button-bg);
+  color: var(--button-text);
+  border: 1px solid var(--border-color);
+}
+body.theme-dark a {
+  color: var(--link-color);
+}
+body.theme-dark .panel,
+body.theme-dark .card {
+  background-color: var(--card-bg);
+  border: 1px solid var(--border-color);
+}
+
+body.theme-lipstick {
+  background-color: var(--bg-color);
+  color: var(--text-color);
+}
+body.theme-lipstick button,
+body.theme-lipstick .start-button {
+  background-color: var(--button-bg);
+  color: var(--button-text);
+  border: 2px solid var(--border-color);
+}
+body.theme-lipstick .panel,
+body.theme-lipstick .card {
+  background-color: var(--card-bg);
+  border: 1px solid var(--border-color);
+}
+
+body.theme-forest {
+  background-color: var(--bg-color);
+  color: var(--text-color);
+}
+body.theme-forest button,
+body.theme-forest .start-button {
+  background-color: var(--button-bg);
+  color: var(--button-text);
+  border: 1px solid var(--border-color);
+}
+body.theme-forest .panel,
+body.theme-forest .card {
+  background-color: var(--card-bg);
+  border: 1px solid var(--border-color);
+}

--- a/data-tools.html
+++ b/data-tools.html
@@ -12,14 +12,10 @@
 
   <div id="themeControl">
     <label for="themeSelector">🎨 Select Theme:</label>
-    <select id="themeSelector">
-      <option value="dark-mode">Dark</option>
-      <option value="light-mode">Light Forest</option>
-      <option value="theme-blue">Blue</option>
-      <option value="theme-blue-sky">Blue Sky</option>
-      <option value="theme-echoes-beyond">Echoes Beyond</option>
-      <option value="theme-love-notes-lipstick">Love Notes & Lipstick</option>
-      <option value="theme-rainbow">Rainbow</option>
+    <select id="themeSelector" onchange="setTheme(this.value)">
+      <option value="lipstick">Lipstick</option>
+      <option value="dark">Dark</option>
+      <option value="forest">Forest</option>
     </select>
   </div>
 

--- a/index.html
+++ b/index.html
@@ -73,10 +73,11 @@
     <h1 class="tk-title">Talk Kink</h1>
 
     <div class="tk-theme-selector">
-      <label for="theme">Select Theme:</label>
-      <select id="theme" onchange="changeTheme(this.value)">
+      <label for="themeSelector">Select Theme:</label>
+      <select id="themeSelector" onchange="setTheme(this.value)">
+        <option value="lipstick">Lipstick</option>
         <option value="dark" selected>Dark</option>
-        <option value="light">Light</option>
+        <option value="forest">Forest</option>
       </select>
     </div>
 
@@ -90,15 +91,16 @@
       window.location.href = "compatibility.html"; // Adjust path if needed
     }
 
-    function changeTheme(theme) {
-      localStorage.setItem('tk-theme', theme);
-      document.documentElement.setAttribute("data-theme", theme);
+    function setTheme(theme) {
+      document.body.className = '';
+      document.body.classList.add(`theme-${theme}`);
+      localStorage.setItem('theme', theme);
     }
 
     window.onload = () => {
-      const savedTheme = localStorage.getItem('tk-theme') || 'dark';
-      document.documentElement.setAttribute("data-theme", savedTheme);
-      const selector = document.getElementById('theme');
+      const savedTheme = localStorage.getItem('theme') || 'dark';
+      setTheme(savedTheme);
+      const selector = document.getElementById('themeSelector');
       if (selector) selector.value = savedTheme;
     };
   </script>

--- a/js/script.js
+++ b/js/script.js
@@ -1,6 +1,6 @@
 import { calculateCompatibility } from './compatibility.js';
 import { pruneSurvey } from './pruneSurvey.js';
-import { initTheme, applyThemeColors, applyPrintStyles } from './theme.js';
+import { initTheme, setTheme, applyPrintStyles } from './theme.js';
 
 // ================== Password Protection ==================
 const PASSWORD = 'toopoortosue';
@@ -432,7 +432,7 @@ function startNewSurvey() {
   if (mainNavButtons) mainNavButtons.style.display = 'none';
 
   if (themeSelector) {
-    applyThemeColors(themeSelector.value);
+    setTheme(themeSelector.value);
   }
 
   categoryOverlay.style.display = 'flex';
@@ -469,7 +469,7 @@ startSurveyBtn.addEventListener('click', () => {
   guidedMode = true;
   if (surveyIntro) surveyIntro.style.display = 'none';
   if (themeSelector) {
-    applyThemeColors(themeSelector.value);
+    setTheme(themeSelector.value);
   }
   startNewSurvey();
 });
@@ -506,7 +506,7 @@ if (deselectAllBtn) {
 
 beginSurveyBtn.addEventListener('click', () => {
   if (themeSelector) {
-    applyThemeColors(themeSelector.value);
+    setTheme(themeSelector.value);
   }
   categoryOrder = Array.from(previewList.querySelectorAll('input[type="checkbox"]'))
     .filter(cb => cb.checked)

--- a/js/theme.js
+++ b/js/theme.js
@@ -1,16 +1,21 @@
+export function setTheme(theme) {
+  document.body.className = '';
+  document.body.classList.add(`theme-${theme}`);
+  localStorage.setItem('theme', theme);
+  applyThemeColors(theme);
+}
+// Expose for inline handlers
+window.setTheme = setTheme;
+
 export function initTheme() {
   const themeSelector = document.getElementById('themeSelector');
-  const savedTheme =
-    localStorage.getItem('selectedTheme') || document.body.className || 'dark-mode';
-  document.body.className = savedTheme;
-  applyThemeColors(savedTheme);
+  const savedTheme = localStorage.getItem('theme') || 'dark';
+  setTheme(savedTheme);
   if (themeSelector) {
     themeSelector.value = savedTheme;
     themeSelector.addEventListener('change', () => {
       const selectedTheme = themeSelector.value;
-      document.body.className = selectedTheme;
-      localStorage.setItem('selectedTheme', selectedTheme);
-      applyThemeColors(selectedTheme);
+      setTheme(selectedTheme);
     });
   }
 }
@@ -19,6 +24,27 @@ export function applyThemeColors(theme) {
   const surveyContent = document.querySelector('#survey-section');
   const categoryPanel = document.querySelector('#categoryPanel');
   const themeStyles = {
+    dark: {
+      fontColor: '#f2f2f2',
+      bgColor: '#0d0d0d',
+      inputBg: '#1a1a1a',
+      inputText: '#f2f2f2',
+      borderColor: '#444'
+    },
+    lipstick: {
+      fontColor: '#fceaff',
+      bgColor: '#1a001f',
+      inputBg: '#300030',
+      inputText: '#fceaff',
+      borderColor: '#ff91f0'
+    },
+    forest: {
+      fontColor: '#1d3b1d',
+      bgColor: '#f0f7f1',
+      inputBg: '#e6f3ea',
+      inputText: '#1d3b1d',
+      borderColor: '#81b89b'
+    },
     'light-mode': {
       fontColor: '#111',
       bgColor: '#939e93',
@@ -71,7 +97,7 @@ export function applyThemeColors(theme) {
   };
 
   const normalized = (theme || '').toLowerCase().replace(/\s+/g, '-');
-  const selected = themeStyles[normalized] || themeStyles['dark-mode'];
+  const selected = themeStyles[normalized] || themeStyles['dark'];
 
   if (surveyContent) {
     surveyContent.style.color = selected.fontColor;

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -17,14 +17,10 @@
   <!-- Theme Selector -->
   <div id="themeControl">
     <label for="themeSelector">🎨 Select Theme:</label>
-    <select id="themeSelector">
-      <option value="dark-mode">Dark</option>
-      <option value="light-mode">Light Forest</option>
-      <option value="theme-blue">Blue</option>
-      <option value="theme-blue-sky">Blue Sky</option>
-      <option value="theme-echoes-beyond">Echoes Beyond</option>
-      <option value="theme-love-notes-lipstick">Love Notes & Lipstick</option>
-      <option value="theme-rainbow">Rainbow</option>
+    <select id="themeSelector" onchange="setTheme(this.value)">
+      <option value="lipstick">Lipstick</option>
+      <option value="dark">Dark</option>
+      <option value="forest">Forest</option>
     </select>
   </div>
 


### PR DESCRIPTION
## Summary
- simplify theme dropdown to Lipstick, Dark and Forest
- keep theme across pages using `setTheme` with localStorage
- integrate new color schemes in `theme.css`
- adjust scripts to use new theme API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688931a971a0832c999b17fc7fa26819