### PR TITLE
Allow long upload button labels to wrap

### DIFF
--- a/auto-pdf.html
+++ b/auto-pdf.html
@@ -12,11 +12,11 @@
 <body>
   <!-- ✅ BUTTONS AT THE TOP -->
   <div id="button-section">
-    <label class="file-upload">
+    <label id="uploadYourSurvey" class="file-upload">
       <span>Upload Your Survey</span>
       <input type="file" id="fileA" hidden />
     </label>
-    <label class="file-upload">
+    <label id="uploadPartnerSurvey" class="file-upload">
       <span>Upload Partner’s Survey</span>
       <input type="file" id="fileB" hidden />
     </label>

--- a/compatibility.html
+++ b/compatibility.html
@@ -63,12 +63,12 @@
     <div class="upload-container">
       <button class="themed-button wide-button" onclick="window.history.back()">← Back</button>
 
-      <label class="upload-button wide-button">
+      <label id="uploadYourSurvey" class="upload-button wide-button">
         <input type="file" id="uploadUser" onchange="handleFileUpload(this)" />
         Upload Your Survey
       </label>
 
-      <label class="upload-button wide-button">
+      <label id="uploadPartnerSurvey" class="upload-button wide-button">
         <input type="file" id="uploadPartner" onchange="handleFileUpload(this)" />
         Upload Partner’s Survey
       </label>

--- a/css/auto-pdf.css
+++ b/css/auto-pdf.css
@@ -311,3 +311,16 @@ body.exporting {
     text-align: center;
   }
 }
+
+/* 🔧 Adjust font sizing and wrapping so long button labels fit */
+#uploadYourSurvey,
+#uploadPartnerSurvey {
+  font-size: 1.1rem;
+  padding: 1.2rem;
+  line-height: 1.3;
+  white-space: normal;
+  word-break: break-word;
+  text-align: center;
+  max-width: 300px;
+  height: auto;
+}

--- a/css/global.css
+++ b/css/global.css
@@ -16,3 +16,16 @@
   margin-bottom: 1rem;
 }
 
+/* 🔧 Adjust font sizing and wrapping so long button labels fit */
+#uploadYourSurvey,
+#uploadPartnerSurvey {
+  font-size: 1.1rem;
+  padding: 1.2rem;
+  line-height: 1.3;
+  white-space: normal;
+  word-break: break-word;
+  text-align: center;
+  max-width: 300px;
+  height: auto;
+}
+


### PR DESCRIPTION
## Summary
- Ensure long upload button labels wrap and stay centered
- Assign ids for upload buttons in compatibility and PDF pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e5288c964832cba7d3400b92b61d6