### PR TITLE
fix: load jsPDF lazily

### DIFF
--- a/js/generateCompatibilityPDF.js
+++ b/js/generateCompatibilityPDF.js
@@ -2,8 +2,7 @@
 // Builds a standalone PDF using jsPDF when the "Download PDF" button is clicked.
 
 (function() {
-  // Initialize jsPDF from the global window object
-  const { jsPDF } = window.jspdf || {};
+  // jsPDF is loaded on demand inside generateCompatibilityPDF()
 
   // Map of long kink labels to shortened versions used in the PDF
   const shortenedLabels = {
@@ -90,8 +89,17 @@
     return symbol;
   };
 
-  function generateCompatibilityPDF() {
+  async function generateCompatibilityPDF() {
     console.log('PDF function triggered');
+    let jsPDF = window.jspdf?.jsPDF;
+    if (!jsPDF || window.jspdf?.isStub) {
+      try {
+        const { loadJsPDF } = await import('./loadJsPDF.js');
+        jsPDF = await loadJsPDF();
+      } catch (err) {
+        console.error('Failed to load jsPDF', err);
+      }
+    }
     if (!jsPDF || window.jspdf?.isStub) {
       alert('Unable to load PDF generator. Please try again later.');
       return;


### PR DESCRIPTION
## Summary
- load jsPDF on demand in compatibility PDF generator to ensure the library is available

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689180564660832c91cb17869ede49a5