### PR TITLE
Add theme panel styles and mascot header

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -70,12 +70,19 @@ body {
   width: 220px;
   background-color: var(--panel-color);
   border-right: 2px solid #444;
-  padding: 15px;
+  padding: 10px;
   height: 100vh;
   overflow-y: auto;
   z-index: 200;
   display: none; /* hidden until a survey loads */
-  transition: left 0.3s ease, width 0.3s ease;
+  border-radius: 10px;
+  margin-bottom: 10px;
+  transition: all 0.3s ease;
+}
+
+.category-panel:focus-within {
+  outline: 2px dashed #ff005b;
+  outline-offset: 4px;
 }
 
 #roleDefinitionsPanel {
@@ -336,6 +343,33 @@ body.theme-rainbow .category-panel {
   background-color: #fff;
   color: #000;
   border-right-color: #603636;
+}
+body.theme-dark .category-panel {
+  border: 2px solid #3fff9c;
+  background-color: rgba(255, 255, 255, 0.03);
+  box-shadow: 0 0 8px rgba(63, 255, 156, 0.2);
+}
+body.theme-dark .category-panel:hover {
+  box-shadow: 0 0 12px rgba(63, 255, 156, 0.4);
+  background-color: rgba(255, 255, 255, 0.06);
+}
+body.theme-forest .category-panel {
+  border: 2px solid #8dd17e;
+  background-color: rgba(141, 209, 126, 0.05);
+  box-shadow: 0 0 8px rgba(141, 209, 126, 0.15);
+}
+body.theme-forest .category-panel:hover {
+  box-shadow: 0 0 12px rgba(141, 209, 126, 0.35);
+  background-color: rgba(141, 209, 126, 0.08);
+}
+body.theme-lipstick .category-panel {
+  border: 2px solid #ff005b;
+  background-color: rgba(255, 0, 91, 0.04);
+  box-shadow: 0 0 8px rgba(255, 0, 91, 0.25);
+}
+body.theme-lipstick .category-panel:hover {
+  box-shadow: 0 0 12px rgba(255, 0, 91, 0.4);
+  background-color: rgba(255, 0, 91, 0.07);
 }
 
 /* === CATEGORY BOX BORDER PER THEME (WEB ONLY) === */
@@ -727,6 +761,22 @@ body.theme-rainbow #comparisonResult {
   font-weight: bold;
   margin: 0 0 16px;
   color: var(--text-color, #2c442e);
+}
+
+#category-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+#duck-mascot {
+  display: inline-block;
+  width: 48px;
+  height: 48px;
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center;
 }
 
 

--- a/data-tools.html
+++ b/data-tools.html
@@ -8,7 +8,10 @@
   <link rel="stylesheet" href="css/theme.css" />
 </head>
 <body class="dark-mode">
-  <h1>What would you like to do next?</h1>
+  <div id="category-header">
+    <div id="duck-mascot"></div>
+    <h1>What would you like to do next?</h1>
+  </div>
 
   <div id="themeControl">
     <label for="themeSelector">🎨 Select Theme:</label>

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -169,7 +169,10 @@
   <!-- Category Selection Panel -->
   <div id="categoryOverlay" class="overlay category-sidebar" style="display:none">
     <div id="categoryPanel">
-      <h3>Select the categories you want to include:</h3>
+      <div id="category-header">
+        <div id="duck-mascot"></div>
+        <h3>Select the categories you want to include:</h3>
+      </div>
       <div class="category-controls">
         <button id="selectAllBtn" class="select-btn">Select All</button>
         <button id="deselectAllBtn" class="select-btn">Deselect All</button>


### PR DESCRIPTION
## Summary
- style category panels per theme (dark, forest, lipstick)
- tweak base `.category-panel` styling and focus outline
- add layout styles for a duck mascot header element
- display the new header with mascot in `data-tools.html` and `kinks/index.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889579a6830832cbed5ac7c5e9b245b