### PR TITLE
Add category match flag display for compatibility results

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -29,3 +29,16 @@
   height: auto;
 }
 
+.results-table .category-title {
+  font-weight: bold;
+  font-size: 1.1rem;
+  display: flex;
+  justify-content: space-between;
+  padding: 0.4rem 0;
+}
+
+.results-table .category-flag {
+  margin-left: auto;
+  font-size: 1.4rem;
+}
+

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -1,6 +1,7 @@
 // Dark mode PDF export styling script using html2canvas and jsPDF
 import { initTheme, applyPrintStyles } from './theme.js';
 import { loadJsPDF } from './loadJsPDF.js';
+import { getMatchFlag, calculateCategoryMatch } from './matchFlag.js';
 
 let surveyA = null;
 let surveyB = null;
@@ -107,6 +108,28 @@ function groupKinksByCategory(data) {
     grouped[category].push(item);
   });
   return grouped;
+}
+
+function renderCategoryTitleRow(categoryName, categoryData) {
+  const matchPercent = calculateCategoryMatch(categoryData);
+  const flag = getMatchFlag(matchPercent);
+  const row = document.createElement('tr');
+  row.innerHTML = `
+    <td colspan="3" class="category-title">
+      <span class="category-label">${categoryName}</span>
+      <span class="category-flag">${flag}</span>
+    </td>`;
+  return row;
+}
+
+function renderCategoryHeaderPDF(doc, categoryName, categoryData) {
+  const matchPercent = calculateCategoryMatch(categoryData);
+  const flag = getMatchFlag(matchPercent);
+  doc.font('Helvetica-Bold')
+    .fontSize(14)
+    .text(`${categoryName} ${flag}`, { align: 'left' })
+    .moveDown(0.2);
+  doc.fontSize(12).text('Partner A', { continued: true }).text('Partner B');
 }
 function loadSavedSurvey() {
   const saved = localStorage.getItem('savedSurvey');
@@ -401,12 +424,7 @@ function updateComparison() {
   };
 
   for (const [category, kinks] of Object.entries(groupedData)) {
-    const catRow = document.createElement('tr');
-    catRow.innerHTML = `
-      <td colspan="3" class="category-header"><strong>${category}</strong></td>
-    `;
-    tbody.appendChild(catRow);
-
+    tbody.appendChild(renderCategoryTitleRow(category, kinks));
     kinks.forEach(kink => {
       const row = document.createElement('tr');
       const nameTd = document.createElement('td');

--- a/js/matchFlag.js
+++ b/js/matchFlag.js
@@ -5,3 +5,19 @@ export function getMatchFlag(percent) {
   if (percent <= 40) return '🚩';   // Red flag
   return '';                        // No flag
 }
+
+// Calculate the percentage of items where both partners match on a rating
+export function calculateCategoryMatch(categoryData) {
+  const total = categoryData.length;
+  let matched = 0;
+  for (const item of categoryData) {
+    if (
+      item.partnerA !== null &&
+      item.partnerA !== undefined &&
+      item.partnerA === item.partnerB
+    ) {
+      matched++;
+    }
+  }
+  return total === 0 ? 0 : Math.round((matched / total) * 100);
+}

--- a/test/matchFlag.test.js
+++ b/test/matchFlag.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import test from 'node:test';
-import { getMatchFlag } from '../js/matchFlag.js';
+import { getMatchFlag, calculateCategoryMatch } from '../js/matchFlag.js';
 
 test('returns star for 100 percent', () => {
   assert.strictEqual(getMatchFlag(100), '⭐');
@@ -19,4 +19,26 @@ test('returns red flag for values 40 or below', () => {
 test('returns empty string for other values', () => {
   assert.strictEqual(getMatchFlag(70), '');
   assert.strictEqual(getMatchFlag(41), '');
+});
+
+test('calculateCategoryMatch returns 0 for empty data', () => {
+  assert.strictEqual(calculateCategoryMatch([]), 0);
+});
+
+test('calculateCategoryMatch computes percentage of matching ratings', () => {
+  const data = [
+    { partnerA: 5, partnerB: 5 },
+    { partnerA: 3, partnerB: 3 },
+    { partnerA: 2, partnerB: 1 }
+  ];
+  assert.strictEqual(calculateCategoryMatch(data), 67);
+});
+
+test('calculateCategoryMatch ignores null values', () => {
+  const data = [
+    { partnerA: null, partnerB: null },
+    { partnerA: 2, partnerB: 2 },
+    { partnerA: 4, partnerB: 0 }
+  ];
+  assert.strictEqual(calculateCategoryMatch(data), 33);
 });


### PR DESCRIPTION
## Summary
- compute category match percentage and share flag utility
- show category match flag in compatibility table and prep for PDF rendering
- style category headers for flags and extend unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688ed5177d08832cbadd5058d45b929d