### PR TITLE
Ensure Partner A present before compatibility PDF export

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -134,7 +134,23 @@
       const b=document.getElementById("downloadBtn")||document.querySelector("[data-download-pdf]");
       if(!b){console.error("[pdf] missing download button");return;}
       const fresh=b.cloneNode(true); b.replaceWith(fresh);
-      fresh.addEventListener("click",()=>downloadCompatibilityPDF().catch(e=>{console.error(e);alert("Could not generate PDF. See console.");}));
+      fresh.addEventListener("click", async ()=>{
+        const table=document.querySelector('#pdf-container table');
+        const ths=table?Array.from(table.querySelectorAll('thead th')):[];
+        const idxA=ths.findIndex(th=> (th.textContent||'').trim().toLowerCase()==='partner a');
+        if(idxA>=0){
+          const hasData=Array.from(table.querySelectorAll(`tbody tr td:nth-child(${idxA+1})`)).some(td=> (td.textContent||'').trim()!=='');
+          if(!hasData){
+            alert('Partner A looks empty in the table. Upload your survey JSON first.');
+            return;
+          }
+        }
+        try{
+          await downloadCompatibilityPDF();
+        }catch(e){
+          console.error(e);alert("Could not generate PDF. See console.");
+        }
+      });
     };
     document.readyState==="loading"?document.addEventListener("DOMContentLoaded",wire):wire();
   </script>

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -345,6 +345,27 @@ function renderFlags(root = document) {
   });
 }
 
+function markPartnerALoaded() {
+  const table = document.querySelector('#pdf-container table');
+  if (!table) return;
+
+  const ths = Array.from(table.querySelectorAll('thead th'));
+  const idxA = ths.findIndex(th => (th.textContent || '').trim().toLowerCase() === 'partner a');
+
+  if (idxA >= 0) {
+    const cells = Array.from(table.querySelectorAll(`tbody tr td:nth-child(${idxA + 1})`));
+    const hasAny = cells.some(td => (td.textContent || '').trim() !== '');
+    if (hasAny) {
+      cells.forEach(td => td.style.outline = '1px dashed rgba(255,255,255,.15)');
+      console.log('[compat] Partner A column populated in the DOM. Ready for PDF.');
+    } else {
+      console.warn('[compat] Partner A column is empty. Did the JSON include ratings for these rows?');
+    }
+  } else {
+    console.warn('[compat] Could not find a "Partner A" table header. Check your table markup.');
+  }
+}
+
 function updateComparison() {
   const container = document.getElementById('compatibility-report');
   const msg = document.getElementById('comparisonResult');
@@ -427,6 +448,7 @@ function updateComparison() {
 
   container.appendChild(table);
   renderFlags(table);
+  markPartnerALoaded();
 
   const categories = Object.entries(lastResult).map(([category, items]) => ({
     category,


### PR DESCRIPTION
## Summary
- Outline Partner A column once survey A data populates the compatibility table
- Prevent PDF export if Partner A column is empty

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897febecf6c832c8627aa988fdffe84