### PR TITLE
feat: label partner columns in compatibility pdf

### DIFF
--- a/js/rawSurveyPdf.js
+++ b/js/rawSurveyPdf.js
@@ -56,6 +56,14 @@ function renderCategoryHeaderPDF(doc, title) {
   doc.setTextColor(255, 255, 255);
   doc.text(title, 50, doc.y);
   doc.y += 10;
+
+  // Column headers so we know which scores belong to which partner
+  doc.setFontSize(10);
+  doc.text('Partner A', 250, doc.y);
+  doc.text('Match', 300, doc.y);
+  doc.text('Flag', 350, doc.y);
+  doc.text('Partner B', 400, doc.y);
+  doc.y += 8;
 }
 
 // 🧾 Render a row: Label | A | Match | Flag | B


### PR DESCRIPTION
## Summary
- add Partner A/B column headers in raw survey PDF generator
- ensure compatibility PDF clearly maps uploaded surveys to each partner

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893dfb50ce4832c8d0ca2c99df4a854