### PR TITLE
feat: revamp dark theme with electric blue accents

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3211,17 +3211,17 @@ body {
   border-radius: 10px;
 }
 
-.themed-button {
-  background-color: var(--button-bg);
-  border: 2px solid var(--accent-color);
-  color: var(--button-text);
-  padding: 12px 24px;
-  font-size: 1rem;
-  border-radius: 8px;
-  font-family: 'Fredoka One', cursive;
-  cursor: pointer;
-  transition: 0.3s;
-}
+  .themed-button {
+    background-color: var(--button-bg);
+    border: 2px solid var(--accent-color);
+    color: var(--button-text);
+    padding: 12px 24px;
+    font-size: 1rem;
+    border-radius: 8px;
+    font-family: 'Fredoka One', cursive;
+    cursor: pointer;
+    transition: all 0.3s ease;
+  }
 
 .themed-button:hover {
   background-color: var(--button-hover);
@@ -3392,14 +3392,14 @@ body {
 
 /* Theme Selector */
 .theme-selector {
-  font-family: 'Fredoka One', sans-serif;
+  font-family: 'Fredoka One', cursive;
   margin-top: 0.75rem;
   font-size: 1rem;
-  padding: 0.5rem 1rem;
+  padding: 10px;
   border-radius: 8px;
-  border: 2px solid var(--accent-text);
-  background-color: transparent;
-  color: var(--accent-text);
+  border: 2px solid var(--accent-color);
+  background-color: var(--button-bg);
+  color: var(--text-color);
   box-shadow: none;
   cursor: pointer;
 }

--- a/css/theme.css
+++ b/css/theme.css
@@ -85,12 +85,12 @@
 body.theme-dark {
   --bg-color: #0d0d0d;
   --text-color: #00ffff; /* electric blue */
-  --accent-color: #f47aff;
+  --accent-color: #00ffff;
   --accent-text: var(--accent-color);
   --theme-accent: var(--accent-color);
-  --border-color: #444;
-  --button-bg: #1a1a1a;
-  --button-hover: #f47aff;
+  --border-color: #00ffff;
+  --button-bg: #0d0d0d;
+  --button-hover: #00ffff;
   --button-text: #00ffff;
   --link-color: var(--accent-color);
   --hover-bg: #333;


### PR DESCRIPTION
## Summary
- update dark mode palette to electric blue accents
- unify button and theme selector styling under dark theme

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e43317820832ca35b21bafd060cec