### PR TITLE
Improve compatibility upload UI

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -8,15 +8,79 @@
   <link rel="stylesheet" href="/css/theme.css" />
   <link rel="stylesheet" href="/css/global.css" />
   <link href="https://fonts.googleapis.com/css2?family=Fredoka+One&display=swap" rel="stylesheet" />
+  <style>
+    .upload-container {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1rem;
+      margin-top: 2rem;
+    }
+
+    .upload-button {
+      position: relative;
+      display: inline-block;
+      background-color: #1a1a1a;
+      color: white;
+      font-family: 'Fredoka One', cursive;
+      font-size: 1rem;
+      padding: 12px 24px;
+      border: 2px solid #f47aff;
+      border-radius: 8px;
+      cursor: pointer;
+      transition: 0.3s;
+      text-align: center;
+    }
+
+    .upload-button input[type="file"] {
+      position: absolute;
+      left: 0;
+      top: 0;
+      opacity: 0;
+      width: 100%;
+      height: 100%;
+      cursor: pointer;
+    }
+
+    .upload-button:hover {
+      background-color: #f47aff;
+      color: #0d0d0d;
+    }
+
+    .themed-button {
+      background-color: #1a1a1a;
+      border: 2px solid #f47aff;
+      color: white;
+      padding: 12px 24px;
+      font-size: 1rem;
+      font-family: 'Fredoka One', cursive;
+      border-radius: 8px;
+      cursor: pointer;
+      transition: 0.3s;
+    }
+
+    .themed-button:hover {
+      background-color: #f47aff;
+      color: #0d0d0d;
+    }
+  </style>
 </head>
 <body class="theme-dark">
   <div class="main-container themed">
     <h1 class="page-title">See Our Compatibility</h1>
+    <div class="upload-container">
+      <button class="themed-button" onclick="window.history.back()">← Back</button>
 
-    <div class="button-group">
-      <button class="themed-button" onclick="window.history.back()">&larr; Back</button>
-      <input type="file" id="uploadUser" class="themed-button" />
-      <input type="file" id="uploadPartner" class="themed-button" />
+      <label class="upload-button">
+        <input type="file" id="uploadUser" onchange="handleFileUpload(this)" />
+        Upload Your Survey
+      </label>
+
+      <label class="upload-button">
+        <input type="file" id="uploadPartner" onchange="handleFileUpload(this)" />
+        Upload Partner’s Survey
+      </label>
+
       <button class="themed-button" id="downloadPdfBtn">Download PDF</button>
     </div>
 

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -423,19 +423,18 @@ function updateComparison() {
   if (cardList) cardList.innerHTML = '';
 }
 
-const fileAInput = document.getElementById('uploadUser');
-if (fileAInput) {
-  fileAInput.addEventListener('change', e => {
-    loadFileA(e.target.files[0]);
-  });
+
+function handleFileUpload(input) {
+  const file = input.files[0];
+  if (!file) return;
+  if (input.id === 'uploadUser') {
+    loadFileA(file);
+  } else if (input.id === 'uploadPartner') {
+    loadFileB(file);
+  }
 }
 
-const fileBInput = document.getElementById('uploadPartner');
-if (fileBInput) {
-  fileBInput.addEventListener('change', e => {
-    loadFileB(e.target.files[0]);
-  });
-}
+window.handleFileUpload = handleFileUpload;
 
 
 


### PR DESCRIPTION
## Summary
- Replace generic file inputs with styled upload interface on compatibility page
- Add client-side `handleFileUpload` helper to process survey uploads

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688dea833194832c885b62a1125796a8