### PR TITLE
Add Express server with token-based auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,18 @@
   "description": "This repository hosts the static files for the Talk Kink website.",
   "main": "index.js",
   "scripts": {
+    "start": "node server.js",
     "test": "node --test"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "module"
+  "type": "module",
+  "dependencies": {
+    "bcrypt": "^5.1.1",
+    "express": "^4.18.2",
+    "express-session": "^1.17.3",
+    "jsonwebtoken": "^9.0.2",
+    "nedb": "^1.8.0"
+  }
 }

--- a/server.js
+++ b/server.js
@@ -1,0 +1,72 @@
+import express from 'express';
+import session from 'express-session';
+import bcrypt from 'bcrypt';
+import jwt from 'jsonwebtoken';
+import Datastore from 'nedb';
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+const JWT_SECRET = process.env.JWT_SECRET || 'super-secret';
+
+const tokenDB = new Datastore({ filename: 'tokens.db', autoload: true });
+
+app.use(express.json());
+app.use(
+  session({
+    secret: process.env.SESSION_SECRET || 'session-secret',
+    resave: false,
+    saveUninitialized: false,
+  })
+);
+
+const destroy = (req, res) => {
+  req.session.destroy(() =>
+    res.status(401).json({ error: 'Authentication required' })
+  );
+};
+
+app.post('/login', (req, res) => {
+  const { token } = req.body;
+  if (!token) {
+    return destroy(req, res);
+  }
+
+  tokenDB.find({ used: { $ne: true } }, async (err, docs) => {
+    if (err) return res.status(500).json({ error: 'Database error' });
+
+    for (const doc of docs) {
+      const match = await bcrypt.compare(token, doc.hash);
+      if (match) {
+        tokenDB.update({ _id: doc._id }, { $set: { used: true } }, {});
+        const jwtToken = jwt.sign({ ip: req.ip }, JWT_SECRET, { expiresIn: '1h' });
+        req.session.jwt = jwtToken;
+        return res.json({ success: true });
+      }
+    }
+
+    destroy(req, res);
+  });
+});
+
+app.post('/logout', (req, res) => {
+  req.session.destroy(() => res.json({ success: true }));
+});
+
+const auth = (req, res, next) => {
+  const { jwt: token } = req.session;
+  if (!token) return destroy(req, res);
+  try {
+    const payload = jwt.verify(token, JWT_SECRET);
+    if (payload.ip !== req.ip) return destroy(req, res);
+    next();
+  } catch (e) {
+    destroy(req, res);
+  }
+};
+
+app.use(auth);
+app.use(express.static(process.cwd()));
+
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- set up Express server with login/logout endpoints and JWT session auth tied to client IP
- serve repository static files and secure routes with middleware
- declare server dependencies and start script

## Testing
- `npm test` *(fails: dependencies could not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_688e5522d8a8832cb201302f63f84846