### PR TITLE
Show kink selector panel when ?start=1

### DIFF
--- a/kinks/index.html
+++ b/kinks/index.html
@@ -114,10 +114,13 @@
 
     function showCategoryPanelIfStart() {
       const panel = document.getElementById('categoryPanel');
+      const overlay = document.getElementById('categoryOverlay');
       if (getQueryParam('start') === '1') {
-        panel.style.display = 'block';
+        if (overlay) overlay.style.display = 'flex';
+        if (panel) panel.style.display = 'block';
       } else {
-        panel.style.display = 'none';
+        if (overlay) overlay.style.display = 'none';
+        if (panel) panel.style.display = 'none';
       }
     }
   </script>


### PR DESCRIPTION
## Summary
- show the category overlay when `?start=1` is present

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d3a2a43b4832caf75063015466b8e