### PR TITLE
Fix Download & Compare redirect

### DIFF
--- a/kinks/index.html
+++ b/kinks/index.html
@@ -276,7 +276,7 @@
         dl.click();
 
       setTimeout(() => {
-        window.location.href = '/compare/';
+        window.location.href = '/kinks/?start=1';
       }, 300);
     });
   });


### PR DESCRIPTION
## Summary
- Redirect Download & Compare button to `https://www.talkkink.org/kinks/?start=1`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688dccaf4920832c8aee9ab7e5abe4a1