### PR TITLE
Ensure kink category panel shows on start

### DIFF
--- a/kinks/index.html
+++ b/kinks/index.html
@@ -111,7 +111,10 @@
       const panel = document.getElementById('categoryPanel');
       const overlay = document.getElementById('categoryOverlay');
       if (overlay) overlay.style.display = 'flex';
-      if (panel) panel.style.display = 'block';
+      if (panel) {
+        panel.classList.remove('hidden');
+        panel.style.display = 'block';
+      }
     }
   </script>
 </body>


### PR DESCRIPTION
## Summary
- fix hidden state of category panel on the kinks page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d4e29d1a8832c904d8f1185b98ede