### PR TITLE
Refine survey layout and theming

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -11,7 +11,7 @@ body {
 }
 
 body.has-category-panel {
-  padding-left: 300px;
+  padding-left: 320px;
 }
 
 @media (max-width: 768px) {
@@ -87,11 +87,11 @@ body {
   left: 0;
   top: 0;
   height: 100vh;
-  width: 360px;
+  width: 320px;
   overflow-y: auto;
   background-color: #000000;
   color: var(--text-color);
-  padding: 10px 12px 0 10px;
+  padding: 10px 10px 20px 10px;
   z-index: 200;
   box-shadow: none;
   -webkit-font-smoothing: antialiased;
@@ -197,6 +197,82 @@ body.light-mode #closeRoleDefinitionsBtn {
 
 #categoryContainer button:hover {
   background-color: #444;
+}
+
+/* Custom styles for kinks survey */
+.category-panel button,
+.category-panel label,
+.category-panel input[type="checkbox"],
+.start-survey-btn {
+  box-shadow: none;
+}
+
+.category-panel button {
+  border: 1px solid var(--accent-color);
+}
+
+.category-panel .category-list {
+  padding-bottom: 40px;
+}
+
+.category-panel .category-list label {
+  display: flex;
+  align-items: center;
+  border: 1px solid var(--accent-color);
+  padding: 6px 8px;
+  margin-bottom: 8px;
+  background: transparent;
+}
+
+.start-survey-btn {
+  margin-top: 10px;
+  padding: 12px 24px;
+  font-size: 1.2rem;
+  border: 2px solid var(--accent-color);
+}
+
+.warning {
+  margin-top: 8px;
+  color: var(--accent-text, var(--accent-color));
+}
+
+.panel-container {
+  margin-left: 340px;
+  padding: 20px;
+}
+
+.survey-category {
+  margin-bottom: 24px;
+  border: 1px solid var(--accent-text, var(--accent-color));
+  padding: 16px;
+  background-color: var(--panel-bg, #111);
+}
+
+.kink-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.kink-row select {
+  background-color: var(--button-bg);
+  color: var(--button-text);
+  border: 1px solid var(--border-color);
+  box-shadow: none;
+}
+
+.rating-tooltip {
+  display: none;
+  font-size: 0.8rem;
+  margin-top: 4px;
+  background-color: var(--panel-bg, #111);
+  border: 1px solid var(--border-color);
+  padding: 6px;
+}
+
+.rating-select:focus + .rating-tooltip {
+  display: block;
 }
 
 #categoryContainer button.active {

--- a/css/theme.css
+++ b/css/theme.css
@@ -97,6 +97,10 @@
   --panel-bg: #1a1a1a;
   --card-bg: #222;
 }
+.theme-dark select,
+.theme-dark option {
+  color: #ffffff;
+}
 .theme-lipstick {
   --bg-color: #1a001f;
   --text-color: #fceaff;
@@ -113,6 +117,10 @@
   --panel-bg: #300030;
   --card-bg: #2a002a;
 }
+.theme-lipstick select,
+.theme-lipstick option {
+  color: #ff90cb;
+}
 .theme-forest {
   --bg-color: #f0f7f1;
   --text-color: #1d3b1d;
@@ -127,6 +135,10 @@
   --hover-text: #fff;
   --panel-bg: #e6f3ea;
   --card-bg: #d9efe1;
+}
+.theme-forest select,
+.theme-forest option {
+  color: #a8e6a3;
 }
 
 body.theme-dark {

--- a/js/theme.js
+++ b/js/theme.js
@@ -57,34 +57,19 @@ export function initTheme() {
 }
 
 export function applyThemeColors(theme) {
-  const surveyContent = document.querySelector('#survey-section');
-  const categoryPanel = document.querySelector('#categoryPanel');
-
   const normalized = (theme || '').toLowerCase().replace(/\s+/g, '-');
   const selected = themeStyles[normalized] || themeStyles['dark'];
 
-  if (surveyContent) {
-    surveyContent.style.color = selected.fontColor;
-    surveyContent.style.backgroundColor = selected.bgColor;
-
-    surveyContent.querySelectorAll('*').forEach(el => {
-      el.style.color = selected.fontColor;
-    });
-
-    surveyContent.querySelectorAll('select, input[type="text"]').forEach(input => {
-      input.style.backgroundColor = selected.inputBg;
-      input.style.color = selected.inputText;
-      input.style.borderColor = selected.borderColor;
-      input.style.borderRadius = '6px';
-      input.style.boxShadow = '0 2px 4px rgba(0, 0, 0, 0.1)';
-    });
-  }
-
-  if (categoryPanel) {
-    categoryPanel.style.color = selected.fontColor;
-  }
+  document.querySelectorAll('select, input[type="text"]').forEach(input => {
+    input.style.backgroundColor = selected.inputBg;
+    input.style.color = selected.inputText;
+    input.style.borderColor = selected.borderColor;
+    input.style.borderRadius = '6px';
+    input.style.boxShadow = 'none';
+  });
 
   document.body.style.backgroundColor = selected.bgColor;
+  document.body.style.color = selected.fontColor;
 }
 
 export const pdfStyles = `

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -17,6 +17,7 @@
       <option value="forest">Forest</option>
     </select>
     <button id="startSurveyBtn" class="themed-button start-survey-btn" disabled>Start Survey</button>
+    <div id="warning" class="warning"></div>
   </div>
   <button id="panelToggle" class="panel-toggle" aria-label="Toggle category panel" aria-controls="categorySurveyPanel" aria-expanded="true">☰</button>
 
@@ -63,109 +64,74 @@
     </div>
   </div>
 
-  <div id="ratingLegend" class="static-rating-legend" style="display:none;">
-    <ul>
-      <li>0 - Not for me / Hard Limit</li>
-      <li>1 - Dislike / Haven’t Considered</li>
-      <li>2 - Would Try for Partner</li>
-      <li>3 - Curious / Might Enjoy</li>
-      <li>4 - Like / Regular Interest</li>
-      <li>5 - Love / Core Interest</li>
-    </ul>
-  </div>
-
-  <div id="progressBanner" class="progress-container" style="display:none;">
-    <div class="progress-label" id="progressLabel"></div>
-    <div class="progress-bar">
-      <div class="progress-fill" id="progressFill"></div>
-    </div>
-  </div>
-
-  <div id="surveyContainer" style="display:none;">
-    <h2 id="categoryTitle"></h2>
-    <p id="categoryDescription"></p>
-    <div id="kinkList"></div>
-    <div class="nav-buttons">
-      <button id="skipCategoryBtn" class="themed-button">Skip Category</button>
-      <button id="nextCategoryBtn" class="themed-button">Next Category</button>
-    </div>
-  </div>
-
   <div id="panelContainer" class="panel-container" style="display:none;"></div>
 
-  <div id="finalScreen" class="final-screen" style="display:none;">
-    <button id="saveSurveyBtn" class="themed-button">Export My List</button>
-    <button id="returnHomeBtn" class="themed-button">Return Home</button>
-  </div>
-
   <script type="module">
-    import { initTheme } from '../js/theme.js';
+    import { initTheme, applyThemeColors } from '../js/theme.js';
     initTheme();
+    window.applyThemeColors = applyThemeColors;
   </script>
   <script>
-    let surveyCategories = [];
-    let currentCategoryIndex = 0;
-
     async function startSurvey() {
-      const startBtn = document.getElementById('startSurveyBtn');
+      const warning = document.getElementById('warning');
       const selected = [...document.querySelectorAll('#categorySurveyPanel input[name="category"]:checked')]
         .map(i => i.value);
       if (!selected.length) {
-        startBtn.classList.add('shake');
-        setTimeout(() => startBtn.classList.remove('shake'), 500);
+        warning.textContent = 'Please select at least one category.';
         return;
       }
+      warning.textContent = '';
       const resp = await fetch('../template-survey.json');
       const data = await resp.json();
-      surveyCategories = selected.map(cat => ({
-        name: cat,
-        kinks: [
+      const container = document.getElementById('panelContainer');
+      container.innerHTML = '';
+      selected.forEach(cat => {
+        const block = document.createElement('section');
+        block.className = 'survey-category';
+        const title = document.createElement('h3');
+        title.textContent = cat;
+        block.appendChild(title);
+        const kinks = [
           ...(data[cat]?.Giving || []),
           ...(data[cat]?.Receiving || []),
           ...(data[cat]?.General || [])
-        ]
-      }));
-      currentCategoryIndex = 0;
+        ];
+        kinks.forEach(k => {
+          const row = document.createElement('div');
+          row.className = 'kink-row';
+          const span = document.createElement('span');
+          span.textContent = k.name;
+          const select = document.createElement('select');
+          select.className = 'rating-select';
+          for (let i = 0; i <= 5; i++) {
+            const opt = document.createElement('option');
+            opt.value = i;
+            opt.textContent = i;
+            select.appendChild(opt);
+          }
+          const tooltip = document.createElement('div');
+          tooltip.className = 'rating-tooltip';
+          tooltip.innerHTML = `
+            <ul>
+              <li>0 - Not for me / Hard Limit</li>
+              <li>1 - Dislike / Haven’t Considered</li>
+              <li>2 - Would Try for Partner</li>
+              <li>3 - Curious / Might Enjoy</li>
+              <li>4 - Like / Regular Interest</li>
+              <li>5 - Love / Core Interest</li>
+            </ul>`;
+          row.appendChild(span);
+          row.appendChild(select);
+          row.appendChild(tooltip);
+          block.appendChild(row);
+        });
+        container.appendChild(block);
+      });
       localStorage.setItem('selectedKinks', JSON.stringify(selected));
       collapsePanel();
-      showCategory();
-    }
-
-    function showCategory() {
-      const surveyContainer = document.getElementById('surveyContainer');
-      const finalScreen = document.getElementById('finalScreen');
-      if (currentCategoryIndex >= surveyCategories.length) {
-        surveyContainer.style.display = 'none';
-        finalScreen.style.display = 'block';
-        return;
-      }
-      finalScreen.style.display = 'none';
-      const category = surveyCategories[currentCategoryIndex];
-      document.getElementById('categoryTitle').textContent = category.name;
-      const list = document.getElementById('kinkList');
-      list.innerHTML = '';
-      category.kinks.forEach(k => {
-        const row = document.createElement('div');
-        row.className = 'kink-row';
-        const span = document.createElement('span');
-        span.textContent = k.name;
-        const select = document.createElement('select');
-        select.setAttribute('aria-label', `Rate ${k.name}`);
-        for (let i = 0; i <= 5; i++) {
-          const opt = document.createElement('option');
-          opt.value = i;
-          opt.textContent = i;
-          select.appendChild(opt);
-        }
-        row.appendChild(span);
-        row.appendChild(select);
-        list.appendChild(row);
-      });
-      document.getElementById('ratingLegend').style.display = 'block';
-      document.getElementById('progressBanner').style.display = 'flex';
-      document.getElementById('progressLabel').textContent = `Category ${currentCategoryIndex + 1} of ${surveyCategories.length}`;
-      document.getElementById('progressFill').style.width = `${(currentCategoryIndex / surveyCategories.length) * 100}%`;
-      surveyContainer.style.display = 'block';
+      container.style.display = 'block';
+      const theme = localStorage.getItem('theme') || 'dark';
+      if (window.applyThemeColors) window.applyThemeColors(theme);
     }
 
     function selectAllCategories() {
@@ -222,15 +188,6 @@
         });
       }
       updateStartButton();
-
-      document.getElementById('nextCategoryBtn').addEventListener('click', () => {
-        currentCategoryIndex++;
-        showCategory();
-      });
-      document.getElementById('skipCategoryBtn').addEventListener('click', () => {
-        currentCategoryIndex++;
-        showCategory();
-      });
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- Rebuild kink survey flow to render selected categories on-page with per-question rating tooltips
- Clean up category panel and controls with dark background, wider layout, and start button styling
- Sync dropdown colors and inputs with active theme and remove box shadows

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688da7d75bb8832c8215306884aa9d93