### PR TITLE
Fix PDF download handler initialization

### DIFF
--- a/js/compatibilityPdf.js
+++ b/js/compatibilityPdf.js
@@ -112,14 +112,21 @@ export function generateCompatibilityPDF() {
 }
 
 if (typeof document !== 'undefined') {
-  document.addEventListener('DOMContentLoaded', () => {
+  const attachHandler = () => {
     const button = document.getElementById('downloadPdfBtn');
     if (button) {
       button.addEventListener('click', generateCompatibilityPDF);
     } else {
       console.error('Download button not found');
     }
-  });
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', attachHandler);
+  } else {
+    // DOM already parsed when script loaded
+    attachHandler();
+  }
 }
 
 export function generateCompatibilityPDFLandscape(data) {

--- a/js/generateCompatibilityPDF.js
+++ b/js/generateCompatibilityPDF.js
@@ -102,26 +102,33 @@ export function generateCompatibilityPDF(data) {
 
 // Attach click handler to trigger PDF generation
 if (typeof document !== "undefined") {
-  document.addEventListener("DOMContentLoaded", () => {
+  const attachHandler = () => {
     const btn = document.getElementById("downloadPdfBtn");
-    if (btn) {
-      btn.addEventListener("click", () => {
-        if (!window.jspdf?.jsPDF) {
-          alert(
-            "PDF library failed to load. Printing the page instead—choose 'Save as PDF' in your browser."
-          );
-          window.print();
-          return;
-        }
+    if (!btn) return;
 
-        if (!window.compatibilityData) {
-          alert("No compatibility data found.");
-          return;
-        }
+    btn.addEventListener("click", () => {
+      if (!window.jspdf?.jsPDF) {
+        alert(
+          "PDF library failed to load. Printing the page instead—choose 'Save as PDF' in your browser."
+        );
+        window.print();
+        return;
+      }
 
-        generateCompatibilityPDF(window.compatibilityData);
-      });
-    }
-  });
+      if (!window.compatibilityData) {
+        alert("No compatibility data found.");
+        return;
+      }
+
+      generateCompatibilityPDF(window.compatibilityData);
+    });
+  };
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", attachHandler);
+  } else {
+    // DOM is already ready (script loaded late); attach immediately
+    attachHandler();
+  }
 }
 

--- a/test/pdfDownloadButton.test.js
+++ b/test/pdfDownloadButton.test.js
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert';
+
+// Ensure the PDF download click handler attaches even if the DOM is already loaded
+
+test('PDF download button handler attaches after DOM ready', async () => {
+  let handler;
+  const button = {
+    addEventListener: (evt, cb) => {
+      if (evt === 'click') handler = cb;
+    },
+  };
+
+  const originalDocument = globalThis.document;
+  const originalWindow = globalThis.window;
+  const originalAlert = globalThis.alert;
+  const originalPrint = globalThis.print;
+
+  try {
+    globalThis.document = {
+      readyState: 'complete',
+      getElementById: id => (id === 'downloadPdfBtn' ? button : null),
+      addEventListener: () => {
+        throw new Error('should not wait for DOMContentLoaded');
+      },
+    };
+    globalThis.window = { jspdf: { jsPDF: function jsPDF() {} }, compatibilityData: { categories: [] }, print: () => {} };
+    globalThis.alert = () => {};
+    globalThis.print = () => {};
+
+    await import('../js/generateCompatibilityPDF.js');
+
+    assert.strictEqual(typeof handler, 'function');
+  } finally {
+    if (originalDocument) globalThis.document = originalDocument; else delete globalThis.document;
+    if (originalWindow) globalThis.window = originalWindow; else delete globalThis.window;
+    if (originalAlert) globalThis.alert = originalAlert; else delete globalThis.alert;
+    if (originalPrint) globalThis.print = originalPrint; else delete globalThis.print;
+  }
+});


### PR DESCRIPTION
## Summary
- Ensure PDF download button attaches click handler even if script loads after DOM content is ready
- Apply same DOM ready check to compatibility PDF script
- Add regression test confirming handler attachment when DOM already loaded

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892773d75d0832ca32e7dad7512774b