### PR TITLE
Add compatibility report PDF rendering helpers

### DIFF
--- a/js/compatibilityReportHelpers.js
+++ b/js/compatibilityReportHelpers.js
@@ -1,0 +1,64 @@
+import { getMatchColor, getFlagEmoji } from './matchFlag.js';
+
+// Match Bar Renderer with label inside
+export function drawMatchBar(doc, x, y, width, height, percentage) {
+  const color = getMatchColor(percentage);
+  const label = percentage !== null && percentage !== undefined ? `${percentage}%` : 'N/A';
+
+  // Bar background
+  doc.setFillColor('black');
+  doc.rect(x, y, width, height, 'F');
+
+  if (percentage !== null && percentage !== undefined) {
+    const fillWidth = Math.floor((percentage / 100) * width);
+    doc.setFillColor(color);
+    doc.rect(x, y, fillWidth, height, 'F');
+  }
+
+  // Text centered in bar
+  doc.setTextColor('white');
+  doc.setFontSize(8);
+  doc.text(label, x + width / 2, y + height / 2 + 2, { align: 'center' });
+}
+
+// Render Category Header Row
+export function renderCategoryHeader(doc, x, y, categoryName) {
+  doc.setFontSize(14);
+  doc.setTextColor('white');
+  doc.text(categoryName, x, y);
+  doc.setFontSize(10);
+}
+
+// Render Individual Row with full layout
+export function renderItemRow(doc, x, y, itemLabel, aScore, bScore, matchPercent) {
+  const barWidth = 40;
+  const barHeight = 8;
+  const labelX = x;
+  const aX = x + 190;
+  const barX = aX + 40;
+  const flagX = barX + barWidth + 5;
+  const bX = flagX + 20;
+
+  doc.setFontSize(10);
+  doc.setTextColor('white');
+  doc.text(itemLabel, labelX, y);
+
+  doc.text(aScore ?? 'N/A', aX, y);
+  drawMatchBar(doc, barX, y - barHeight + 1, barWidth, barHeight, matchPercent);
+  doc.text(getFlagEmoji(matchPercent), flagX, y);
+  doc.text(bScore ?? 'N/A', bX, y);
+}
+
+// Render Category Section
+export function renderCategorySection(doc, startX, startY, categoryName, items) {
+  renderCategoryHeader(doc, startX, startY, categoryName);
+  let currentY = startY + 10;
+
+  for (const item of items) {
+    const { label, partnerA, partnerB, match } = item;
+    renderItemRow(doc, startX, currentY, label, partnerA, partnerB, match);
+    currentY += 12;
+  }
+
+  return currentY;
+}

--- a/test/compatibilityReportHelpers.test.js
+++ b/test/compatibilityReportHelpers.test.js
@@ -1,0 +1,42 @@
+import assert from 'node:assert';
+import test from 'node:test';
+import { drawMatchBar, renderCategorySection } from '../js/compatibilityReportHelpers.js';
+
+function createDocMock() {
+  const calls = [];
+  const record = (name) => (...args) => {
+    calls.push([name, args]);
+  };
+  return {
+    calls,
+    setFillColor: record('setFillColor'),
+    rect: record('rect'),
+    setTextColor: record('setTextColor'),
+    setFontSize: record('setFontSize'),
+    text: record('text')
+  };
+}
+
+test('drawMatchBar fills width proportional to percentage', () => {
+  const doc = createDocMock();
+  drawMatchBar(doc, 10, 10, 100, 8, 50);
+  const rectCalls = doc.calls.filter(c => c[0] === 'rect');
+  assert.deepStrictEqual(rectCalls[0], ['rect', [10, 10, 100, 8, 'F']]);
+  assert.deepStrictEqual(rectCalls[1], ['rect', [10, 10, 50, 8, 'F']]);
+  const textCall = doc.calls.find(c => c[0] === 'text');
+  assert.deepStrictEqual(textCall, ['text', ['50%', 60, 16, { align: 'center' }]]);
+});
+
+test('renderCategorySection renders each item and returns final y', () => {
+  const doc = createDocMock();
+  const items = [
+    { label: 'First', partnerA: 1, partnerB: 1, match: 100 },
+    { label: 'Second', partnerA: 2, partnerB: 3, match: 75 }
+  ];
+  const endY = renderCategorySection(doc, 5, 20, 'MyCat', items);
+  assert.strictEqual(endY, 20 + 10 + 12 * items.length);
+  const texts = doc.calls.filter(c => c[0] === 'text').map(c => c[1][0]);
+  assert(texts.includes('MyCat'));
+  assert(texts.includes('First'));
+  assert(texts.includes('Second'));
+});


### PR DESCRIPTION
## Summary
- add reusable helpers for drawing PDF match bars, headers, and rows
- cover new helpers with unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893b2872b84832c9c43b16b9fd3be05