### PR TITLE
Revamp compatibility PDF generator

### DIFF
--- a/js/generateCompatibilityPDF.js
+++ b/js/generateCompatibilityPDF.js
@@ -8,40 +8,9 @@ function getBarColor(matchPercentage) {
   return 'green';
 }
 
-// Subcategory label shortening (2–4 words max)
+// Subcategory label shortening (1–4 words)
 function shortenLabel(text = '') {
-  return text
-    .replace(/Choosing my partner.+?scene/, 'Choose outfit')
-    .replace(/Selecting.+?layers/, 'Underwear')
-    .replace(/Styling.+?etc\./, 'Style hair')
-    .replace(/Picking head coverings.+?protection/, 'Headwear')
-    .replace(/Offering makeup.+?play/, 'Makeup/accessories')
-    .replace(/Creating themed looks.+?etc\./, 'Themed looks')
-    .replace(/Dressing them.+?etc\./, 'Roleplay outfits')
-    .replace(/Curating time-period.+?50s\)/, 'Historical outfits')
-    .replace(/Helping them present.+?request/, 'Femme/masc styling')
-    .replace(/Coordinating.+?scenes/, 'Coordinated looks')
-    .replace(/Implementing.+?preparation/, 'Dress ritual')
-    .replace(/Enforcing.+?tied hair\)/, 'Visual protocol')
-    .replace(/Having my outfit.+?partner/, 'They pick my outfit')
-    .replace(/Wearing the underwear.+?choose/, 'They pick my lingerie')
-    .replace(/Having my hair.+?them/, 'Hair for them')
-    .replace(/Putting on.+?they chose/, 'Headwear (by request)')
-    .replace(/Following visual.+?submission/, 'Visual protocol (rules)')
-    .replace(/Wearing makeup.+?request/, 'Requested makeup')
-    .replace(/Dressing to please.+?etc\./, 'Dress to please')
-    .replace(/Wearing roleplay.+?looks/, 'Roleplay costumes')
-    .replace(/Presenting.+?aesthetic/, 'Match their aesthetic')
-    .replace(/Participating in.+?ceremonies/, 'Dressing rituals')
-    .replace(/Being admired.+?direction/, 'Admired by them')
-    .replace(/Receiving praise.+?appearance/, 'Appearance praise')
-    .replace(/Cosplay.+?etc\./, 'Cosplay looks')
-    .replace(/Time-period dress-up.+?etc\./, 'Historic dress-up')
-    .replace(/Dollification.+?aesthetics/, 'Dollification')
-    .replace(/Uniforms.+?etc\./, 'Uniforms')
-    .replace(/Hair-based play.+?styles\)/, 'Hair-based play')
-    .replace(/Head coverings.+?dynamics/, 'Ritual headwear')
-    .replace(/Matching dress.+?codes/, 'Matching dress codes');
+  return text.split(/\s+/).slice(0, 4).join(' ');
 }
 
 // PDF layout settings
@@ -72,23 +41,22 @@ function drawBar(doc, x, y, matchPercentage) {
   if (filledWidth > 0) {
     doc.setFillColor(barColor);
     doc.rect(x, y, filledWidth, pdfStyles.barHeight, 'F');
-  }
-
-  doc.setFont(pdfStyles.bodyFont, 'normal');
-  doc.setFontSize(10);
-  if (matchPercentage === null) {
-    doc.setTextColor('#888888');
-    doc.text('N/A', x + width + 5, y + pdfStyles.barHeight - 3);
-  } else {
+    doc.setFont(pdfStyles.bodyFont, 'normal');
+    doc.setFontSize(10);
     doc.setTextColor(pdfStyles.textColor);
     doc.text(`${matchPercentage}%`, x + width + 5, y + pdfStyles.barHeight - 3);
+  } else {
+    doc.setFont(pdfStyles.bodyFont, 'normal');
+    doc.setFontSize(9);
+    doc.setTextColor('#CCCCCC');
+    doc.text('N/A', x + width / 2, y + pdfStyles.barHeight - 3, { align: 'center' });
   }
   doc.setTextColor(pdfStyles.textColor);
 }
 
 export function generateCompatibilityPDF(compatibilityData) {
   const { jsPDF } = window.jspdf;
-  const doc = new jsPDF({ unit: 'pt', format: 'letter' });
+  const doc = new jsPDF({ orientation: 'portrait', unit: 'pt', format: 'a4' });
 
   const pageWidth = doc.internal.pageSize.getWidth();
   const pageHeight = doc.internal.pageSize.getHeight();
@@ -139,11 +107,13 @@ export function generateCompatibilityPDF(compatibilityData) {
         typeof item.scoreA === 'number' ? item.scoreA : null;
       const b = typeof item.partnerB === 'number' ? item.partnerB :
         typeof item.scoreB === 'number' ? item.scoreB : null;
-      const match = a === null || b === null ? null : Math.max(0, 100 - Math.abs(a - b) * 20);
+      const match = (a === 0 && b === 0) || a === null || b === null
+        ? null
+        : Math.max(0, 100 - Math.abs(a - b) * 20);
 
       doc.setFont(pdfStyles.bodyFont, 'normal');
       doc.setFontSize(10);
-      doc.text(label, margin, y + boxSize - 2);
+      doc.text(label, margin, y + boxSize - 2, { maxWidth: barX - margin - gap });
       drawScoreBox(boxAX, y, a);
       drawBar(doc, barX, y, match);
       const flag = getMatchFlag(match, a, b);
@@ -168,7 +138,7 @@ export function generateCompatibilityPDF(compatibilityData) {
     }
   });
 
-  doc.save('TalkKink-Compatibility.pdf');
+  doc.save('kink-compatibility.pdf');
   return doc;
 }
 

--- a/js/matchFlag.js
+++ b/js/matchFlag.js
@@ -1,11 +1,9 @@
 // Shared utility for match flag generation
-export function getMatchFlag(percent, a, b) {
+export function getMatchFlag(percent) {
   if (percent === null || percent === undefined) return '';
-  if (percent === 100) return '⭐'; // Gold star for perfect match
-  if (percent <= 50) return '🚩';   // Red flag for low compatibility
-  if ((a === 5 || b === 5) && a !== b) return '🟨'; // Priority mismatch
-  if (percent >= 85) return '🟩';   // Green flag for strong compatibility
-  return '';                        // No flag
+  if (percent >= 90) return '⭐'; // Star for strong compatibility
+  if (percent <= 50) return '🚩'; // Red flag for low compatibility
+  return '';
 }
 
 // Determine progress bar color based on percentage

--- a/test/matchFlag.test.js
+++ b/test/matchFlag.test.js
@@ -2,13 +2,9 @@ import assert from 'node:assert';
 import test from 'node:test';
 import { getMatchFlag, calculateCategoryMatch, getProgressBarColor } from '../js/matchFlag.js';
 
-test('returns star for 100 percent', () => {
+test('returns star for 90 percent and above', () => {
   assert.strictEqual(getMatchFlag(100), '⭐');
-});
-
-test('returns green flag for values 85 and above', () => {
-  assert.strictEqual(getMatchFlag(90), '🟩');
-  assert.strictEqual(getMatchFlag(85), '🟩');
+  assert.strictEqual(getMatchFlag(90), '⭐');
 });
 
 test('returns red flag for values 50 or below', () => {
@@ -16,12 +12,8 @@ test('returns red flag for values 50 or below', () => {
   assert.strictEqual(getMatchFlag(0), '🚩');
 });
 
-test('returns yellow flag for priority mismatches', () => {
-  assert.strictEqual(getMatchFlag(60, 5, 3), '🟨');
-});
-
 test('returns empty string for other values', () => {
-  assert.strictEqual(getMatchFlag(70), '');
+  assert.strictEqual(getMatchFlag(75), '');
   assert.strictEqual(getMatchFlag(51), '');
 });
 


### PR DESCRIPTION
## Summary
- simplify match flag logic to star high matches and red flag low ones
- generate A4 portrait compatibility PDF with short labels and colored bars
- return N/A bars when both partners scored zero and save as `kink-compatibility.pdf`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892b90f2418832c8b05dfc7e0cbf299