### PR TITLE
feat: timestamped token saving

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 *.log
 coverage/
+tokens/
+tokens.txt

--- a/generateTokens.js
+++ b/generateTokens.js
@@ -15,5 +15,21 @@ tokens.forEach((token, index) => {
   console.log(`${index + 1}: ${token}`);
 });
 
-// Optional: write to file
-fs.writeFileSync('tokens.txt', tokens.join('\n'), 'utf-8');
+// Ensure tokens directory exists
+fs.mkdirSync('tokens', { recursive: true });
+
+// Build timestamped filename: tokens/tokens_YYYY-MM-DD_HHMM.txt
+const now = new Date();
+const pad = (num) => num.toString().padStart(2, '0');
+const baseName = `tokens/tokens_${now.getFullYear()}-${pad(now.getMonth() + 1)}-${pad(now.getDate())}_${pad(now.getHours())}${pad(now.getMinutes())}`;
+
+// Ensure we don't overwrite existing files
+let fileName = `${baseName}.txt`;
+let counter = 1;
+while (fs.existsSync(fileName)) {
+  fileName = `${baseName}_${counter}.txt`;
+  counter++;
+}
+
+// Write one token per line
+fs.writeFileSync(fileName, `${tokens.join('\n')}\n`, 'utf-8');


### PR DESCRIPTION
## Summary
- generate tokens into timestamped files under `tokens/`
- ignore generated token files in git

## Testing
- `npm test`
- `node generateTokens.js`


------
https://chatgpt.com/codex/tasks/task_e_688eaa449630832ca24ae18f122426b8