### PR TITLE
Maintain dark theme across PDF pages

### DIFF
--- a/js/rawSurveyPdf.js
+++ b/js/rawSurveyPdf.js
@@ -7,14 +7,25 @@
 
 export function generateCompatibilityPDF(partnerAData, partnerBData, doc) {
   const categories = Object.keys(partnerAData); // Same keys assumed in partnerBData
+  const pageHeight = doc.internal.pageSize.getHeight();
+
+  const ensureSpace = () => {
+    if (doc.y >= pageHeight - 20) {
+      doc.addPage();
+      applyDarkThemeBackground(doc);
+      doc.y = 50;
+    }
+  };
 
   categories.forEach((category) => {
+    ensureSpace();
     const items = Object.keys(partnerAData[category]);
 
     // 🧠 Render category header (e.g., "Appearance Play")
     renderCategoryHeaderPDF(doc, category);
 
     items.forEach((item) => {
+      ensureSpace();
       // 1️⃣ Get scores
       const scoreA = partnerAData?.[category]?.[item];
       const scoreB = partnerBData?.[category]?.[item];
@@ -79,6 +90,18 @@ function renderRowPDF(doc, { label, scoreA, match, flag, scoreB }) {
   doc.text(scoreB, 400, y);     // Partner B
 
   doc.y += 8;
+}
+
+function applyDarkThemeBackground(doc) {
+  doc.setFillColor(0, 0, 0);
+  doc.rect(
+    0,
+    0,
+    doc.internal.pageSize.getWidth(),
+    doc.internal.pageSize.getHeight(),
+    'F'
+  );
+  doc.setTextColor(255, 255, 255);
 }
 
 export default generateCompatibilityPDF;

--- a/test/rawSurveyPdf.test.js
+++ b/test/rawSurveyPdf.test.js
@@ -7,6 +7,10 @@ function createDoc() {
     y: 20,
     setFontSize() {},
     setTextColor() {},
+    setFillColor() {},
+    rect() {},
+    addPage() {},
+    internal: { pageSize: { getHeight: () => 200, getWidth: () => 200 } },
     text(...args) { textCalls.push(args); }
   };
   return { doc, textCalls };


### PR DESCRIPTION
## Summary
- ensure raw survey PDF generator adds dark background to new pages
- update rawSurveyPdf tests for new page-handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893e57906a0832cbefc582235079ba0