### PR TITLE
Add export and compare controls to survey

### DIFF
--- a/kinks/index.html
+++ b/kinks/index.html
@@ -82,6 +82,9 @@
     <button id="skipCategoryBtn" class="themed-button">Skip Category</button>
     <button id="nextCategoryBtn" class="themed-button">Next Category</button>
   </div>
+  <div id="exportControls" style="display:none; margin-top: 30px; text-align: center;">
+    <button id="exportAndCompareBtn" class="themed-button">Download & Compare</button>
+  </div>
 </div>
 
 <!-- Panel Container (still hidden until needed) -->
@@ -255,6 +258,8 @@
     document.getElementById('progressFill').style.width = `${(currentCategoryIndex / surveyCategories.length) * 100}%`;
     surveyContainer.style.display = 'block';
     surveyContainer.scrollIntoView({ behavior: 'smooth' });
+    const exportControls = document.getElementById('exportControls');
+    exportControls.style.display = (currentCategoryIndex === surveyCategories.length - 1) ? 'block' : 'none';
   }
 
   async function renderSurvey(selectedIds) {
@@ -325,6 +330,29 @@
       currentCategoryIndex++;
       showCategory();
     });
+
+    const exportBtn = document.getElementById('exportAndCompareBtn');
+    exportBtn.addEventListener('click', () => {
+      const responses = {};
+      const categories = surveyCategories;
+
+      categories.forEach(cat => {
+        cat.kinks.forEach(kink => {
+          const selector = document.querySelector(`select[aria-label="Rate ${kink.name}"]`);
+          responses[kink.name] = parseInt(selector.value || 0);
+        });
+      });
+
+      const dataStr = "data:text/json;charset=utf-8," + encodeURIComponent(JSON.stringify(responses, null, 2));
+      const dl = document.createElement('a');
+      dl.setAttribute('href', dataStr);
+      dl.setAttribute('download', 'kink-survey.json');
+      dl.click();
+
+      setTimeout(() => {
+        window.location.href = '/compare/';
+      }, 300);
+    });
   });
 </script>
 
@@ -348,6 +376,7 @@
     display: flex;
     align-items: center;
     gap: 12px;
+    justify-content: space-between;
   }
 
   .rating-select:focus + .rating-tooltip,


### PR DESCRIPTION
## Summary
- add "Download & Compare" export controls to survey container
- toggle export controls on final category and handle download/redirect
- space kink rows evenly with flexbox

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688db29d4994832cb25fbc0adcdf542a