### PR TITLE
Add villain panel under compatibility button

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -721,6 +721,36 @@ body.theme-rainbow #comparisonResult {
   box-shadow: 0 0 12px rgba(0, 0, 0, 0.8);
 }
 
+/* General villain panel styling used outside the intro overlay */
+.villain-panel {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  margin-top: 2rem;
+  padding: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.villain-image {
+  max-width: 240px;
+  border-radius: 12px;
+  box-shadow: 0 0 12px rgba(0, 0, 0, 0.7);
+}
+
+.villain-quote {
+  font-family: 'UnifrakturCook', cursive;
+  font-size: 1.6rem;
+  color: var(--accent-text, #ff4dd2);
+  border: 2px solid currentColor;
+  padding: 1rem;
+  max-width: 500px;
+  background-color: rgba(0, 0, 0, 0.6);
+  border-radius: 12px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.8);
+  text-align: center;
+}
+
 /* Overlay displayed for password entry */
 #passwordOverlay {
   position: fixed;

--- a/css/theme.css
+++ b/css/theme.css
@@ -85,6 +85,7 @@
   --bg-color: #0d0d0d;
   --text-color: #f2f2f2;
   --accent-color: #333;
+  --accent-text: #dddddd;
   --button-bg: #1a1a1a;
   --button-text: #f2f2f2;
   --border-color: #444;
@@ -98,6 +99,7 @@
   --bg-color: #1a001f;
   --text-color: #fceaff;
   --accent-color: #ff4ecb;
+  --accent-text: #ff4dd2;
   --highlight-color: #a200ff;
   --button-bg: #ff4ecb;
   --button-text: #1a001f;
@@ -112,6 +114,7 @@
   --bg-color: #f0f7f1;
   --text-color: #1d3b1d;
   --accent-color: #3d6651;
+  --accent-text: #8be49e;
   --button-bg: #a6d5b5;
   --button-text: #1d3b1d;
   --border-color: #81b89b;

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -197,6 +197,14 @@
     <button id="compatibilityBtn" class="survey-button" onclick="location.href='../compatibility.html'">See Our Compatibility</button>
   </div>
 
+  <!-- Villain Panel: Goes under the "See Our Compatibility" button -->
+  <div class="villain-panel">
+    <img src="../ChangeBL.png" alt="Villain Image" class="villain-image" />
+    <div class="villain-quote">
+      “They swear I’m the villain, but all I did was survive the exile—this cold, blackened heart forged in the hush they tried to make me swallow.”
+    </div>
+  </div>
+
   <!-- Script -->
   <script src="../js/template-survey.js"></script>
   <script type="module" src="../js/script.js"></script>


### PR DESCRIPTION
## Summary
- add villain panel to the kinks index page
- style villain panel globally in CSS
- expose `--accent-text` variable for dark, lipstick, and forest themes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889718db3e4832cb32f8ada75edab6f