### PR TITLE
Fix cleanup test to verify expired entry removal

### DIFF
--- a/server.js
+++ b/server.js
@@ -422,4 +422,4 @@ if (NODE_ENV !== 'production') {
   );
 }
 
-export { app, server, cleanup };
+export { app, server, cleanup, tokenStore, sessionStore };

--- a/test/cleanupLogs.test.js
+++ b/test/cleanupLogs.test.js
@@ -7,15 +7,14 @@ async function getToken(baseUrl) {
   return data.token;
 }
 
-test('cleanup logs expired entries', async t => {
+test('cleanup removes expired entries', async t => {
   process.env.PORT = 0;
   process.env.SESSION_IDLE_TIMEOUT = 50;
   process.env.SESSION_MAX_LIFETIME = 1000;
   process.env.TOKEN_EXPIRATION_MS = 50;
-  const logs = [];
-  const originalLog = console.log;
-  console.log = (...args) => logs.push(args.join(' '));
-  const { server, cleanup } = await import(`../server.js?${Math.random()}`);
+  const { server, cleanup, tokenStore, sessionStore } = await import(
+    `../server.js?${Math.random()}`
+  );
   const port = server.address().port;
   const base = `http://localhost:${port}`;
   t.after(() => {
@@ -24,20 +23,16 @@ test('cleanup logs expired entries', async t => {
     delete process.env.SESSION_IDLE_TIMEOUT;
     delete process.env.SESSION_MAX_LIFETIME;
     delete process.env.TOKEN_EXPIRATION_MS;
-    console.log = originalLog;
   });
   await fetch(`${base}/admin/generate-token`, { method: 'POST' });
   const token = await getToken(base);
-  const submitRes = await fetch(`${base}/submit-token`, {
+  await fetch(`${base}/submit-token`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ token }),
   });
-  const cookie = submitRes.headers.get('set-cookie');
   await new Promise(r => setTimeout(r, 60));
   cleanup._onTimeout();
-  const tokenLog = logs.find(l => l.includes('Token') && l.includes('expired'));
-  const sessionLog = logs.find(l => l.includes('Session') && l.includes('expired'));
-  assert.ok(tokenLog);
-  assert.ok(sessionLog);
+  assert.strictEqual(tokenStore.size, 0);
+  assert.strictEqual(sessionStore.size, 0);
 });


### PR DESCRIPTION
## Summary
- export token and session stores to support assertions
- replace log-based cleanup test with direct store checks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68910f68476c832cb782d045027faaf3