### PR TITLE
Compare categories with flag icons

### DIFF
--- a/css/auto-pdf.css
+++ b/css/auto-pdf.css
@@ -9,6 +9,7 @@ body {
 .icon-star { color: #ffd700; }
 .icon-red-flag { color: #e60000; }
 .icon-yellow-flag { color: #f1c40f; }
+.icon-green-flag { color: #00c853; }
 
 #button-section {
   display: flex;

--- a/css/style.css
+++ b/css/style.css
@@ -2213,6 +2213,7 @@ body {
 .icon-star { color: #ffd700; }
 .icon-red-flag { color: #e60000; }
 .icon-yellow-flag { color: #f1c40f; }
+.icon-green-flag { color: #00c853; }
 
 
 .page-break { display: none; }


### PR DESCRIPTION
## Summary
- show green/red flag icons and track category scores only when comparing surveys
- update PDF generator to export the category table
- style new flag icons for PDF and site

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688ddf3cb964832c814576d55f6ba9b3