### PR TITLE
Fix layout for villain section on /kinks page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -769,6 +769,15 @@ body.theme-rainbow #comparisonResult {
   width: 100%;
 }
 
+.center-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
 .villain-block .villain-quote {
   border: 2px solid var(--accent-text);
   max-width: 500px;

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -80,9 +80,6 @@
           <button id="returnHomeBtn">Return Home</button>
         </div>
 
-        <div class="button-group" id="mainButtons">
-          <button class="compatibility-button" onclick="seeCompatibility()">See Our Compatibility</button>
-        </div>
     </div>
   </div>
 
@@ -211,8 +208,11 @@
     <h1 class="themed-header">Talk Kink</h1>
   </div>
 
-  <div class="villain-block no-print">
+  <div class="center-stack no-print">
+    <button class="themed-button" onclick="seeCompatibility()">See Our Compatibility</button>
+
     <img src="/assets/images/BLChange.png" alt="Villain Mascot" class="villain-image" />
+
     <div class="villain-quote">
       “They swear I’m the villain, but all I did was survive the exile—<br>
       this cold, blackened heart forged in the hush<br>


### PR DESCRIPTION
## Summary
- realign the villain section on `kinks/index.html`
- add a new `.center-stack` utility class
- move the compatibility button under the header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bb97339cc832c8e6a7e715ddf4674