### PR TITLE
Remove category decorations and fix PDF export

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -154,12 +154,12 @@
               },100);
             });
           }
-          if (typeof downloadCompatibilityPDF !== 'function') {
+          if (typeof window.downloadCompatibilityPDF !== 'function') {
             console.error('[err] downloadCompatibilityPDF() is not defined on this page.');
             alert('PDF function missing. Make sure the exporter function is included.');
             return;
           }
-          await downloadCompatibilityPDF();
+          await window.downloadCompatibilityPDF();
         } catch (e) {
           console.error('[err] PDF click handler failed:', e);
           alert('Could not generate PDF. See console for details.');

--- a/css/compat-table.css
+++ b/css/compat-table.css
@@ -39,8 +39,9 @@ table.compat thead th.pb {
 .category-title {
   font-weight: 800;
   font-size: 1.25rem;
-  border-top: 2px solid #333;
-  border-bottom: 2px solid #333;
+  /* Remove top and bottom borders to eliminate box appearance */
+  border-top: none;
+  border-bottom: none;
   padding: 14px 12px !important;
 }
 

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -425,7 +425,8 @@ function updateComparison() {
     block.dataset.category = category;
 
     const titleRow = document.createElement('tr');
-    titleRow.innerHTML = `<td class="category-title" colspan="5"><span class="category-icon">🏳️‍🌈</span> ${category}</td>`;
+    // Remove decorative emoji from category headers in web view
+    titleRow.innerHTML = `<td class="category-title" colspan="5">${category}</td>`;
     block.appendChild(titleRow);
 
     kinks.forEach(kink => {


### PR DESCRIPTION
## Summary
- Drop decorative rainbow icon from category headers and clean up CSS borders.
- Adjust PDF download button to call `window.downloadCompatibilityPDF` ensuring the exporter is found.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68968bcb1670832c9be6f8d2f0c537c8