### PR TITLE
Style category titles red in compatibility PDF

### DIFF
--- a/js/compatibilityPdf.js
+++ b/js/compatibilityPdf.js
@@ -89,16 +89,17 @@ export async function generateCompatibilityPDF(data) {
       y = 20;
     }
 
-    // Render category title
+    // Render category title in red
     doc.setFontSize(12);
     doc.setFont('helvetica', 'bold');
-    doc.setTextColor(255, 255, 255);
+    doc.setTextColor(255, 0, 0);
     doc.text(category.name, margin, y);
     y += 8;
 
     // Render header row
     doc.setFontSize(10);
     doc.setFont('helvetica', 'bold');
+    doc.setTextColor(255, 255, 255);
     doc.text('Partner A', 110, y);
     doc.text('Partner B', 160, y);
     y += 6;


### PR DESCRIPTION
## Summary
- Show category titles in red in `generateCompatibilityPDF`
- Reset header row text color to white after category title

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68903497c0c0832c9637410c8d3863de