### PR TITLE
Add basic survey PDF generator

### DIFF
--- a/js/rawSurveyPdf.js
+++ b/js/rawSurveyPdf.js
@@ -1,0 +1,51 @@
+export function generateCompatibilityPDF(partnerAData, partnerBData, doc) {
+  const categories = Object.keys(partnerAData);
+  categories.forEach(category => {
+    const items = Object.keys(partnerAData[category]);
+    renderCategoryHeaderPDF(doc, category);
+    items.forEach(item => {
+      const scoreA = partnerAData?.[category]?.[item];
+      const scoreB = partnerBData?.[category]?.[item];
+      const displayA = scoreA !== undefined ? scoreA : 'N/A';
+      const displayB = scoreB !== undefined ? scoreB : 'N/A';
+      let match = 'N/A';
+      if (scoreA !== undefined && scoreB !== undefined) {
+        const diff = Math.abs(scoreA - scoreB);
+        match = 100 - diff * 20;
+      }
+      let flag = '';
+      if (match !== 'N/A') {
+        if (match >= 90) flag = '⭐';
+        else if (match >= 80) flag = '🟩';
+        else if (match <= 40) flag = '🚩';
+      }
+      renderRowPDF(doc, {
+        label: item,
+        scoreA: displayA,
+        scoreB: displayB,
+        match: match !== 'N/A' ? `${match}%` : 'N/A',
+        flag
+      });
+    });
+  });
+}
+
+function renderCategoryHeaderPDF(doc, category) {
+  doc.setFontSize(14);
+  doc.setTextColor(255, 255, 255);
+  doc.text(category, 50, doc.y);
+  doc.y += 10;
+}
+
+function renderRowPDF(doc, { label, scoreA, scoreB, match, flag }) {
+  const y = doc.y;
+  doc.setFontSize(10);
+  doc.text(label, 50, y);
+  doc.text(String(scoreA), 250, y);
+  doc.text(String(match), 300, y);
+  doc.text(String(flag), 350, y);
+  doc.text(String(scoreB), 400, y);
+  doc.y += 8;
+}
+
+export default generateCompatibilityPDF;

--- a/test/rawSurveyPdf.test.js
+++ b/test/rawSurveyPdf.test.js
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert';
+
+function createDoc() {
+  const textCalls = [];
+  const doc = {
+    y: 20,
+    setFontSize() {},
+    setTextColor() {},
+    text(...args) { textCalls.push(args); }
+  };
+  return { doc, textCalls };
+}
+
+test('renders categories, scores, matches and flags', async () => {
+  const { doc, textCalls } = createDoc();
+  const { generateCompatibilityPDF } = await import('../js/rawSurveyPdf.js');
+  const partnerA = { Cat: { Item1: 5, Item2: 4 } };
+  const partnerB = { Cat: { Item1: 5, Item2: 3 } };
+  generateCompatibilityPDF(partnerA, partnerB, doc);
+  const texts = textCalls.map(c => c[0]);
+  assert.ok(texts.includes('Cat'));
+  assert.ok(texts.includes('Item1'));
+  assert.ok(texts.includes('5'));
+  assert.ok(texts.includes('100%'));
+  assert.ok(texts.includes('⭐'));
+  assert.ok(texts.includes('80%'));
+  assert.ok(texts.includes('🟩'));
+});
+
+test('handles missing scores as N/A', async () => {
+  const { doc, textCalls } = createDoc();
+  const { generateCompatibilityPDF } = await import('../js/rawSurveyPdf.js');
+  const partnerA = { Cat: { Item1: 5 } };
+  const partnerB = { Cat: {} };
+  generateCompatibilityPDF(partnerA, partnerB, doc);
+  const texts = textCalls.map(c => c[0]);
+  assert.ok(texts.includes('N/A'));
+});


### PR DESCRIPTION
## Summary
- implement simple compatibility PDF generator operating on raw survey data
- test generator for flag, match, and missing data handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893d333932c832cbb3246262a8137c9