### PR TITLE
Stretch PDF table to full width and tighten columns

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2404,15 +2404,15 @@ body {
 
 /* Simple compatibility results table */
 .results-table {
-  max-width: 700px;
-  margin: 2rem auto;
   width: 100%;
+  max-width: none;
+  margin: 0;
   border-collapse: collapse;
   table-layout: fixed;
 }
 .results-table th,
 .results-table td {
-  padding: 8px 12px;
+  padding: 4px 6px;
   text-align: center;
 }
 .results-table th:first-child,
@@ -2420,9 +2420,17 @@ body {
   text-align: left;
   width: 40%;
 }
-.results-table th:not(:first-child),
-.results-table td:not(:first-child) {
-  width: 15%;
+.results-table th:nth-child(2),
+.results-table td:nth-child(2),
+.results-table th:nth-child(5),
+.results-table td:nth-child(5) {
+  width: 20%;
+}
+.results-table th:nth-child(3),
+.results-table td:nth-child(3),
+.results-table th:nth-child(4),
+.results-table td:nth-child(4) {
+  width: 10%;
 }
 .results-table th {
   border-bottom: 2px solid #444;
@@ -2796,8 +2804,8 @@ body {
   #compatibility-wrapper {
     display: table;
     margin: 0 auto !important;
-    transform: scale(0.85);
-    transform-origin: top center;
+    width: 100% !important;
+    max-width: none !important;
   }
 }
 

--- a/js/pdfDownload.js
+++ b/js/pdfDownload.js
@@ -15,6 +15,7 @@ if (typeof document !== 'undefined' && typeof document.createElement === 'functi
 
     #pdf-container table {
       width: 100%;
+      border-collapse: collapse;
       table-layout: fixed;
     }
 
@@ -22,6 +23,27 @@ if (typeof document !== 'undefined' && typeof document.createElement === 'functi
     #pdf-container th {
       word-wrap: break-word;
       white-space: normal;
+      padding: 4px 6px;
+    }
+
+    .results-table th:nth-child(1),
+    .results-table td:nth-child(1) {
+      text-align: left;
+      width: 40%;
+    }
+
+    .results-table th:nth-child(2),
+    .results-table td:nth-child(2),
+    .results-table th:nth-child(5),
+    .results-table td:nth-child(5) {
+      width: 20%;
+    }
+
+    .results-table th:nth-child(3),
+    .results-table td:nth-child(3),
+    .results-table th:nth-child(4),
+    .results-table td:nth-child(4) {
+      width: 10%;
     }
   `;
   document.head.appendChild(style);
@@ -55,15 +77,23 @@ export function exportToPDF() {
     element.style.color = '#1d3b1d';
   }
 
-  // Ensure layout has consistent column spacing
-  const allRows = element.querySelectorAll('.row');
-  allRows.forEach((row) => {
-    row.style.display = 'grid';
-    row.style.gridTemplateColumns = '2fr 1fr 1fr 1fr 1fr';
-    row.style.alignItems = 'center';
-    row.style.gap = '1em';
-    row.style.padding = '2px 0';
-  });
+  // Stretch inner wrapper and table to fill the page
+  const wrapper = document.getElementById('compatibility-wrapper');
+  if (wrapper) {
+    wrapper.style.width = '100%';
+    wrapper.style.maxWidth = '100%';
+    wrapper.style.margin = '0';
+  }
+
+  const table = element.querySelector('.results-table');
+  if (table) {
+    const widths = ['40%', '20%', '10%', '10%', '20%'];
+    Array.from(table.rows).forEach(row => {
+      widths.forEach((w, i) => {
+        if (row.cells[i]) row.cells[i].style.width = w;
+      });
+    });
+  }
 
   // Force layout to stretch across full page and generate PDF
   window.scrollTo(0, 0);


### PR DESCRIPTION
## Summary
- Expand compatibility results table to span the full PDF width and remove excess margins
- Allocate fixed widths for each of the 5 columns so Match and Flag stay compact
- Ensure wrapper and table are stretched during export for consistent alignment

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895077ba810832ca7502295b0940bd3