### PR TITLE
Refine PDF export styling

### DIFF
--- a/js/pdfDownload.js
+++ b/js/pdfDownload.js
@@ -5,36 +5,42 @@ export function exportToPDF() {
     return;
   }
 
-  // Full bleed width enforcement
-  element.style.width = '100vw';
-  element.style.maxWidth = 'none';
-  element.style.margin = '0';
+  // Enforce full width and visibility
+  element.style.width = '100%';
+  element.style.maxWidth = '100%';
+  element.style.margin = '0 auto';
   element.style.padding = '0';
   element.style.overflow = 'visible';
 
-  // Force tables to obey
+  // Normalize table layout
   const tables = element.querySelectorAll('table');
   tables.forEach(table => {
     table.style.width = '100%';
     table.style.tableLayout = 'fixed';
+    table.style.borderCollapse = 'collapse';
+    const cells = table.querySelectorAll('td, th');
+    cells.forEach(cell => {
+      cell.style.padding = '2px';
+      cell.style.lineHeight = '1.2';
+    });
   });
 
-  // Force body to match
+  // Set body + html width to avoid margin bleed
   document.body.style.margin = '0';
   document.body.style.padding = '0';
-  document.body.style.width = '100vw';
-  document.body.style.overflow = 'visible';
+  document.body.style.width = '100%';
+  document.documentElement.style.width = '100%';
 
   // PDF Settings
   html2pdf().from(element).set({
     margin: 0,
     filename: 'kink-compatibility.pdf',
     html2canvas: {
-      scale: 3,
-      scrollX: 0,
-      scrollY: 0,
+      scale: 2.5,
       backgroundColor: '#000000',
-      windowWidth: document.body.scrollWidth
+      windowWidth: Math.min(document.body.scrollWidth, 1500),
+      scrollX: 0,
+      scrollY: 0
     },
     jsPDF: {
       unit: 'in',


### PR DESCRIPTION
## Summary
- Ensure PDF container uses full width with normalized tables and cell sizing
- Adjust body and HTML dimensions to avoid margin bleed
- Cap html2canvas window width and tweak scaling for reliable PDF rendering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68951cecf54c832cac376051c018b6cb