### PR TITLE
Fix token generation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,21 +138,17 @@ close the browser or the session expires.
 
 ### Generate a Token
 
-Create a token with:
+Start the server (for example, `npm start`) in another terminal and request a token:
 
 ```bash
 npm run generate-token
 ```
 
-Copy the printed token and share it only through secure channels.
+The script calls the running server's `/admin/generate-token` endpoint so the
+token is registered for your IP address. Copy the printed token and share it
+only through secure channels.
 
-### Start the Server and Log In
-
-Start the server:
-
-```bash
-npm start
-```
+### Log In
 
 Open the server URL in your browser and enter the token on the login page.
 Once accepted, the token is tied to your IP and you will remain logged in for

--- a/scripts/generateToken.js
+++ b/scripts/generateToken.js
@@ -1,4 +1,18 @@
-import crypto from 'crypto';
+// Request a one-time token from the running auth server so that the
+// generated token is stored in the server's in-memory token store. The
+// previous implementation simply printed a random token which the server
+// would reject as "Invalid token" because it was never registered.
 
-const token = crypto.randomBytes(24).toString('hex');
-console.log(token);
+const baseUrl = `http://localhost:${process.env.PORT || 3000}`;
+
+try {
+  const res = await fetch(`${baseUrl}/admin/generate-token`, { method: 'POST' });
+  if (!res.ok) {
+    throw new Error(`Server responded with ${res.status}`);
+  }
+  const data = await res.json();
+  console.log(data.token);
+} catch (err) {
+  console.error(`Failed to generate token: ${err.message}`);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- generate one-time tokens by calling the running auth server so they're registered
- document the need to run the server before requesting tokens

## Testing
- `npm test`
- `npm run generate-token`
- `curl -i -X POST -H 'Content-Type: application/json' -d '{"token":"a36a652e898fc50068d94787bf4689fc5e60cd545a539eb6"}' http://localhost:3000/submit-token`

------
https://chatgpt.com/codex/tasks/task_e_689132116830832cb6a3ec2e5c5aa6a7