### PR TITLE
feat: align villain image and quote under compatibility button with theme styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -732,7 +732,8 @@ body.theme-rainbow #comparisonResult {
   flex-wrap: wrap;
 }
 
-.villain-image {
+.villain-image,
+.villain-img {
   max-width: 240px;
   border-radius: 12px;
   box-shadow: 0 0 12px rgba(0, 0, 0, 0.7);

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -198,13 +198,13 @@
   </div>
 
   <!-- Villain Panel: Goes under the "See Our Compatibility" button -->
-  <div class="villain-block no-print">
-    <div class="villain-panel">
-      <img src="../BLChange.png" alt="Villain Image" class="villain-image" />
-      <div class="villain-quote">
-        “They swear I’m the villain, but all I did was survive the exile—this cold, blackened heart forged in the hush they tried to make me swallow.”
-      </div>
+  <div class="villain-panel no-print">
+    <div class="villain-quote">
+      “They swear I’m the villain, but all I did was survive the exile—<br>
+      this cold, blackened heart forged in the hush<br>
+      they tried to make me swallow.”
     </div>
+    <img src="/BLChange.png" alt="Villain Mascot" class="villain-img" />
   </div>
 
   <!-- Script -->


### PR DESCRIPTION
## Summary
- revise bottom villain panel on `/kinks/` page to align image and quote
- update path for villain image and insert line breaks in quote
- style `.villain-img` alongside existing `.villain-image` style

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688a638920b4832c803c6d60eea9bc01