### PR TITLE
Add theme selector to landing page

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3189,7 +3189,7 @@ body {
   justify-content: center;
   min-height: 90vh;
   text-align: center;
-  gap: 2rem;
+  gap: 1.5rem;
 }
 
 /* Talk Kink title */
@@ -3217,4 +3217,17 @@ body {
 .themed-start-btn:hover {
   background-color: var(--theme-accent);
   color: #000;
+}
+
+/* Theme Selector */
+.theme-selector {
+  font-family: 'Fredoka One', sans-serif;
+  margin-top: 0.75rem;
+  font-size: 1rem;
+  padding: 0.5rem 1rem;
+  border-radius: 8px;
+  border: 2px solid var(--theme-accent);
+  background-color: transparent;
+  color: var(--theme-accent);
+  cursor: pointer;
 }

--- a/index.html
+++ b/index.html
@@ -12,6 +12,12 @@
   <div class="landing-wrapper">
     <h1 class="themed-title">Talk Kink</h1>
     <button id="startSurveyBtn" class="themed-start-btn">Start Survey</button>
+
+    <select id="themeSelector" class="theme-selector">
+      <option value="dark">Dark Theme</option>
+      <option value="forest">Forest Theme</option>
+      <option value="lipstick">Lipstick Theme</option>
+    </select>
   </div>
 
   <script src="js/template-survey.js"></script>


### PR DESCRIPTION
## Summary
- add theme selector dropdown on landing page
- style theme selector and tweak landing page spacing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688bca9a7544832c9763b9106d3f3a97