### PR TITLE
feat: expand match flag logic

### DIFF
--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -76,7 +76,7 @@ function maxRating(obj) {
 function colorClass(percent) {
   if (percent === null || percent === undefined) return 'black';
   if (percent >= 80) return 'green';
-  if (percent >= 51) return 'yellow';
+  if (percent >= 60) return 'yellow';
   return 'red';
 }
 

--- a/js/compatibilityPdf.js
+++ b/js/compatibilityPdf.js
@@ -125,7 +125,8 @@ export function generateCompatibilityPDF() {
         typeof aScore === 'number' && typeof bScore === 'number'
           ? Math.max(0, 100 - Math.abs(aScore - bScore) * 25)
           : null;
-      const flag = match === null ? '' : getFlagEmoji(match);
+      const flag =
+        match === null ? '' : getFlagEmoji(match, aScore, bScore);
       const label = item.label || item.kink || '';
 
       // Debug output to verify values are pulled correctly

--- a/js/compatibilityReportHelpers.js
+++ b/js/compatibilityReportHelpers.js
@@ -10,10 +10,16 @@ function getMatchColor(percentage) {
 }
 
 // Determine which flag emoji to show
-function getFlagEmoji(percentage) {
+function getFlagEmoji(percentage, a, b) {
   if (percentage === null || percentage === undefined) return '';
   if (percentage >= 90) return '⭐';
-  if (percentage <= 50) return '🚩';
+  if (percentage >= 80) return '🟩';
+  if (percentage <= 40) return '🚩';
+  if (
+    (a === 5 && typeof b === 'number' && b < 5) ||
+    (b === 5 && typeof a === 'number' && a < 5)
+  )
+    return '🟨';
   return '';
 }
 
@@ -61,7 +67,7 @@ function renderItemRow(doc, layout, y, label, partnerA, partnerB, match) {
   drawMatchBar(doc, colBar, y - barHeight + 2.5, barWidth, barHeight, match);
 
   doc.setFontSize(9);
-  doc.text(getFlagEmoji(match), colFlag, y);
+  doc.text(getFlagEmoji(match, partnerA, partnerB), colFlag, y);
 
   doc.text(partnerB ?? 'N/A', colB, y);
 }

--- a/js/generateCompatibilityPDF.js
+++ b/js/generateCompatibilityPDF.js
@@ -45,7 +45,7 @@ const pdfStyles = {
 function getHistoryIcon(score) {
   if (typeof score !== 'number') return '⚪';
   if (score >= 80) return '🟢';
-  if (score >= 51) return '🟡';
+  if (score >= 60) return '🟡';
   return '🔴';
 }
 

--- a/js/matchFlag.js
+++ b/js/matchFlag.js
@@ -1,8 +1,14 @@
-// Generate flag emoji based on compatibility percentage
-export function getFlagEmoji(percent) {
+// Generate flag emoji based on compatibility percentage and individual scores
+export function getFlagEmoji(percent, a, b) {
   if (percent === null || percent === undefined) return '';
-  if (percent >= 90) return '⭐'; // Star for strong compatibility
-  if (percent <= 50) return '🚩'; // Red flag for low compatibility
+  if (percent >= 90) return '⭐';
+  if (percent >= 80) return '🟩';
+  if (percent <= 40) return '🚩';
+  if (
+    (a === 5 && typeof b === 'number' && b < 5) ||
+    (b === 5 && typeof a === 'number' && a < 5)
+  )
+    return '🟨';
   return '';
 }
 
@@ -10,8 +16,8 @@ export function getFlagEmoji(percent) {
 export function getMatchColor(percent) {
   if (percent === null || percent === undefined) return 'black';
   if (percent >= 80) return 'green';
-  if (percent >= 51) return 'yellow';
-  return 'red'; // 50 or less
+  if (percent >= 60) return 'yellow';
+  return 'red';
 }
 
 // Calculate the percentage of items where both partners match on a rating

--- a/test/generateCompatibilityPDF.test.js
+++ b/test/generateCompatibilityPDF.test.js
@@ -29,7 +29,12 @@ test('generates PDF with score columns and percent', async () => {
     categories: [
       {
         category: 'Test',
-        items: [ { label: 'Bondage', partnerA: 5, partnerB: 1, match: 20 } ]
+        items: [
+          { label: 'Star', partnerA: 5, partnerB: 5 },
+          { label: 'Green', partnerA: 5, partnerB: 4 },
+          { label: 'Yellow', partnerA: 5, partnerB: 3 },
+          { label: 'Red', partnerA: 5, partnerB: 1 }
+        ]
       }
     ]
   };
@@ -38,13 +43,17 @@ test('generates PDF with score columns and percent', async () => {
 
   assert.ok(rectCalls.length > 0);
   assert.ok(textCalls.some(c => c[0] === 'Kink Compatibility Report'));
-  assert.ok(textCalls.some(c => c[0] === 'Bondage'));
-  assert.ok(textCalls.some(c => String(c[0]) === '5'));
-  assert.ok(textCalls.some(c => String(c[0]) === '1'));
+  assert.ok(textCalls.some(c => c[0] === 'Star'));
+  assert.ok(textCalls.some(c => c[0] === 'Green'));
+  assert.ok(textCalls.some(c => c[0] === 'Yellow'));
+  assert.ok(textCalls.some(c => c[0] === 'Red'));
   assert.ok(textCalls.some(c => c[0] === 'Partner A'));
   assert.ok(textCalls.some(c => c[0] === 'Partner B'));
   assert.ok(textCalls.some(c => c[0] === 'Flag'));
-  // For low match scores, a red flag indicator should be shown
+  // Indicators for various match scenarios
+  assert.ok(textCalls.some(c => c[0] === '⭐'));
+  assert.ok(textCalls.some(c => c[0] === '🟩'));
+  assert.ok(textCalls.some(c => c[0] === '🟨'));
   assert.ok(textCalls.some(c => c[0] === '🚩'));
 });
 

--- a/test/matchFlag.test.js
+++ b/test/matchFlag.test.js
@@ -7,14 +7,23 @@ test('returns star for 90 percent and above', () => {
   assert.strictEqual(getFlagEmoji(90), '⭐');
 });
 
-test('returns red flag for values 50 or below', () => {
-  assert.strictEqual(getFlagEmoji(50), '🚩');
+test('returns green square for values 80-89', () => {
+  assert.strictEqual(getFlagEmoji(85), '🟩');
+});
+
+test('returns red flag for values 40 or below', () => {
+  assert.strictEqual(getFlagEmoji(40), '🚩');
   assert.strictEqual(getFlagEmoji(0), '🚩');
+});
+
+test('returns yellow flag when one partner loves it and the other does not', () => {
+  assert.strictEqual(getFlagEmoji(60, 5, 3), '🟨');
+  assert.strictEqual(getFlagEmoji(60, 3, 5), '🟨');
 });
 
 test('returns empty string for other values', () => {
   assert.strictEqual(getFlagEmoji(75), '');
-  assert.strictEqual(getFlagEmoji(51), '');
+  assert.strictEqual(getFlagEmoji(41), '');
 });
 
 test('calculateCategoryMatch returns 0 for empty data', () => {
@@ -42,7 +51,7 @@ test('calculateCategoryMatch ignores missing values', () => {
 
 test('getMatchColor returns expected color names', () => {
   assert.strictEqual(getMatchColor(85), 'green');
-  assert.strictEqual(getMatchColor(70), 'yellow');
-  assert.strictEqual(getMatchColor(50), 'red');
+  assert.strictEqual(getMatchColor(60), 'yellow');
+  assert.strictEqual(getMatchColor(59), 'red');
   assert.strictEqual(getMatchColor(null), 'black');
 });


### PR DESCRIPTION
## Summary
- add granular match flags for star, green square, yellow caution and red flag
- apply new flag logic in PDF rendering helpers
- align yellow bar threshold to 60% and update tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893ce18a2e4832c9986c4292b37e0ac