### PR TITLE
Fix landing page theme styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3190,6 +3190,7 @@ body {
   min-height: 90vh;
   text-align: center;
   gap: 1.5rem;
+  color: var(--text-color);
 }
 
 /* Talk Kink title */

--- a/css/theme.css
+++ b/css/theme.css
@@ -86,8 +86,8 @@
   --bg-color: #0d0d0d;
   --text-color: #f2f2f2;
   --accent-color: #333;
-  --accent-text: #00bfff;
-  --theme-accent: #00bfff; /* Deep sky blue */
+  --accent-text: #00ffff;
+  --theme-accent: #00ffff; /* Electric blue */
   --button-bg: #1a1a1a;
   --button-text: #f2f2f2;
   --border-color: #444;

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 </head>
 <body class="theme-dark">
   <div class="landing-wrapper">
-    <h1 class="themed-title">Talk Kink</h1>
+    <h1 class="talk-kink-title">Talk Kink</h1>
     <button id="startSurveyBtn" class="themed-start-btn">Start Survey</button>
 
     <select id="themeSelector" class="theme-selector">


### PR DESCRIPTION
## Summary
- restore highlight around the Talk Kink header
- ensure landing page text uses current theme colors
- tweak dark theme accent to electric blue

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688bcc10cf1c832c9acd16a2ff4d629d