### PR TITLE
Add flag/star compatibility column and remove diagnostics

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -12,6 +12,25 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <style>
+  #pdf-container {
+    width: 100%;
+    max-width: 100%;
+  }
+  table {
+    width: 100%;
+    table-layout: fixed;
+  }
+  th, td {
+    text-align: center;
+    vertical-align: middle;
+    padding: 6px;
+  }
+  th:first-child, td:first-child {
+    text-align: left;
+    padding-left: 10px;
+  }
+  </style>
+  <style>
     .upload-container {
       display: flex;
       flex-direction: column;
@@ -119,85 +138,6 @@
      };
      document.readyState === 'loading' ? document.addEventListener('DOMContentLoaded', wire) : wire();
    </script>
-
-  <!-- ================= PDF DIAGNOSTIC HARNESS (paste at end of <body>) ================= -->
-  <style>
-    #pdf-diagnostics { position: fixed; right: 12px; bottom: 12px; z-index: 999999; }
-    #pdf-diagnostics button { padding: 8px 10px; border-radius: 8px; border: 0; cursor: pointer; }
-  </style>
-  <div id="pdf-diagnostics">
-    <button id="pdf-diag-btn">Diagnose PDF</button>
-  </div>
-
-  <script>
-  (function(){
-    const el = document.getElementById('pdf-diag-btn');
-    if (!el) return;
-
-    function exists(sel){ return !!document.querySelector(sel); }
-
-    el.addEventListener('click', async () => {
-      console.clear();
-      console.log('%c[pdf] DIAG START','color:#0af');
-
-      // 1) Environment check
-      const jsPDFCtor = (window.jspdf && window.jspdf.jsPDF) || (window.jsPDF && window.jsPDF.jsPDF);
-      const env = {
-        html2canvas: !!window.html2canvas,
-        jsPDF: !!jsPDFCtor,
-        exporterFn: typeof window.downloadCompatibilityPDF,
-        button: !!(document.getElementById('downloadBtn') || document.querySelector('[data-download-pdf]')),
-        container: !!document.getElementById('pdf-container')
-      };
-      console.table(env);
-
-      // 2) Inspect the container
-      let cont = document.getElementById('pdf-container');
-      if (!cont) {
-        alert('PDF FAIL: #pdf-container not found.\nMake sure your report is wrapped in <div id="pdf-container">…</div>.');
-        return;
-      }
-      const cr = cont.getBoundingClientRect();
-      const hasRows = Array.from(cont.querySelectorAll('table tbody')).some(tb => tb.children && tb.children.length > 0);
-      console.log('[pdf] container metrics:', { w: cr.width, h: cr.height, scrollW: cont.scrollWidth, scrollH: cont.scrollHeight, hasRows });
-
-      // 3) Verify the exporter function is callable
-      if (env.exporterFn !== 'function') {
-        alert('PDF FAIL: downloadCompatibilityPDF is not a function.\n\nFix: ensure your wiring exposes it:\nwindow.downloadCompatibilityPDF = downloadCompatibilityPDF;');
-        return;
-      }
-
-      // 4) Verify the libs (MUST be loaded BEFORE exporter)
-      if (!env.html2canvas || !env.jsPDF) {
-        alert('PDF FAIL: Required libs missing.\n\nYou MUST load these BEFORE your exporter code:\n<script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>\n<script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>');
-        return;
-      }
-
-      // 5) Run the exporter and catch the real error
-      try {
-        console.log('[pdf] calling downloadCompatibilityPDF()…');
-        await window.downloadCompatibilityPDF();
-        console.log('%c[pdf] success','color:#0a0');
-      } catch (err) {
-        console.error('[pdf] ERROR THROWN BY EXPORTER:', err);
-        alert('Could not generate PDF.\n\nReason: ' + (err?.message || err) + '\n\nOpen Console to see [pdf] logs.');
-      }
-    });
-
-    // Optional: simple SMOKE TEST to prove the libs work even if your container doesn’t.
-    // Call window.__pdfSmokeTest() in the console.
-    window.__pdfSmokeTest = async function(){
-      const jsPDFCtor = (window.jspdf && window.jspdf.jsPDF) || (window.jsPDF && window.jsPDF.jsPDF);
-      if (!jsPDFCtor) return console.error('[pdf] jsPDF missing');
-      const pdf = new jsPDFCtor({ unit:'pt', format:'letter', orientation:'portrait' });
-      pdf.setFillColor(0,0,0); pdf.rect(0,0,612,792,'F'); // black page
-      pdf.setTextColor(255,255,255); pdf.setFontSize(14);
-      pdf.text('Smoke test OK — libs loaded and save works.', 40, 60);
-      pdf.save('smoke.pdf');
-      console.log('[pdf] smoke test saved smoke.pdf');
-    };
-  })();
-  </script>
   <!-- ================================================================================ -->
   </body>
 </html>

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -313,7 +313,18 @@ function loadFileB(file) {
   reader.readAsText(file);
 }
 
-const FLAG_DIFF_THRESHOLD = 0;
+function calculateMatchPercent(a, b) {
+  if (!Number.isFinite(a) || !Number.isFinite(b)) return null;
+  return Math.max(0, 100 - Math.abs(a - b) * 20);
+}
+
+function getFlagOrStar(match, scoreA, scoreB) {
+  if (match >= 90) return '⭐';
+  const high = val => Number.isFinite(val) && val >= 4;
+  const missing = val => val === null || val === undefined || val === '' || val === 0;
+  if (match <= 50 || ((high(scoreA) || high(scoreB)) && (missing(scoreA) || missing(scoreB)))) return '🚩';
+  return '';
+}
 
 function renderFlags(root = document) {
   const rows = root.querySelectorAll('.item-row');
@@ -326,15 +337,10 @@ function renderFlags(root = document) {
     flagCell.textContent = '';
     matchCell.textContent = '-';
 
-    if (Number.isFinite(a) && Number.isFinite(b)) {
-      const diff = Math.abs(a - b);
-      matchCell.textContent = diff <= FLAG_DIFF_THRESHOLD ? '✓' : '—';
-      if (diff > FLAG_DIFF_THRESHOLD) {
-        const span = document.createElement('span');
-        span.className = 'red-flag';
-        span.textContent = '🚩';
-        flagCell.appendChild(span);
-      }
+    const match = calculateMatchPercent(a, b);
+    if (match !== null) {
+      matchCell.textContent = match + '%';
+      flagCell.textContent = getFlagOrStar(match, a, b);
     }
   });
 }
@@ -385,7 +391,7 @@ function updateComparison() {
         <th class="label"></th>
         <th class="pa">Partner A</th>
         <th class="match">Match</th>
-        <th class="flag">Flag</th>
+        <th class="flag">Flag/Star</th>
         <th class="pb">Partner B</th>
       </tr>
     </thead>

--- a/js/matchFlag.js
+++ b/js/matchFlag.js
@@ -2,8 +2,9 @@
 export function getFlagEmoji(percent, a, b) {
   if (percent === null || percent === undefined) return '';
   if (percent >= 90) return '⭐';
-  if ((a === 5 && typeof b === 'number' && b < 5) || (b === 5 && typeof a === 'number' && a < 5)) return '🟨';
-  if (percent < 30) return '🚩';
+  const high = val => typeof val === 'number' && val >= 4;
+  const missing = val => val === '' || val === null || val === undefined || val === 0;
+  if (percent <= 50 || ((high(a) || high(b)) && (missing(a) || missing(b)))) return '🚩';
   return '';
 }
 


### PR DESCRIPTION
## Summary
- remove PDF diagnostic harness from compatibility page
- make PDF table full-width and add Flag/Star column logic
- update flag/star calculation rules across compatibility scripts

## Testing
- `npm test` *(fails: 2, pass: 45)*

------
https://chatgpt.com/codex/tasks/task_e_6896f48eb88c832c821bbb6813687360