### PR TITLE
feat: use white category headers in PDF

### DIFF
--- a/js/compatibilityPdf.js
+++ b/js/compatibilityPdf.js
@@ -89,17 +89,16 @@ export async function generateCompatibilityPDF(data) {
       y = 20;
     }
 
-    // Render category title in red
+    // Category header: white, bold, left-aligned
     doc.setFontSize(12);
     doc.setFont('helvetica', 'bold');
-    doc.setTextColor(255, 0, 0);
+    doc.setTextColor(255, 255, 255);
     doc.text(category.name, margin, y);
     y += 8;
 
-    // Render header row
+    // Column headers
     doc.setFontSize(10);
     doc.setFont('helvetica', 'bold');
-    doc.setTextColor(255, 255, 255);
     doc.text('Partner A', 110, y);
     doc.text('Partner B', 160, y);
     y += 6;


### PR DESCRIPTION
## Summary
- render category headers in white rather than red in compatibility PDF
- keep column headers for both partners

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68903c35a14c832cb2cf35f196f6b34c