### PR TITLE
Fix category panel auto-start

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -438,6 +438,8 @@ function startNewSurvey() {
   }
 
   categoryOverlay.style.display = 'flex';
+  // Ensure the category selection panel is visible
+  if (categoryPanel) categoryPanel.classList.remove('hidden');
   if (panelContainer) panelContainer.style.display = 'none';
   surveyContainer.style.display = 'none';
   finalScreen.style.display = 'none';


### PR DESCRIPTION
## Summary
- ensure the category panel becomes visible when starting a new survey

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688c6bc63960832cbc006776559dcac1