### PR TITLE
Add jsPDF load check in auto PDF generation

### DIFF
--- a/js/auto-pdf.js
+++ b/js/auto-pdf.js
@@ -33,6 +33,12 @@ async function generatePDF() {
   pdfGenerated = true;
   const { loadJsPDF } = await import('./loadJsPDF.js');
   await loadJsPDF();
+  const { jsPDF } = window.jspdf || {};
+  if (!jsPDF) {
+    const err = new Error('jsPDF failed to load');
+    console.error(err);
+    throw err;
+  }
   const { generateCompatibilityPDF } = await import('./compatibilityPdf.js');
   generateCompatibilityPDF();
 }


### PR DESCRIPTION
## Summary
- ensure jsPDF is available before generating compatibility PDF
- surface an explicit error when jsPDF fails to load

## Testing
- `npm test`
- `node --input-type=module - <<'NODE'
// Preload jsPDF and then remove to simulate failure
global.window = {};
const loader = await import('./js/loadJsPDF.js');
await loader.loadJsPDF();
delete window.jspdf;
async function testGeneratePDF() {
  const { loadJsPDF } = await import('./js/loadJsPDF.js');
  await loadJsPDF();
  const { jsPDF } = window.jspdf || {};
  if (!jsPDF) {
    const err = new Error('jsPDF failed to load');
    console.error(err.message);
    throw err;
  }
}
try {
  await testGeneratePDF();
} catch (e) {
  console.log('Caught:', e.message);
}
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68955dcbc7d4832cb3fd9c38111346c9