### PR TITLE
Use color names and show match column in PDF report

### DIFF
--- a/js/compatibilityPdf.js
+++ b/js/compatibilityPdf.js
@@ -99,6 +99,7 @@ export function generateCompatibilityPDF() {
     doc.text(category.category || category.name, config.margin, y);
     doc.setFontSize(10);
     doc.text('Partner A', config.colA, y);
+    doc.text('Match', config.centerX + config.barWidth / 2, y, { align: 'center' });
     doc.text('Flag', config.centerX + config.barWidth + 2, y);
     doc.text('Partner B', config.colB, y);
     y += 6;

--- a/js/generateCompatibilityPDF.js
+++ b/js/generateCompatibilityPDF.js
@@ -27,17 +27,17 @@ function shortenLabel(text = '') {
 
 // PDF layout settings
 const pdfStyles = {
-  backgroundColor: '#000000',
+  backgroundColor: 'black',
   textColor: '#FFFFFF',
   headingFont: 'helvetica',
   bodyFont: 'helvetica',
   barHeight: 10,
   barSpacing: 6,
   barColors: {
-    green: '#00FF00',
-    yellow: '#FFFF00',
-    red: '#FF0000',
-    black: '#000000'
+    green: 'green',
+    yellow: 'yellow',
+    red: 'red',
+    black: 'black'
   }
 };
 
@@ -136,6 +136,7 @@ export function generateCompatibilityPDF(compatibilityData) {
     doc.setFont(pdfStyles.bodyFont, 'bold');
     doc.setFontSize(9);
     doc.text('Partner A', boxAX + boxSize / 2, y, { align: 'center' });
+    doc.text('Match', barX + barWidth / 2, y, { align: 'center' });
     doc.text('Flag', flagX + flagWidth / 2, y, { align: 'center' });
     doc.text('Partner B', boxBX + boxSize / 2, y, { align: 'center' });
     y += pdfStyles.barSpacing;

--- a/js/matchFlag.js
+++ b/js/matchFlag.js
@@ -8,10 +8,10 @@ export function getFlagEmoji(percent) {
 
 // Determine bar color based on percentage
 export function getMatchColor(percent) {
-  if (percent === null || percent === undefined) return '#000000';
-  if (percent >= 80) return '#00cc66';   // Green for 80% and above
-  if (percent >= 51) return '#ffcc00';   // Yellow for 51-79%
-  return '#ff4444';                     // Red for 0-50%
+  if (percent === null || percent === undefined) return 'black';
+  if (percent >= 80) return 'green';
+  if (percent >= 51) return 'yellow';
+  return 'red'; // 50 or less
 }
 
 // Calculate the percentage of items where both partners match on a rating

--- a/test/matchFlag.test.js
+++ b/test/matchFlag.test.js
@@ -40,9 +40,9 @@ test('calculateCategoryMatch ignores missing values', () => {
   assert.strictEqual(calculateCategoryMatch(data), 50);
 });
 
-test('getMatchColor returns expected hex codes', () => {
-  assert.strictEqual(getMatchColor(85), '#00cc66');
-  assert.strictEqual(getMatchColor(70), '#ffcc00');
-  assert.strictEqual(getMatchColor(50), '#ff4444');
-  assert.strictEqual(getMatchColor(null), '#000000');
+test('getMatchColor returns expected color names', () => {
+  assert.strictEqual(getMatchColor(85), 'green');
+  assert.strictEqual(getMatchColor(70), 'yellow');
+  assert.strictEqual(getMatchColor(50), 'red');
+  assert.strictEqual(getMatchColor(null), 'black');
 });


### PR DESCRIPTION
## Summary
- return color names for match bar styling
- add Match header to PDF compatibility reports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6892d80c2aa4832ca3f842d8c97d74d9