### PR TITLE
Ensure compatibility PDF download works with jsPDF CDN

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -38,7 +38,8 @@
       width: 100%;
     }
   </style>
-  <script src="js/vendor/jspdf.umd.min.js"></script>
+  <!-- Load jsPDF from CDN for PDF generation -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 </head>
 <body class="theme-dark">
   <div class="main-container themed">
@@ -56,7 +57,7 @@
         Upload Partner’s Survey
       </label>
 
-      <button class="themed-button wide-button" id="downloadPDF">Download PDF</button>
+      <button class="themed-button wide-button" id="downloadPdfBtn">Download PDF</button>
     </div>
 
     <div id="comparisonResults">

--- a/js/compatibilityPdf.js
+++ b/js/compatibilityPdf.js
@@ -1,4 +1,5 @@
 export function generateCompatibilityPDF() {
+  console.log('PDF function triggered');
   const { jsPDF } = window.jspdf;
   const doc = new jsPDF({ orientation: 'landscape' });
 
@@ -117,8 +118,14 @@ export function generateCompatibilityPDF() {
 }
 
 if (typeof document !== 'undefined') {
-  const button = document.getElementById('downloadPDF');
-  if (button) button.addEventListener('click', generateCompatibilityPDF);
+  document.addEventListener('DOMContentLoaded', () => {
+    const button = document.getElementById('downloadPdfBtn');
+    if (button) {
+      button.addEventListener('click', generateCompatibilityPDF);
+    } else {
+      console.error('Download button not found');
+    }
+  });
 }
 
 export function generateCompatibilityPDFLandscape(data) {

--- a/js/generateCompatibilityPDF.js
+++ b/js/generateCompatibilityPDF.js
@@ -2,20 +2,8 @@
 // Builds a standalone PDF using jsPDF when the "Download PDF" button is clicked.
 
 (function() {
-  // Lazily load jsPDF so the button still responds even if the library must
-  // be fetched at click time. Falls back to a CDN if the bundled stub is loaded.
-  const getJsPDF = async () => {
-    if (window.jspdf?.jsPDF && !window.jspdf.isStub) {
-      return window.jspdf.jsPDF;
-    }
-    try {
-      const { loadJsPDF } = await import('./loadJsPDF.js');
-      return await loadJsPDF();
-    } catch (err) {
-      console.warn('Unable to load jsPDF library', err);
-      return null;
-    }
-  };
+  // Initialize jsPDF from the global window object
+  const { jsPDF } = window.jspdf || {};
 
   // Map of long kink labels to shortened versions used in the PDF
   const shortenedLabels = {
@@ -102,8 +90,8 @@
     return symbol;
   };
 
-  async function generateCompatibilityPDF() {
-    const jsPDF = await getJsPDF();
+  function generateCompatibilityPDF() {
+    console.log('PDF function triggered');
     if (!jsPDF || window.jspdf?.isStub) {
       alert('Unable to load PDF generator. Please try again later.');
       return;
@@ -197,7 +185,11 @@
   }
 
   document.addEventListener('DOMContentLoaded', () => {
-    const btn = document.getElementById('downloadPDF');
-    if (btn) btn.addEventListener('click', generateCompatibilityPDF);
+    const btn = document.getElementById('downloadPdfBtn');
+    if (btn) {
+      btn.addEventListener('click', generateCompatibilityPDF);
+    } else {
+      console.error('Download button not found');
+    }
   });
 })();


### PR DESCRIPTION
## Summary
- Load jsPDF from a reliable CDN and update compatibility PDF button markup
- Initialize jsPDF globally, add debug logging, and attach PDF generation after DOM load
- Align compatibility PDF helper with new button ID and DOMContentLoaded behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68917d807ccc832cadd43e03a4b68b81