### PR TITLE
Refactor compatibility PDF layout with shared builder

### DIFF
--- a/js/generateCompatibilityPDF.js
+++ b/js/generateCompatibilityPDF.js
@@ -1,4 +1,4 @@
-import { renderCategorySection } from './compatibilityReportHelpers.js';
+import { renderCategorySection, buildLayout } from './compatibilityReportHelpers.js';
 
 // Shortened label lookup for verbose subcategory names
 const shortLabels = {
@@ -112,13 +112,13 @@ export function generateCompatibilityPDF(compatibilityData) {
       }
     }
 
+    const layout = buildLayout(columnX[currentColumn], columnWidth);
     const endY = renderCategorySection(
       doc,
-      columnX[currentColumn],
-      columnY[currentColumn],
       category.category || category.name,
       items,
-      columnWidth
+      layout,
+      columnY[currentColumn]
     );
     columnY[currentColumn] = endY + pdfStyles.barSpacing;
   });

--- a/js/matchFlag.js
+++ b/js/matchFlag.js
@@ -2,20 +2,15 @@
 export function getFlagEmoji(percent, a, b) {
   if (percent === null || percent === undefined) return '';
   if (percent >= 90) return '⭐';
-  if (percent >= 80) return '🟩';
-  if (percent <= 40) return '🚩';
-  if (
-    (a === 5 && typeof b === 'number' && b < 5) ||
-    (b === 5 && typeof a === 'number' && a < 5)
-  )
-    return '🟨';
+  if ((a === 5 && typeof b === 'number' && b < 5) || (b === 5 && typeof a === 'number' && a < 5)) return '🟨';
+  if (percent < 30) return '🚩';
   return '';
 }
 
 // Determine bar color based on percentage
 export function getMatchColor(percent) {
   if (percent === null || percent === undefined) return 'black';
-  if (percent >= 80) return 'green';
+  if (percent >= 90) return 'green';
   if (percent >= 60) return 'yellow';
   return 'red';
 }

--- a/test/compatibilityReportHelpers.test.js
+++ b/test/compatibilityReportHelpers.test.js
@@ -4,7 +4,8 @@ import {
   drawMatchBar,
   renderCategorySection,
   normalizeScore,
-  getMatchPercentage
+  getMatchPercentage,
+  buildLayout
 } from '../js/compatibilityReportHelpers.js';
 
 function createDocMock() {
@@ -23,12 +24,13 @@ function createDocMock() {
   };
 }
 
-test('drawMatchBar fills width proportional to percentage', () => {
+test('drawMatchBar renders black bar with colored text', () => {
   const doc = createDocMock();
   drawMatchBar(doc, 10, 10, 100, 8, 50);
   const rectCalls = doc.calls.filter(c => c[0] === 'rect');
   assert.deepStrictEqual(rectCalls[0], ['rect', [10, 10, 100, 8, 'F']]);
-  assert.deepStrictEqual(rectCalls[1], ['rect', [10, 10, 50, 8, 'F']]);
+  const textColorCall = doc.calls.find(c => c[0] === 'setTextColor');
+  assert.deepStrictEqual(textColorCall, ['setTextColor', ['red']]);
   const textCall = doc.calls.find(c => c[0] === 'text' && c[1][0] === '50%');
   assert.ok(textCall, 'percentage label should be rendered');
 });
@@ -41,7 +43,8 @@ test('renderCategorySection renders each item and returns final y', () => {
   ];
   const margin = 5;
   const usableWidth = doc.internal.pageSize.getWidth() - margin * 2;
-  const endY = renderCategorySection(doc, margin, 20, 'MyCat', items, usableWidth);
+  const layout = buildLayout(margin, usableWidth);
+  const endY = renderCategorySection(doc, 'MyCat', items, layout, 20);
   assert.strictEqual(endY, 20 + 23 + 12 * items.length);
   const texts = doc.calls.filter(c => c[0] === 'text').map(c => c[1][0]);
   assert(texts.includes('MyCat'));

--- a/test/matchFlag.test.js
+++ b/test/matchFlag.test.js
@@ -7,12 +7,8 @@ test('returns star for 90 percent and above', () => {
   assert.strictEqual(getFlagEmoji(90), '⭐');
 });
 
-test('returns green square for values 80-89', () => {
-  assert.strictEqual(getFlagEmoji(85), '🟩');
-});
-
-test('returns red flag for values 40 or below', () => {
-  assert.strictEqual(getFlagEmoji(40), '🚩');
+test('returns red flag for values below 30', () => {
+  assert.strictEqual(getFlagEmoji(25), '🚩');
   assert.strictEqual(getFlagEmoji(0), '🚩');
 });
 
@@ -24,6 +20,7 @@ test('returns yellow flag when one partner loves it and the other does not', () 
 test('returns empty string for other values', () => {
   assert.strictEqual(getFlagEmoji(75), '');
   assert.strictEqual(getFlagEmoji(41), '');
+  assert.strictEqual(getFlagEmoji(80), '');
 });
 
 test('calculateCategoryMatch returns 0 for empty data', () => {
@@ -50,8 +47,8 @@ test('calculateCategoryMatch ignores missing values', () => {
 });
 
 test('getMatchColor returns expected color names', () => {
-  assert.strictEqual(getMatchColor(85), 'green');
-  assert.strictEqual(getMatchColor(60), 'yellow');
+  assert.strictEqual(getMatchColor(95), 'green');
+  assert.strictEqual(getMatchColor(75), 'yellow');
   assert.strictEqual(getMatchColor(59), 'red');
   assert.strictEqual(getMatchColor(null), 'black');
 });


### PR DESCRIPTION
## Summary
- centralize layout logic for kink compatibility PDF using a shared `buildLayout`
- render match bars with colored text and handle missing scores with "N/A"
- streamline flag emoji and color rules for compatibility scores

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68943980ad68832cac49f5ed757188e1