### PR TITLE
Restore stacking for villain layout

### DIFF
--- a/basic-survey.html
+++ b/basic-survey.html
@@ -129,6 +129,15 @@
     <button class="compatibility-button" onclick="seeCompatibility()">See Our Compatibility</button>
   </div>
 
+  <div class="villain-block no-print">
+    <img src="assets/images/BLChange.png" alt="Villain Mascot" class="villain-image" />
+    <div class="villain-quote">
+      “They swear I’m the villain, but all I did was survive the exile—<br>
+      this cold, blackened heart forged in the hush<br>
+      they tried to make me swallow.”
+    </div>
+  </div>
+
   <script>
     let currentCategory = 0;
     const totalCategories = 28;

--- a/css/style.css
+++ b/css/style.css
@@ -62,6 +62,7 @@ body {
   --bg-color: #0f0f0f;
   --panel-color: #000;
   --text-color: #f0f0f0;
+  --accent-text: #00ff99; /* fallback default for dark mode */
   --button-bg: #444;
   --button-text: #ffffff;
   --button-hover-bg: #666;


### PR DESCRIPTION
## Summary
- define `--accent-text` in the base CSS variables
- show the villain image and quote below the compatibility button on the basic survey page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688baca2b894832cb195a0283de24751