### PR TITLE
Add rate limiting to token submission

### DIFF
--- a/test/submitTokenRateLimit.test.js
+++ b/test/submitTokenRateLimit.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert';
+
+const fetchOpts = {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ token: 'bad-token' }),
+};
+
+test('rate limits token submission after five attempts', async t => {
+  process.env.PORT = 0;
+  const { server, cleanup } = await import('../server.js');
+  const port = server.address().port;
+  t.after(() => {
+    server.close();
+    clearInterval(cleanup);
+  });
+  const url = `http://localhost:${port}/submit-token`;
+  for (let i = 0; i < 5; i++) {
+    const res = await fetch(url, fetchOpts);
+    assert.strictEqual(res.status, 401);
+  }
+  const res6 = await fetch(url, fetchOpts);
+  assert.strictEqual(res6.status, 429);
+});


### PR DESCRIPTION
## Summary
- limit /submit-token requests per IP to five per minute
- test that sixth submission is blocked

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688e86713e18832c8cbdbfa8f1aecd75