### PR TITLE
Add themed header and styling on kinks page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -35,7 +35,8 @@ body {
   border-radius: 10px;
   padding: 16px;
   margin-bottom: 16px;
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  border: 1px solid var(--accent-text, rgba(255, 255, 255, 0.2));
+  color: var(--accent-text);
 }
 
 .bar-label,

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -7,13 +7,6 @@
   <link rel="stylesheet" href="../css/style.css" />
   <link rel="stylesheet" href="../css/theme.css" />
   <style>
-  .villain-quote-box {
-    display: flex;
-    justify-content: center;
-    margin-top: 1rem;
-    margin-bottom: 2rem;
-  }
-
   .villain-quote {
     font-size: 1.15rem;
     text-align: center;
@@ -40,6 +33,48 @@
     --villain-font: 'Fredoka One';
   }
 
+  /* New themed elements */
+  .top-section {
+    text-align: center;
+    margin-top: 1rem;
+  }
+
+  .themed-header {
+    font-family: 'Fredoka One', sans-serif;
+    font-size: 3.2rem;
+    color: var(--accent-text);
+    display: inline-block;
+    padding: 0.4rem 1.2rem;
+    border: 2px solid var(--accent-text);
+    border-radius: 10px;
+    background-color: rgba(0, 0, 0, 0.2);
+    box-shadow: 0 0 10px var(--accent-text);
+  }
+
+  .themed-button {
+    background: transparent;
+    color: var(--accent-text);
+    border: 2px solid var(--accent-text);
+    padding: 8px 16px;
+    border-radius: 6px;
+    font-weight: bold;
+    cursor: pointer;
+  }
+
+  .themed-button:hover {
+    background: var(--accent-text);
+    color: var(--bg-color);
+  }
+
+  .themed-border {
+    border: 2px solid var(--accent-text);
+    color: var(--accent-text);
+  }
+
+  .themed-font {
+    font-family: 'Fredoka One', sans-serif;
+  }
+
   @media print {
     .no-print {
       display: none !important;
@@ -56,7 +91,7 @@
     </div>
   </div>
 
-  <h1 class="talk-kink-title no-print">Talk Kink</h1>
+  <!-- Moved header into themed top section below -->
 
   <!-- Instruction banner and theme selector removed -->
 
@@ -229,17 +264,14 @@
     </div>
   </div>
 
-  <!-- Buttons -->
-  <div class="menu-container">
-    <button id="compatibilityBtn" class="survey-button compatibility-button" onclick="location.href='../compatibility.html'">See Our Compatibility</button>
+  <div class="top-section no-print">
+    <h1 class="themed-header">Talk Kink</h1>
   </div>
 
-  <!-- BL Change mascot below compatibility button -->
-  <div class="no-print" style="text-align:center; margin-top:1.5rem;">
-    <img src="../assets/images/BLChange.png" alt="BL Change" class="villain-img" />
-  </div>
-  <div class="villain-quote-box no-print">
-    <div class="villain-quote">
+  <div class="villain-block no-print">
+    <button id="compatibilityBtn" class="see-compatibility themed-button" onclick="location.href='../compatibility.html'">See Our Compatibility</button>
+    <img src="../assets/images/BLChange.png" alt="Villain Mascot" class="villain-image" />
+    <div class="villain-quote themed-border themed-font">
       “They swear I’m the villain, but all I did was survive the exile—<br>
       this cold, blackened heart forged in the hush<br>
       they tried to make me swallow.”


### PR DESCRIPTION
## Summary
- add themed header structure with compatibility button on `kinks` page
- match fonts and borders to accent color
- style category blocks with theme accent color

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688afe390c44832c8a9e8b205f0df73b