### PR TITLE
Auto-generate compatibility PDF

### DIFF
--- a/js/auto-pdf.js
+++ b/js/auto-pdf.js
@@ -2,6 +2,16 @@ import { calculateCategoryMatch } from './matchFlag.js';
 
 let surveyA = null;
 let surveyB = null;
+let pdfGenerated = false;
+
+async function generatePDF() {
+  if (pdfGenerated) return;
+  pdfGenerated = true;
+  const { loadJsPDF } = await import('./loadJsPDF.js');
+  await loadJsPDF();
+  const { generateCompatibilityPDF } = await import('./compatibilityPdf.js');
+  generateCompatibilityPDF();
+}
 
 const PAGE_BREAK_CATEGORIES = new Set([
   'Communication',
@@ -349,5 +359,6 @@ function updateComparison() {
     };
   });
   window.compatibilityData = { categories: pdfCategories };
+  generatePDF();
 }
 


### PR DESCRIPTION
## Summary
- Automatically load jsPDF and generate the compatibility PDF once both surveys are uploaded
- Guard against multiple downloads by tracking whether a PDF was already produced

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68918dec9f64832c9c532a7acc1860c7