### PR TITLE
Require token on all pages except landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,13 +35,5 @@
 
   });
   </script>
-  <script>
-    fetch("/check-session", { credentials: "include" })
-      .then(res => {
-        if (res.status === 401) {
-          window.location.href = "/token.html";
-        }
-      });
-  </script>
 </body>
 </html>

--- a/server.js
+++ b/server.js
@@ -327,6 +327,9 @@ app.use((req, res, next) => {
     '/check-session',
     '/favicon.ico',
   ];
+  if (req.url === '/' || req.url === '/index.html') {
+    return next();
+  }
   if (exemptPaths.some(path => req.url.startsWith(path))) {
     return next();
   }


### PR DESCRIPTION
## Summary
- Allow unauthenticated access to landing page by removing session check
- Exempt `/` and `/index.html` from session validation so other routes still require token

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891342d9d0c832ca9fdc07ab874660b