### PR TITLE
Fix download PDF button by handling missing label property

### DIFF
--- a/js/generateCompatibilityPDF.js
+++ b/js/generateCompatibilityPDF.js
@@ -113,7 +113,7 @@ function generateCompatibilityPDF() {
         y = 60;
       }
 
-      const shortLabel = shortenLabel(item.name);
+      const shortLabel = shortenLabel(item.label || item.name || item.kink || "");
       const scoreA = item.partnerA ?? null;
       const scoreB = item.partnerB ?? null;
       const percent = scoreA !== null && scoreB !== null ? 100 - Math.abs(scoreA - scoreB) * 25 : null;


### PR DESCRIPTION
## Summary
- Fix generateCompatibilityPDF to use item labels when available

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689108fd06f4832ca92e1e3207277b15