### PR TITLE
Enforce session token on all pages

### DIFF
--- a/BratLife/index.html
+++ b/BratLife/index.html
@@ -183,6 +183,14 @@
 
   <footer>
   </footer>
+  <script>
+    fetch("/check-session", { credentials: "include" })
+      .then(res => {
+        if (res.status === 401) {
+          window.location.href = "/token.html";
+        }
+      });
+  </script>
 </body>
 <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 <script src="stories.js"></script>

--- a/auto-pdf.html
+++ b/auto-pdf.html
@@ -30,5 +30,13 @@
       <div id="compatibility-report"></div>
     </div>
   </div>
+  <script>
+    fetch("/check-session", { credentials: "include" })
+      .then(res => {
+        if (res.status === 401) {
+          window.location.href = "/token.html";
+        }
+      });
+  </script>
 </body>
 </html>

--- a/basic-survey.html
+++ b/basic-survey.html
@@ -284,5 +284,13 @@
       alert("Your average interest score is: " + average.toFixed(2));
     }
   </script>
+  <script>
+    fetch("/check-session", { credentials: "include" })
+      .then(res => {
+        if (res.status === 401) {
+          window.location.href = "/token.html";
+        }
+      });
+  </script>
 </body>
 </html>

--- a/compatibility.html
+++ b/compatibility.html
@@ -79,5 +79,13 @@
     initTheme();
     window.applyThemeColors = applyThemeColors;
   </script>
+  <script>
+    fetch("/check-session", { credentials: "include" })
+      .then(res => {
+        if (res.status === 401) {
+          window.location.href = "/token.html";
+        }
+      });
+  </script>
 </body>
 </html>

--- a/data-tools.html
+++ b/data-tools.html
@@ -143,5 +143,13 @@
     document.getElementById('closeRoleDefinitionsBtn').addEventListener('click', hidePanel);
     overlay.addEventListener('click', hidePanel);
   </script>
+  <script>
+    fetch("/check-session", { credentials: "include" })
+      .then(res => {
+        if (res.status === 401) {
+          window.location.href = "/token.html";
+        }
+      });
+  </script>
 </body>
 </html>

--- a/greenlight/calendar.html
+++ b/greenlight/calendar.html
@@ -61,5 +61,13 @@
       window.addEventListener('load', () => navigator.serviceWorker.register('sw.js'));
     }
   </script>
+  <script>
+    fetch("/check-session", { credentials: "include" })
+      .then(res => {
+        if (res.status === 401) {
+          window.location.href = "/token.html";
+        }
+      });
+  </script>
 </body>
 </html>

--- a/greenlight/index.html
+++ b/greenlight/index.html
@@ -156,6 +156,14 @@
     window.addEventListener('load', () => navigator.serviceWorker.register('sw.js'));
   }
 </script>
+  <script>
+    fetch("/check-session", { credentials: "include" })
+      .then(res => {
+        if (res.status === 401) {
+          window.location.href = "/token.html";
+        }
+      });
+  </script>
 </body>
 </html>
 

--- a/greenlight/partner-notes/index.html
+++ b/greenlight/partner-notes/index.html
@@ -25,5 +25,13 @@
       window.addEventListener('load', () => navigator.serviceWorker.register('../sw.js'));
     }
   </script>
+  <script>
+    fetch("/check-session", { credentials: "include" })
+      .then(res => {
+        if (res.status === 401) {
+          window.location.href = "/token.html";
+        }
+      });
+  </script>
 </body>
 </html>

--- a/greenlight/shared-scheduler/index.html
+++ b/greenlight/shared-scheduler/index.html
@@ -40,5 +40,13 @@
       window.addEventListener('load', () => navigator.serviceWorker.register('../sw.js'));
     }
   </script>
+  <script>
+    fetch("/check-session", { credentials: "include" })
+      .then(res => {
+        if (res.status === 401) {
+          window.location.href = "/token.html";
+        }
+      });
+  </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -35,5 +35,13 @@
 
   });
   </script>
+  <script>
+    fetch("/check-session", { credentials: "include" })
+      .then(res => {
+        if (res.status === 401) {
+          window.location.href = "/token.html";
+        }
+      });
+  </script>
 </body>
 </html>

--- a/kink-list.html
+++ b/kink-list.html
@@ -261,5 +261,13 @@
       doc.save('kink-compatibility-results.pdf');
     }
   </script>
+  <script>
+    fetch("/check-session", { credentials: "include" })
+      .then(res => {
+        if (res.status === 401) {
+          window.location.href = "/token.html";
+        }
+      });
+  </script>
 </body>
 </html>

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -368,5 +368,13 @@
   }
   </style>
 
-  </body>
+    <script>
+    fetch("/check-session", { credentials: "include" })
+      .then(res => {
+        if (res.status === 401) {
+          window.location.href = "/token.html";
+        }
+      });
+  </script>
+</body>
 </html>

--- a/protected/dashboard.html
+++ b/protected/dashboard.html
@@ -7,5 +7,13 @@
 <body>
   <h1>Protected Dashboard</h1>
   <p>You have access to this protected content.</p>
+  <script>
+    fetch("/check-session", { credentials: "include" })
+      .then(res => {
+        if (res.status === 401) {
+          window.location.href = "/token.html";
+        }
+      });
+  </script>
 </body>
 </html>

--- a/snippet-category-panel.html
+++ b/snippet-category-panel.html
@@ -168,5 +168,13 @@ document.getElementById('deselectAll').addEventListener('click', () => {
   document.querySelectorAll('.category-list input[type="checkbox"]').forEach(cb => cb.checked = false);
 });
 </script>
+  <script>
+    fetch("/check-session", { credentials: "include" })
+      .then(res => {
+        if (res.status === 401) {
+          window.location.href = "/token.html";
+        }
+      });
+  </script>
 </body>
 </html>

--- a/training-plan.html
+++ b/training-plan.html
@@ -17,5 +17,13 @@
     <li>Document updates in the README and verify pages locally using a simple web server.</li>
     <li>Open a pull request so changes can be reviewed and deployed to GitHub Pages.</li>
   </ol>
+  <script>
+    fetch("/check-session", { credentials: "include" })
+      .then(res => {
+        if (res.status === 401) {
+          window.location.href = "/token.html";
+        }
+      });
+  </script>
 </body>
 </html>

--- a/villain-quote.html
+++ b/villain-quote.html
@@ -21,5 +21,13 @@
       they tried to make me swallow.”
     </div>
   </div>
+  <script>
+    fetch("/check-session", { credentials: "include" })
+      .then(res => {
+        if (res.status === 401) {
+          window.location.href = "/token.html";
+        }
+      });
+  </script>
 </body>
 </html>

--- a/your-roles.html
+++ b/your-roles.html
@@ -148,5 +148,13 @@
       };
       reader.readAsText(file);
     });  </script>
+  <script>
+    fetch("/check-session", { credentials: "include" })
+      .then(res => {
+        if (res.status === 401) {
+          window.location.href = "/token.html";
+        }
+      });
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- apply session validation middleware globally with exemptions for token and admin routes
- serve token entry page when session is invalid
- add optional check-session endpoint and client-side redirect scripts on public pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688eab6b2c2c832c80a42fe06922dc40