### PR TITLE
fix: load pdf libs before export

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -9,7 +9,8 @@
   <link rel="stylesheet" href="/css/global.css" />
   <link rel="stylesheet" href="/css/compat-table.css" />
   <link href="https://fonts.googleapis.com/css2?family=Fredoka+One&display=swap" rel="stylesheet" />
-  <script src="https://unpkg.com/html2pdf.js@0.9.3/dist/html2pdf.bundle.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <style>
     .upload-container {
       display: flex;
@@ -121,7 +122,6 @@
     }
     (document.readyState === 'loading') ? document.addEventListener('DOMContentLoaded', wire) : wire();
     console.log('[pdf] env', {
-      html2pdf: !!window.html2pdf,
       html2canvas: !!window.html2canvas,
       jsPDF: !!(window.jspdf && window.jspdf.jsPDF),
       fn: typeof window.downloadCompatibilityPDF
@@ -151,7 +151,6 @@
       // 1) Environment check
       const jsPDFCtor = (window.jspdf && window.jspdf.jsPDF) || (window.jsPDF && window.jsPDF.jsPDF);
       const env = {
-        html2pdf: !!window.html2pdf,
         html2canvas: !!window.html2canvas,
         jsPDF: !!jsPDFCtor,
         exporterFn: typeof window.downloadCompatibilityPDF,
@@ -177,8 +176,8 @@
       }
 
       // 4) Verify the libs (MUST be loaded BEFORE exporter)
-      if (!env.html2pdf || !env.html2canvas || !env.jsPDF) {
-        alert('PDF FAIL: Required libs missing.\n\nYou MUST load this BEFORE your exporter code:\n<script src="https://unpkg.com/html2pdf.js@0.9.3/dist/html2pdf.bundle.min.js"></script>');
+      if (!env.html2canvas || !env.jsPDF) {
+        alert('PDF FAIL: Required libs missing.\n\nYou MUST load these BEFORE your exporter code:\n<script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>\n<script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>');
         return;
       }
 

--- a/pdf-download-test.html
+++ b/pdf-download-test.html
@@ -4,7 +4,8 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>PDF Download Test</title>
-  <script src="https://unpkg.com/html2pdf.js@0.9.3/dist/html2pdf.bundle.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 </head>
 <body>
   <button id="downloadBtn">Download PDF</button>
@@ -32,7 +33,6 @@
     }
     (document.readyState === 'loading') ? document.addEventListener('DOMContentLoaded', wire) : wire();
     console.log('[pdf] env', {
-      html2pdf: !!window.html2pdf,
       html2canvas: !!window.html2canvas,
       jsPDF: !!(window.jspdf && window.jspdf.jsPDF),
       fn: typeof window.downloadCompatibilityPDF
@@ -62,7 +62,6 @@
       // 1) Environment check
       const jsPDFCtor = (window.jspdf && window.jspdf.jsPDF) || (window.jsPDF && window.jsPDF.jsPDF);
       const env = {
-        html2pdf: !!window.html2pdf,
         html2canvas: !!window.html2canvas,
         jsPDF: !!jsPDFCtor,
         exporterFn: typeof window.downloadCompatibilityPDF,
@@ -88,8 +87,8 @@
       }
 
       // 4) Verify the libs (MUST be loaded BEFORE exporter)
-      if (!env.html2pdf || !env.html2canvas || !env.jsPDF) {
-        alert('PDF FAIL: Required libs missing.\n\nYou MUST load this BEFORE your exporter code:\n<script src="https://unpkg.com/html2pdf.js@0.9.3/dist/html2pdf.bundle.min.js"></script>');
+      if (!env.html2canvas || !env.jsPDF) {
+        alert('PDF FAIL: Required libs missing.\n\nYou MUST load these BEFORE your exporter code:\n<script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>\n<script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>');
         return;
       }
 


### PR DESCRIPTION
## Summary
- load html2canvas and jsPDF from CDN before invoking `downloadCompatibilityPDF`
- update diagnostic checks to require these libraries and adjust guidance

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6896e4f0d260832cb7f446cc5f481293