### PR TITLE
Refine survey start flow and category panel layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -543,6 +543,7 @@ button {
   background-color: var(--button-bg);
   color: var(--button-text);
   transition: background-color 0.3s;
+  cursor: pointer;
 }
 
 /* Base style for role selection buttons */
@@ -3152,11 +3153,12 @@ body {
 }
 
 .start-survey-btn {
-  padding: 12px 20px;
+  margin-top: 1.5rem;
+  padding: 12px 32px;
   font-size: 1.25rem;
   border: 2px solid var(--accent-color);
   background-color: transparent;
-  color: var(--accent-color);
+  color: var(--text-color);
   min-width: 220px;
   border-radius: 8px;
   outline: 2px solid var(--accent-color);
@@ -3180,6 +3182,16 @@ body {
   opacity: 0.5;
   cursor: not-allowed;
   box-shadow: none;
+}
+
+@keyframes shake {
+  0%, 100% { transform: translateX(0); }
+  20%, 60% { transform: translateX(-5px); }
+  40%, 80% { transform: translateX(5px); }
+}
+
+.shake {
+  animation: shake 0.5s;
 }
 
  
@@ -3353,8 +3365,14 @@ body {
   z-index: 10;
   background-color: #000000;
   display: flex;
-  gap: 0.5rem;
   padding: 0.5rem 1rem;
+}
+
+.top-buttons {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin-bottom: 10px;
 }
 #categorySurveyPanel .category-buttons .themed-button {
   height: 32px;
@@ -3362,6 +3380,7 @@ body {
   display: flex;
   align-items: center;
   font-size: 1rem;
+  margin: 0;
 }
 #categorySurveyPanel .category-list {
   flex: 1 1 auto;
@@ -3373,8 +3392,8 @@ body {
   min-height: 48px;
   display: flex;
   align-items: center;
-  padding: 0.5rem 1rem 0.5rem 0.5rem;
-  margin: 0.25rem 0;
+  padding: 0.5rem 20px 0.5rem 0.5rem;
+  margin: 0.25rem 5px 0.25rem 0;
   border: 2px solid var(--accent-color);
   border-radius: 6px;
   font-size: 0.9rem;

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -23,7 +23,7 @@
   <!-- Category selection panel -->
   <div id="categorySurveyPanel" class="category-panel open" role="region" aria-label="Category selection">
     <h2>Select the categories you want to include:</h2>
-    <div class="category-buttons">
+    <div class="category-buttons top-buttons">
       <button id="selectAll" class="themed-button">Select All</button>
       <button id="deselectAll" class="themed-button">Deselect All</button>
     </div>
@@ -106,11 +106,13 @@
     let surveyCategories = [];
     let currentCategoryIndex = 0;
 
-    async function StartSurvey() {
+    async function startSurvey() {
+      const startBtn = document.getElementById('startSurveyBtn');
       const selected = [...document.querySelectorAll('#categorySurveyPanel input[name="category"]:checked')]
         .map(i => i.value);
       if (!selected.length) {
-        alert('Please select at least one category.');
+        startBtn.classList.add('shake');
+        setTimeout(() => startBtn.classList.remove('shake'), 500);
         return;
       }
       const resp = await fetch('../template-survey.json');
@@ -203,7 +205,7 @@
     document.addEventListener('DOMContentLoaded', () => {
       document.getElementById('selectAll').addEventListener('click', selectAllCategories);
       document.getElementById('deselectAll').addEventListener('click', deselectAllCategories);
-      document.getElementById('startSurveyBtn').addEventListener('click', StartSurvey);
+      document.getElementById('startSurveyBtn').addEventListener('click', startSurvey);
       document.getElementById('panelToggle').addEventListener('click', togglePanel);
       document.querySelectorAll('#categorySurveyPanel .category-list label').forEach(label => {
         label.setAttribute('title', label.textContent.trim());
@@ -221,7 +223,7 @@
       updateStartButton();
       const params = new URLSearchParams(window.location.search);
       if (params.get('start') === '1' && stored.length) {
-        StartSurvey();
+        startSurvey();
       }
 
       document.getElementById('nextCategoryBtn').addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- Space category labels away from scrollbar and align Select/Deselect buttons on one line.
- Add shake feedback and dynamic launch for Start Survey button.
- Restyle Start Survey button to fit theme and give breathing room from theme selector.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688d8fba1508832caac4b4078d4bcd9d