### PR TITLE
Polish category panel and restrict survey start

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -87,16 +87,17 @@ body {
   left: 0;
   top: 0;
   height: 100vh;
-  width: 340px;
+  width: 360px;
   overflow-y: auto;
   background-color: #000000;
   color: var(--text-color);
-  border-right: 2px solid var(--accent-color);
-  padding: 10px;
+  padding: 10px 12px 0 10px;
   z-index: 200;
   box-shadow: none;
   -webkit-font-smoothing: antialiased;
   scrollbar-color: var(--accent-color) #000000;
+  border: none;
+  box-sizing: border-box;
 }
 
 .category-panel::-webkit-scrollbar {
@@ -112,8 +113,7 @@ body {
 }
 
 .category-panel:focus-within {
-  outline: 2px dashed #ff005b;
-  outline-offset: 4px;
+  outline: none;
 }
 
 #roleDefinitionsPanel {
@@ -3381,10 +3381,12 @@ body {
   align-items: center;
   font-size: 1rem;
   margin: 0;
+  border: 1px solid var(--accent-color);
+  box-shadow: none;
 }
 #categorySurveyPanel .category-list {
   flex: 1 1 auto;
-  padding: 0 0 1rem 1rem;
+  padding: 0 12px 1rem 1rem;
 }
 #categorySurveyPanel .category-list label {
   width: 100%;
@@ -3394,7 +3396,7 @@ body {
   align-items: center;
   padding: 0.5rem 20px 0.5rem 0.5rem;
   margin: 0.25rem 5px 0.25rem 0;
-  border: 2px solid var(--accent-color);
+  border: 1px solid var(--accent-color);
   border-radius: 6px;
   font-size: 0.9rem;
   font-weight: 600;
@@ -3409,6 +3411,7 @@ body {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  box-shadow: none;
 }
 #categorySurveyPanel .category-list label span {
   flex: 1;

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -221,10 +221,6 @@
         });
       }
       updateStartButton();
-      const params = new URLSearchParams(window.location.search);
-      if (params.get('start') === '1' && stored.length) {
-        startSurvey();
-      }
 
       document.getElementById('nextCategoryBtn').addEventListener('click', () => {
         currentCategoryIndex++;


### PR DESCRIPTION
## Summary
- widen and restyle category panel for better spacing and dark theme consistency
- soften category button/label borders and remove glow
- ensure survey only loads after explicit Start click

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d922deff8832cbab3ce9abd8030ba