### PR TITLE
Redirect download & compare button to compatibility page

### DIFF
--- a/kinks/index.html
+++ b/kinks/index.html
@@ -276,7 +276,7 @@
         dl.click();
 
       setTimeout(() => {
-        window.location.href = '/kinks/?start=1';
+        window.location.href = 'https://www.talkkink.org/compatibility.html';
       }, 300);
     });
   });


### PR DESCRIPTION
## Summary
- Redirect survey's "Download & Compare" button to https://www.talkkink.org/compatibility.html after exporting results

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688dd0095c98832c8f1782e9f20dbef4