### PR TITLE
refine category panel layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3321,12 +3321,12 @@ body {
   position: fixed;
   top: 0;
   left: 0;
-  width: 300px;
+  width: 320px;
   height: 100vh;
   display: flex;
   flex-direction: column;
   margin: 0;
-  padding: 0;
+  padding: 0 10px 0 0;
   box-sizing: border-box;
   background-color: #000000;
   color: var(--text-color);
@@ -3337,6 +3337,12 @@ body {
   scrollbar-width: thin;
   scrollbar-color: var(--accent-color) transparent;
   z-index: 10;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+}
+#categorySurveyPanel:hover {
+  box-shadow: none;
 }
 #categorySurveyPanel::-webkit-scrollbar {
   width: 10px;
@@ -3386,16 +3392,15 @@ body {
 }
 #categorySurveyPanel .category-list {
   flex: 1 1 auto;
-  padding: 0 12px 1rem 1rem;
+  padding: 0 0 2rem 1rem;
 }
 #categorySurveyPanel .category-list label {
   width: 100%;
-  min-width: 320px;
   min-height: 48px;
   display: flex;
   align-items: center;
-  padding: 0.5rem 20px 0.5rem 0.5rem;
-  margin: 0.25rem 5px 0.25rem 0;
+  padding: 0.5rem 1.25rem 0.5rem 0.5rem;
+  margin: 0.25rem 0 0.25rem 0;
   border: 1px solid var(--accent-color);
   border-radius: 6px;
   font-size: 0.9rem;

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -150,6 +150,7 @@
         const span = document.createElement('span');
         span.textContent = k.name;
         const select = document.createElement('select');
+        select.setAttribute('aria-label', `Rate ${k.name}`);
         for (let i = 0; i <= 5; i++) {
           const opt = document.createElement('option');
           opt.value = i;


### PR DESCRIPTION
## Summary
- widen and pad category panel for comfortable scrolling
- clean up category buttons and improve font rendering
- add aria labels to rating dropdowns

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688d93efe39c832c9c447e2c2db8965c