### PR TITLE
Improve PDF export layout and add match columns

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2408,11 +2408,21 @@ body {
   margin: 2rem auto;
   width: 100%;
   border-collapse: collapse;
+  table-layout: fixed;
 }
 .results-table th,
 .results-table td {
   padding: 8px 12px;
+  text-align: center;
+}
+.results-table th:first-child,
+.results-table td:first-child {
   text-align: left;
+  width: 40%;
+}
+.results-table th:not(:first-child),
+.results-table td:not(:first-child) {
+  width: 15%;
 }
 .results-table th {
   border-bottom: 2px solid #444;

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -133,7 +133,7 @@ function renderCategoryRow(categoryName, categoryData) {
   const tr = document.createElement('tr');
   tr.classList.add('category-header');
   tr.innerHTML = `
-    <td colspan="3" class="category-cell">
+    <td colspan="5" class="category-cell">
       <div class="category-banner">
         <span class="category-flag">${flag}</span>
         <span class="category-name">${categoryName}</span>
@@ -373,7 +373,7 @@ function updateComparison() {
 
   const table = document.createElement('table');
   table.className = 'results-table';
-  table.innerHTML = '<thead><tr><th>Kink</th><th>Partner A</th><th>Partner B</th></tr></thead>';
+  table.innerHTML = '<thead><tr><th>Kink</th><th>Partner A</th><th>Match</th><th>Flag</th><th>Partner B</th></tr></thead>';
   const tbody = document.createElement('tbody');
 
   const renderCell = rating => {
@@ -393,8 +393,23 @@ function updateComparison() {
       const nameTd = document.createElement('td');
       nameTd.textContent = kink.name;
       row.appendChild(nameTd);
+
       row.appendChild(renderCell(kink.partnerA));
+
+      const matchPercent =
+        kink.partnerA != null && kink.partnerB != null
+          ? Math.round(100 - Math.abs(kink.partnerA - kink.partnerB) * 20)
+          : null;
+      const matchTd = document.createElement('td');
+      matchTd.textContent = matchPercent === null ? '-' : matchPercent + '%';
+      row.appendChild(matchTd);
+
+      const flagTd = document.createElement('td');
+      flagTd.textContent = getFlagEmoji(matchPercent, kink.partnerA, kink.partnerB);
+      row.appendChild(flagTd);
+
       row.appendChild(renderCell(kink.partnerB));
+
       tbody.appendChild(row);
     });
   }

--- a/js/pdfDownload.js
+++ b/js/pdfDownload.js
@@ -1,115 +1,60 @@
-import { applyPrintStyles } from './theme.js';
-
-export function exportKinkCompatibilityPDF() {
-  const data = window.compatibilityData;
-  const categories = Array.isArray(data) ? data : data?.categories;
-  if (!categories || categories.length === 0) {
-    alert('Both surveys must be uploaded before generating PDF.');
+export function exportToPDF() {
+  const element = document.getElementById('pdf-container');
+  if (!element) {
+    alert('PDF content not found.');
     return;
   }
 
-  const partnerAData = {};
-  const partnerBData = {};
-  categories.forEach(cat => {
-    const name = cat.category || cat.name;
-    partnerAData[name] = {};
-    partnerBData[name] = {};
-    (cat.items || []).forEach(item => {
-      const label = item.label || item.kink || item.name;
-      const scoreA = typeof item.a === 'number'
-        ? item.a
-        : typeof item.partnerA === 'number'
-          ? item.partnerA
-          : typeof item.scoreA === 'number'
-            ? item.scoreA
-            : undefined;
-      const scoreB = typeof item.b === 'number'
-        ? item.b
-        : typeof item.partnerB === 'number'
-          ? item.partnerB
-          : typeof item.scoreB === 'number'
-            ? item.scoreB
-            : undefined;
-      partnerAData[name][label] = scoreA;
-      partnerBData[name][label] = scoreB;
-    });
-  });
+  const mode = localStorage.getItem('theme') || 'dark';
+  element.style.fontFamily = 'sans-serif';
+  element.style.padding = '1in';
+  element.style.margin = '0';
+  element.style.width = '100%';
+  element.style.maxWidth = '100%';
 
-  const activeTheme =
-    localStorage.getItem('theme') ||
-    [...document.body.classList]
-      .find(cls => cls.startsWith('theme-'))?.replace('theme-', '') ||
-    'dark';
+  if (mode === 'dark') {
+    element.style.backgroundColor = '#000000';
+    element.style.color = '#ffffff';
+  } else if (mode === 'lipstick') {
+    element.style.backgroundColor = '#1a001f';
+    element.style.color = '#fceaff';
+  } else if (mode === 'forest') {
+    element.style.backgroundColor = '#f0f7f1';
+    element.style.color = '#1d3b1d';
+  }
 
-  const themeOptions = {
-    dark: {
-      bgColor: '#000000',
-      textColor: '#ffffff',
-      barFillColor: '#000000',
-      barTextColor: '#ffffff',
-      font: 'helvetica'
-    },
-    lipstick: {
-      bgColor: '#1a001f',
-      textColor: '#fceaff',
-      barFillColor: '#ff90cb',
-      barTextColor: '#1a001f',
-      font: 'times'
-    },
-    forest: {
-      bgColor: '#f0f7f1',
-      textColor: '#1d3b1d',
-      barFillColor: '#81b89b',
-      barTextColor: '#1d3b1d',
-      font: 'courier'
-    }
-  };
-
-  const themeSettings = themeOptions[activeTheme] || themeOptions.dark;
-
-  // Preferred method: html2pdf if available
-  if (typeof window.html2pdf === 'function') {
-    applyPrintStyles(activeTheme);
-
-    const element = document.getElementById('pdf-container');
-    if (!element) {
-      alert('PDF content not found.');
-      return;
-    }
-
+  requestAnimationFrame(() => {
     window.scrollTo(0, 0);
+
     window.html2pdf()
       .set({
-        margin: 0,
+        margin: [0, 0],
         filename: 'kink-compatibility.pdf',
         image: { type: 'jpeg', quality: 1 },
         html2canvas: {
           scale: 2,
           useCORS: true,
-          backgroundColor: themeSettings.bgColor,
-          scrollY: 0
+          scrollY: 0,
+          backgroundColor: null,
         },
-        jsPDF: { unit: 'in', format: 'letter', orientation: 'landscape' },
-        pagebreak: { mode: ['avoid-all'] },
+        jsPDF: {
+          unit: 'in',
+          format: 'letter',
+          orientation: 'landscape',
+        },
+        pagebreak: { mode: ['avoid-all', 'css', 'legacy'] }
       })
       .from(element)
       .save();
-  } else {
-    // Fallback: Use jsPDF rendering directly
-    const { jsPDF } = window.jspdf;
-    const doc = new jsPDF({ orientation: 'landscape' });
-
-    generateCompatibilityPDF(partnerAData, partnerBData, doc, themeSettings);
-    doc.save('kink-compatibility.pdf');
-  }
+  });
 }
 
-// Attach click handler for the Download PDF button
+export const exportKinkCompatibilityPDF = exportToPDF;
+
 if (typeof window !== 'undefined') {
   window.addEventListener('DOMContentLoaded', () => {
     const downloadBtn = document.getElementById('downloadPdfBtn');
     if (!downloadBtn) return;
-    downloadBtn.addEventListener('click', exportKinkCompatibilityPDF);
+    downloadBtn.addEventListener('click', exportToPDF);
   });
 }
-


### PR DESCRIPTION
## Summary
- Render `#pdf-container` with theme styles and export via html2pdf using `requestAnimationFrame`
- Extend compatibility table with Partner A, Match, Flag, and Partner B columns
- Ensure results table columns are evenly spaced and use sans-serif fonts for PDF output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894f8a75034832ca96f3d6df0549164