### PR TITLE
Fix script block closure in kinks survey page

### DIFF
--- a/kinks/index.html
+++ b/kinks/index.html
@@ -131,8 +131,6 @@
     // Call your category-rendering logic here
     renderCategory(surveyCategories[currentCategoryIndex]);
   }
-</script>
-
       const resp = await fetch('../template-survey.json');
       const data = await resp.json();
       const container = document.getElementById('panelContainer');
@@ -181,6 +179,7 @@
       });
       localStorage.setItem('selectedKinks', JSON.stringify(selected));
       collapsePanel();
+</script>
 <!-- Survey Display + Progress -->
 <div id="progressBanner" class="progress-container" style="display:none;">
   <div class="progress-label" id="progressLabel"></div>
@@ -407,8 +406,11 @@
   }
 
   /* Fix dropdown background on theme switch */
-  select option {
-    background-color: var(--bg-color, #000);
-    color: var(--text-color, #fff);
-  }
-</style>
+    select option {
+      background-color: var(--bg-color, #000);
+      color: var(--text-color, #fff);
+    }
+  </style>
+
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- move closing `</script>` to follow `collapsePanel()` so survey markup renders
- close HTML document with `</body>`/`</html>` tags

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688db44618b4832cb7365e96f1a0d7ea