### PR TITLE
Annotate comparison rows and refine Partner A loader

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -680,150 +680,91 @@ window.__compatDump = () => {
     }
   });
 })();
-</script>
-<script>
-/* ===================== ROBUST ROW KEY ANNOTATION + DIAGNOSTICS ===================== *
- * Purpose: Your table labels are visually truncated (…), while JSON uses full phrases.
- * This derives a stable data-key for each <tr> from full-label sources if present, else visible text.
- * Works alongside the existing Partner A/B loader scripts. Paste AFTER them.
- */
-
+  </script>
+  <script>
+/* ROW KEY ANNOTATOR + AUTO REFILL + DIAGNOSTICS (works with truncated labels) */
 (function(){
-  const CONTAINER = '#pdf-container';
+  const ROOT = document.querySelector('#pdf-container');
+  if (!ROOT) return;
 
-  // Normalization used for keys: unify punctuation, remove ellipses, squash whitespace
-  function normKey(s){
-    return (s||'')
+  function norm(s){
+    return String(s||'')
       .replace(/[\u2018\u2019\u2032]/g,"'")
       .replace(/[\u201C\u201D\u2033]/g,'"')
       .replace(/[\u2013\u2014]/g,'-')
-      .replace(/\u2026/g,'')            // remove "…" ellipses
-      .replace(/\s*\.\.\.\s*$/,'')      // remove trailing "..."
+      .replace(/\u2026/g,'')
+      .replace(/\s*\.\.\.\s*$/,'')
       .replace(/\s+/g,' ')
-      .trim().toLowerCase();
+      .trim()
+      .toLowerCase();
   }
 
-  // Best-available full label for a row (attributes > hidden full text > visible text)
-  function getFullLabel(tr){
+  function deriveLabel(tr){
     const first = tr.querySelector('td:first-child, th:first-child');
-    // Attributes on row or first cell
+    // Prefer attributes first
     const fromAttr =
-      tr.getAttribute('data-full')      || tr.getAttribute('data-label') ||
+      tr.getAttribute('data-full') || tr.getAttribute('data-label') ||
       (first && (first.getAttribute('data-full') || first.getAttribute('data-label'))) ||
-      tr.getAttribute('title')          || tr.getAttribute('aria-label') ||
+      tr.getAttribute('title') || tr.getAttribute('aria-label') ||
       (first && (first.getAttribute('title') || first.getAttribute('aria-label')));
     if (fromAttr) return fromAttr;
-    // Hidden/auxiliary nodes developers often add for full text
-    const hidden =
-      tr.querySelector('.full-label')   || tr.querySelector('[data-full-label]') ||
-      (first && (first.querySelector('.full-label') || first.querySelector('[data-full-label]')));
+    // Hidden full label node
+    const hidden = tr.querySelector('.full-label') || (first && first.querySelector('.full-label'));
     if (hidden && hidden.textContent) return hidden.textContent;
-    // Fallback to visible first-cell text (might be truncated)
+    // Fallback to visible text (may be ellipsized)
     return first ? first.textContent : '';
   }
 
-  // Annotate every row with a strong data-key so loaders can match reliably
-  function annotateRows(){
-    const root = document.querySelector(CONTAINER);
-    if (!root) return;
-    const rows = Array.from(root.querySelectorAll('table tbody tr'));
-    rows.forEach(tr=>{
-      const already = tr.getAttribute('data-key') || tr.getAttribute('data-id');
-      if (already && already.trim()) return;
-      const label = getFullLabel(tr);
-      const key   = normKey(label);
+  function annotate(){
+    ROOT.querySelectorAll('table tbody tr').forEach(tr=>{
+      if ((tr.getAttribute('data-key') || tr.getAttribute('data-id') || '').trim()) return;
+      const key = norm(deriveLabel(tr));
       if (key) tr.setAttribute('data-key', key);
     });
   }
 
-  // Build lookups for mismatch report from whatever the loaders stored
-  function currentJsonLookups(){
-    function toMap(obj){
-      const m = new Map();
-      if (obj && typeof obj === 'object'){
-        for (const [k,v] of Object.entries(obj)) m.set(normKey(k), v);
+  // Call Partner A/B fillers if available (from your existing loader scripts)
+  function tryRefill(){
+    try {
+      if (window.partnerASurvey && typeof window.fillPartnerAAll === 'function') {
+        window.fillPartnerAAll(window.partnerASurvey);
       }
-      return m;
-    }
-    return {
-      A: toMap(window.partnerASurvey),
-      B: toMap(window.partnerBSurvey)
-    };
-  }
-
-  // Log what still doesn’t match (helps fix residual issues)
-  function reportMismatches(){
-    const root = document.querySelector(CONTAINER);
-    if (!root) return;
-
-    const {A,B} = currentJsonLookups();
-
-    function scan(label){
-      const unmatchedRows = [];
-      const tables = Array.from(root.querySelectorAll('table'));
-      const allRowKeys = [];
-      tables.forEach(t=>{
-        t.querySelectorAll('tbody tr').forEach(tr=>{
-          const rk = (tr.getAttribute('data-key') || '').trim();
-          if (rk) allRowKeys.push(rk);
-          const map = label==='A' ? A : B;
-          if (map.size && rk && !map.has(rk)) unmatchedRows.push(rk);
-        });
-      });
-
-      const map = label==='A' ? A : B;
-      const unmatchedKeys = [];
-      map.forEach((_, k)=>{
-        if (!allRowKeys.includes(k)) unmatchedKeys.push(k);
-      });
-
-      console.group(`[compat] Unmatched report Partner ${label}`);
-      console.log('Rows not matched by JSON (sample):', unmatchedRows.slice(0,60));
-      console.log('JSON keys not matched by any row (sample):', unmatchedKeys.slice(0,60));
-      console.log('(showing up to 60 each)');
-      console.groupEnd();
-    }
-
-    if (A.size) scan('A');
-    if (B.size) scan('B');
-  }
-
-  // Run once now, then whenever the table re-renders
-  function bootAnnotator(){
-    annotateRows();
-    const root = document.querySelector(CONTAINER);
-    if (!root) return;
-    const mo = new MutationObserver(()=>{
-      annotateRows();
-      // After keys exist, give loaders another chance to fill
-      try {
-        if (window.partnerASurvey && typeof window.fillPartnerAAll === 'function'){
-          window.fillPartnerAAll(window.partnerASurvey);
-        }
-        if (window.partnerBSurvey && typeof window.fillPartnerBAll === 'function'){
-          window.fillPartnerBAll(window.partnerBSurvey);
-        }
-        if (typeof window.populateFlags === 'function') window.populateFlags();
-      } catch(_) {}
-    });
-    mo.observe(root, {childList:true, subtree:true});
-  }
-
-  // Expose quick console commands
-  window.__compatAnnotate = annotateRows;
-  window.__compatMismatch = reportMismatches;
-
-  document.addEventListener('DOMContentLoaded', ()=>{
-    bootAnnotator();
-    // After uploads finish and the table refreshes, print a mismatch summary
-    document.addEventListener('change', (e)=>{
-      if (e.target && (e.target.matches('#uploadSurveyA, [data-upload-a]') ||
-                       e.target.matches('#uploadSurveyB, [data-upload-b]'))){
-        setTimeout(reportMismatches, 600);
+      if (window.partnerBSurvey && typeof window.fillPartnerBAll === 'function') {
+        window.fillPartnerBAll(window.partnerBSurvey);
       }
+      if (typeof window.populateFlags === 'function') window.populateFlags();
+    } catch(e) { console.warn('[compat] refill error', e); }
+  }
+
+  // Diagnostics to help if something still doesn’t match
+  function toMap(obj){
+    const m=new Map();
+    if (obj && typeof obj==='object') for (const [k,v] of Object.entries(obj)) m.set(norm(k), v);
+    return m;
+  }
+  function mismatch(){
+    const A = toMap(window.partnerASurvey);
+    const B = toMap(window.partnerBSurvey);
+    const keysInDom = [];
+    ROOT.querySelectorAll('table tbody tr').forEach(tr=>{
+      const k = (tr.getAttribute('data-key')||'').trim();
+      if (k) keysInDom.push(k);
     });
-  });
+    const jsonNotFound = (M) => [...M.keys()].filter(k => !keysInDom.includes(k));
+    console.group('[compat] mismatch report');
+    if (A.size) console.log('Partner A JSON keys not found in DOM:', jsonNotFound(A).slice(0,60));
+    if (B.size) console.log('Partner B JSON keys not found in DOM:', jsonNotFound(B).slice(0,60));
+    console.groupEnd();
+  }
+  window.__compatMismatch = mismatch;
+  window.__compatAnnotate = annotate;
+
+  // Run now and on future DOM updates
+  annotate();
+  tryRefill();
+  const mo = new MutationObserver(()=>{ annotate(); tryRefill(); });
+  mo.observe(ROOT, {childList:true, subtree:true});
 })();
-</script>
+  </script>
 </body>
 </html>

--- a/js/auto-pdf.js
+++ b/js/auto-pdf.js
@@ -194,6 +194,19 @@ function colorClass(percent) {
   return 'red';
 }
 
+function compatNormalizeKey(s){
+  return String(s || '')
+    .replace(/[\u2018\u2019\u2032]/g,"'")
+    .replace(/[\u201C\u201D\u2033]/g,'"')
+    .replace(/[\u2013\u2014]/g,'-')
+    .replace(/\u2026/g,'')
+    .replace(/\s*\.\.\.\s*$/,'')
+    .replace(/\s+/g,' ')
+    .trim()
+    .toLowerCase();
+}
+if (typeof window !== 'undefined') window.compatNormalizeKey = compatNormalizeKey;
+
 function barFillColor(percent) {
   if (percent >= 80) return '#00c853';
   if (percent >= 60) return '#fbc02d';
@@ -367,10 +380,17 @@ function updateComparison() {
   categories.forEach(cat => {
     const row = document.createElement('tr');
     row.className = 'row';
+    const fullLabel = cat.name;
+    row.setAttribute('data-key', compatNormalizeKey(fullLabel));
     const nameTd = document.createElement('td');
     nameTd.className = 'kink-name';
     const icons = buildCategoryIcons(cat.you, cat.partner);
     nameTd.innerHTML = icons ? `${cat.name} ${icons}` : cat.name;
+    const hidden = document.createElement('span');
+    hidden.className = 'full-label';
+    hidden.textContent = fullLabel;
+    hidden.hidden = true;
+    nameTd.appendChild(hidden);
     row.appendChild(nameTd);
     row.appendChild(makeTd(cat.you));
     row.appendChild(makeTd(cat.partner));

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -80,6 +80,19 @@ function colorClass(percent) {
   return 'red';
 }
 
+function compatNormalizeKey(s){
+  return String(s || '')
+    .replace(/[\u2018\u2019\u2032]/g,"'")
+    .replace(/[\u201C\u201D\u2033]/g,'"')
+    .replace(/[\u2013\u2014]/g,'-')
+    .replace(/\u2026/g,'')
+    .replace(/\s*\.\.\.\s*$/,'')
+    .replace(/\s+/g,' ')
+    .trim()
+    .toLowerCase();
+}
+if (typeof window !== 'undefined') window.compatNormalizeKey = compatNormalizeKey;
+
 function makeBar(percent) {
   const outer = document.createElement('div');
   outer.className = 'partner-bar';
@@ -433,6 +446,8 @@ function updateComparison() {
       row.className = 'item-row';
       if (kink.partnerA != null) row.dataset.a = kink.partnerA;
       if (kink.partnerB != null) row.dataset.b = kink.partnerB;
+      const fullLabel = kink.name;
+      row.setAttribute('data-key', compatNormalizeKey(fullLabel));
       row.innerHTML = `
         <td class="label">${kink.name}</td>
         <td class="pa">${kink.partnerA ?? '-'}</td>
@@ -440,6 +455,12 @@ function updateComparison() {
         <td class="flag flag-cell"></td>
         <td class="pb">${kink.partnerB ?? '-'}</td>
       `;
+      const firstCell = row.querySelector('td.label');
+      const hidden = document.createElement('span');
+      hidden.className = 'full-label';
+      hidden.textContent = fullLabel;
+      hidden.hidden = true;
+      firstCell.appendChild(hidden);
       block.appendChild(row);
     });
 

--- a/js/partnerALoader.js
+++ b/js/partnerALoader.js
@@ -69,7 +69,8 @@ async function handlePartnerAUpload(file) {
   setTimeout(() => {
     const matched = fillPartnerA(normalized);
     if (!matched) {
-      alert(`Partner A did not appear in the table.\n\nCheck that:\n• Rows have a data-key/data-id, or the first column matches your JSON keys\n• Table has td.pa cells OR a header named "${CFG.partnerAHeaderText}"\n• updateComparison() writes Partner A values`);
+      console.warn('[Partner A] No values found yet — will attempt to annotate and refill.');
+      if (window.__compatMismatch) setTimeout(window.__compatMismatch, 300);
     }
   }, 300);
 }


### PR DESCRIPTION
## Summary
- Normalize comparison labels with `compatNormalizeKey` and store hidden full labels for reliable data-key matching.
- Drop in a row key annotator script and remove aggressive Partner A alert in favor of diagnostics.
- Ensure auto-pdf rendering uses the same row keys for survey refills.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a6b8f0ce4832c8db8e1d2f094fe04