### PR TITLE
Style landing page links without underlines

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3225,6 +3225,7 @@ body {
     font-family: 'Fredoka One', cursive;
     cursor: pointer;
     transition: all 0.3s ease;
+    text-decoration: none;
   }
 
 .themed-button:hover {


### PR DESCRIPTION
## Summary
- remove default link underlines on landing buttons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e4e5e83b0832c9cc509c88aa8464e