### PR TITLE
Fix Start Survey link

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
     import { initTheme } from './js/theme.js';
 
     function startSurvey() {
-      window.location.href = 'compatibility.html';
+      window.location.href = 'kinks/';
     }
 
     initTheme();


### PR DESCRIPTION
## Summary
- direct the Start Survey button on the landing page to the survey interface

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68894685d1ec832c9c7bc75f44f7b906