### PR TITLE
Implement themed landing page classes

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3171,19 +3171,17 @@ body {
     display: none !important;
   }
 }
-/* Hide all other landing page elements */
-#villain-image,
-.villain-quote,
+/* Hide all extra UI elements */
 .nav-buttons,
-.extra-elements,
-.sidebar,
-.footer,
+#villain-image,
 #mascot-left,
-#quote-box {
+.footer,
+.extra-elements,
+.villain-quote {
   display: none !important;
 }
 
-/* Only center Talk Kink + Start Survey */
+/* Base layout */
 .landing-wrapper {
   display: flex;
   flex-direction: column;
@@ -3194,26 +3192,29 @@ body {
   gap: 2rem;
 }
 
-/* Talk Kink text */
-.themed-header {
+/* Talk Kink title */
+.themed-title {
   font-family: 'Fredoka One', sans-serif;
-  font-size: 3.5rem;
-  color: var(--accent-text);
+  font-size: 4rem;
+  font-weight: bold;
+  color: var(--theme-accent);
+  margin: 0;
 }
 
-/* Start Survey button */
-.themed-button {
+/* Start Survey Button */
+.themed-start-btn {
   font-family: 'Fredoka One', sans-serif;
-  padding: 0.8rem 1.6rem;
-  font-size: 1.2rem;
-  background: transparent;
-  border: 2px solid var(--accent-text);
-  color: var(--accent-text);
-  border-radius: 10px;
-  transition: all 0.3s ease;
+  font-size: 1.5rem;
+  padding: 0.9rem 2.2rem;
+  background-color: transparent;
+  border: 3px solid var(--theme-accent);
+  color: var(--theme-accent);
+  border-radius: 12px;
+  cursor: pointer;
+  transition: all 0.25s ease;
 }
 
-.themed-button:hover {
-  background-color: var(--accent-text);
+.themed-start-btn:hover {
+  background-color: var(--theme-accent);
   color: #000;
 }

--- a/css/theme.css
+++ b/css/theme.css
@@ -87,6 +87,7 @@
   --text-color: #f2f2f2;
   --accent-color: #333;
   --accent-text: #00bfff;
+  --theme-accent: #00bfff; /* Deep sky blue */
   --button-bg: #1a1a1a;
   --button-text: #f2f2f2;
   --border-color: #444;
@@ -101,6 +102,7 @@
   --text-color: #fceaff;
   --accent-color: #ff4ecb;
   --accent-text: #ff3399;
+  --theme-accent: #ff3399; /* Bold pink */
   --highlight-color: #a200ff;
   --button-bg: #ff4ecb;
   --button-text: #1a001f;
@@ -116,6 +118,7 @@
   --text-color: #1d3b1d;
   --accent-color: #3d6651;
   --accent-text: #66ff66;
+  --theme-accent: #228b22; /* Forest green */
   --button-bg: #a6d5b5;
   --button-text: #1d3b1d;
   --border-color: #81b89b;

--- a/index.html
+++ b/index.html
@@ -10,8 +10,8 @@
 </head>
 <body class="theme-dark">
   <div class="landing-wrapper">
-    <h1 class="themed-header">Talk Kink</h1>
-    <button id="startSurveyBtn" class="themed-button">Start Survey</button>
+    <h1 class="themed-title">Talk Kink</h1>
+    <button id="startSurveyBtn" class="themed-start-btn">Start Survey</button>
   </div>
 
   <script src="js/template-survey.js"></script>

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -10,8 +10,8 @@
 </head>
 <body class="theme-dark">
   <div class="landing-wrapper">
-    <h1 class="themed-header">Talk Kink</h1>
-    <button id="startSurveyBtn" class="themed-button">Start Survey</button>
+    <h1 class="themed-title">Talk Kink</h1>
+    <button id="startSurveyBtn" class="themed-start-btn">Start Survey</button>
   </div>
 
   <script src="../js/template-survey.js"></script>


### PR DESCRIPTION
## Summary
- switch landing page markup to `.themed-title` and `.themed-start-btn`
- define `--theme-accent` color for each theme
- style new classes in `style.css`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bc851e428832c9b749a9e1fe5194d