### PR TITLE
Load jsPDF dynamically to avoid CDN failures

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -38,11 +38,7 @@
       width: 100%;
     }
   </style>
-  <!-- Load jsPDF from CDN for PDF generation -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"
-          integrity="sha512-jQcGc+9A0El+oSRTGHxiNoD4ZRU4QwnfQYFgHH1A2phz7qPQk1V6JEFc6NKjqhAIv+xwUWyEr0QU8I96DJ+lZg=="
-          crossorigin="anonymous"
-          referrerpolicy="no-referrer"></script>
+  <!-- jsPDF loaded dynamically in generateCompatibilityPDF.js -->
 </head>
 <body class="theme-dark">
   <div class="main-container themed">

--- a/js/generateCompatibilityPDF.js
+++ b/js/generateCompatibilityPDF.js
@@ -6,22 +6,21 @@ document.addEventListener("DOMContentLoaded", () => {
     return;
   }
 
-  btn.addEventListener("click", () => {
-    // Fail-safe check
-    if (!window.jspdf || !window.jspdf.jsPDF) {
+  btn.addEventListener("click", async () => {
+    try {
+      const { loadJsPDF } = await import("./loadJsPDF.js");
+      const jsPDF = await loadJsPDF();
+      const doc = new jsPDF();
+
+      // Replace this with actual report content generation
+      doc.setFontSize(18);
+      doc.text("✅ Kink Compatibility PDF Test", 20, 20);
+      doc.text("If you see this, jsPDF loaded and click event worked.", 20, 30);
+
+      doc.save("test-compatibility.pdf");
+    } catch (err) {
       alert("❌ jsPDF failed to load. Check your internet or CDN blocking.");
-      console.error("❌ jsPDF not available:", window.jspdf);
-      return;
+      console.error("❌ jsPDF load error:", err);
     }
-
-    const { jsPDF } = window.jspdf;
-    const doc = new jsPDF();
-
-    // Replace this with actual report content generation
-    doc.setFontSize(18);
-    doc.text("✅ Kink Compatibility PDF Test", 20, 20);
-    doc.text("If you see this, jsPDF loaded and click event worked.", 20, 30);
-
-    doc.save("test-compatibility.pdf");
   });
 });


### PR DESCRIPTION
## Summary
- load jsPDF on demand when generating compatibility PDFs
- drop static CDN script tag in compatibility page and rely on dynamic loader

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891893255e4832cad777ba0b6f5eea8