### PR TITLE
Apply Fredoka font to page titles and compatibility buttons

### DIFF
--- a/basic-survey.html
+++ b/basic-survey.html
@@ -126,7 +126,7 @@
   <div class="button-group" id="mainButtons">
     <button onclick="startSurvey()">Start New Survey</button>
     <button onclick="exportList()">Export My List</button>
-    <button onclick="seeCompatibility()">See Our Compatibility</button>
+    <button class="compatibility-button" onclick="seeCompatibility()">See Our Compatibility</button>
   </div>
 
   <script>

--- a/css/style.css
+++ b/css/style.css
@@ -409,6 +409,7 @@ body.theme-forest:not(.exporting) .category-box {
 
 /* Header */
 h1 {
+  font-family: 'Fredoka One', cursive;
   text-align: center;
   margin-bottom: 30px;
 }
@@ -1221,6 +1222,7 @@ body.light-mode .static-rating-legend {
 }
 
 .compatibility-button {
+  font-family: 'Fredoka One', cursive;
   width: 260px;
   height: 50px;
   font-size: 16px;

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -230,7 +230,7 @@
 
   <!-- Buttons -->
   <div class="menu-container">
-    <button id="compatibilityBtn" class="survey-button" onclick="location.href='../compatibility.html'">See Our Compatibility</button>
+    <button id="compatibilityBtn" class="survey-button compatibility-button" onclick="location.href='../compatibility.html'">See Our Compatibility</button>
   </div>
 
   <!-- BL Change mascot below compatibility button -->


### PR DESCRIPTION
## Summary
- use the Fredoka One font for all `<h1>` elements
- style `.compatibility-button` with the brand font
- mark compatibility buttons in pages so they use the new style

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688af4af8b24832c89919cdb2f6e4c60