### PR TITLE
refactor: use html2pdf for compatibility export

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -87,7 +87,7 @@
       });
   </script>
 
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
-  <script type="module" src="js/pdfDownload.js"></script>
-</body>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
+    <script type="module" src="js/pdfDownload.js"></script>
+  </body>
 </html>

--- a/pdf-download-test.html
+++ b/pdf-download-test.html
@@ -4,14 +4,8 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>PDF Download Test</title>
-  <!-- 1. Include jsPDF from CDN -->
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"
-          integrity="sha512-jQcGc+9A0El+oSRTGHxiNoD4ZRU4QwnfQYFgHH1A2phz7qPQk1V6JEFc6NKjqhAIv+xwUWyEr0QU8I96DJ+lZg=="
-          crossorigin="anonymous"
-          referrerpolicy="no-referrer"></script>
-  <script>
-    window.jspdf = window.jspdf || window.jspdf;
-  </script>
+  <!-- 1. Include html2pdf from CDN -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html2pdf.js/0.10.1/html2pdf.bundle.min.js"></script>
 </head>
 <body>
   <!-- 2. Button (already present in HTML) -->

--- a/test/pdfDownloadButton.test.js
+++ b/test/pdfDownloadButton.test.js
@@ -24,8 +24,12 @@ test('PDF download button handler attaches on DOMContentLoaded', async () => {
       addEventListener: (evt, cb) => {
         if (evt === 'DOMContentLoaded') domReadyHandler = cb;
       },
-      jspdf: { jsPDF: function jsPDF() {} },
       compatibilityData: [],
+      html2pdf: () => ({
+        set: () => ({
+          from: () => ({ save: () => Promise.resolve() })
+        })
+      }),
     };
     globalThis.document = {
       getElementById: id => (id === 'downloadPdfBtn' ? button : null),


### PR DESCRIPTION
## Summary
- replace jsPDF workflow with html2pdf for compatibility report download
- apply theme-aware print styles before generating the PDF
- update tests and HTML templates to remove jsPDF references

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68944477dd44832cb0d7fac7f502d6a2