### PR TITLE
Fix villain quote block styles

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,3 +1,4 @@
+@import url('https://fonts.googleapis.com/css2?family=Fredoka+One&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=UnifrakturCook:wght@700&display=swap');
 
 /* Base Page Layout */
@@ -749,6 +750,17 @@ body.theme-rainbow #comparisonResult {
   border-radius: 12px;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.8);
   text-align: center;
+}
+
+/* Dedicated block for villain quotes displayed on pages */
+.villain-block {
+  display: flex;
+  justify-content: center;
+  margin-top: 2rem;
+}
+
+.villain-block .villain-quote {
+  border: 2px solid var(--accent-text, #ff66b2);
 }
 
 /* Overlay displayed for password entry */

--- a/css/theme.css
+++ b/css/theme.css
@@ -144,6 +144,21 @@ body.theme-dark .card {
   border: 1px solid var(--border-color);
 }
 
+.theme-lipstick .villain-block .villain-quote {
+  color: #ff4da6;
+  border-color: #ff4da6;
+}
+
+.theme-dark .villain-block .villain-quote {
+  color: #ffffff;
+  border-color: #666666;
+}
+
+.theme-forest .villain-block .villain-quote {
+  color: #a8ff8a;
+  border-color: #a8ff8a;
+}
+
 body.theme-lipstick {
   background-color: var(--bg-color);
   color: var(--text-color);

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -198,10 +198,12 @@
   </div>
 
   <!-- Villain Panel: Goes under the "See Our Compatibility" button -->
-  <div class="villain-panel">
-    <img src="../BLChange.png" alt="Villain Image" class="villain-image" />
-    <div class="villain-quote">
-      “They swear I’m the villain, but all I did was survive the exile—this cold, blackened heart forged in the hush they tried to make me swallow.”
+  <div class="villain-block no-print">
+    <div class="villain-panel">
+      <img src="../BLChange.png" alt="Villain Image" class="villain-image" />
+      <div class="villain-quote">
+        “They swear I’m the villain, but all I did was survive the exile—this cold, blackened heart forged in the hush they tried to make me swallow.”
+      </div>
     </div>
   </div>
 

--- a/villain-quote.html
+++ b/villain-quote.html
@@ -51,10 +51,12 @@
   </style>
 </head>
 <body class="theme-lipstick">
-  <div class="villain-panel">
-    <img src="BLChange.png" alt="Villain Image" class="villain-image" />
-    <div class="villain-quote">
-      “They swear I’m the villain, but all I did was survive the exile—this cold, blackened heart forged in the hush they tried to make me swallow.”
+  <div class="villain-block no-print">
+    <div class="villain-panel">
+      <img src="BLChange.png" alt="Villain Image" class="villain-image" />
+      <div class="villain-quote">
+        “They swear I’m the villain, but all I did was survive the exile—this cold, blackened heart forged in the hush they tried to make me swallow.”
+      </div>
     </div>
   </div>
 </body>


### PR DESCRIPTION
## Summary
- load Fredoka One font
- add `.villain-block` container styles
- override themed colors for villain quote blocks
- exclude villain quote from print and wrap in `.villain-block`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688985b121c8832cb5e6131ac91897ef