### PR TITLE
Add jsPDF download test page

### DIFF
--- a/js/generateCompatibilityPDF.js
+++ b/js/generateCompatibilityPDF.js
@@ -94,7 +94,7 @@
     let jsPDF = window.jspdf?.jsPDF;
     if (!jsPDF || window.jspdf?.isStub) {
       try {
-        const { loadJsPDF } = await import('./loadJsPDF.js');
+        const { loadJsPDF } = await import('/js/loadJsPDF.js');
         jsPDF = await loadJsPDF();
       } catch (err) {
         console.error('Failed to load jsPDF', err);

--- a/pdf-download-test.html
+++ b/pdf-download-test.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>PDF Download Test</title>
+  <!-- 1. Include jsPDF from CDN -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+</head>
+<body>
+  <!-- 2. Button (already present in HTML) -->
+  <button id="downloadPdfBtn">Download PDF</button>
+
+  <!-- 3. Full JavaScript with working download logic -->
+  <script>
+    const { jsPDF } = window.jspdf;
+
+    function generateCompatibilityPDF() {
+      console.log('Download PDF clicked');
+      const doc = new jsPDF();
+      doc.setFontSize(18);
+      doc.text('✅ Kink Compatibility PDF', 20, 20);
+      doc.text("This is a test PDF to confirm it's working.", 20, 30);
+      doc.save('compatibility.pdf');
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+      const downloadBtn = document.getElementById('downloadPdfBtn');
+      if (!downloadBtn) {
+        console.error('❌ Download PDF button not found');
+        return;
+      }
+      downloadBtn.addEventListener('click', generateCompatibilityPDF);
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add standalone pdf download test page using jsPDF
- fix jsPDF loader path so Download PDF button can load library when CDN fails

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689182126c70832c9f9711d157101aed