### PR TITLE
Improve category panel UI and survey launch

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -87,14 +87,28 @@ body {
   left: 0;
   top: 0;
   height: 100vh;
-  width: 300px;
+  width: 340px;
   overflow-y: auto;
-  background-color: var(--bg-color);
+  background-color: #000000;
   color: var(--text-color);
   border-right: 2px solid var(--accent-color);
   padding: 10px;
   z-index: 200;
   box-shadow: none;
+  -webkit-font-smoothing: antialiased;
+  scrollbar-color: var(--accent-color) #000000;
+}
+
+.category-panel::-webkit-scrollbar {
+  width: 8px;
+}
+
+.category-panel::-webkit-scrollbar-thumb {
+  background-color: var(--accent-color);
+}
+
+.category-panel::-webkit-scrollbar-track {
+  background: #000000;
 }
 
 .category-panel:focus-within {
@@ -365,14 +379,14 @@ body.theme-dark .category-panel,
 body.theme-forest .category-panel,
 body.theme-lipstick .category-panel {
   border: 2px solid var(--accent-color);
-  background-color: var(--bg-color);
+  background-color: #000000;
   box-shadow: none;
 }
 
 body.theme-dark .category-panel:hover,
 body.theme-forest .category-panel:hover,
 body.theme-lipstick .category-panel:hover {
-  background-color: var(--bg-color);
+  background-color: #000000;
   box-shadow: none;
 }
 
@@ -3147,15 +3161,25 @@ body {
   border-radius: 8px;
   outline: 2px solid var(--accent-color);
   outline-offset: 2px;
+  box-shadow: 0 0 6px var(--accent-color);
+  transition: background-color 0.3s, color 0.3s, box-shadow 0.3s;
 }
 
-.start-survey-btn:hover {
-  filter: brightness(1.1);
+.start-survey-btn:hover:not(:disabled) {
+  background-color: var(--accent-color);
+  color: #000;
+  box-shadow: 0 0 10px var(--accent-color);
 }
 
-.start-survey-btn:active {
+.start-survey-btn:active:not(:disabled) {
   filter: brightness(0.9);
   transform: scale(0.98);
+}
+
+.start-survey-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  box-shadow: none;
 }
 
  
@@ -3332,23 +3356,30 @@ body {
   gap: 0.5rem;
   padding: 0.5rem 1rem;
 }
+#categorySurveyPanel .category-buttons .themed-button {
+  height: 32px;
+  padding: 0 0.75rem;
+  display: flex;
+  align-items: center;
+  font-size: 1rem;
+}
 #categorySurveyPanel .category-list {
   flex: 1 1 auto;
   padding: 0 0 1rem 1rem;
 }
 #categorySurveyPanel .category-list label {
   width: 100%;
-  min-width: 260px;
-  min-height: 50px;
+  min-width: 320px;
+  min-height: 48px;
   display: flex;
   align-items: center;
-  padding: 0.75rem 1rem;
+  padding: 0.5rem 1rem 0.5rem 0.5rem;
   margin: 0.25rem 0;
   border: 2px solid var(--accent-color);
   border-radius: 6px;
   font-size: 0.9rem;
   font-weight: 600;
-  font-family: 'Inter', sans-serif;
+  font-family: 'Fredoka One', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -16,7 +16,7 @@
       <option value="lipstick">Lipstick</option>
       <option value="forest">Forest</option>
     </select>
-    <button id="startSurveyBtn" class="themed-button start-survey-btn">Start Survey</button>
+    <button id="startSurveyBtn" class="themed-button start-survey-btn" disabled>Start Survey</button>
   </div>
   <button id="panelToggle" class="panel-toggle" aria-label="Toggle category panel" aria-controls="categorySurveyPanel" aria-expanded="true">☰</button>
 
@@ -103,30 +103,86 @@
     initTheme();
   </script>
   <script>
-    function StartSurvey() {
+    let surveyCategories = [];
+    let currentCategoryIndex = 0;
+
+    async function StartSurvey() {
       const selected = [...document.querySelectorAll('#categorySurveyPanel input[name="category"]:checked')]
         .map(i => i.value);
       if (!selected.length) {
         alert('Please select at least one category.');
         return;
       }
+      const resp = await fetch('../template-survey.json');
+      const data = await resp.json();
+      surveyCategories = selected.map(cat => ({
+        name: cat,
+        kinks: [
+          ...(data[cat]?.Giving || []),
+          ...(data[cat]?.Receiving || []),
+          ...(data[cat]?.General || [])
+        ]
+      }));
+      currentCategoryIndex = 0;
       localStorage.setItem('selectedKinks', JSON.stringify(selected));
       collapsePanel();
-      if (typeof startNewSurvey === 'function') {
-        startNewSurvey();
+      showCategory();
+    }
+
+    function showCategory() {
+      const surveyContainer = document.getElementById('surveyContainer');
+      const finalScreen = document.getElementById('finalScreen');
+      if (currentCategoryIndex >= surveyCategories.length) {
+        surveyContainer.style.display = 'none';
+        finalScreen.style.display = 'block';
+        return;
       }
+      finalScreen.style.display = 'none';
+      const category = surveyCategories[currentCategoryIndex];
+      document.getElementById('categoryTitle').textContent = category.name;
+      const list = document.getElementById('kinkList');
+      list.innerHTML = '';
+      category.kinks.forEach(k => {
+        const row = document.createElement('div');
+        row.className = 'kink-row';
+        const span = document.createElement('span');
+        span.textContent = k.name;
+        const select = document.createElement('select');
+        for (let i = 0; i <= 5; i++) {
+          const opt = document.createElement('option');
+          opt.value = i;
+          opt.textContent = i;
+          select.appendChild(opt);
+        }
+        row.appendChild(span);
+        row.appendChild(select);
+        list.appendChild(row);
+      });
+      document.getElementById('ratingLegend').style.display = 'block';
+      document.getElementById('progressBanner').style.display = 'flex';
+      document.getElementById('progressLabel').textContent = `Category ${currentCategoryIndex + 1} of ${surveyCategories.length}`;
+      document.getElementById('progressFill').style.width = `${(currentCategoryIndex / surveyCategories.length) * 100}%`;
+      surveyContainer.style.display = 'block';
     }
 
     function selectAllCategories() {
       document.querySelectorAll('#categorySurveyPanel input[type="checkbox"]').forEach(cb => {
         cb.checked = true;
       });
+      updateStartButton();
     }
 
     function deselectAllCategories() {
       document.querySelectorAll('#categorySurveyPanel input[type="checkbox"]').forEach(cb => {
         cb.checked = false;
       });
+      updateStartButton();
+    }
+
+    function updateStartButton() {
+      const btn = document.getElementById('startSurveyBtn');
+      const hasSelection = document.querySelectorAll('#categorySurveyPanel input[name="category"]:checked').length > 0;
+      btn.disabled = !hasSelection;
     }
 
     function togglePanel() {
@@ -152,6 +208,9 @@
       document.querySelectorAll('#categorySurveyPanel .category-list label').forEach(label => {
         label.setAttribute('title', label.textContent.trim());
       });
+      document.querySelectorAll('#categorySurveyPanel input[name="category"]').forEach(cb => {
+        cb.addEventListener('change', updateStartButton);
+      });
 
       const stored = JSON.parse(localStorage.getItem('selectedKinks') || '[]');
       if (stored.length) {
@@ -159,10 +218,20 @@
           cb.checked = stored.includes(cb.value);
         });
       }
+      updateStartButton();
       const params = new URLSearchParams(window.location.search);
       if (params.get('start') === '1' && stored.length) {
         StartSurvey();
       }
+
+      document.getElementById('nextCategoryBtn').addEventListener('click', () => {
+        currentCategoryIndex++;
+        showCategory();
+      });
+      document.getElementById('skipCategoryBtn').addEventListener('click', () => {
+        currentCategoryIndex++;
+        showCategory();
+      });
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- restyle category panel buttons and list for cleaner layout
- enable and style Start Survey button with theme-aware glow
- wire Start Survey to load selected categories and navigate survey

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d8cdcbc48832ca9f9bebaeda014e3