### PR TITLE
Sort category list alphabetically

### DIFF
--- a/js/compatibility.js
+++ b/js/compatibility.js
@@ -1,5 +1,5 @@
 export function calculateCompatibility(surveyA, surveyB) {
-  const categories = Object.keys(surveyA);
+  const categories = Object.keys(surveyA).sort((a, b) => a.localeCompare(b));
   let totalScore = 0;
   let count = 0;
   let redFlags = [];

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -210,7 +210,7 @@ function mergeSurveyWithTemplate(survey, template) {
 
 function buildKinkBreakdown(surveyA, surveyB) {
   const breakdown = {};
-  const categories = Object.keys(surveyA);
+  const categories = Object.keys(surveyA).sort((a, b) => a.localeCompare(b));
   categories.forEach(category => {
     if (!surveyB[category]) return;
     const catA = surveyA[category];

--- a/js/pruneSurvey.js
+++ b/js/pruneSurvey.js
@@ -2,7 +2,9 @@ export function pruneSurvey(survey) {
   const result = {};
   if (!survey || typeof survey !== 'object') return result;
 
-  for (const [category, data] of Object.entries(survey)) {
+  const sortedCategories = Object.keys(survey).sort((a, b) => a.localeCompare(b));
+  for (const category of sortedCategories) {
+    const data = survey[category];
     const cat = {};
     ['Giving', 'Receiving', 'General'].forEach(role => {
       const items = Array.isArray(data[role]) ? data[role] : [];

--- a/js/script.js
+++ b/js/script.js
@@ -359,7 +359,8 @@ function initializeSurvey(data) {
   filterGeneralOptions(surveyA);
   updateTabsForCategory();
   previewList.innerHTML = '';
-  Object.keys(surveyA).forEach(cat => {
+  const categoryNames = Object.keys(surveyA).sort((a, b) => a.localeCompare(b));
+  categoryNames.forEach(cat => {
     const label = document.createElement('label');
     label.className = 'checkbox-item';
     const cb = document.createElement('input');
@@ -557,7 +558,7 @@ function loadSurveyAFile(file) {
       filterGeneralOptions(surveyA);
       updateTabsForCategory();
       if (guidedMode) {
-        categoryOrder = Object.keys(surveyA);
+        categoryOrder = Object.keys(surveyA).sort((a, b) => a.localeCompare(b));
         categoryIndex = 0;
         currentCategory = categoryOrder[0] || null;
         if (currentCategory) {
@@ -614,7 +615,7 @@ if (fileBInput) {
 
 function showCategories() {
   if (!surveyA) return [];
-  return Object.keys(surveyA);
+  return Object.keys(surveyA).sort((a, b) => a.localeCompare(b));
 }
 
 function showKinks(category) {


### PR DESCRIPTION
## Summary
- sort categories alphabetically when the survey is initialized
- keep alphabetical order when loading a survey file or listing categories
- maintain sorted categories in compatibility calculations and survey export

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a50561f90832c9342f74dc1f5546e