### PR TITLE
Use relative path for compatibility redirect

### DIFF
--- a/kinks/index.html
+++ b/kinks/index.html
@@ -299,7 +299,7 @@
         dl.click();
 
       setTimeout(() => {
-        window.location.href = 'https://www.talkkink.org/compatibility.html';
+        window.location.href = '/compatibility.html';
       }, 300);
     });
   });


### PR DESCRIPTION
## Summary
- Switch kink survey redirect to a relative `/compatibility.html` so it works on any host.

## Testing
- `npm test`
- `node -e "function redirect(base){const {URL}=require('url');const origin=new URL(base);const href='/compatibility.html';console.log(base+' -> '+new URL(href, origin).href);} redirect('http://localhost:3000/kinks/'); redirect('https://www.talkkink.org/kinks/');"`
- `curl -I https://www.talkkink.org/compatibility.html | head -n 5` *(403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689173858258832c97a69d8fb9e8d1be