### PR TITLE
feat: add match bar compatibility PDF

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -73,7 +73,6 @@
 
   <script src="js/template-survey.js"></script>
   <script type="module" src="js/compatibilityPage.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
   <script type="module">
     import { initTheme, applyThemeColors } from './js/theme.js';
     initTheme();

--- a/js/compatibilityPdf.js
+++ b/js/compatibilityPdf.js
@@ -1,54 +1,103 @@
 import { loadJsPDF } from './loadJsPDF.js';
 import { getMatchFlag } from './matchFlag.js';
 
+// Generate a PDF summarizing kink compatibility with match bars and column headers
+// `data` structure:
+// {
+//   categories: [
+//     {
+//       name: "Category Name",
+//       matchPercent: 92,
+//       items: [
+//         { kink: "Bondage", partnerA: 5, partnerB: 5 },
+//         ...
+//       ]
+//     },
+//     ...
+//   ]
+// }
 export async function generateCompatibilityPDF(data) {
   const jsPDF = await loadJsPDF();
-  const doc = new jsPDF({
-    orientation: 'portrait',
-    unit: 'mm',
-    format: 'a4'
-  });
-  const pageWidth = 210;
-  const margin = 10;
-  const usableWidth = pageWidth - margin * 2;
-  const kinkColWidth = usableWidth * 0.5;
-  const partnerColWidth = usableWidth * 0.25;
+  const doc = new jsPDF({ orientation: 'portrait', unit: 'mm', format: 'a4' });
+  const pageWidth = doc.internal.pageSize.getWidth();
+  const margin = 15;
   let y = 20;
 
-  doc.setFont('helvetica', 'bold');
-  doc.setFontSize(16);
-  doc.text('Kink Compatibility Report', pageWidth / 2, 15, { align: 'center' });
-
-  doc.setFontSize(12);
-  doc.setFont('helvetica', 'normal');
+  drawTitle(doc, pageWidth);
+  y += 15;
 
   data.categories.forEach(category => {
     const flag = getMatchFlag(category.matchPercent);
-    const header = `${flag ? flag + ' ' : ''}${category.name}`;
+    const header = `${category.name} ${flag}`;
 
-    doc.setTextColor(255);
-    doc.setFillColor(40, 40, 40);
-    doc.rect(margin, y, usableWidth, 10, 'F');
-    doc.text(header, margin + 3, y + 7);
-
+    drawSectionHeader(doc, header, y, pageWidth, margin);
     y += 12;
 
-    category.items.forEach(item => {
-      if (y > 275) {
+    drawBar(doc, margin + 2, y, pageWidth - margin * 2 - 4, category.matchPercent);
+    y += 8;
+
+    drawColumnHeaders(doc, y);
+    y += 6;
+
+    category.items.forEach(kink => {
+      doc.setFont('helvetica', 'normal');
+      doc.setFontSize(10);
+      doc.setTextColor(0);
+      doc.text(kink.kink, margin, y, { maxWidth: 90 });
+      doc.text(String(kink.partnerA ?? '-'), 115, y);
+      doc.text(String(kink.partnerB ?? '-'), 160, y);
+      y += 6;
+
+      if (y > 270) {
         doc.addPage();
         y = 20;
       }
-
-      doc.setFontSize(10);
-      doc.setTextColor(0);
-      doc.text(item.kink, margin, y, { maxWidth: kinkColWidth });
-      doc.text(String(item.partnerA ?? '-'), margin + kinkColWidth + 2, y);
-      doc.text(String(item.partnerB ?? '-'), margin + kinkColWidth + partnerColWidth + 2, y);
-      y += 6;
     });
 
-    y += 5;
+    y += 8;
   });
 
   doc.save('compatibility_report.pdf');
 }
+
+// Helper: Title
+function drawTitle(doc, pageWidth) {
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(16);
+  doc.text('Kink Compatibility Report', pageWidth / 2, 15, { align: 'center' });
+}
+
+// Helper: Section Header
+function drawSectionHeader(doc, text, y, pageWidth, margin) {
+  doc.setFillColor(40, 40, 40);
+  doc.setTextColor(255);
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(12);
+  doc.rect(margin, y, pageWidth - margin * 2, 10, 'F');
+  doc.text(text, pageWidth / 2, y + 7, { align: 'center' });
+}
+
+// Helper: Bar Graph
+function drawBar(doc, x, y, width, percent) {
+  let color;
+  if (percent >= 85) color = [0, 200, 0]; // Green
+  else if (percent >= 60) color = [255, 165, 0]; // Orange
+  else color = [255, 0, 0]; // Red
+
+  doc.setDrawColor(200);
+  doc.setFillColor(...color);
+  doc.rect(x, y, width * (percent / 100), 5, 'F');
+  doc.setDrawColor(0);
+  doc.rect(x, y, width, 5); // border
+}
+
+// Helper: Table Headings
+function drawColumnHeaders(doc, y) {
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(10);
+  doc.setTextColor(100);
+  doc.text('Kink', 15, y);
+  doc.text('Partner A', 115, y);
+  doc.text('Partner B', 160, y);
+}
+


### PR DESCRIPTION
## Summary
- replace old pdf generator with full-page jsPDF report showing match bars and headers
- wire Download PDF button to new generator and remove html2pdf dependency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_688fd9a4a920832c8760dd94d44caa78