### PR TITLE
Add training plan page

### DIFF
--- a/training-plan.html
+++ b/training-plan.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>High-Level Training Plan</title>
+  <link rel="stylesheet" href="css/style.css" />
+  <link rel="stylesheet" href="css/theme.css" />
+</head>
+<body class="dark-mode">
+  <h1>Project Training Plan</h1>
+  <p>This outline helps new contributors get up to speed with the Talk Kink repository.</p>
+  <ol>
+    <li>Set up a local development environment by cloning the repo and running <code>setup.sh</code>.</li>
+    <li>Review the survey JSON templates and JavaScript modules under <code>template-survey.json</code> and <code>js/</code>.</li>
+    <li>Make incremental changes in feature branches and confirm that <code>npm test</code> passes before committing.</li>
+    <li>Document updates in the README and verify pages locally using a simple web server.</li>
+    <li>Open a pull request so changes can be reviewed and deployed to GitHub Pages.</li>
+  </ol>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `training-plan.html` describing steps for onboarding

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68893b96a3c4832cb6438be8ad351173