### PR TITLE
feat: add CLI token generator

### DIFF
--- a/generateTokens.js
+++ b/generateTokens.js
@@ -1,0 +1,19 @@
+import crypto from 'crypto';
+import fs from 'fs';
+
+const generateToken = () => crypto.randomBytes(24).toString('hex');
+
+const NUM_TOKENS = 10;
+const tokens = [];
+
+for (let i = 0; i < NUM_TOKENS; i++) {
+  tokens.push(generateToken());
+}
+
+console.log("\ud83d\udd10 Generated One-Time Tokens:");
+tokens.forEach((token, index) => {
+  console.log(`${index + 1}: ${token}`);
+});
+
+// Optional: write to file
+fs.writeFileSync('tokens.txt', tokens.join('\n'), 'utf-8');

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "node server.js",
     "test": "node --test",
     "test:coverage": "node --test --experimental-test-coverage",
-    "generate-token": "node scripts/generateToken.js"
+    "generate-token": "node scripts/generateToken.js",
+    "generate:tokens": "node generateTokens.js"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- add CLI script to generate 10 one-time tokens and save them to `tokens.txt`
- expose script via `npm run generate:tokens`

## Testing
- `npm test`
- `npm run generate:tokens`


------
https://chatgpt.com/codex/tasks/task_e_688ea8bfbc34832c8e5dba55f9365731