### PR TITLE
test: add coverage for getTotalLove

### DIFF
--- a/js/getTotalLove.js
+++ b/js/getTotalLove.js
@@ -1,0 +1,17 @@
+export function getTotalLove(data) {
+  const categories = Array.isArray(data)
+    ? data
+    : Array.isArray(data?.categories)
+      ? data.categories
+      : [];
+  let total = 0;
+  for (const cat of categories) {
+    const items = Array.isArray(cat?.items) ? cat.items : [];
+    for (const item of items) {
+      const a = item.partnerA ?? item.a;
+      const b = item.partnerB ?? item.b;
+      if (a === 5 && b === 5) total++;
+    }
+  }
+  return total;
+}

--- a/test/getTotalLove.test.js
+++ b/test/getTotalLove.test.js
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { getTotalLove } from '../js/getTotalLove.js';
+
+test('counts mutual loves across categories', () => {
+  const data = {
+    categories: [
+      { category: 'A', items: [
+        { label: 'K1', partnerA: 5, partnerB: 5 },
+        { label: 'K2', partnerA: 5, partnerB: 3 },
+      ]},
+      { category: 'B', items: [
+        { label: 'K3', partnerA: 5, partnerB: 5 },
+      ]}
+    ]
+  };
+  assert.strictEqual(getTotalLove(data), 2);
+});
+
+test('ignores missing or non-love ratings', () => {
+  const data = {
+    categories: [
+      { category: 'X', items: [
+        { label: 'K1', partnerA: 5, partnerB: null },
+        { label: 'K2', partnerA: 4, partnerB: 5 },
+        { label: 'K3', partnerA: 5, partnerB: 4 },
+      ]}
+    ]
+  };
+  assert.strictEqual(getTotalLove(data), 0);
+});

--- a/test/pdfDownloadButton.test.js
+++ b/test/pdfDownloadButton.test.js
@@ -9,6 +9,8 @@ test('PDF download button handler attaches on DOMContentLoaded', async () => {
     addEventListener: (evt, cb) => {
       if (evt === 'click') clickHandler = cb;
     },
+    cloneNode: () => button,
+    replaceWith: () => {},
   };
 
   let domReadyHandler;
@@ -31,8 +33,17 @@ test('PDF download button handler attaches on DOMContentLoaded', async () => {
         })
       }),
     };
+    const head = { appendChild: () => {} };
     globalThis.document = {
+      head,
       getElementById: id => (id === 'downloadBtn' ? button : null),
+      querySelector: () => null,
+      createElement: () => ({
+        setAttribute: () => {},
+        style: {},
+        appendChild: () => {},
+        textContent: ''
+      }),
     };
     globalThis.alert = () => {};
     globalThis.print = () => {};


### PR DESCRIPTION
## Summary
- add getTotalLove helper to count mutual loves in data
- test getTotalLove for mutual and missing ratings
- stub DOM features in pdf download button test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896a7cd45e8832ca5785a3f9cf3a4e2