### PR TITLE
Adjust match flag thresholds and PDF generation

### DIFF
--- a/js/compatibilityPdf.js
+++ b/js/compatibilityPdf.js
@@ -1,3 +1,5 @@
+import { getMatchFlag } from './matchFlag.js';
+
 export function generateCompatibilityPDF() {
   console.log('PDF function triggered');
   const { jsPDF } = window.jspdf;
@@ -49,21 +51,13 @@ export function generateCompatibilityPDF() {
     doc.rect(x, y, config.boxWidth, config.boxHeight);
     doc.setFontSize(8);
     doc.setTextColor(255, 255, 255);
-    doc.text(`${score ?? 0}%`, x + 1.5, y + 6);
+    doc.text(String(score ?? 0), x + 1.5, y + 6);
   };
 
   const drawMatchBar = (x, y, match) => {
     const color = match >= 80 ? [0, 255, 0] : match >= 60 ? [255, 255, 0] : [255, 0, 0];
     doc.setFillColor(...color);
-    doc.rect(x, y, config.barWidth, config.boxHeight, 'F');
-  };
-
-  const getFlag = (match, a, b) => {
-    if (match >= 90) return '⭐';
-    if (match >= 85) return '🟩';
-    if (match <= 40) return '🚩';
-    if ((a === 5 && b < 5) || (b === 5 && a < 5)) return '🟨';
-    return '';
+    doc.rect(x, y, config.barWidth * (match / 100), config.boxHeight, 'F');
   };
 
   const compatibilityData = window.compatibilityData;
@@ -97,8 +91,8 @@ export function generateCompatibilityPDF() {
 
       const a = item.partnerA ?? 0;
       const b = item.partnerB ?? 0;
-      const match = 100 - Math.abs(a - b);
-      const flag = getFlag(match, a, b);
+      const match = Math.max(0, 100 - Math.abs(a - b) * 25);
+      const flag = getMatchFlag(match);
       const label = item.label || item.kink || '';
 
       doc.setFontSize(9);

--- a/js/matchFlag.js
+++ b/js/matchFlag.js
@@ -1,8 +1,8 @@
 // Shared utility for match flag generation
 export function getMatchFlag(percent) {
   if (percent === 100) return '⭐'; // Gold star for perfect match
-  if (percent >= 85) return '🟩';   // Green flag
-  if (percent <= 40) return '🚩';   // Red flag
+  if (percent >= 80) return '🟩';   // Green flag
+  if (percent <= 50) return '🚩';   // Red flag
   return '';                        // No flag
 }
 

--- a/test/matchFlag.test.js
+++ b/test/matchFlag.test.js
@@ -6,19 +6,19 @@ test('returns star for 100 percent', () => {
   assert.strictEqual(getMatchFlag(100), '⭐');
 });
 
-test('returns green flag for values between 85 and 99', () => {
+test('returns green flag for values between 80 and 99', () => {
   assert.strictEqual(getMatchFlag(90), '🟩');
-  assert.strictEqual(getMatchFlag(85), '🟩');
+  assert.strictEqual(getMatchFlag(80), '🟩');
 });
 
-test('returns red flag for values 40 or below', () => {
-  assert.strictEqual(getMatchFlag(40), '🚩');
+test('returns red flag for values 50 or below', () => {
+  assert.strictEqual(getMatchFlag(50), '🚩');
   assert.strictEqual(getMatchFlag(0), '🚩');
 });
 
 test('returns empty string for other values', () => {
   assert.strictEqual(getMatchFlag(70), '');
-  assert.strictEqual(getMatchFlag(41), '');
+  assert.strictEqual(getMatchFlag(51), '');
 });
 
 test('calculateCategoryMatch returns 0 for empty data', () => {


### PR DESCRIPTION
## Summary
- update match flag thresholds: green >=80%, red <=50%, star at 100%
- refactor compatibility PDF to use shared match flag logic, display raw scores, and scale match bars
- revise tests for new flag thresholds

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689195c30564832cb0647ba2a83dd309