### PR TITLE
Improve theme selector functionality

### DIFF
--- a/data-tools.html
+++ b/data-tools.html
@@ -13,8 +13,8 @@
   <div id="themeControl">
     <label for="themeSelector">🎨 Select Theme:</label>
     <select id="themeSelector" onchange="setTheme(this.value)">
-      <option value="lipstick">Lipstick</option>
       <option value="dark">Dark</option>
+      <option value="lipstick">Lipstick</option>
       <option value="forest">Forest</option>
     </select>
   </div>

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Talk Kink</title>
+  <link rel="stylesheet" href="css/theme.css" />
   <style>
     /* Landing Page Wrapper */
     .tk-start-screen {
@@ -75,8 +76,8 @@
     <div class="tk-theme-selector">
       <label for="themeSelector">Select Theme:</label>
       <select id="themeSelector" onchange="setTheme(this.value)">
-        <option value="lipstick">Lipstick</option>
         <option value="dark" selected>Dark</option>
+        <option value="lipstick">Lipstick</option>
         <option value="forest">Forest</option>
       </select>
     </div>
@@ -86,23 +87,15 @@
     <button class="tk-start-button" onclick="startSurvey()">Start Survey</button>
   </div>
 
-  <script>
+  <script type="module">
+    import { initTheme } from './js/theme.js';
+
     function startSurvey() {
-      window.location.href = "compatibility.html"; // Adjust path if needed
+      window.location.href = 'compatibility.html';
     }
 
-    function setTheme(theme) {
-      document.body.className = '';
-      document.body.classList.add(`theme-${theme}`);
-      localStorage.setItem('theme', theme);
-    }
-
-    window.onload = () => {
-      const savedTheme = localStorage.getItem('theme') || 'dark';
-      setTheme(savedTheme);
-      const selector = document.getElementById('themeSelector');
-      if (selector) selector.value = savedTheme;
-    };
+    initTheme();
+    window.startSurvey = startSurvey;
   </script>
 
 </body>

--- a/js/theme.js
+++ b/js/theme.js
@@ -1,5 +1,14 @@
 export function setTheme(theme) {
-  document.body.className = '';
+  if (document.body.classList.contains('exporting')) {
+    localStorage.setItem('theme', theme);
+    return;
+  }
+
+  const current = Array.from(document.body.classList);
+  current
+    .filter(cls => cls.startsWith('theme-'))
+    .forEach(cls => document.body.classList.remove(cls));
+
   document.body.classList.add(`theme-${theme}`);
   localStorage.setItem('theme', theme);
   applyThemeColors(theme);

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -18,8 +18,8 @@
   <div id="themeControl">
     <label for="themeSelector">🎨 Select Theme:</label>
     <select id="themeSelector" onchange="setTheme(this.value)">
-      <option value="lipstick">Lipstick</option>
       <option value="dark">Dark</option>
+      <option value="lipstick">Lipstick</option>
       <option value="forest">Forest</option>
     </select>
   </div>


### PR DESCRIPTION
## Summary
- ensure theme changes skip PDF export
- reorder theme options so dark is default first
- apply theme JS on landing page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68893d50f1c0832cb6a21e4debe70fd9