### PR TITLE
Revamp dark theme colors

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -17,22 +17,22 @@
       margin-top: 3rem;
     }
 
-    .upload-button,
-    .themed-button {
-      position: relative;
-      display: inline-block;
-      background-color: #1a1a1a;
-      color: white;
-      font-family: 'Fredoka One', cursive;
-      font-size: 1.1rem;
-      padding: 18px 28px;
-      border: 2px solid #f47aff;
-      border-radius: 10px;
-      cursor: pointer;
-      text-align: center;
-      transition: background-color 0.3s ease;
-      height: 60px;
-    }
+      .upload-button,
+      .themed-button {
+        position: relative;
+        display: inline-block;
+        background-color: var(--button-bg);
+        color: var(--button-text);
+        font-family: 'Fredoka One', cursive;
+        font-size: 1.1rem;
+        padding: 18px 28px;
+        border: 2px solid var(--accent-color);
+        border-radius: 8px;
+        cursor: pointer;
+        text-align: center;
+        transition: background-color 0.3s ease;
+        height: 60px;
+      }
 
     .upload-button input[type="file"] {
       position: absolute;
@@ -44,11 +44,11 @@
       cursor: pointer;
     }
 
-    .upload-button:hover,
-    .themed-button:hover {
-      background-color: #f47aff;
-      color: #0d0d0d;
-    }
+      .upload-button:hover,
+      .themed-button:hover {
+        background-color: var(--button-hover);
+        color: var(--bg-color);
+      }
 
     .wide-button {
       min-width: 260px;

--- a/css/style.css
+++ b/css/style.css
@@ -3211,7 +3211,23 @@ body {
   border-radius: 10px;
 }
 
-.themed-button,
+.themed-button {
+  background-color: var(--button-bg);
+  border: 2px solid var(--accent-color);
+  color: var(--button-text);
+  padding: 12px 24px;
+  font-size: 1rem;
+  border-radius: 8px;
+  font-family: 'Fredoka One', cursive;
+  cursor: pointer;
+  transition: 0.3s;
+}
+
+.themed-button:hover {
+  background-color: var(--button-hover);
+  color: var(--bg-color);
+}
+
 .select-toggle-button {
   background: transparent;
   border: 2px solid var(--accent-color);
@@ -3226,7 +3242,6 @@ body {
   margin: 0.2rem;
 }
 
-.themed-button:hover,
 .select-toggle-button:hover {
   background: var(--accent-color);
   color: #000;

--- a/css/theme.css
+++ b/css/theme.css
@@ -82,24 +82,34 @@
 }
 
 /* New simplified themes */
-.theme-dark {
-  --bg-color: #000;
-  --text-color: #f2f2f2;
-  --accent-color: #7df9ff;
-  --accent-text: #7df9ff;
-  --theme-accent: #7df9ff;
-  --button-bg: #1a1a1a;
-  --button-text: #f2f2f2;
+body.theme-dark {
+  --bg-color: #0d0d0d;
+  --text-color: #00ffff; /* electric blue */
+  --accent-color: #f47aff;
+  --accent-text: var(--accent-color);
+  --theme-accent: var(--accent-color);
   --border-color: #444;
-  --link-color: #7df9ff;
+  --button-bg: #1a1a1a;
+  --button-hover: #f47aff;
+  --button-text: #00ffff;
+  --link-color: var(--accent-color);
   --hover-bg: #333;
   --hover-text: #ffffff;
   --panel-bg: #1a1a1a;
   --card-bg: #222;
+  background-color: var(--bg-color);
+  color: var(--text-color);
+  font-family: 'Fredoka One', cursive;
 }
-.theme-dark select,
-.theme-dark option {
-  color: #ffffff;
+body.theme-dark *,
+body.theme-dark *::before,
+body.theme-dark *::after {
+  text-shadow: none !important;
+  filter: none !important;
+}
+body.theme-dark select,
+body.theme-dark option {
+  color: var(--text-color);
 }
 .theme-lipstick {
   --bg-color: #1a001f;
@@ -141,10 +151,6 @@
   color: #a8e6a3;
 }
 
-body.theme-dark {
-  background-color: var(--bg-color);
-  color: var(--text-color);
-}
 body.theme-dark button,
 body.theme-dark .start-button {
   background-color: var(--button-bg);


### PR DESCRIPTION
## Summary
- Re-style dark theme with neon palette and font enhancements
- Strip text-shadow/glow from dark theme elements
- Refresh themed-button styles and update compatibility page buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e41752a08832cae0e0b4a663eabf4