### PR TITLE
feat: use dynamic pdf column widths

### DIFF
--- a/js/compatibilityReportHelpers.js
+++ b/js/compatibilityReportHelpers.js
@@ -48,14 +48,8 @@ function renderCategoryHeader(doc, x, y, category) {
 }
 
 // Render a single item row
-function renderItemRow(doc, x, y, label, partnerA, partnerB, match) {
-  const colLabel = x;
-  const colA = x + 185;
-  const colBar = colA + 42;
-  const colFlag = colBar + 47;
-  const colB = colFlag + 20;
-  const barW = 45;
-  const barH = 9;
+function renderItemRow(doc, layout, y, label, partnerA, partnerB, match) {
+  const { colLabel, colA, colBar, colFlag, colB, barWidth, barHeight } = layout;
 
   doc.setTextColor('white');
 
@@ -64,7 +58,7 @@ function renderItemRow(doc, x, y, label, partnerA, partnerB, match) {
 
   doc.text(partnerA ?? 'N/A', colA, y);
 
-  drawMatchBar(doc, colBar, y - 6.5, barW, barH, match);
+  drawMatchBar(doc, colBar, y - barHeight + 2.5, barWidth, barHeight, match);
 
   doc.setFontSize(9);
   doc.text(getFlagEmoji(match), colFlag, y);
@@ -73,24 +67,32 @@ function renderItemRow(doc, x, y, label, partnerA, partnerB, match) {
 }
 
 // Render an entire category section including column headers
-export function renderCategorySection(doc, startX, startY, categoryLabel, items) {
+export function renderCategorySection(doc, startX, startY, categoryLabel, items, usableWidth) {
   renderCategoryHeader(doc, startX, startY, categoryLabel);
   let currentY = startY + 13;
+
+  const colLabel = startX;
+  const colA = startX + usableWidth * 0.45;
+  const barWidth = usableWidth * 0.15;
+  const colBar = startX + usableWidth * 0.6;
+  const colFlag = colBar + barWidth + usableWidth * 0.02;
+  const colB = startX + usableWidth * 0.85;
+  const layout = { colLabel, colA, colBar, colFlag, colB, barWidth, barHeight: 9 };
 
   // Column titles
   doc.setFontSize(9);
   doc.setTextColor('white');
-  doc.text('Partner A', startX + 185, currentY);
-  doc.text('Match', startX + 230, currentY);
-  doc.text('Flag', startX + 278, currentY);
-  doc.text('Partner B', startX + 298, currentY);
+  doc.text('Partner A', colA, currentY);
+  doc.text('Match', colBar + barWidth / 2, currentY, { align: 'center' });
+  doc.text('Flag', colFlag, currentY);
+  doc.text('Partner B', colB, currentY);
 
   currentY += 10;
 
   for (const item of items) {
     renderItemRow(
       doc,
-      startX,
+      layout,
       currentY,
       item.label,
       item.partnerA,

--- a/js/generateCompatibilityPDF.js
+++ b/js/generateCompatibilityPDF.js
@@ -60,6 +60,7 @@ export function generateCompatibilityPDF(compatibilityData) {
   const pageWidth = doc.internal.pageSize.getWidth();
   const pageHeight = doc.internal.pageSize.getHeight();
   const margin = 40;
+  const usableWidth = pageWidth - margin * 2;
   const lineHeight = pdfStyles.barHeight + pdfStyles.barSpacing;
 
   const drawBackground = () => {
@@ -94,7 +95,14 @@ export function generateCompatibilityPDF(compatibilityData) {
       };
     });
 
-    y = renderCategorySection(doc, margin, y, category.category || category.name, items);
+    y = renderCategorySection(
+      doc,
+      margin,
+      y,
+      category.category || category.name,
+      items,
+      usableWidth
+    );
     y += pdfStyles.barSpacing;
     if (y + lineHeight > pageHeight - margin) {
       doc.addPage();

--- a/test/compatibilityReportHelpers.test.js
+++ b/test/compatibilityReportHelpers.test.js
@@ -34,7 +34,9 @@ test('renderCategorySection renders each item and returns final y', () => {
     { label: 'First', partnerA: 1, partnerB: 1, match: 100 },
     { label: 'Second', partnerA: 2, partnerB: 3, match: 75 }
   ];
-  const endY = renderCategorySection(doc, 5, 20, 'MyCat', items);
+  const margin = 5;
+  const usableWidth = doc.internal.pageSize.getWidth() - margin * 2;
+  const endY = renderCategorySection(doc, margin, 20, 'MyCat', items, usableWidth);
   assert.strictEqual(endY, 20 + 23 + 12 * items.length);
   const texts = doc.calls.filter(c => c[0] === 'text').map(c => c[1][0]);
   assert(texts.includes('MyCat'));


### PR DESCRIPTION
## Summary
- spread compatibility report columns using page width to avoid cramped PDF layout
- compute usable page width dynamically and pass to section renderer
- adjust compatibility section helper to position columns relatively

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893c5e12498832c8262741528170d09