### PR TITLE
Ensure PDF generator accesses uploaded surveys

### DIFF
--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -283,6 +283,7 @@ function loadFileA(file) {
       mergeSurveyWithTemplate(surveyA, window.templateSurvey);
       normalizeRatings(surveyA);
       filterGeneralOptions(surveyA);
+      window.partnerASurvey = surveyA;
       updateComparison();
     } catch (err) {
       console.warn('Failed to load Survey A:', err);
@@ -305,6 +306,7 @@ function loadFileB(file) {
       mergeSurveyWithTemplate(surveyB, window.templateSurvey);
       normalizeRatings(surveyB);
       filterGeneralOptions(surveyB);
+      window.partnerBSurvey = surveyB;
       updateComparison();
     } catch (err) {
       console.warn('Failed to load Survey B:', err);

--- a/js/pdfDownload.js
+++ b/js/pdfDownload.js
@@ -100,9 +100,12 @@ window.addEventListener("DOMContentLoaded", () => {
     });
 
     try {
-      const surveyDataA = window.partnerASurvey || {};
-      const surveyDataB = window.partnerBSurvey || {};
-      if (!surveyDataA || !surveyDataB) {
+      const surveyDataA = window.partnerASurvey;
+      const surveyDataB = window.partnerBSurvey;
+      if (
+        Object.keys(surveyDataA || {}).length === 0 ||
+        Object.keys(surveyDataB || {}).length === 0
+      ) {
         alert("Both surveys must be uploaded before generating PDF.");
         return;
       }


### PR DESCRIPTION
## Summary
- Expose parsed survey data on `window.partnerASurvey` and `window.partnerBSurvey`
- Guard PDF generation by verifying both surveys are present before proceeding

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689295335d64832ca9f6dad82035014d