### PR TITLE
Simplify category headers and layout

### DIFF
--- a/css/auto-pdf.css
+++ b/css/auto-pdf.css
@@ -89,13 +89,13 @@ body.exporting {
 
 /* Make the section headers black */
 .exporting .category-header {
-  background-color: #000 !important;
   color: #ff3333 !important;
   font-weight: bold;
   font-size: 1.2em;
   padding: 12px 16px;
   text-align: center;
-  border-bottom: 2px solid #333;
+  break-inside: avoid;
+  page-break-inside: avoid;
 }
 
 /* Ensure full table width and text wrapping */
@@ -250,15 +250,15 @@ body.exporting {
   }
 
   .category-header {
-    background-color: #000 !important;
     color: red !important;
     font-weight: bold;
     padding: 12px 16px;
     font-size: 1.2em;
     text-align: center;
-    border-bottom: 1px solid #333;
     word-wrap: break-word;
     white-space: normal;
+    break-inside: avoid;
+    page-break-inside: avoid;
   }
 
   @page {

--- a/css/style.css
+++ b/css/style.css
@@ -2146,14 +2146,17 @@ body {
   font-size: 20px;
   font-weight: 700;
   text-align: center;
-  border-bottom: 1px solid #555;
   padding: 4px 0;
   margin: 12px 0 4px;
 }
 .category-wrapper {
   margin-bottom: 24px;
   padding-bottom: 20px;
-  border-bottom: 1px solid #ddd;
+}
+
+#listOutput section {
+  break-inside: avoid;
+  page-break-inside: avoid;
 }
 .category-header.green { color: #00cc66; }
 .category-header.yellow { color: #ffcc00; }
@@ -2555,7 +2558,11 @@ body {
     font-size: 0.85rem;
     text-align: center;
     padding: 0.25rem 0;
-    border-bottom: 1px solid #ccc;
+  }
+
+  #listOutput section {
+    page-break-inside: avoid;
+    break-inside: avoid;
   }
 
   .category-header.green { color: #00cc44; }
@@ -2996,7 +3003,6 @@ body {
 
 /* Make the section headers black */
 .exporting .category-header {
-  background-color: #000 !important;
   color: #ff4444 !important;
   text-align: center;
 }
@@ -3093,7 +3099,6 @@ body {
 
 /* Force black header background instead of dark blue */
 .exporting .category-header {
-  background-color: #000 !important;
   color: #f00 !important; /* Or #fff if you'd rather use white text */
   text-align: center;
 }

--- a/js/theme.js
+++ b/js/theme.js
@@ -425,8 +425,8 @@ export function applyPrintStyles(mode = 'dark') {
       .category-wrapper {
         margin-bottom: 24px;
         padding: 6px;
-        border-bottom: 1px solid #ddd;
-        background-color: var(--panel-color, #000) !important;
+        break-inside: avoid;
+        page-break-inside: avoid;
       }
 
       .print-footer {
@@ -493,12 +493,12 @@ export function applyPrintStyles(mode = 'dark') {
         }
 
         .category-wrapper {
-          background-color: var(--panel-color, #000) !important;
           color: var(--text-color, #ffffff) !important;
-          border: 1px solid #cccccc;
           padding: 1rem;
           border-radius: 6px;
           margin-bottom: 1rem;
+          break-inside: avoid;
+          page-break-inside: avoid;
         }
 
         .page-break {

--- a/kink-list.html
+++ b/kink-list.html
@@ -111,15 +111,12 @@
         const section = document.createElement('section');
         const h2 = document.createElement('h2');
         h2.className = 'category-header';
+        h2.textContent = category;
         const score = scoreMap.get(category) ?? 0;
         if (score <= 40) {
-          h2.append('🚩 ', category);
           h2.classList.add('flag-low');
         } else if (score >= 85) {
-          h2.append('✅ ', category);
           h2.classList.add('flag-high');
-        } else {
-          h2.textContent = category;
         }
         section.appendChild(h2);
         ['Giving','Receiving','General'].forEach(role => {


### PR DESCRIPTION
## Summary
- Drop emoji from kink list category titles
- Remove borders/backgrounds from category headers across site and export styles
- Prevent category sections from breaking across pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68958bf00e2c832ca4e9d15fa18fd272