### PR TITLE
Ensure html2pdf bundle loads before PDF export

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -9,7 +9,7 @@
   <link rel="stylesheet" href="/css/global.css" />
   <link rel="stylesheet" href="/css/compat-table.css" />
   <link href="https://fonts.googleapis.com/css2?family=Fredoka+One&display=swap" rel="stylesheet" />
-  <script src="js/vendor/html2pdf.bundle.min.js"></script>
+  <script src="https://unpkg.com/html2pdf.js@0.9.3/dist/html2pdf.bundle.min.js"></script>
   <style>
     .upload-container {
       display: flex;


### PR DESCRIPTION
## Summary
- Load html2pdf.js bundle from CDN before pdfDownload.js
- Remove async html2pdf loader and simplify jsPDF constructor detection

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896bb70f824832cb75d9000402213a1