### PR TITLE
Handle equals in cookie parser

### DIFF
--- a/server.js
+++ b/server.js
@@ -86,8 +86,8 @@ function cookieParser(req, _res, next) {
   const cookies = {};
   if (header) {
     header.split(';').forEach(part => {
-      const [k, v] = part.trim().split('=');
-      if (k) cookies[k] = decodeURIComponent(v || '');
+      const [k, ...v] = part.trim().split('=');
+      if (k) cookies[k] = decodeURIComponent(v.join('=') || '');
     });
   }
   req.cookies = cookies;
@@ -425,4 +425,4 @@ if (NODE_ENV !== 'production') {
   );
 }
 
-export { app, server, cleanup, tokenStore, sessionStore };
+export { app, server, cleanup, tokenStore, sessionStore, cookieParser };

--- a/test/cookieParser.test.js
+++ b/test/cookieParser.test.js
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { cookieParser, server, cleanup } from '../server.js';
+
+test('cookieParser handles equals in values', t => {
+  const req = { headers: { cookie: 'a=1=2; b=3' } };
+  cookieParser(req, null, null);
+  assert.deepStrictEqual(req.cookies, { a: '1=2', b: '3' });
+  t.after(() => {
+    server.close();
+    clearInterval(cleanup);
+  });
+});


### PR DESCRIPTION
## Summary
- fix cookie parser to properly decode values containing `=` characters
- export `cookieParser` for reuse and testing
- add test ensuring parser handles values with extra equals and clean up server artifacts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68953a745f8c832cba44da94fb1eaca1