### PR TITLE
Align compatibility page theme

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -86,9 +86,50 @@
       }
     }
   </style>
+  <style>
+    body.theme-dark {
+      background-color: #0d0d0d;
+      color: #f2f2f2;
+    }
+
+    table {
+      background-color: transparent;
+      color: inherit;
+      width: 100%;
+      border-collapse: collapse;
+    }
+
+    th, td {
+      padding: 12px 16px;
+      border-bottom: 1px solid #444;
+    }
+
+    th {
+      font-size: 1rem;
+      font-weight: bold;
+      text-align: left;
+    }
+
+    tr:nth-child(even) {
+      background-color: rgba(255, 255, 255, 0.03);
+    }
+
+    .comparison-bar {
+      background-color: #333;
+      border-radius: 5px;
+      height: 8px;
+      overflow: hidden;
+    }
+
+    .comparison-fill {
+      background-color: #f47aff;
+      height: 100%;
+    }
+  </style>
 </head>
-<body class="dark-mode">
-  <div class="scroll-container scrollable-panel">
+<body class="theme-dark">
+  <div class="main-container themed">
+    <div class="scroll-container scrollable-panel">
     <h1 class="themed-header">See Our Compatibility</h1>
     <div class="back-button-container">
       <button onclick="window.location.href='https://www.talkkink.org'">&larr; Back</button>
@@ -125,6 +166,7 @@
       </div>
       <button id="toggleVillainQuote" class="villain-toggle-btn">Toggle Villain Quote</button>
     </div>
+    </div>
   </div>
   <script src="js/template-survey.js"></script>
   <script type="module" src="js/compatibilityPage.js"></script>
@@ -150,6 +192,10 @@
         quoteEl.style.display = quoteEl.style.display === 'none' ? 'block' : 'none';
       });
     }
+  </script>
+  <script type="module">
+    import { initTheme, applyThemeColors } from './js/theme.js';
+    initTheme();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Sync compatibility page layout with shared theme wrapper
- Add dark-themed table and comparison bar styling
- Initialize page theme via shared module

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688de2274d80832c9a41355b8e54cc33