### PR TITLE
Show category panel after starting survey

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
     import { initTheme } from './js/theme.js';
 
     function startSurvey() {
-      window.location.href = 'kinks/';
+      window.location.href = 'kinks/?start=1';
     }
 
     initTheme();

--- a/js/script.js
+++ b/js/script.js
@@ -987,7 +987,10 @@ function init() {
   if (saved) {
     initializeSurvey(saved);
   }
-  startNewSurvey();
+  const params = new URLSearchParams(window.location.search);
+  if (params.has('start')) {
+    startNewSurvey();
+  }
 }
 
 if (document.readyState !== 'loading') {


### PR DESCRIPTION
## Summary
- redirect to kinks page with `?start=1` when starting survey
- only call `startNewSurvey()` when `?start=1` is present

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68894c2fc618832c9f0730695ba9dce4