### PR TITLE
Skip intro overlay on Start Survey

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
     import { initTheme } from './js/theme.js';
 
     function startSurvey() {
-      window.location.href = 'kinks/';
+      window.location.href = 'kinks/?start=1';
     }
 
     initTheme();

--- a/js/script.js
+++ b/js/script.js
@@ -426,6 +426,7 @@ if (roleDefinitionsOverlay) roleDefinitionsOverlay.addEventListener('click', hid
 
 function startNewSurvey() {
   guidedMode = true;
+  if (surveyIntro) surveyIntro.style.display = 'none';
   if (newSurveyBtn) newSurveyBtn.style.display = 'none';
   if (downloadBtn) downloadBtn.style.display = 'none';
   if (homeBtn) homeBtn.style.display = 'block';


### PR DESCRIPTION
## Summary
- link main Start Survey button to `kinks/?start=1`
- hide the intro overlay automatically when starting a new survey

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889750cc004832cadfb35f538fb9fc6