### PR TITLE
Refactor PDF generator to accept data parameter

### DIFF
--- a/js/auto-pdf.js
+++ b/js/auto-pdf.js
@@ -28,13 +28,13 @@ if (typeof window !== 'undefined') {
   window.compatibilityHistory = loadHistory();
 }
 
-async function generatePDF() {
+async function generatePDF(data) {
   if (pdfGenerated) return;
   pdfGenerated = true;
   const { loadJsPDF } = await import('./loadJsPDF.js');
   await loadJsPDF();
   const { generateCompatibilityPDF } = await import('./compatibilityPdf.js');
-  generateCompatibilityPDF();
+  generateCompatibilityPDF(data);
 }
 
 const PAGE_BREAK_CATEGORIES = new Set([
@@ -380,7 +380,8 @@ function updateComparison() {
   }));
   const compat = calculateCompatibility(surveyA, surveyB);
   const history = addHistoryEntry(compat.compatibilityScore);
-  window.compatibilityData = { categories: pdfCategories, history };
-  generatePDF();
+  const compatData = { categories: pdfCategories, history };
+  window.compatibilityData = compatData;
+  generatePDF(compatData);
 }
 

--- a/js/compatibilityPdf.js
+++ b/js/compatibilityPdf.js
@@ -1,7 +1,7 @@
 import { getFlagEmoji } from './matchFlag.js';
 import { buildLayout, drawMatchBar, getMatchPercentage } from './compatibilityReportHelpers.js';
 
-export function generateCompatibilityPDF() {
+export function generateCompatibilityPDF(data = { categories: [] }) {
   console.log('PDF function triggered');
   const { jsPDF } = window.jspdf;
   const doc = new jsPDF({ orientation: 'landscape' });
@@ -52,8 +52,10 @@ export function generateCompatibilityPDF() {
     drawMatchBar(doc, x, y, layout.barWidth, layout.barHeight, match);
   };
 
-  const data = window.compatibilityData;
   const categories = Array.isArray(data) ? data : data?.categories || [];
+  if (categories.length === 0) {
+    console.warn('generateCompatibilityPDF called without data');
+  }
   let y = 20;
 
   drawBackground();
@@ -141,7 +143,7 @@ if (typeof document !== 'undefined') {
   const attachHandler = () => {
     const button = document.getElementById('downloadPdfBtn');
     if (button) {
-      button.addEventListener('click', generateCompatibilityPDF);
+      button.addEventListener('click', () => generateCompatibilityPDF(window.compatibilityData));
     } else {
       console.error('Download button not found');
     }

--- a/test/compatibilityPdfZero.test.js
+++ b/test/compatibilityPdfZero.test.js
@@ -19,23 +19,21 @@ test('renders zero scores for both partners', async () => {
     save() {}
   }
 
-  globalThis.window = {
-    jspdf: { jsPDF: JsPDFMock },
-    compatibilityData: {
-      categories: [
-        {
-          category: 'Appearance Play',
-          items: [
-            { label: 'Choosing my partner\'s outfit', partnerA: 0, partnerB: 4 },
-            { label: 'Selecting their underwear, lingerie', partnerA: 2, partnerB: 0 }
-          ]
-        }
-      ]
-    }
+  globalThis.window = { jspdf: { jsPDF: JsPDFMock } };
+  const data = {
+    categories: [
+      {
+        category: 'Appearance Play',
+        items: [
+          { label: 'Choosing my partner\'s outfit', partnerA: 0, partnerB: 4 },
+          { label: 'Selecting their underwear, lingerie', partnerA: 2, partnerB: 0 }
+        ]
+      }
+    ]
   };
 
   const { generateCompatibilityPDF } = await import('../js/compatibilityPdf.js');
-  generateCompatibilityPDF();
+  generateCompatibilityPDF(data);
 
   // Ensure zeros are printed and no N/A appears
   const texts = textCalls.map(c => c[0]);


### PR DESCRIPTION
## Summary
- Refactor `generateCompatibilityPDF` to accept compatibility data as a parameter and warn when none is supplied.
- Pass compatibility data explicitly from `auto-pdf.js` to the PDF generator and through the download button handler.
- Update tests to use the new function signature.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68955dc7e718832cba77a5cfc5c691f2