### PR TITLE
Enhance dark theme accent and buttons

### DIFF
--- a/basic-survey.html
+++ b/basic-survey.html
@@ -126,7 +126,7 @@
   <div class="button-group" id="mainButtons">
     <button onclick="startSurvey()">Start New Survey</button>
     <button onclick="exportList()">Export My List</button>
-    <button class="compatibility-button" onclick="seeCompatibility()">See Our Compatibility</button>
+    <button class="themed-button" onclick="seeCompatibility()">See Our Compatibility</button>
   </div>
 
   <div class="villain-block no-print">

--- a/compatibility.html
+++ b/compatibility.html
@@ -89,7 +89,7 @@
 </head>
 <body class="dark-mode">
   <div class="scroll-container scrollable-panel">
-    <h1>See Our Compatibility</h1>
+    <h1 class="themed-header">See Our Compatibility</h1>
     <div class="back-button-container">
       <button onclick="window.location.href='https://www.talkkink.org'">&larr; Back</button>
     </div>

--- a/css/style.css
+++ b/css/style.css
@@ -62,7 +62,7 @@ body {
   --bg-color: #0f0f0f;
   --panel-color: #000;
   --text-color: #f0f0f0;
-  --accent-text: #00ffff; /* fallback default for dark mode */
+  --accent-text: #00bfff; /* fallback default for dark mode */
   --button-bg: #444;
   --button-text: #ffffff;
   --button-hover-bg: #666;
@@ -3085,7 +3085,7 @@ body {
 
 /* Theme-specific overrides */
 .theme-dark {
-  --accent-text: #00ffff; /* neon blue */
+  --accent-text: #00bfff; /* deep electric blue */
 }
 
 .theme-forest {
@@ -3106,7 +3106,8 @@ body {
   margin-bottom: 1rem;
 }
 
-.themed-button {
+.themed-button,
+.select-toggle-button {
   background: transparent;
   border: 2px solid var(--accent-text);
   color: var(--accent-text);
@@ -3115,9 +3116,11 @@ body {
   font-family: 'Fredoka One', sans-serif;
   border-radius: 8px;
   transition: all 0.3s ease;
+  margin: 0.2rem;
 }
 
-.themed-button:hover {
+.themed-button:hover,
+.select-toggle-button:hover {
   background: var(--accent-text);
   color: #000;
 }

--- a/css/theme.css
+++ b/css/theme.css
@@ -2,7 +2,7 @@
   --bg-color: #0f0f0f;
   --panel-color: #000;
   --text-color: #f0f0f0;
-  --accent-text: #00ffff;
+  --accent-text: #00bfff; /* deep electric blue */
   --button-bg: #444;
   --button-text: #ffffff;
   --button-hover-bg: #666;
@@ -86,7 +86,7 @@
   --bg-color: #0d0d0d;
   --text-color: #f2f2f2;
   --accent-color: #333;
-  --accent-text: #00ffff;
+  --accent-text: #00bfff; /* deep electric blue */
   --button-bg: #1a1a1a;
   --button-text: #f2f2f2;
   --border-color: #444;

--- a/index.html
+++ b/index.html
@@ -195,8 +195,8 @@
         <h3>Select the categories you want to include:</h3>
       </div>
       <div class="category-controls">
-        <button id="selectAllBtn" class="select-btn">Select All</button>
-        <button id="deselectAllBtn" class="select-btn">Deselect All</button>
+        <button id="selectAllBtn" class="select-toggle-button">Select All</button>
+        <button id="deselectAllBtn" class="select-toggle-button">Deselect All</button>
       </div>
       <div id="previewList" class="category-list scrollable-panel"></div>
       <button id="beginSurveyBtn" class="start-btn">Begin Survey</button>

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -196,8 +196,8 @@
         <h3>Select the categories you want to include:</h3>
       </div>
       <div class="category-controls">
-        <button id="selectAllBtn" class="select-btn">Select All</button>
-        <button id="deselectAllBtn" class="select-btn">Deselect All</button>
+        <button id="selectAllBtn" class="select-toggle-button">Select All</button>
+        <button id="deselectAllBtn" class="select-toggle-button">Deselect All</button>
       </div>
       <div id="previewList" class="category-list scrollable-panel"></div>
       <button id="beginSurveyBtn" class="start-btn">Begin Survey</button>


### PR DESCRIPTION
## Summary
- tweak dark theme accent color
- style select all/deselect all buttons to match accent
- color compatibility header with accent styling
- update fallback accent color and compatibility button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bc0abc8d8832c90c585a147689290