### PR TITLE
feat: generate black themed compatibility pdf

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -38,11 +38,6 @@
       width: 100%;
     }
   </style>
-  <!-- Include jsPDF from CDN -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
-  <script>
-    window.jspdf = window.jspdf || window.jspdf;
-  </script>
 </head>
 <body class="theme-dark">
   <div class="main-container themed">
@@ -76,29 +71,7 @@
     </div>
   </div>
 
-  <script>
-    window.compatibilityData = {
-      categories: [
-        {
-          name: "Appearance Play",
-          items: [
-            {
-              label: "Choosing my partner's outfit for the day or a scene",
-              partnerA: 5,
-              partnerB: 5
-            },
-            {
-              label: "Styling their hair (braiding, brushing, tying, etc.)",
-              partnerA: 4,
-              partnerB: 3
-            }
-          ]
-        }
-      ]
-    };
-  </script>
   <script src="js/template-survey.js"></script>
-  <script type="module" src="js/generateCompatibilityPDF.js"></script>
   <script type="module" src="js/compatibilityPage.js"></script>
   <script type="module">
     import { initTheme, applyThemeColors } from './js/theme.js';
@@ -112,6 +85,132 @@
           window.location.href = "/token.html";
         }
       });
+  </script>
+
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+  <script>
+  // Test Data
+  window.compatibilityData = {
+    categories: [
+      {
+        name: "Appearance Play",
+        items: [
+          { label: "Choosing my partner’s outfit for the day or a scene", partnerA: 0, partnerB: 0, marker: "+P" },
+          { label: "Selecting their underwear, lingerie, or base layers", partnerA: 0, partnerB: 0, marker: "+P" },
+          { label: "Styling their hair (braiding, brushing, tying, etc.)", partnerA: 0, partnerB: 0, marker: "+P" },
+          // Add more items as needed
+        ]
+      }
+    ]
+  };
+
+  const shortenLabel = (label) => {
+    const map = {
+      "Choosing my partner’s outfit for the day or a scene": "Choose outfit",
+      "Selecting their underwear, lingerie, or base layers": "Underwear",
+      "Styling their hair (braiding, brushing, tying, etc.)": "Style hair",
+      "Picking head coverings (bonnets, veils, hoods, hats) for mood or protocol": "Headwear",
+      "Offering makeup, polish, or accessories as part of ritual or play": "Makeup/accessories",
+      "Creating themed looks (slutty, innocent, doll-like, sharp, etc.)": "Themed looks",
+      "Dressing them in role-specific costumes (maid, bunny, doll, etc.)": "Roleplay outfits",
+      "Curating time-period or historical outfits (e.g., Victorian, 50s)": "Historical outfits",
+      "Helping them present more femme, masc, or androgynous by request": "Femme/masc styling",
+      "Coordinating their look with mine for public or private scenes": "Coordinated looks",
+      "Implementing a “dress ritual” or aesthetic preparation": "Dress ritual",
+      "Enforcing a visual protocol (e.g., no bra, heels required, tied hair)": "Visual protocol",
+      "Having my outfit selected for me by a partner": "They pick my outfit",
+      "Wearing the underwear or lingerie they choose": "They pick my lingerie",
+      "Having my hair brushed, braided, tied, or styled for them": "Hair for them"
+    };
+    return map[label] || label;
+  };
+
+  const getMatchFlag = (percent, a, b) => {
+    if (percent >= 90) return "⭐";
+    if (percent >= 85) return "🟩";
+    if (percent <= 30) return "🚩";
+    if (a === 5 && b < 5) return "🟨";
+    return "";
+  };
+
+  async function generateCompatibilityPDF(data) {
+    const { jsPDF } = window.jspdf;
+    const doc = new jsPDF();
+    const pageWidth = doc.internal.pageSize.getWidth();
+    const pageHeight = doc.internal.pageSize.getHeight();
+    const margin = 10;
+    let y = 15;
+
+    doc.setFillColor(0, 0, 0);
+    doc.rect(0, 0, pageWidth, pageHeight, "F");
+
+    doc.setTextColor(255, 255, 255);
+    doc.setFontSize(18);
+    doc.text("Kink Compatibility Report", pageWidth / 2, y, { align: "center" });
+    y += 10;
+
+    doc.setFontSize(12);
+    doc.text("Kink", margin, y);
+    doc.text("A", pageWidth - 70, y);
+    doc.text("B", pageWidth - 50, y);
+    doc.text("%", pageWidth - 30, y);
+    y += 7;
+
+    for (const category of data.categories) {
+      doc.setTextColor(100, 150, 255);
+      doc.setFontSize(13);
+      doc.text(category.name, margin, y);
+      y += 6;
+
+      for (const item of category.items) {
+        const label = shortenLabel(item.label);
+        const a = item.partnerA ?? 0;
+        const b = item.partnerB ?? 0;
+        const marker = item.marker ?? "";
+        const percent = 100 - Math.abs(a - b) * 20;
+        const flag = getMatchFlag(percent, a, b);
+        const percentLabel = `${percent}% ${flag} ${marker}`.trim();
+
+        doc.setTextColor(255, 255, 255);
+        doc.setFontSize(11);
+        doc.text(label, margin, y);
+        doc.text(`${a}`, pageWidth - 70, y);
+        doc.text(`${b}`, pageWidth - 50, y);
+        doc.text(percentLabel, pageWidth - 30, y, { align: "right" });
+        y += 6;
+
+        if (y > pageHeight - 20) {
+          doc.addPage();
+          doc.setFillColor(0, 0, 0);
+          doc.rect(0, 0, pageWidth, pageHeight, "F");
+          y = 15;
+        }
+      }
+      y += 4;
+    }
+
+    doc.save("kink-compatibility.pdf");
+  }
+
+  document.addEventListener("DOMContentLoaded", () => {
+    const btn = document.getElementById("downloadPdfBtn");
+    if (btn) {
+      btn.addEventListener("click", () => {
+        if (!window.jspdf?.jsPDF) {
+          alert("PDF library failed to load. Printing the page instead—choose 'Save as PDF' in your browser.");
+          window.print();
+          return;
+        }
+
+        if (!window.compatibilityData) {
+          alert("No compatibility data found.");
+          return;
+        }
+
+        generateCompatibilityPDF(window.compatibilityData);
+      });
+    }
+  });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load jsPDF from CDN and generate PDF with black theme, category headers, markers, and match flags
- compute compatibility percentage between partner scores with flags and markers
- fallback to browser print if jsPDF fails

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689262f8db84832c8ac956bc196213a4