### PR TITLE
Revert print scaling adjustments

### DIFF
--- a/css/auto-pdf.css
+++ b/css/auto-pdf.css
@@ -283,7 +283,7 @@ body.exporting {
     max-width: 100%;
     display: flex;
     justify-content: center; /* Center the table horizontally */
-    transform: none;
+    transform: scale(0.88) translateX(20px); /* Shift right */
     transform-origin: top center;
   }
 

--- a/css/style.css
+++ b/css/style.css
@@ -2846,7 +2846,7 @@ body {
     max-width: 100%;
     display: flex;
     justify-content: center; /* Center the table horizontally */
-    transform: none;
+    transform: scale(0.88) translateX(20px); /* Shift right */
     transform-origin: top center;
   }
 


### PR DESCRIPTION
## Summary
- revert print layout scaling changes that removed transform on PDF export

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d39d68a00832c8f4fd814fafc8147