### PR TITLE
Allow kink name wrapping in compatibility table

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2418,6 +2418,10 @@ body {
 .results-table .kink-name {
   color: #ccc;
   font-weight: bold;
+  white-space: normal;
+  word-break: break-word;
+  line-height: 1.4;
+  max-width: 220px;
 }
 .results-table .row {
   border-bottom: 1px solid #333;

--- a/js/auto-pdf.js
+++ b/js/auto-pdf.js
@@ -304,7 +304,7 @@ function updateComparison() {
 
   const table = document.createElement('table');
   table.className = 'results-table';
-  table.innerHTML = '<thead><tr><th>Category</th><th>Partner A</th><th>Partner B</th></tr></thead>';
+  table.innerHTML = '<thead><tr><th>Kink</th><th>Partner A</th><th>Partner B</th></tr></thead>';
   const tbody = document.createElement('tbody');
 
   const makeTd = percent => {

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -391,7 +391,7 @@ function updateComparison() {
 
   const table = document.createElement('table');
   table.className = 'results-table';
-  table.innerHTML = '<thead><tr><th>Category</th><th>Partner A</th><th>Partner B</th></tr></thead>';
+  table.innerHTML = '<thead><tr><th>Kink</th><th>Partner A</th><th>Partner B</th></tr></thead>';
   const tbody = document.createElement('tbody');
 
   const makeTd = percent => {

--- a/js/theme.js
+++ b/js/theme.js
@@ -315,6 +315,10 @@ export function applyPrintStyles(mode = 'dark') {
       .results-table .kink-name {
         color: #ccc;
         font-weight: bold;
+        white-space: normal;
+        word-break: break-word;
+        line-height: 1.4;
+        max-width: 220px;
       }
       .results-table .row {
         border-bottom: 1px solid #333;


### PR DESCRIPTION
## Summary
- Rename comparison table header to "Kink"
- Allow kink names to wrap to two lines without truncation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688de1c629c8832c85828a8c942771ca