### PR TITLE
Remove rainbow flag remnants from compatibility views

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -51,11 +51,6 @@
     }
   </style>
   <style>
-    /* Remove rainbow/emoji from headers in WEB immediately */
-    .category-emoji,
-    .category-header .emoji,
-    .section-title .emoji { display: none !important; }
-
     /* Keep rows from splitting in both web and print */
     .compat-section tr { break-inside: avoid; page-break-inside: avoid; }
 

--- a/css/compat-table.css
+++ b/css/compat-table.css
@@ -66,9 +66,6 @@ td.pb {
 .flag-cell { text-align: left; }
 .flag-cell .red-flag { color: #ff4d4f; }
 
-/* Optional: category icon styling */
-.category-icon { color: #ff4d4f; margin-right: 10px; }
-
 /* Print adjustments */
 @media print {
   body {

--- a/css/global.css
+++ b/css/global.css
@@ -29,22 +29,4 @@
   height: auto;
 }
 
-.results-table .category-cell {
-  padding: 0.6rem 1rem;
-  background-color: #000;
-}
-
-.results-table .category-banner {
-  width: 100%;
-  display: flex;
-  align-items: center;
-  font-size: 1.2rem;
-  font-weight: bold;
-  color: red;
-  gap: 0.5rem;
-}
-
-.results-table .category-flag {
-  font-size: 1.5rem;
-}
 

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -126,34 +126,6 @@ function groupKinksByCategory(data) {
   });
   return grouped;
 }
-
-function renderCategoryRow(categoryName, categoryData) {
-  const percent = calculateCategoryMatch(categoryData);
-  const flag = getFlagEmoji(percent);
-  const tr = document.createElement('tr');
-  tr.classList.add('category-header');
-  tr.innerHTML = `
-    <td colspan="5" class="category-cell">
-      <div class="category-banner">
-        <span class="category-flag">${flag}</span>
-        <span class="category-name">${categoryName}</span>
-      </div>
-    </td>`;
-  return tr;
-}
-
-function renderCategoryHeaderPDF(doc, categoryName, categoryData) {
-  const percent = calculateCategoryMatch(categoryData);
-  const flag = getFlagEmoji(percent);
-  doc.moveDown(0.4);
-  doc
-    .fontSize(14)
-    .font('Helvetica-Bold')
-    .fillColor('red')
-    .text(`${flag} ${categoryName}`, { align: 'left' })
-    .moveDown(0.2);
-  doc.fillColor('white');
-}
 function loadSavedSurvey() {
   const saved = localStorage.getItem('savedSurvey');
   if (!saved) return;


### PR DESCRIPTION
## Summary
- Clean up compatibility page by dropping temporary CSS that hid rainbow emojis
- Remove unused category flag renderers and related styles for a cleaner survey and PDF

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68968f2c8834832c8b29af87d915a4ff