### PR TITLE
Update landing header style

### DIFF
--- a/css/theme.css
+++ b/css/theme.css
@@ -200,17 +200,3 @@ body.theme-forest .card {
   border: 1px solid var(--border-color);
 }
 
-/* Shared title styling for the Talk Kink header */
-.talk-kink-title {
-  font-family: 'Fredoka One', sans-serif;
-  font-size: 3.2rem;
-  color: var(--accent-text);
-  text-align: center;
-  margin: 0 auto 0.8rem auto;
-  padding: 0.4rem 1.2rem;
-  border: 2px solid var(--accent-text);
-  border-radius: 10px;
-  background-color: rgba(0, 0, 0, 0.2);
-  box-shadow: 0 0 10px var(--accent-text);
-  display: inline-block;
-}

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
 </head>
 <body class="theme-dark">
   <div class="landing-wrapper">
-    <h1 class="talk-kink-title">Talk Kink</h1>
+    <div class="themed-header">Talk Kink</div>
     <button id="startSurveyBtn" class="themed-start-btn">Start Survey</button>
 
     <select id="themeSelector" class="theme-selector">


### PR DESCRIPTION
## Summary
- switch index header to use shared `.themed-header` class
- drop unused `.talk-kink-title` rules from theme CSS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688be3ade928832cbc73c9ed1d40119a