### PR TITLE
feat: share normalization utility

### DIFF
--- a/js/compatNormalizeKey.js
+++ b/js/compatNormalizeKey.js
@@ -1,0 +1,14 @@
+export function compatNormalizeKey(s){
+  return String(s || '')
+    .replace(/[\u2018\u2019\u2032]/g,"'")
+    .replace(/[\u201C\u201D\u2033]/g,'"')
+    .replace(/[\u2013\u2014]/g,'-')
+    .replace(/\u2026/g,'')
+    .replace(/\s*\.\.\.\s*$/,'')
+    .replace(/\s+/g,' ')
+    .trim()
+    .toLowerCase();
+}
+
+if (typeof window !== 'undefined') window.compatNormalizeKey = compatNormalizeKey;
+

--- a/js/partnerALoader.js
+++ b/js/partnerALoader.js
@@ -1,6 +1,8 @@
 // Partner A Loader: attaches JSON upload handler and PDF download guard
 // Auto-generated based on provided snippet.
 
+import { compatNormalizeKey as normalize } from './compatNormalizeKey.js';
+
 const CFG = {
   uploadSelector: '#uploadSurveyA, [data-upload-a]',
   downloadSelector: '#downloadBtn',
@@ -12,9 +14,6 @@ const CFG = {
 
 const $one = (sel, ctx = document) => ctx.querySelector(sel);
 const $all = (sel, ctx = document) => [...ctx.querySelectorAll(sel)];
-const normalize = str => (str || '').trim()
-  .replace(/[“”]/g, '"').replace(/[‘’]/g, "'")
-  .replace(/\s+/g, ' ').toLowerCase();
 window.__compatDump = () => {
   console.log('Headers:', getHeaders());
   console.log('Row samples:', $all(`${CFG.tableContainer} tr`).slice(0, 5).map(r => ({

--- a/test/compatNormalizeKey.test.js
+++ b/test/compatNormalizeKey.test.js
@@ -1,0 +1,31 @@
+import assert from 'node:assert';
+import test from 'node:test';
+import { compatNormalizeKey } from '../js/compatNormalizeKey.js';
+
+test('normalizes typographic quotes', () => {
+  const curlyDouble = '“Fancy” test';
+  const straightDouble = '"Fancy" test';
+  const curlySingle = '‘single’ test';
+  const straightSingle = "'single' test";
+  assert.strictEqual(compatNormalizeKey(curlyDouble), compatNormalizeKey(straightDouble));
+  assert.strictEqual(compatNormalizeKey(curlySingle), compatNormalizeKey(straightSingle));
+});
+
+test('normalizes dashes', () => {
+  const enDash = 'dash – test';
+  const emDash = 'dash — test';
+  const plainDash = 'dash - test';
+  const normalized = compatNormalizeKey(plainDash);
+  assert.strictEqual(compatNormalizeKey(enDash), normalized);
+  assert.strictEqual(compatNormalizeKey(emDash), normalized);
+});
+
+test('removes trailing ellipses', () => {
+  const dots = 'more...';
+  const unicode = 'more\u2026';
+  const plain = 'more';
+  const normalized = compatNormalizeKey(plain);
+  assert.strictEqual(compatNormalizeKey(dots), normalized);
+  assert.strictEqual(compatNormalizeKey(unicode), normalized);
+});
+


### PR DESCRIPTION
## Summary
- add `compatNormalizeKey` utility for consistent key normalization
- use shared normalizer in Partner A loader
- test normalization of quotes, dashes, and ellipses

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a7c24c038832c82610430e535c4c5