### PR TITLE
feat: invert colors for compatibility PDF

### DIFF
--- a/js/pdfDownload.js
+++ b/js/pdfDownload.js
@@ -54,7 +54,25 @@ window.addEventListener('DOMContentLoaded', () => {
 
     const { jsPDF } = window.jspdf;
     const doc = new jsPDF({ orientation: 'landscape' });
-    doc.y = 50;
+
+    // Set black background
+    doc.setFillColor(0, 0, 0);
+    doc.rect(
+      0,
+      0,
+      doc.internal.pageSize.getWidth(),
+      doc.internal.pageSize.getHeight(),
+      'F'
+    );
+
+    // Set default text color to white
+    doc.setTextColor(255, 255, 255);
+
+    // Set default font and position
+    doc.setFont('helvetica', 'normal');
+    doc.setFontSize(12);
+    doc.y = 50; // initial y position
+
     generateCompatibilityPDF(partnerAData, partnerBData, doc);
     doc.save('kink-compatibility.pdf');
   });

--- a/js/rawSurveyPdf.js
+++ b/js/rawSurveyPdf.js
@@ -53,7 +53,7 @@ export function generateCompatibilityPDF(partnerAData, partnerBData, doc) {
 // 📍 Draw category title (left-aligned)
 function renderCategoryHeaderPDF(doc, title) {
   doc.setFontSize(16);
-  doc.setTextColor(0, 0, 0);
+  doc.setTextColor(255, 255, 255);
   doc.text(title, 50, doc.y);
   doc.y += 10;
 
@@ -70,7 +70,7 @@ function renderCategoryHeaderPDF(doc, title) {
 function renderRowPDF(doc, { label, scoreA, match, flag, scoreB }) {
   const y = doc.y;
   doc.setFontSize(10);
-  doc.setTextColor(0, 0, 0);
+  doc.setTextColor(255, 255, 255);
 
   doc.text(label, 50, y);       // Kink subcategory
   doc.text(scoreA, 250, y);     // Partner A


### PR DESCRIPTION
## Summary
- initialize jsPDF documents with black background and white text when generating compatibility PDFs
- render compatibility report headers and rows in white text for contrast

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893e3da6ee0832c918b567273d66985