### PR TITLE
refactor pdf generation with color bars and flags

### DIFF
--- a/js/matchFlag.js
+++ b/js/matchFlag.js
@@ -1,8 +1,10 @@
 // Shared utility for match flag generation
-export function getMatchFlag(percent) {
+export function getMatchFlag(percent, a, b) {
+  if (percent === null || percent === undefined) return '';
   if (percent === 100) return '⭐'; // Gold star for perfect match
-  if (percent >= 80) return '🟩';   // Green flag
-  if (percent <= 50) return '🚩';   // Red flag
+  if (percent <= 50) return '🚩';   // Red flag for low compatibility
+  if ((a === 5 || b === 5) && a !== b) return '🟨'; // Priority mismatch
+  if (percent >= 85) return '🟩';   // Green flag for strong compatibility
   return '';                        // No flag
 }
 

--- a/test/matchFlag.test.js
+++ b/test/matchFlag.test.js
@@ -6,14 +6,18 @@ test('returns star for 100 percent', () => {
   assert.strictEqual(getMatchFlag(100), '⭐');
 });
 
-test('returns green flag for values between 80 and 99', () => {
+test('returns green flag for values 85 and above', () => {
   assert.strictEqual(getMatchFlag(90), '🟩');
-  assert.strictEqual(getMatchFlag(80), '🟩');
+  assert.strictEqual(getMatchFlag(85), '🟩');
 });
 
 test('returns red flag for values 50 or below', () => {
   assert.strictEqual(getMatchFlag(50), '🚩');
   assert.strictEqual(getMatchFlag(0), '🚩');
+});
+
+test('returns yellow flag for priority mismatches', () => {
+  assert.strictEqual(getMatchFlag(60, 5, 3), '🟨');
 });
 
 test('returns empty string for other values', () => {


### PR DESCRIPTION
## Summary
- streamline compatibility PDF generation with color-coded bars, match flags, and label shortening
- support priority-mismatch flags and refined thresholds in matchFlag utility
- align tests with updated flag logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892b36f8150832cbf05f0728aa55d43