### PR TITLE
Fix template path for nested pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ The website is built from the following files in this repository:
 - `js/script.js`
 - `template-survey.json`
 
-The **Start New Survey** button fetches `template-survey.json` when the page is
-served over HTTP so you always start with a fresh set of kinks. If you open
-`index.html` directly from your file system, the script falls back to an
-embedded copy of the template.
+The **Start New Survey** button fetches `../template-survey.json` so nested
+pages like `/kinks/` load the template correctly. If you open the pages
+directly from your file system, the script falls back to an embedded copy of
+the template.
 
 Running a local web server is still recommended while developing so the latest
 JSON is loaded and all paths behave consistently. See below for quick server

--- a/js/script.js
+++ b/js/script.js
@@ -443,7 +443,7 @@ function startNewSurvey() {
   const initialize = data => initializeSurvey(data);
 
   if (location.protocol.startsWith('http')) {
-    fetch('template-survey.json', { cache: 'no-store' })
+    fetch('../template-survey.json', { cache: 'no-store' })
       .then(res => res.json())
       .then(data => {
         window.templateSurvey = normalizeSurveyFormat(data);


### PR DESCRIPTION
## Summary
- load `template-survey.json` from the site root so `/kinks/` works
- document the new fetch path in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68896ef7cee8832c82e92e6a095a47a4