### PR TITLE
Fix PDF download button by loading jsPDF locally

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -38,7 +38,7 @@
       width: 100%;
     }
   </style>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+  <script src="js/vendor/jspdf.umd.min.js"></script>
 </head>
 <body class="theme-dark">
   <div class="main-container themed">

--- a/js/generateCompatibilityPDF.js
+++ b/js/generateCompatibilityPDF.js
@@ -2,8 +2,9 @@
 // Builds a standalone PDF using jsPDF when the "Download PDF" button is clicked.
 
 (function() {
-  const { jsPDF } = window.jspdf || {};
-  if (!jsPDF) return;
+  // Lazily access jsPDF so the button still responds even if the library fails
+  // to load. We'll notify the user instead of silently doing nothing.
+  const getJsPDF = () => window.jspdf?.jsPDF;
 
   // Map of long kink labels to shortened versions used in the PDF
   const shortenedLabels = {
@@ -91,6 +92,12 @@
   };
 
   function generateCompatibilityPDF() {
+    const jsPDF = getJsPDF();
+    if (!jsPDF) {
+      alert('Unable to load PDF generator. Please try again later.');
+      return;
+    }
+
     const doc = new jsPDF('portrait', 'mm', 'a4');
     const pageHeight = doc.internal.pageSize.getHeight();
     const margin = 20;


### PR DESCRIPTION
## Summary
- Serve jsPDF from local vendor copy to ensure PDF generation works offline
- Alert the user if jsPDF fails to load instead of silently ignoring the click

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68912136b5a4832c8ea111125200eac2