### PR TITLE
Handle jsPDF load failures gracefully

### DIFF
--- a/js/generateCompatibilityPDF.js
+++ b/js/generateCompatibilityPDF.js
@@ -19,7 +19,6 @@ document.addEventListener("DOMContentLoaded", () => {
 
       doc.save("test-compatibility.pdf");
     } catch (err) {
-      alert("❌ jsPDF failed to load. Check your internet or CDN blocking.");
       console.error("❌ jsPDF load error:", err);
     }
   });

--- a/js/loadJsPDF.js
+++ b/js/loadJsPDF.js
@@ -1,20 +1,68 @@
 let jsPDFLib = null;
+
+/**
+ * Attempt to load jsPDF from a local vendor file first and fall back to a CDN
+ * when available. If neither source is reachable, a very small stub is
+ * provided so calling code can continue without throwing runtime errors.
+ */
 export async function loadJsPDF() {
   if (jsPDFLib) return jsPDFLib;
-  if (window.jspdf && window.jspdf.jsPDF && !window.jspdf.isStub) {
+
+  // Already available (either real library or stub)
+  if (window.jspdf && window.jspdf.jsPDF) {
     jsPDFLib = window.jspdf.jsPDF;
     return jsPDFLib;
   }
+
+  // Try to import the local copy
   try {
     await import('./vendor/jspdf.umd.min.js');
-    if (window.jspdf && window.jspdf.jsPDF && !window.jspdf.isStub) {
-      jsPDFLib = window.jspdf.jsPDF;
-      return jsPDFLib;
-    }
   } catch (err) {
     console.warn('Failed to load local jsPDF:', err);
   }
-  await import('https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js');
+
+  // If still not loaded, try the CDN
+  if (!window.jspdf || !window.jspdf.jsPDF) {
+    try {
+      await import('https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js');
+    } catch (err) {
+      console.warn('Failed to load jsPDF from CDN:', err);
+    }
+  }
+
+  // Final fallback – ensure a stub exists so downstream code doesn't crash
+  if (!window.jspdf || !window.jspdf.jsPDF) {
+    console.warn('jsPDF not available; falling back to stub');
+    window.jspdf = {
+      jsPDF: function () {
+        const message =
+          "PDF library failed to load. Printing the page instead—choose 'Save as PDF' in your browser.";
+        if (typeof alert === 'function') {
+          alert(message);
+          try {
+            window.print && window.print();
+          } catch {}
+        } else {
+          console.error(message);
+        }
+        // Methods used in the app are provided as no-ops
+        return {
+          setFillColor() {},
+          rect() {},
+          setDrawColor() {},
+          line() {},
+          setTextColor() {},
+          setFont() {},
+          setFontSize() {},
+          text() {},
+          addPage() {},
+          save() {},
+        };
+      },
+      isStub: true,
+    };
+  }
+
   jsPDFLib = window.jspdf.jsPDF;
   return jsPDFLib;
 }


### PR DESCRIPTION
## Summary
- make jsPDF loading resilient to missing local file or blocked CDN by falling back to a stub
- streamline compatibility PDF generation to log loading errors instead of alerting the user

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68918a7536f0832cbd62b14b757e4f34