### PR TITLE
Refine category panel and survey launch

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -91,7 +91,7 @@ body {
   overflow-y: auto;
   background-color: var(--bg-color);
   color: var(--text-color);
-  border: 2px solid var(--accent-color);
+  border-right: 2px solid var(--accent-color);
   padding: 10px;
   z-index: 200;
   box-shadow: none;
@@ -3145,6 +3145,8 @@ body {
   color: var(--accent-color);
   min-width: 220px;
   border-radius: 8px;
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
 }
 
 .start-survey-btn:hover {
@@ -3290,15 +3292,15 @@ body {
   margin: 0;
   padding: 0;
   box-sizing: border-box;
-  background-color: var(--bg-color);
+  background-color: #000000;
   color: var(--text-color);
-  border: 2px solid var(--accent-color);
+  border-right: 2px solid var(--accent-color);
   border-radius: 0;
   box-shadow: none;
   overflow-y: auto;
   scrollbar-width: thin;
   scrollbar-color: var(--accent-color) transparent;
-  z-index: 1000;
+  z-index: 10;
 }
 #categorySurveyPanel::-webkit-scrollbar {
   width: 10px;
@@ -3319,13 +3321,13 @@ body {
   position: sticky;
   top: 0;
   z-index: 20;
-  background-color: var(--bg-color);
+  background-color: #000000;
 }
 #categorySurveyPanel .category-buttons {
   position: sticky;
   top: 2.5rem;
   z-index: 10;
-  background-color: var(--bg-color);
+  background-color: #000000;
   display: flex;
   gap: 0.5rem;
   padding: 0.5rem 1rem;
@@ -3337,6 +3339,7 @@ body {
 #categorySurveyPanel .category-list label {
   width: 100%;
   min-width: 260px;
+  min-height: 50px;
   display: flex;
   align-items: center;
   padding: 0.75rem 1rem;

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -106,6 +106,10 @@
     function StartSurvey() {
       const selected = [...document.querySelectorAll('#categorySurveyPanel input[name="category"]:checked')]
         .map(i => i.value);
+      if (!selected.length) {
+        alert('Please select at least one category.');
+        return;
+      }
       localStorage.setItem('selectedKinks', JSON.stringify(selected));
       collapsePanel();
       if (typeof startNewSurvey === 'function') {
@@ -148,6 +152,17 @@
       document.querySelectorAll('#categorySurveyPanel .category-list label').forEach(label => {
         label.setAttribute('title', label.textContent.trim());
       });
+
+      const stored = JSON.parse(localStorage.getItem('selectedKinks') || '[]');
+      if (stored.length) {
+        document.querySelectorAll('#categorySurveyPanel input[name="category"]').forEach(cb => {
+          cb.checked = stored.includes(cb.value);
+        });
+      }
+      const params = new URLSearchParams(window.location.search);
+      if (params.get('start') === '1' && stored.length) {
+        StartSurvey();
+      }
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- Make category panel span full height with themed accent borders and stickied controls
- Warn when no categories selected and use stored selections for auto starting survey
- Tweak Start Survey button outline to match theme and ensure category boxes are larger for readability
- Restrict category panel border to right edge to match design

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d88bf9664832c9fc3a0199e60acb9