### PR TITLE
Add progress bar color utility

### DIFF
--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -1,7 +1,7 @@
 // Dark mode PDF export styling script using html2canvas and jsPDF
 import { initTheme, applyPrintStyles } from './theme.js';
 import { loadJsPDF } from './loadJsPDF.js';
-import { getMatchFlag, calculateCategoryMatch } from './matchFlag.js';
+import { getMatchFlag, calculateCategoryMatch, getProgressBarColor } from './matchFlag.js';
 
 let surveyA = null;
 let surveyB = null;
@@ -56,20 +56,13 @@ function colorClass(percent) {
   return 'red';
 }
 
-function barFillColor(percent) {
-  if (percent >= 80) return '#00c853';
-  if (percent >= 60) return '#fbc02d';
-  return '#d32f2f';
-}
-
-
 function makeBar(percent) {
   const outer = document.createElement('div');
   outer.className = 'partner-bar';
   const fill = document.createElement('div');
   fill.className = 'partner-fill ' + colorClass(percent ?? 0);
   fill.style.width = percent === null ? '0%' : percent + '%';
-  fill.style.backgroundColor = barFillColor(percent ?? 0);
+  fill.style.backgroundColor = getProgressBarColor(percent ?? 0);
   outer.appendChild(fill);
   const text = document.createElement('span');
   text.className = 'partner-text ' + colorClass(percent ?? 0);
@@ -422,9 +415,9 @@ function updateComparison() {
   const renderCell = rating => {
     const percent = toPercent(rating);
     const pct = percent === null ? 0 : percent;
-    const cls = colorClass(percent ?? 0);
+    const color = getProgressBarColor(percent ?? 0);
     const td = document.createElement('td');
-    td.innerHTML = `<div class="bar-container"><div class="bar ${cls}" style="width: ${pct}%"></div></div>` +
+    td.innerHTML = `<div class="bar-container"><div class="bar" style="width: ${pct}%; background-color: ${color}"></div></div>` +
       `<div class="percent-label">${percent === null ? '-' : percent + '%'}</div>`;
     return td;
   };

--- a/js/matchFlag.js
+++ b/js/matchFlag.js
@@ -6,6 +6,13 @@ export function getMatchFlag(percent) {
   return '';                        // No flag
 }
 
+// Determine progress bar color based on percentage
+export function getProgressBarColor(percent) {
+  if (percent >= 80) return '#00cc66';   // Green for 80% and above
+  if (percent >= 60) return '#ffcc00';   // Yellow for 60-79%
+  return '#ff4444';                     // Red for below 60%
+}
+
 // Calculate the percentage of items where both partners match on a rating
 // Ignoring entries that are missing or marked with '-' for either partner
 export function calculateCategoryMatch(categoryData) {

--- a/test/matchFlag.test.js
+++ b/test/matchFlag.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert';
 import test from 'node:test';
-import { getMatchFlag, calculateCategoryMatch } from '../js/matchFlag.js';
+import { getMatchFlag, calculateCategoryMatch, getProgressBarColor } from '../js/matchFlag.js';
 
 test('returns star for 100 percent', () => {
   assert.strictEqual(getMatchFlag(100), '⭐');
@@ -42,4 +42,10 @@ test('calculateCategoryMatch ignores missing values', () => {
     { partnerA: 4, partnerB: 0 }
   ];
   assert.strictEqual(calculateCategoryMatch(data), 50);
+});
+
+test('getProgressBarColor returns expected hex codes', () => {
+  assert.strictEqual(getProgressBarColor(85), '#00cc66');
+  assert.strictEqual(getProgressBarColor(70), '#ffcc00');
+  assert.strictEqual(getProgressBarColor(50), '#ff4444');
 });


### PR DESCRIPTION
## Summary
- Introduce `getProgressBarColor` for consistent match bar traffic-light colors.
- Apply dynamic color styling to compatibility progress bars.
- Add unit tests covering new color logic.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688edf10e4d8832c855c6779d27fc6aa