### PR TITLE
Refine category match flag handling

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -29,16 +29,22 @@
   height: auto;
 }
 
-.results-table .category-title {
-  font-weight: bold;
-  font-size: 1.1rem;
+.results-table .category-cell {
+  padding: 0.6rem 1rem;
+  background-color: #111;
+}
+
+.results-table .category-banner {
+  width: 100%;
   display: flex;
-  justify-content: space-between;
-  padding: 0.4rem 0;
+  align-items: center;
+  font-size: 1.2rem;
+  font-weight: bold;
+  color: red;
+  gap: 0.5rem;
 }
 
 .results-table .category-flag {
-  margin-left: auto;
-  font-size: 1.4rem;
+  font-size: 1.5rem;
 }
 

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -110,26 +110,32 @@ function groupKinksByCategory(data) {
   return grouped;
 }
 
-function renderCategoryTitleRow(categoryName, categoryData) {
-  const matchPercent = calculateCategoryMatch(categoryData);
-  const flag = getMatchFlag(matchPercent);
-  const row = document.createElement('tr');
-  row.innerHTML = `
-    <td colspan="3" class="category-title">
-      <span class="category-label">${categoryName}</span>
-      <span class="category-flag">${flag}</span>
+function renderCategoryRow(categoryName, categoryData) {
+  const percent = calculateCategoryMatch(categoryData);
+  const flag = getMatchFlag(percent);
+  const tr = document.createElement('tr');
+  tr.classList.add('category-header');
+  tr.innerHTML = `
+    <td colspan="3" class="category-cell">
+      <div class="category-banner">
+        <span class="category-flag">${flag}</span>
+        <span class="category-name">${categoryName}</span>
+      </div>
     </td>`;
-  return row;
+  return tr;
 }
 
 function renderCategoryHeaderPDF(doc, categoryName, categoryData) {
-  const matchPercent = calculateCategoryMatch(categoryData);
-  const flag = getMatchFlag(matchPercent);
-  doc.font('Helvetica-Bold')
+  const percent = calculateCategoryMatch(categoryData);
+  const flag = getMatchFlag(percent);
+  doc.moveDown(0.4);
+  doc
     .fontSize(14)
-    .text(`${categoryName} ${flag}`, { align: 'left' })
+    .font('Helvetica-Bold')
+    .fillColor('red')
+    .text(`${flag} ${categoryName}`, { align: 'left' })
     .moveDown(0.2);
-  doc.fontSize(12).text('Partner A', { continued: true }).text('Partner B');
+  doc.fillColor('white');
 }
 function loadSavedSurvey() {
   const saved = localStorage.getItem('savedSurvey');
@@ -424,7 +430,7 @@ function updateComparison() {
   };
 
   for (const [category, kinks] of Object.entries(groupedData)) {
-    tbody.appendChild(renderCategoryTitleRow(category, kinks));
+    tbody.appendChild(renderCategoryRow(category, kinks));
     kinks.forEach(kink => {
       const row = document.createElement('tr');
       const nameTd = document.createElement('td');

--- a/js/matchFlag.js
+++ b/js/matchFlag.js
@@ -7,17 +7,24 @@ export function getMatchFlag(percent) {
 }
 
 // Calculate the percentage of items where both partners match on a rating
+// Ignoring entries that are missing or marked with '-' for either partner
 export function calculateCategoryMatch(categoryData) {
-  const total = categoryData.length;
+  let total = 0;
   let matched = 0;
   for (const item of categoryData) {
+    const a = item.partnerA;
+    const b = item.partnerB;
     if (
-      item.partnerA !== null &&
-      item.partnerA !== undefined &&
-      item.partnerA === item.partnerB
+      a !== null &&
+      a !== undefined &&
+      a !== '-' &&
+      b !== null &&
+      b !== undefined &&
+      b !== '-'
     ) {
-      matched++;
+      total++;
+      if (a === b) matched++;
     }
   }
-  return total === 0 ? 0 : Math.round((matched / total) * 100);
+  return total > 0 ? Math.round((matched / total) * 100) : 0;
 }

--- a/test/matchFlag.test.js
+++ b/test/matchFlag.test.js
@@ -34,11 +34,12 @@ test('calculateCategoryMatch computes percentage of matching ratings', () => {
   assert.strictEqual(calculateCategoryMatch(data), 67);
 });
 
-test('calculateCategoryMatch ignores null values', () => {
+test('calculateCategoryMatch ignores missing values', () => {
   const data = [
     { partnerA: null, partnerB: null },
+    { partnerA: '-', partnerB: '-' },
     { partnerA: 2, partnerB: 2 },
     { partnerA: 4, partnerB: 0 }
   ];
-  assert.strictEqual(calculateCategoryMatch(data), 33);
+  assert.strictEqual(calculateCategoryMatch(data), 50);
 });


### PR DESCRIPTION
## Summary
- skip missing ratings when computing category matches and flags
- restyle category headers with banner and color-coded flag for web and PDF
- document behavior with updated tests

## Testing
- `npm test` *(fails: cleanup logs expired entries)*
- `node --test test/matchFlag.test.js`


------
https://chatgpt.com/codex/tasks/task_e_688ed826f134832ca9fbed75b6fe8fb6