### PR TITLE
Update accent colors and center villain layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -62,7 +62,7 @@ body {
   --bg-color: #0f0f0f;
   --panel-color: #000;
   --text-color: #f0f0f0;
-  --accent-text: #00ff99; /* fallback default for dark mode */
+  --accent-text: #00ffff; /* fallback default for dark mode */
   --button-bg: #444;
   --button-text: #ffffff;
   --button-hover-bg: #666;
@@ -738,7 +738,7 @@ body.theme-rainbow #comparisonResult {
 
 .villain-image,
 .villain-img {
-  width: 160px;
+  width: 180px;
   max-width: 90%;
   height: auto;
   margin-bottom: 1rem;
@@ -756,6 +756,7 @@ body.theme-rainbow #comparisonResult {
   max-width: 500px;
   text-align: center;
   line-height: 1.5;
+  background-color: rgba(0, 0, 0, 0.4);
 }
 
 /* Dedicated block for villain quotes displayed on pages */
@@ -765,7 +766,7 @@ body.theme-rainbow #comparisonResult {
   align-items: center;
   justify-content: center;
   margin-top: 1.5rem;
-  gap: 1rem;
+  gap: 1.2rem;
   width: 100%;
 }
 
@@ -774,7 +775,7 @@ body.theme-rainbow #comparisonResult {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 1rem;
+  gap: 1.2rem;
   margin-top: 1.5rem;
 }
 
@@ -785,6 +786,7 @@ body.theme-rainbow #comparisonResult {
   font-size: 1.2rem;
   text-align: center;
   line-height: 1.5;
+  background-color: rgba(0, 0, 0, 0.4);
 }
 
 .villain-toggle-btn {
@@ -1238,19 +1240,21 @@ body.light-mode .static-rating-legend {
   height: 50px;
   font-size: 16px;
   font-weight: bold;
-  border: none;
   border-radius: 6px;
-  background-color: #444;
-  color: white;
+  background: transparent;
+  border: 2px solid var(--accent-text);
+  color: var(--accent-text);
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
   text-align: center;
+  transition: all 0.3s ease;
 }
 
 .compatibility-button:hover {
-  background-color: #666;
+  background: var(--accent-text);
+  color: #000;
 }
 
 .file-upload input[type="file"] {
@@ -1751,7 +1755,7 @@ body {
 #cr-results-container h2 {
   font-size: 20px;
   margin-bottom: 10px;
-  color: #00ff99;
+  color: var(--accent-text);
   text-align: center;
 }
 
@@ -3076,20 +3080,20 @@ body {
 
 /* === Theme-Compatible Elements for /kinks/ page === */
 :root {
-  --accent-text: #00ff99; /* default (dark) */
+  --accent-text: #00ffff; /* fallback: neon blue */
 }
 
 /* Theme-specific overrides */
 .theme-dark {
-  --accent-text: #00ff99;
+  --accent-text: #00ffff; /* neon blue */
 }
 
 .theme-forest {
-  --accent-text: #66ff66;
+  --accent-text: #228B22; /* forest green */
 }
 
 .theme-lipstick {
-  --accent-text: #ff3399;
+  --accent-text: #ff3399; /* hot pink */
 }
 
 /* MAIN TALK KINK HEADER */
@@ -3099,7 +3103,7 @@ body {
   text-align: center;
   color: var(--accent-text);
   margin-top: 2rem;
-  margin-bottom: 2rem;
+  margin-bottom: 1rem;
 }
 
 .themed-button {
@@ -3141,6 +3145,7 @@ body {
   max-width: 500px;
   text-align: center;
   line-height: 1.5;
+  background-color: rgba(0, 0, 0, 0.4);
 }
 
 .villain-image {
@@ -3154,7 +3159,7 @@ body {
   align-items: center;
   justify-content: center;
   margin-top: 1.5rem;
-  gap: 1rem;
+  gap: 1.2rem;
   width: 100%;
 }
 

--- a/css/theme.css
+++ b/css/theme.css
@@ -2,7 +2,7 @@
   --bg-color: #0f0f0f;
   --panel-color: #000;
   --text-color: #f0f0f0;
-  --accent-text: #00ff99;
+  --accent-text: #00ffff;
   --button-bg: #444;
   --button-text: #ffffff;
   --button-hover-bg: #666;
@@ -86,7 +86,7 @@
   --bg-color: #0d0d0d;
   --text-color: #f2f2f2;
   --accent-color: #333;
-  --accent-text: #00ff99;
+  --accent-text: #00ffff;
   --button-bg: #1a1a1a;
   --button-text: #f2f2f2;
   --border-color: #444;
@@ -115,7 +115,7 @@
   --bg-color: #f0f7f1;
   --text-color: #1d3b1d;
   --accent-color: #3d6651;
-  --accent-text: #66ff66;
+  --accent-text: #228B22;
   --button-bg: #a6d5b5;
   --button-text: #1d3b1d;
   --border-color: #81b89b;

--- a/villain-quote.html
+++ b/villain-quote.html
@@ -13,7 +13,7 @@
 
   <button class="themed-button no-print">See Our Compatibility</button>
 
-  <div class="villain-block no-print">
+  <div class="center-stack no-print">
     <img src="/assets/images/BLChange.png" alt="Villain Mascot" class="villain-image" />
     <div class="villain-quote">
       “They swear I’m the villain, but all I did was survive the exile—<br />


### PR DESCRIPTION
## Summary
- tweak accent color variables for dark, forest and lipstick themes
- refine themed button styles and villain quote layout
- convert villain quote demo to use `center-stack`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bbdcb8f5c832c953a0008f120462a