### PR TITLE
Revert layout changes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -62,7 +62,7 @@ body {
   --bg-color: #0f0f0f;
   --panel-color: #000;
   --text-color: #f0f0f0;
-  --accent-text: #00bfff; /* fallback default for dark mode */
+  --accent-text: #00ff99; /* fallback default for dark mode */
   --button-bg: #444;
   --button-text: #ffffff;
   --button-hover-bg: #666;
@@ -738,7 +738,7 @@ body.theme-rainbow #comparisonResult {
 
 .villain-image,
 .villain-img {
-  width: 180px;
+  width: 160px;
   max-width: 90%;
   height: auto;
   margin-bottom: 1rem;
@@ -756,7 +756,6 @@ body.theme-rainbow #comparisonResult {
   max-width: 500px;
   text-align: center;
   line-height: 1.5;
-  background-color: rgba(0, 0, 0, 0.4);
 }
 
 /* Dedicated block for villain quotes displayed on pages */
@@ -766,7 +765,7 @@ body.theme-rainbow #comparisonResult {
   align-items: center;
   justify-content: center;
   margin-top: 1.5rem;
-  gap: 1.2rem;
+  gap: 1rem;
   width: 100%;
 }
 
@@ -775,7 +774,7 @@ body.theme-rainbow #comparisonResult {
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 1.2rem;
+  gap: 1rem;
   margin-top: 1.5rem;
 }
 
@@ -786,7 +785,6 @@ body.theme-rainbow #comparisonResult {
   font-size: 1.2rem;
   text-align: center;
   line-height: 1.5;
-  background-color: rgba(0, 0, 0, 0.4);
 }
 
 .villain-toggle-btn {
@@ -1240,21 +1238,19 @@ body.light-mode .static-rating-legend {
   height: 50px;
   font-size: 16px;
   font-weight: bold;
+  border: none;
   border-radius: 6px;
-  background: transparent;
-  border: 2px solid var(--accent-text);
-  color: var(--accent-text);
+  background-color: #444;
+  color: white;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
   text-align: center;
-  transition: all 0.3s ease;
 }
 
 .compatibility-button:hover {
-  background: var(--accent-text);
-  color: #000;
+  background-color: #666;
 }
 
 .file-upload input[type="file"] {
@@ -1755,7 +1751,7 @@ body {
 #cr-results-container h2 {
   font-size: 20px;
   margin-bottom: 10px;
-  color: var(--accent-text);
+  color: #00ff99;
   text-align: center;
 }
 
@@ -3080,20 +3076,20 @@ body {
 
 /* === Theme-Compatible Elements for /kinks/ page === */
 :root {
-  --accent-text: #00ffff; /* fallback: neon blue */
+  --accent-text: #00ff99; /* default (dark) */
 }
 
 /* Theme-specific overrides */
 .theme-dark {
-  --accent-text: #00bfff; /* deep electric blue */
+  --accent-text: #00ff99;
 }
 
 .theme-forest {
-  --accent-text: #228B22; /* forest green */
+  --accent-text: #66ff66;
 }
 
 .theme-lipstick {
-  --accent-text: #ff3399; /* hot pink */
+  --accent-text: #ff3399;
 }
 
 /* MAIN TALK KINK HEADER */
@@ -3103,7 +3099,7 @@ body {
   text-align: center;
   color: var(--accent-text);
   margin-top: 2rem;
-  margin-bottom: 1rem;
+  margin-bottom: 2rem;
 }
 
 .themed-button,
@@ -3148,7 +3144,6 @@ body {
   max-width: 500px;
   text-align: center;
   line-height: 1.5;
-  background-color: rgba(0, 0, 0, 0.4);
 }
 
 .villain-image {
@@ -3162,7 +3157,7 @@ body {
   align-items: center;
   justify-content: center;
   margin-top: 1.5rem;
-  gap: 1.2rem;
+  gap: 1rem;
   width: 100%;
 }
 

--- a/css/theme.css
+++ b/css/theme.css
@@ -2,7 +2,7 @@
   --bg-color: #0f0f0f;
   --panel-color: #000;
   --text-color: #f0f0f0;
-  --accent-text: #00bfff; /* deep electric blue */
+  --accent-text: #00ff99;
   --button-bg: #444;
   --button-text: #ffffff;
   --button-hover-bg: #666;
@@ -86,7 +86,7 @@
   --bg-color: #0d0d0d;
   --text-color: #f2f2f2;
   --accent-color: #333;
-  --accent-text: #00bfff; /* deep electric blue */
+  --accent-text: #00ff99;
   --button-bg: #1a1a1a;
   --button-text: #f2f2f2;
   --border-color: #444;
@@ -115,7 +115,7 @@
   --bg-color: #f0f7f1;
   --text-color: #1d3b1d;
   --accent-color: #3d6651;
-  --accent-text: #228B22;
+  --accent-text: #66ff66;
   --button-bg: #a6d5b5;
   --button-text: #1d3b1d;
   --border-color: #81b89b;

--- a/villain-quote.html
+++ b/villain-quote.html
@@ -13,7 +13,7 @@
 
   <button class="themed-button no-print">See Our Compatibility</button>
 
-  <div class="center-stack no-print">
+  <div class="villain-block no-print">
     <img src="/assets/images/BLChange.png" alt="Villain Mascot" class="villain-image" />
     <div class="villain-quote">
       “They swear I’m the villain, but all I did was survive the exile—<br />


### PR DESCRIPTION
## Summary
- revert layout updates from 9e778ed that modified accent colors and villain section

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688bc25c11c8832c97d3d36070493ea0