### PR TITLE
fix: handle missing html2pdf

### DIFF
--- a/js/pdfDownload.js
+++ b/js/pdfDownload.js
@@ -68,8 +68,15 @@ export async function downloadCompatibilityPDF() {
     jsPDF: { unit: 'pt', format: 'letter', orientation: 'portrait' },
     pagebreak: { mode: ['avoid-all', 'css', 'legacy'], before: '.compat-section' }
   };
+  const html2pdfFn =
+    globalThis.html2pdf || (typeof window !== 'undefined' ? window.html2pdf : undefined);
+  if (!html2pdfFn) {
+    console.error('PDF generation failed: html2pdf library not found');
+    document.body.removeChild(shell);
+    return;
+  }
   try {
-    await html2pdf().set(opt).from(shell).save();
+    await html2pdfFn().set(opt).from(shell).save();
   } catch (err) {
     console.error('PDF generation failed:', err);
   } finally {


### PR DESCRIPTION
## Summary
- handle missing html2pdf library gracefully in PDF downloader

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896972077c8832c8e27e42bc3459191