### PR TITLE
Use numeric RGB for match bar fill

### DIFF
--- a/js/compatibilityReportHelpers.js
+++ b/js/compatibilityReportHelpers.js
@@ -24,7 +24,7 @@ export function drawMatchBar(doc, x, y, width, height, percentage) {
   const textColor = getFontColor(percentage);
 
   // Black background
-  doc.setFillColor('black');
+  doc.setFillColor(0, 0, 0);
   doc.rect(x, y, width, height, 'F');
 
   // Label centered inside the bar

--- a/test/compatibilityReportHelpers.test.js
+++ b/test/compatibilityReportHelpers.test.js
@@ -29,6 +29,8 @@ test('drawMatchBar renders black bar with colored text', () => {
   drawMatchBar(doc, 10, 10, 100, 8, 50);
   const rectCalls = doc.calls.filter(c => c[0] === 'rect');
   assert.deepStrictEqual(rectCalls[0], ['rect', [10, 10, 100, 8, 'F']]);
+  const fillColorCall = doc.calls.find(c => c[0] === 'setFillColor');
+  assert.deepStrictEqual(fillColorCall, ['setFillColor', [0, 0, 0]]);
   const textColorCall = doc.calls.find(c => c[0] === 'setTextColor');
   assert.deepStrictEqual(textColorCall, ['setTextColor', ['red']]);
   const textCall = doc.calls.find(c => c[0] === 'text' && c[1][0] === '50%');


### PR DESCRIPTION
## Summary
- ensure match bars in compatibility PDF use black RGB fill
- add test asserting black RGB fill color

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68955dc092d4832c83e2a5cf55e6d7a2