### PR TITLE
Revert PDF generator changes to restore prior layout

### DIFF
--- a/css/auto-pdf.css
+++ b/css/auto-pdf.css
@@ -7,9 +7,9 @@ body {
 }
 
 .icon-star { color: #ffd700; }
-.icon-red-flag { color: #ff4444; }
-.icon-yellow-flag { color: #ffcc00; }
-.icon-green-flag { color: #00cc66; }
+.icon-red-flag { color: #e60000; }
+.icon-yellow-flag { color: #f1c40f; }
+.icon-green-flag { color: #00c853; }
 
 #button-section {
   display: flex;
@@ -49,23 +49,6 @@ th, td {
   white-space: normal;
   word-wrap: break-word;
   overflow-wrap: break-word;
-}
-
-.bar-container {
-  width: 100%;
-  background-color: #222;
-  border-radius: 4px;
-  overflow: hidden;
-  height: 12px;
-}
-
-.bar {
-  height: 12px;
-}
-
-.percent-label {
-  font-size: 0.85rem;
-  color: #aaa;
 }
 
 @page {

--- a/css/global.css
+++ b/css/global.css
@@ -38,7 +38,6 @@
   width: 100%;
   display: flex;
   align-items: center;
-  flex-wrap: nowrap;
   font-size: 1.2rem;
   font-weight: bold;
   color: red;

--- a/css/style.css
+++ b/css/style.css
@@ -80,7 +80,7 @@ body {
   --button-bg: #444;
   --button-text: #ffffff;
   --button-hover-bg: #666;
-  --progress-fill-color: #00cc66;
+  --progress-fill-color: #00e676;
 }
 .category-panel {
   position: fixed;
@@ -1527,7 +1527,7 @@ body.light-mode .static-rating-legend {
 .progress-fill {
   height: 100%;
   width: 0;
-  background-color: #00cc66;
+  background-color: #00e676;
   transition: width 0.4s ease;
   border-radius: 4px 0 0 4px;
 }
@@ -2214,8 +2214,8 @@ body {
 
 .icon-star { color: #ffd700; }
 .icon-red-flag { color: #e60000; }
-.icon-yellow-flag { color: #ffcc00; }
-.icon-green-flag { color: #00cc66; }
+.icon-yellow-flag { color: #f1c40f; }
+.icon-green-flag { color: #00c853; }
 
 
 .page-break { display: none; }
@@ -2329,7 +2329,7 @@ li {
 }
 
 .progress-bar-fill {
-  background-color: #00cc66 !important;
+  background-color: #00e676 !important;
 }
 
 table,
@@ -2385,7 +2385,7 @@ body {
 }
 
 .score-bar {
-  background-color: #00cc66;
+  background-color: #00c853;
   color: #000;
   border-radius: 4px;
   padding: 2px 6px;
@@ -2438,9 +2438,9 @@ body {
 .results-table .bar {
   height: 12px;
 }
-.results-table .green { background-color: #00cc66; }
-.results-table .yellow { background-color: #ffcc00; }
-.results-table .red { background-color: #ff4444; }
+.results-table .green { background-color: #00e676; }
+.results-table .yellow { background-color: #ffee58; }
+.results-table .red { background-color: #f44336; }
 .results-table .percent-label {
   font-size: 0.85rem;
   color: #aaa;
@@ -2643,31 +2643,24 @@ body {
   zoom: 0.8;
 }
 
-
 .exporting #compatibility-wrapper {
-    width: 100% !important;
-    max-width: 100% !important;
-    padding: 0 !important;
-    margin: 0 !important;
-    overflow-x: hidden !important;
-    box-sizing: border-box;
-  }
+  width: 100% !important;
+  max-width: 100% !important;
+  padding: 10px !important;
+  margin: 0 auto !important;
+  overflow-x: hidden !important;
+  box-sizing: border-box;
+}
 
 .exporting .results-table {
-    width: 100% !important;
-    max-width: 100% !important;
-    table-layout: fixed !important;
-    border-collapse: collapse;
-    word-wrap: break-word;
-    overflow-wrap: break-word;
-    font-size: 13px;
-    margin: 0 !important;
-  }
-  .exporting .results-table th,
-  .exporting .results-table td {
-    width: 33.33%;
-    padding: 4px 6px;
-  }
+  width: 100% !important;
+  max-width: 100% !important;
+  table-layout: fixed !important;
+  border-collapse: collapse;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  font-size: 13px;
+}
 
 .exporting .kink-label {
   white-space: normal;

--- a/css/theme.css
+++ b/css/theme.css
@@ -6,7 +6,7 @@
   --button-bg: #444;
   --button-text: #ffffff;
   --button-hover-bg: #666;
-  --progress-fill-color: #00cc66;
+  --progress-fill-color: #00e676;
 }
 
 .theme-lightforest,
@@ -28,7 +28,7 @@
   --button-bg: #444;
   --button-text: #ffffff;
   --button-hover-bg: #666;
-  --progress-fill-color: #00cc66;
+  --progress-fill-color: #00e676;
 }
 
 .theme-blue {

--- a/js/auto-pdf.js
+++ b/js/auto-pdf.js
@@ -141,10 +141,16 @@ function maxRating(obj) {
   return vals.length ? Math.max(...vals) : null;
 }
 
+function colorClass(percent) {
+  if (percent >= 80) return 'green';
+  if (percent >= 60) return 'yellow';
+  return 'red';
+}
+
 function barFillColor(percent) {
-  if (percent >= 80) return '#00cc66';
-  if (percent >= 60) return '#ffcc00';
-  return '#ff4444';
+  if (percent >= 80) return '#00c853';
+  if (percent >= 60) return '#fbc02d';
+  return '#d32f2f';
 }
 
 function avgPercent(a, b) {
@@ -304,9 +310,9 @@ function updateComparison() {
   const makeTd = percent => {
     const td = document.createElement('td');
     const pct = percent === null ? 0 : percent;
-    const color = barFillColor(percent ?? 0);
+    const cls = colorClass(percent ?? 0);
     td.innerHTML =
-      `<div class="bar-container"><div class="bar" style="width: ${pct}%; background-color: ${color}"></div></div>` +
+      `<div class="bar-container"><div class="bar ${cls}" style="width: ${pct}%"></div></div>` +
       `<div class="percent-label">${percent === null ? '-' : percent + '%'}</div>`;
     return td;
   };

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -104,9 +104,7 @@ function groupKinksByCategory(data) {
 }
 
 function renderCategoryRow(categoryName, categoryData) {
-  const partnerA = categoryData.map(k => k.partnerA);
-  const partnerB = categoryData.map(k => k.partnerB);
-  const percent = calculateCategoryMatch(partnerA, partnerB);
+  const percent = calculateCategoryMatch(categoryData);
   const flag = getMatchFlag(percent);
   const tr = document.createElement('tr');
   tr.classList.add('category-header');
@@ -121,9 +119,7 @@ function renderCategoryRow(categoryName, categoryData) {
 }
 
 function renderCategoryHeaderPDF(doc, categoryName, categoryData) {
-  const partnerA = categoryData.map(k => k.partnerA);
-  const partnerB = categoryData.map(k => k.partnerB);
-  const percent = calculateCategoryMatch(partnerA, partnerB);
+  const percent = calculateCategoryMatch(categoryData);
   const flag = getMatchFlag(percent);
   doc.moveDown(0.4);
   doc
@@ -291,7 +287,7 @@ async function generateComparisonPDF() {
   window.scrollTo(0, 0);
 
   // ensure the export container has no margin or padding and a black background
-  container.style.margin = '0';
+  container.style.margin = '0 auto';
   container.style.padding = '0';
   container.style.background = '#000';
   container.style.paddingBottom = '0';

--- a/js/matchFlag.js
+++ b/js/matchFlag.js
@@ -14,16 +14,13 @@ export function getProgressBarColor(percent) {
 }
 
 // Calculate the percentage of items where both partners match on a rating
-// Accepts two parallel arrays representing ratings for Partner A and Partner B
-// Ignores entries that are missing or marked with '-' for either partner
-export function calculateCategoryMatch(partnerA, partnerB) {
-  if (!Array.isArray(partnerA) || !Array.isArray(partnerB)) return 0;
-  const len = Math.min(partnerA.length, partnerB.length);
+// Ignoring entries that are missing or marked with '-' for either partner
+export function calculateCategoryMatch(categoryData) {
   let total = 0;
   let matched = 0;
-  for (let i = 0; i < len; i++) {
-    const a = partnerA[i];
-    const b = partnerB[i];
+  for (const item of categoryData) {
+    const a = item.partnerA;
+    const b = item.partnerB;
     if (
       a !== null &&
       a !== undefined &&

--- a/js/theme.js
+++ b/js/theme.js
@@ -120,7 +120,7 @@ export const pdfStyles = `
     }
 
     .match-bar-fill {
-      background-color: #00cc66 !important; /* bright green */
+      background-color: #00c853 !important; /* bright green */
     }
 
     .score-flag-high {
@@ -128,11 +128,11 @@ export const pdfStyles = `
     }
 
     .score-flag-low {
-      color: #ff4444 !important; /* red */
+      color: #d32f2f !important; /* red */
     }
 
     .score-flag-mismatch {
-      color: #ffcc00 !important; /* yellow */
+      color: #fbc02d !important; /* yellow */
     }
   }
 `;
@@ -185,7 +185,7 @@ export const lightPdfStyles = `
     }
 
     .match-bar-fill {
-      background-color: #00cc66 !important; /* bright green */
+      background-color: #00c853 !important; /* bright green */
     }
 
     .score-flag-high {
@@ -193,11 +193,11 @@ export const lightPdfStyles = `
     }
 
     .score-flag-low {
-      color: #ff4444 !important; /* red */
+      color: #d32f2f !important; /* red */
     }
 
     .score-flag-mismatch {
-      color: #ffcc00 !important; /* yellow */
+      color: #fbc02d !important; /* yellow */
     }
   }
 `;
@@ -239,9 +239,9 @@ export function applyPrintStyles(mode = 'dark') {
         padding-top: 8px;
         color: #b00020 !important;
       }
-      .category-header.green { color: #00cc66 !important; }
-      .category-header.yellow { color: #ffcc00 !important; }
-      .category-header.red { color: #ff4444 !important; }
+      .category-header.green { color: #00c853 !important; }
+      .category-header.yellow { color: #fbc02d !important; }
+      .category-header.red { color: #d32f2f !important; }
 
       .compare-row {
         display: flex;
@@ -259,9 +259,9 @@ export function applyPrintStyles(mode = 'dark') {
         font-size: 14px;
         color: #dddddd !important;
       }
-      .compare-label.green { color: #00cc66 !important; }
-      .compare-label.yellow { color: #ffcc00 !important; }
-      .compare-label.red { color: #ff4444 !important; }
+      .compare-label.green { color: #00c853 !important; }
+      .compare-label.yellow { color: #fbc02d !important; }
+      .compare-label.red { color: #d32f2f !important; }
 
       .partner-bar {
         flex: 1;
@@ -272,9 +272,9 @@ export function applyPrintStyles(mode = 'dark') {
         margin: 0 6px;
         box-shadow: none !important;
       }
-      .partner-fill.green { background-color: #00cc66; }
-      .partner-fill.yellow { background-color: #ffcc00; }
-      .partner-fill.red { background-color: #ff4444; }
+      .partner-fill.green { background-color: #00c853; }
+      .partner-fill.yellow { background-color: #fbc02d; }
+      .partner-fill.red { background-color: #d32f2f; }
 
       .partner-text {
         position: absolute;
@@ -333,9 +333,9 @@ export function applyPrintStyles(mode = 'dark') {
       .results-table .bar {
         height: 12px;
       }
-        .results-table .green { background-color: #00cc66; }
-        .results-table .yellow { background-color: #ffcc00; }
-        .results-table .red { background-color: #ff4444; }
+      .results-table .green { background-color: #00e676; }
+      .results-table .yellow { background-color: #ffee58; }
+      .results-table .red { background-color: #f44336; }
       .results-table .percent-label {
         font-size: 0.85rem;
         color: #aaa;
@@ -376,9 +376,9 @@ export function applyPrintStyles(mode = 'dark') {
         left: 0;
         top: 0;
       }
-      .bar-fill.green { background: #00cc66; }
-      .bar-fill.yellow { background: #ffcc00; }
-      .bar-fill.red { background: #ff4444; }
+      .bar-fill.green { background: #00c853; }
+      .bar-fill.yellow { background: #fbc02d; }
+      .bar-fill.red { background: #d32f2f; }
       .more-info {
         flex-shrink: 0;
         font-size: 12px;

--- a/test/matchFlag.test.js
+++ b/test/matchFlag.test.js
@@ -22,19 +22,26 @@ test('returns empty string for other values', () => {
 });
 
 test('calculateCategoryMatch returns 0 for empty data', () => {
-  assert.strictEqual(calculateCategoryMatch([], []), 0);
+  assert.strictEqual(calculateCategoryMatch([]), 0);
 });
 
 test('calculateCategoryMatch computes percentage of matching ratings', () => {
-  const a = [5, 3, 2];
-  const b = [5, 3, 1];
-  assert.strictEqual(calculateCategoryMatch(a, b), 67);
+  const data = [
+    { partnerA: 5, partnerB: 5 },
+    { partnerA: 3, partnerB: 3 },
+    { partnerA: 2, partnerB: 1 }
+  ];
+  assert.strictEqual(calculateCategoryMatch(data), 67);
 });
 
 test('calculateCategoryMatch ignores missing values', () => {
-  const a = [null, '-', 2, 4];
-  const b = [null, '-', 2, 0];
-  assert.strictEqual(calculateCategoryMatch(a, b), 50);
+  const data = [
+    { partnerA: null, partnerB: null },
+    { partnerA: '-', partnerB: '-' },
+    { partnerA: 2, partnerB: 2 },
+    { partnerA: 4, partnerB: 0 }
+  ];
+  assert.strictEqual(calculateCategoryMatch(data), 50);
 });
 
 test('getProgressBarColor returns expected hex codes', () => {


### PR DESCRIPTION
## Summary
- revert merge that altered PDF colors and export styles so PDF output matches previous appearance

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688eeb86e3d0832c9ec2b72af236e04d