### PR TITLE
refactor: use internal compatibility pdf generator

### DIFF
--- a/auto-pdf.html
+++ b/auto-pdf.html
@@ -5,9 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Kink Compatibility PDF</title>
   <link rel="stylesheet" href="css/auto-pdf.css" />
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
   <script src="js/template-survey.js"></script>
-  <script src="js/auto-pdf.js" defer></script>
+  <script type="module" src="js/auto-pdf.js"></script>
 </head>
 <body>
   <!-- ✅ BUTTONS AT THE TOP -->


### PR DESCRIPTION
## Summary
- remove html2pdf dependency from standalone generator
- build category breakdown and export using internal PDF helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688fea9ec244832cb08e549c19cdcf2c