### PR TITLE
Enable PDF download for survey results

### DIFF
--- a/js/pdfDownload.js
+++ b/js/pdfDownload.js
@@ -275,5 +275,13 @@ function wireBtn(){
 }
 if (typeof window !== 'undefined') {
   window.downloadCompatibilityPDF = downloadCompatibilityPDF;
-  window.addEventListener('DOMContentLoaded', wireBtn);
+  window.addEventListener('DOMContentLoaded', () => {
+    wireBtn();
+    console.log('[pdf] env', {
+      html2pdf: !!window.html2pdf,
+      html2canvas: !!window.html2canvas,
+      jsPDF: !!(window.jspdf && window.jspdf.jsPDF),
+      fn: typeof window.downloadCompatibilityPDF,
+    });
+  });
 }

--- a/pdf-download-test.html
+++ b/pdf-download-test.html
@@ -17,6 +17,7 @@
     </table>
   </div>
 
+  <script src="https://unpkg.com/html2pdf.js@0.9.3/dist/html2pdf.bundle.min.js"></script>
   <script type="module" src="js/pdfDownloadDebug.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Log PDF library availability and wire button on DOM ready
- Ensure test page loads html2pdf bundle before debug exporter

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896bd9436a8832c8b0bf562b69d13fe