### PR TITLE
Adjust fonts to match category heading

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,5 +1,4 @@
 @import url('https://fonts.googleapis.com/css2?family=Fredoka+One&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=UnifrakturCook:wght@700&display=swap');
 
 /* Base Page Layout */
 body {
@@ -711,7 +710,7 @@ body.theme-rainbow #comparisonResult {
 }
 
 #surveyIntro .villain-quote {
-  font-family: 'UnifrakturCook', cursive;
+  font-family: 'Inter', 'Open Sans', system-ui, sans-serif;
   font-size: 1.4rem;
   color: var(--accent-text, #ff4dd2);
   border: 2px solid currentColor;
@@ -740,7 +739,7 @@ body.theme-rainbow #comparisonResult {
 }
 
 .villain-quote {
-  font-family: 'UnifrakturCook', cursive;
+  font-family: 'Inter', 'Open Sans', system-ui, sans-serif;
   font-size: 1.6rem;
   color: var(--accent-text, #ff4dd2);
   border: 2px solid currentColor;

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
       justify-content: center;
       align-items: center;
       text-align: center;
-      font-family: system-ui, sans-serif;
+      font-family: 'Inter', 'Open Sans', system-ui, sans-serif;
       padding: 40px 20px;
     }
 

--- a/villain-quote.html
+++ b/villain-quote.html
@@ -6,7 +6,7 @@
   <title>Villain Quote</title>
   <link rel="stylesheet" href="css/theme.css">
   <style>
-    @import url('https://fonts.googleapis.com/css2?family=UnifrakturCook:wght@700&display=swap');
+    @import url('https://fonts.googleapis.com/css2?family=Inter&display=swap');
     .villain-panel {
       display: flex;
       align-items: center;
@@ -23,7 +23,7 @@
       box-shadow: 0 0 10px rgba(0,0,0,0.6);
     }
     .villain-quote {
-      font-family: 'UnifrakturCook', cursive;
+      font-family: 'Inter', 'Open Sans', system-ui, sans-serif;
       font-size: 1.6rem;
       color: var(--accent-text, #ff4dd2); /* fallback if theme variable not set */
       border: 2px solid currentColor;


### PR DESCRIPTION
## Summary
- remove old villain font import
- use Inter font for villain quotes
- apply Inter font on landing page
- adjust villain quote page styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6889879f2d14832cb59998a1f6cdf29d