### PR TITLE
feat: add partner progress bars to pdf

### DIFF
--- a/test/generateCompatibilityPDF.test.js
+++ b/test/generateCompatibilityPDF.test.js
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert';
+
+// Test that PDF generator draws separate progress bars for partners
+
+test('generates portrait PDF with partner progress bars', async () => {
+  const rectCalls = [];
+  const textCalls = [];
+  let options;
+
+  class JsPDFMock {
+    constructor(opts) {
+      options = opts;
+      this.internal = { pageSize: { getWidth: () => 210, getHeight: () => 297 } };
+    }
+    setDrawColor() {}
+    setFillColor() {}
+    rect(...args) { rectCalls.push(args); }
+    setTextColor() {}
+    setFontSize() {}
+    text(...args) { textCalls.push(args); }
+    addPage() {}
+    save() {}
+  }
+
+  globalThis.window = { jspdf: { jsPDF: JsPDFMock } };
+  const { generateCompatibilityPDF } = await import('../js/generateCompatibilityPDF.js');
+
+  const data = {
+    categories: [
+      {
+        name: 'Test',
+        items: [ { kink: 'Bondage', partnerA: 5, partnerB: 3 } ]
+      }
+    ]
+  };
+
+  generateCompatibilityPDF(data);
+
+  assert.strictEqual(options.orientation, 'portrait');
+  assert.ok(textCalls.some(c => c[0] === 'Kink Compatibility Report'));
+  // Expect a progress bar width corresponding to partnerB score (3 -> 60% of 40 = 24)
+  assert.ok(rectCalls.some(c => c[2] === 24 && c[3] === 4));
+});


### PR DESCRIPTION
## Summary
- show separate color-coded progress bars for partners A and B in the compatibility PDF
- export PDF generator and add unit test verifying partner bar widths

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891cfa91dc8832c96b13d1bc7149590