### PR TITLE
chore: switch dark grey backgrounds to pure black

### DIFF
--- a/basic-survey.html
+++ b/basic-survey.html
@@ -6,7 +6,7 @@
   <title>Kink Interest Survey</title>
   <style>
     body {
-      background-color: #121212;
+      background-color: #000000;
       color: #fff;
       font-family: Arial, sans-serif;
       text-align: center;
@@ -16,7 +16,7 @@
     .progress-container {
       width: 60%;
       margin: 20px auto;
-      background-color: #2b2b2b;
+      background-color: #000000;
       border-radius: 10px;
       height: 18px;
       overflow: hidden;
@@ -58,7 +58,7 @@
       padding: 20px;
       border: 1px solid #333;
       border-radius: 10px;
-      background-color: #1e1e1e;
+      background-color: #000000;
       max-width: 700px;
       margin-left: auto;
       margin-right: auto;

--- a/css/global.css
+++ b/css/global.css
@@ -31,7 +31,7 @@
 
 .results-table .category-cell {
   padding: 0.6rem 1rem;
-  background-color: #111;
+  background-color: #000;
 }
 
 .results-table .category-banner {

--- a/css/style.css
+++ b/css/style.css
@@ -26,7 +26,7 @@ body.has-category-panel {
 
 html,
 body {
-  background-color: #0f0f0f;
+  background-color: #000000;
   color: #f0f0f0;
   font-family: 'Inter', 'Open Sans', system-ui, sans-serif;
 }
@@ -34,7 +34,7 @@ body {
 .card,
 .survey-section,
 .result-card {
-  background-color: #1a1a1a !important;
+  background-color: #000000 !important;
   color: #f0f0f0 !important;
   border: 1px solid rgba(255, 255, 255, 0.2) !important;
   box-shadow: none !important;
@@ -45,7 +45,7 @@ body {
 
 /* Unified styling for each kink category block */
 .kink-category {
-  background-color: #1a1a1a;
+  background-color: #000000;
   border-radius: 10px;
   padding: 16px;
   margin-bottom: 16px;
@@ -66,14 +66,14 @@ body {
 .header,
 .top-bar,
 .partner-labels {
-  background-color: #0a0a0a !important;
+  background-color: #000000 !important;
   color: #ffffff !important;
   border: none;
 }
 
 /* Default theme variables */
 :root {
-  --bg-color: #0f0f0f;
+  --bg-color: #000000;
   --panel-color: #000;
   --text-color: #f0f0f0;
   --accent-text: #00ccff; /* fallback default for dark mode */
@@ -166,7 +166,7 @@ body.light-mode #closeRoleDefinitionsBtn {
   }
 
   .category-sidebar #categoryPanel {
-    background-color: var(--panel-color, #1e1e1e);
+    background-color: var(--panel-color, #000);
     max-width: 450px;
     width: 90%;
     max-height: 90vh;
@@ -245,7 +245,7 @@ body.light-mode #closeRoleDefinitionsBtn {
   margin-bottom: 24px;
   border: 1px solid var(--accent-text, var(--accent-color));
   padding: 16px;
-  background-color: var(--panel-bg, #111);
+  background-color: var(--panel-bg, #000);
 }
 
 .kink-row {
@@ -266,7 +266,7 @@ body.light-mode #closeRoleDefinitionsBtn {
   display: none;
   font-size: 0.8rem;
   margin-top: 4px;
-  background-color: var(--panel-bg, #111);
+  background-color: var(--panel-bg, #000);
   border: 1px solid var(--border-color);
   padding: 6px;
 }
@@ -363,7 +363,7 @@ body.theme-rainbow #mainCategoryList button.active {
 
 /* Theme Styling */
 body.dark-mode {
-  background-color: #0f0f0f;
+  background-color: #000000;
   color: #f0f0f0;
   --panel-color: #000;
   --text-color: #f0f0f0;
@@ -558,7 +558,7 @@ body.light-mode .tab.active {
   border: 1px solid #000;
 }
 body.dark-mode .tab {
-  background-color: #222;
+  background-color: #000000;
   color: #f5f5f5;
 }
 body.dark-mode .tab.active {
@@ -942,7 +942,7 @@ body.theme-rainbow #comparisonResult {
   left: 0;
   height: 100vh;
   width: 320px;
-  background-color: var(--panel-color, #1e1e1e);
+  background-color: var(--panel-color, #000);
   color: var(--text-color, #ffffff);
   overflow-y: auto;
   padding: 24px 20px;
@@ -1692,7 +1692,7 @@ body.light-mode .json-display {
 /* Scrollbar styling for panels */
 .scrollable-panel {
   scrollbar-width: thin;
-  scrollbar-color: #888 #2b2b2b;
+  scrollbar-color: #888 #000000;
   padding-bottom: 12px;
 }
 
@@ -1707,7 +1707,7 @@ body.light-mode .json-display {
 }
 
 .scrollable-panel::-webkit-scrollbar-track {
-  background: #2b2b2b;
+  background: #000000;
 }
 
 body.light-mode .scrollable-panel {
@@ -1827,7 +1827,7 @@ body {
 /* Mimics BDSMTest.org style while preserving original role data */
 
 #cr-results-container {
-  background-color: #111;
+  background-color: #000000;
   border: 2px solid #ccc;
   border-radius: 6px;
   padding: 20px;
@@ -1963,7 +1963,7 @@ body {
   justify-content: space-between;
   padding: 10px 14px;
   margin-bottom: 6px;
-  background-color: #1a1a1a;
+  background-color: #000000;
   border-radius: 6px;
   border: 1px solid rgba(255, 255, 255, 0.15);
 }
@@ -1979,7 +1979,7 @@ body {
 }
 
 .download-btn {
-  background-color: #222;
+  background-color: #000000;
   color: #fff;
   border: none;
   padding: 12px 20px;
@@ -2048,7 +2048,7 @@ body {
 
 /* ===== Comparison Chart ===== */
 #comparison-chart {
-  background-color: #111;
+  background-color: #000000;
   color: white;
   font-family: Arial, sans-serif;
   padding: 24px;
@@ -2084,7 +2084,7 @@ body {
 
 .bar-container {
   flex: 2;
-  background: #222;
+  background: #000000;
   height: 10px;
   border-radius: 5px;
   overflow: hidden;
@@ -2182,7 +2182,7 @@ body {
   flex: 1;
   position: relative;
   height: 12px;
-  background: #2b2b2b;
+  background: #000000;
   border-radius: 8px;
   margin: 0 6px;
 }
@@ -2327,7 +2327,7 @@ li {
 }
 
 .progress-bar-container {
-  background-color: #222 !important;
+  background-color: #000000 !important;
 }
 
 .progress-bar-fill {
@@ -2338,7 +2338,7 @@ table,
 tr,
 td,
 th {
-  background-color: #111 !important;
+  background-color: #000000 !important;
   color: #fff !important;
 }
 
@@ -2454,7 +2454,7 @@ body {
 }
 .results-table .bar-container {
   width: 100%;
-  background-color: #222;
+  background-color: #000000;
   border-radius: 4px;
   overflow: hidden;
   height: 12px;
@@ -2472,7 +2472,7 @@ body {
 
 /* Slimmed-down result card for compatibility results */
 .result-card {
-  background-color: #1e1e1e; /* softer black for dark mode */
+  background-color: #000000; /* pure black for dark mode */
   border-radius: 6px;
   padding: 6px 12px;
   margin-bottom: 8px;
@@ -3244,7 +3244,7 @@ body {
     padding: 0.75rem 1.5rem;
     border-radius: 10px;
     border: 2px solid var(--accent-color, #00ffff);
-    background-color: #111;
+    background-color: #000000;
     color: var(--accent-color, #00ffff);
     font-weight: 700;
     text-align: center;
@@ -3257,12 +3257,12 @@ body {
   }
 
 .themed-button:hover {
-  background-color: #0e0e0e;
+  background-color: #000000;
   transform: scale(1.02);
 }
 
 .themed-button:active {
-  background-color: #1a1a1a;
+  background-color: #000000;
   transform: scale(0.98);
 }
 

--- a/css/theme.css
+++ b/css/theme.css
@@ -1,5 +1,5 @@
 :root {
-  --bg-color: #0f0f0f;
+  --bg-color: #000000;
   --panel-color: #000;
   --text-color: #f0f0f0;
   --accent-text: #7df9ff;
@@ -22,7 +22,7 @@
 
 .theme-darkviolet,
 .dark-mode {
-  --bg-color: #0f0f0f;
+  --bg-color: #000000;
   --panel-color: #000;
   --text-color: #f0f0f0;
   --button-bg: #444;
@@ -83,20 +83,20 @@
 
 /* New simplified themes */
 body.theme-dark {
-  --bg-color: #0d0d0d;
+  --bg-color: #000000;
   --text-color: #00ffff !important; /* electric blue */
   --accent-color: #00ffff !important;
   --accent-text: var(--accent-color);
   --theme-accent: var(--accent-color);
   --border-color: #00ffff !important;
-  --button-bg: #0d0d0d;
+  --button-bg: #000000;
   --button-hover: #00ffff;
   --button-text: #00ffff;
   --link-color: var(--accent-color);
   --hover-bg: #333;
   --hover-text: #ffffff;
-  --panel-bg: #1a1a1a;
-  --card-bg: #222;
+  --panel-bg: #000000;
+  --card-bg: #000000;
   background-color: var(--bg-color);
   color: var(--text-color) !important;
   font-family: 'Fredoka One', cursive;

--- a/js/theme.js
+++ b/js/theme.js
@@ -1,8 +1,8 @@
 const themeStyles = {
   dark: {
     fontColor: '#f2f2f2',
-    bgColor: '#0d0d0d',
-    inputBg: '#1a1a1a',
+    bgColor: '#000000',
+    inputBg: '#000000',
     inputText: '#f2f2f2',
     borderColor: '#444'
   },
@@ -362,7 +362,7 @@ export function applyPrintStyles(mode = 'dark') {
       }
       .results-table .bar-container {
         width: 100%;
-        background-color: #222;
+        background-color: #000000;
         border-radius: 4px;
         overflow: hidden;
         height: 12px;
@@ -401,7 +401,7 @@ export function applyPrintStyles(mode = 'dark') {
       }
       .bar-container {
         flex: 2;
-        background: #222;
+        background: #000000;
         border-radius: 4px;
         height: 10px;
         position: relative;
@@ -447,7 +447,7 @@ export function applyPrintStyles(mode = 'dark') {
       }
 
       .comparison-card {
-        background-color: #1a1a1a !important;
+        background-color: #000000 !important;
         color: #f1f1f1 !important;
         border-radius: 8px;
         margin: 0.5rem 0;

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -325,7 +325,7 @@
   .rating-tooltip {
     display: none;
     position: absolute;
-    background: #111;
+    background: #000;
     color: #eee;
     padding: 6px 10px;
     border-radius: 8px;

--- a/snippet-category-panel.html
+++ b/snippet-category-panel.html
@@ -70,7 +70,7 @@
   font-family: 'Fredoka One', sans-serif;
   font-size: 0.75rem;
   padding: 0.3rem 0.7rem;
-  background-color: #111;
+  background-color: #000;
   border: 2px solid var(--accent-text);
   color: white;
   border-radius: 6px;


### PR DESCRIPTION
## Summary
- ensure survey and tooltip backgrounds render true black for higher contrast
- standardize global styles and theme variables to #000
- align dynamic PDF styling with new pure black backgrounds

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895289d020c832c8e05de206a67034c