### PR TITLE
Set dark theme as default option

### DIFF
--- a/kinks/index.html
+++ b/kinks/index.html
@@ -13,8 +13,8 @@
     <h1 class="themed-title">Talk Kink</h1>
     <button id="startSurveyBtn" class="themed-start-btn">Start Survey</button>
     <select id="themeSelector">
-      <option value="lipstick">Lipstick</option>
       <option value="dark">Dark</option>
+      <option value="lipstick">Lipstick</option>
       <option value="forest">Forest</option>
     </select>
   </div>


### PR DESCRIPTION
## Summary
- reorder the theme options on the survey landing page to put Dark first

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d3bf53ff0832c9b16d05cb0a37d68