### PR TITLE
feat: add landscape compatibility pdf generator

### DIFF
--- a/js/compatibilityPdf.js
+++ b/js/compatibilityPdf.js
@@ -60,6 +60,45 @@ export async function generateCompatibilityPDF(data) {
   doc.save('compatibility_report.pdf');
 }
 
+// Generate a PDF listing all kinks with their combined score in landscape mode
+// Combined score is the average of Partner A and Partner B ratings when both
+// are present; otherwise the existing rating is shown or '-' if none exist.
+export async function generateCompatibilityPDFLandscape(data) {
+  const jsPDF = await loadJsPDF();
+  const doc = new jsPDF({ orientation: 'landscape', unit: 'mm', format: 'a4' });
+  const pageWidth = doc.internal.pageSize.getWidth();
+  const pageHeight = doc.internal.pageSize.getHeight();
+  const margin = 15;
+  let y = 20;
+
+  drawTitle(doc, pageWidth);
+  y += 15;
+
+  doc.setFont('helvetica', 'bold');
+  doc.setFontSize(10);
+  doc.setTextColor(100);
+  doc.text('Kink', margin, y);
+  doc.text('Combined Score', pageWidth - margin, y, { align: 'right' });
+  y += 6;
+
+  const allItems = data.categories.flatMap(cat => cat.items);
+  allItems.forEach(kink => {
+    const score = combinedScore(kink.partnerA, kink.partnerB);
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(10);
+    doc.setTextColor(0);
+    doc.text(kink.kink, margin, y, { maxWidth: pageWidth - margin * 2 - 30 });
+    doc.text(score, pageWidth - margin, y, { align: 'right' });
+    y += 6;
+    if (y > pageHeight - 20) {
+      doc.addPage();
+      y = 20;
+    }
+  });
+
+  doc.save('compatibility_report_landscape.pdf');
+}
+
 // Helper: Title
 function drawTitle(doc, pageWidth) {
   doc.setFont('helvetica', 'bold');
@@ -99,5 +138,16 @@ function drawColumnHeaders(doc, y) {
   doc.text('Kink', 15, y);
   doc.text('Partner A', 115, y);
   doc.text('Partner B', 160, y);
+}
+
+// Helper: Combined score calculation
+function combinedScore(a, b) {
+  const aNum = typeof a === 'number' ? a : null;
+  const bNum = typeof b === 'number' ? b : null;
+  if (aNum === null && bNum === null) return '-';
+  if (aNum === null) return String(bNum);
+  if (bNum === null) return String(aNum);
+  const avg = (aNum + bNum) / 2;
+  return Number.isInteger(avg) ? String(avg) : avg.toFixed(1);
 }
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test": "node --test",
     "test:coverage": "node --test --experimental-test-coverage",
     "generate-token": "node scripts/generateToken.js",
-    "generate:tokens": "node generateTokens.js"
+    "generate:tokens": "node generateTokens.js",
+    "generate-pdf:landscape": "node --input-type=module -e \"globalThis.window={};await import('./js/vendor/jspdf.umd.min.js');(await import('./js/compatibilityPdf.js')).generateCompatibilityPDFLandscape({categories: []})\""
   },
   "keywords": [],
   "author": "",

--- a/test/compatibilityPdfLandscape.test.js
+++ b/test/compatibilityPdfLandscape.test.js
@@ -1,0 +1,51 @@
+import assert from 'node:assert';
+import test from 'node:test';
+
+// The landscape generator relies on jsPDF being available on window.jspdf.
+// This test provides a minimal mock implementation to capture calls.
+
+test('generates landscape compatibility PDF with combined scores', async () => {
+  const textCalls = [];
+  let options;
+  class JsPDFMock {
+    constructor(opts) {
+      options = opts;
+      this.internal = {
+        pageSize: {
+          getWidth: () => 297,
+          getHeight: () => 210
+        }
+      };
+    }
+    setFont() {}
+    setFontSize() {}
+    setTextColor() {}
+    setFillColor() {}
+    rect() {}
+    addPage() {}
+    text(...args) { textCalls.push(args); }
+    save() {}
+  }
+
+  globalThis.window = { jspdf: { jsPDF: JsPDFMock } };
+  const { generateCompatibilityPDFLandscape } = await import('../js/compatibilityPdf.js');
+
+  const data = {
+    categories: [
+      {
+        items: [
+          { kink: 'Bondage', partnerA: 5, partnerB: 3 }
+        ]
+      }
+    ]
+  };
+
+  await generateCompatibilityPDFLandscape(data);
+
+  assert.strictEqual(options.orientation, 'landscape');
+  assert.ok(textCalls.some(c => c[0] === 'Kink Compatibility Report'));
+  assert.ok(textCalls.some(c => c[0] === 'Kink'));
+  assert.ok(textCalls.some(c => c[0] === 'Combined Score'));
+  assert.ok(textCalls.some(c => c[0] === 'Bondage'));
+  assert.ok(textCalls.some(c => c[0] === '4'));
+});


### PR DESCRIPTION
## Summary
- add landscape PDF generation listing kinks with combined scores
- expose generator via `npm run generate-pdf:landscape`
- cover generator with unit test

## Testing
- `npm test`
- `npm run generate-pdf:landscape` *(fails: ERR_UNSUPPORTED_ESM_URL_SCHEME)*
- `npm install jspdf` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689018ba1854832ca90116b637fd09cc