### PR TITLE
feat: improve PDF compatibility report visuals

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2193,6 +2193,7 @@ body {
 .partner-fill.green { background-color: #00cc66; box-shadow: 0 0 5px rgba(0,204,102,0.6); }
 .partner-fill.yellow { background-color: #ffcc00; box-shadow: 0 0 5px rgba(255,204,0,0.6); }
 .partner-fill.red { background-color: #ff4444; box-shadow: 0 0 5px rgba(255,68,68,0.6); }
+.partner-fill.black { background-color: #000000; box-shadow: none; }
 .partner-text {
   position: absolute;
   top: -2px;
@@ -2206,6 +2207,7 @@ body {
 .partner-text.green { color: #ffffff; }
 .partner-text.yellow { color: #ffffff; }
 .partner-text.red { color: #ffffff; }
+.partner-text.black { color: #ffffff; }
 .compare-icons {
   width: 40px;
   text-align: right;

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -1,6 +1,6 @@
 // Compatibility results page logic and PDF export helpers
 import { initTheme } from './theme.js';
-import { getMatchFlag, calculateCategoryMatch, getProgressBarColor } from './matchFlag.js';
+import { getFlagEmoji, calculateCategoryMatch, getMatchColor } from './matchFlag.js';
 import { calculateCompatibility } from './compatibility.js';
 
 let surveyA = null;
@@ -74,8 +74,9 @@ function maxRating(obj) {
 }
 
 function colorClass(percent) {
+  if (percent === null || percent === undefined) return 'black';
   if (percent >= 80) return 'green';
-  if (percent >= 60) return 'yellow';
+  if (percent >= 51) return 'yellow';
   return 'red';
 }
 
@@ -83,12 +84,12 @@ function makeBar(percent) {
   const outer = document.createElement('div');
   outer.className = 'partner-bar';
   const fill = document.createElement('div');
-  fill.className = 'partner-fill ' + colorClass(percent ?? 0);
+  fill.className = 'partner-fill ' + colorClass(percent);
   fill.style.width = percent === null ? '0%' : percent + '%';
-  fill.style.backgroundColor = getProgressBarColor(percent ?? 0);
+  fill.style.backgroundColor = getMatchColor(percent);
   outer.appendChild(fill);
   const text = document.createElement('span');
-  text.className = 'partner-text ' + colorClass(percent ?? 0);
+  text.className = 'partner-text ' + colorClass(percent);
   text.textContent = percent === null ? '-' : percent + '%';
   outer.appendChild(text);
   return outer;
@@ -128,7 +129,7 @@ function groupKinksByCategory(data) {
 
 function renderCategoryRow(categoryName, categoryData) {
   const percent = calculateCategoryMatch(categoryData);
-  const flag = getMatchFlag(percent);
+  const flag = getFlagEmoji(percent);
   const tr = document.createElement('tr');
   tr.classList.add('category-header');
   tr.innerHTML = `
@@ -143,7 +144,7 @@ function renderCategoryRow(categoryName, categoryData) {
 
 function renderCategoryHeaderPDF(doc, categoryName, categoryData) {
   const percent = calculateCategoryMatch(categoryData);
-  const flag = getMatchFlag(percent);
+  const flag = getFlagEmoji(percent);
   doc.moveDown(0.4);
   doc
     .fontSize(14)
@@ -378,7 +379,7 @@ function updateComparison() {
   const renderCell = rating => {
     const percent = toPercent(rating);
     const pct = percent === null ? 0 : percent;
-    const color = getProgressBarColor(percent ?? 0);
+    const color = getMatchColor(percent);
     const td = document.createElement('td');
     td.innerHTML = `<div class="bar-container"><div class="bar" style="width: ${pct}%; background-color: ${color}"></div></div>` +
       `<div class="percent-label">${percent === null ? '-' : percent + '%'}</div>`;

--- a/js/compatibilityPdf.js
+++ b/js/compatibilityPdf.js
@@ -1,4 +1,4 @@
-import { getMatchFlag } from './matchFlag.js';
+import { getFlagEmoji, getMatchColor } from './matchFlag.js';
 
 export function generateCompatibilityPDF() {
   console.log('PDF function triggered');
@@ -55,9 +55,27 @@ export function generateCompatibilityPDF() {
   };
 
   const drawMatchBar = (x, y, match) => {
-    const color = match >= 80 ? [0, 255, 0] : match >= 60 ? [255, 255, 0] : [255, 0, 0];
-    doc.setFillColor(...color);
-    doc.rect(x, y, config.barWidth * (match / 100), config.boxHeight, 'F');
+    doc.setFillColor(0, 0, 0);
+    doc.rect(x, y, config.barWidth, config.boxHeight, 'F');
+    if (match !== null && match !== undefined) {
+      const color = getMatchColor(match);
+      doc.setFillColor(color);
+      doc.rect(x, y, config.barWidth * (match / 100), config.boxHeight, 'F');
+      doc.setTextColor(255);
+      doc.setFontSize(8);
+      doc.text(`${match}%`, x + config.barWidth / 2, y + config.boxHeight / 2, {
+        align: 'center',
+        baseline: 'middle'
+      });
+    } else {
+      doc.setTextColor(255);
+      doc.setFontSize(8);
+      doc.text('N/A', x + config.barWidth / 2, y + config.boxHeight / 2, {
+        align: 'center',
+        baseline: 'middle'
+      });
+    }
+    doc.setTextColor(255);
   };
 
   const data = window.compatibilityData;
@@ -80,6 +98,7 @@ export function generateCompatibilityPDF() {
     doc.text(category.category || category.name, config.margin, y);
     doc.setFontSize(10);
     doc.text('Partner A', config.colA, y);
+    doc.text('Flag', config.centerX + config.barWidth + 2, y);
     doc.text('Partner B', config.colB, y);
     y += 6;
 
@@ -93,7 +112,7 @@ export function generateCompatibilityPDF() {
       const a = item.a ?? item.partnerA ?? 0;
       const b = item.b ?? item.partnerB ?? 0;
       const match = Math.max(0, 100 - Math.abs(a - b) * 25);
-      const flag = getMatchFlag(match);
+      const flag = getFlagEmoji(match);
       const label = item.label || item.kink || '';
 
       doc.setFontSize(9);

--- a/js/matchFlag.js
+++ b/js/matchFlag.js
@@ -1,16 +1,17 @@
-// Shared utility for match flag generation
-export function getMatchFlag(percent) {
+// Generate flag emoji based on compatibility percentage
+export function getFlagEmoji(percent) {
   if (percent === null || percent === undefined) return '';
   if (percent >= 90) return '⭐'; // Star for strong compatibility
   if (percent <= 50) return '🚩'; // Red flag for low compatibility
   return '';
 }
 
-// Determine progress bar color based on percentage
-export function getProgressBarColor(percent) {
+// Determine bar color based on percentage
+export function getMatchColor(percent) {
+  if (percent === null || percent === undefined) return '#000000';
   if (percent >= 80) return '#00cc66';   // Green for 80% and above
-  if (percent >= 60) return '#ffcc00';   // Yellow for 60-79%
-  return '#ff4444';                     // Red for below 60%
+  if (percent >= 51) return '#ffcc00';   // Yellow for 51-79%
+  return '#ff4444';                     // Red for 0-50%
 }
 
 // Calculate the percentage of items where both partners match on a rating

--- a/test/generateCompatibilityPDF.test.js
+++ b/test/generateCompatibilityPDF.test.js
@@ -41,6 +41,9 @@ test('generates PDF with score columns and percent', async () => {
   assert.ok(textCalls.some(c => c[0] === 'Bondage'));
   assert.ok(textCalls.some(c => c[0] === '5'));
   assert.ok(textCalls.some(c => c[0] === '1'));
+  assert.ok(textCalls.some(c => c[0] === 'Partner A'));
+  assert.ok(textCalls.some(c => c[0] === 'Partner B'));
+  assert.ok(textCalls.some(c => c[0] === 'Flag'));
   // For low match scores, a red flag indicator should be shown
   assert.ok(textCalls.some(c => c[0] === '🚩'));
 });

--- a/test/matchFlag.test.js
+++ b/test/matchFlag.test.js
@@ -1,20 +1,20 @@
 import assert from 'node:assert';
 import test from 'node:test';
-import { getMatchFlag, calculateCategoryMatch, getProgressBarColor } from '../js/matchFlag.js';
+import { getFlagEmoji, calculateCategoryMatch, getMatchColor } from '../js/matchFlag.js';
 
 test('returns star for 90 percent and above', () => {
-  assert.strictEqual(getMatchFlag(100), '⭐');
-  assert.strictEqual(getMatchFlag(90), '⭐');
+  assert.strictEqual(getFlagEmoji(100), '⭐');
+  assert.strictEqual(getFlagEmoji(90), '⭐');
 });
 
 test('returns red flag for values 50 or below', () => {
-  assert.strictEqual(getMatchFlag(50), '🚩');
-  assert.strictEqual(getMatchFlag(0), '🚩');
+  assert.strictEqual(getFlagEmoji(50), '🚩');
+  assert.strictEqual(getFlagEmoji(0), '🚩');
 });
 
 test('returns empty string for other values', () => {
-  assert.strictEqual(getMatchFlag(75), '');
-  assert.strictEqual(getMatchFlag(51), '');
+  assert.strictEqual(getFlagEmoji(75), '');
+  assert.strictEqual(getFlagEmoji(51), '');
 });
 
 test('calculateCategoryMatch returns 0 for empty data', () => {
@@ -40,8 +40,9 @@ test('calculateCategoryMatch ignores missing values', () => {
   assert.strictEqual(calculateCategoryMatch(data), 50);
 });
 
-test('getProgressBarColor returns expected hex codes', () => {
-  assert.strictEqual(getProgressBarColor(85), '#00cc66');
-  assert.strictEqual(getProgressBarColor(70), '#ffcc00');
-  assert.strictEqual(getProgressBarColor(50), '#ff4444');
+test('getMatchColor returns expected hex codes', () => {
+  assert.strictEqual(getMatchColor(85), '#00cc66');
+  assert.strictEqual(getMatchColor(70), '#ffcc00');
+  assert.strictEqual(getMatchColor(50), '#ff4444');
+  assert.strictEqual(getMatchColor(null), '#000000');
 });


### PR DESCRIPTION
## Summary
- add color-aware `drawMatchBar` that centers text and handles missing data
- introduce shared `getFlagEmoji` and `getMatchColor` helpers
- label PDF columns and left-align category titles for clarity

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892ce04bcd0832c8cb5a7b0687baa0a