### PR TITLE
Normalize Partner A survey inputs

### DIFF
--- a/js/partnerALoader.js
+++ b/js/partnerALoader.js
@@ -15,14 +15,16 @@ const $all = (sel, ctx = document) => [...ctx.querySelectorAll(sel)];
 const normalize = str => (str || '').trim()
   .replace(/[“”]/g, '"').replace(/[‘’]/g, "'")
   .replace(/\s+/g, ' ').toLowerCase();
-window.__compatDump = () => {
-  console.log('Headers:', getHeaders());
-  console.log('Row samples:', $all(`${CFG.tableContainer} tr`).slice(0, 5).map(r => ({
-    label: normalize(r.dataset.key || r.cells[0]?.textContent || ''),
-    dataKey: r.dataset.key || '',
-    partnerA: r.querySelector(CFG.partnerACellSelector)?.textContent
-  })));
-};
+if (typeof window !== 'undefined') {
+  window.__compatDump = () => {
+    console.log('Headers:', getHeaders());
+    console.log('Row samples:', $all(`${CFG.tableContainer} tr`).slice(0, 5).map(r => ({
+      label: normalize(r.dataset.key || r.cells[0]?.textContent || ''),
+      dataKey: r.dataset.key || '',
+      partnerA: r.querySelector(CFG.partnerACellSelector)?.textContent
+    })));
+  };
+}
 
 function getHeaders() {
   const headerRow = $one(`${CFG.tableContainer} thead tr`) || $one(`${CFG.tableContainer} tr`);
@@ -57,17 +59,71 @@ function fillPartnerA(data) {
   return matched;
 }
 
+function normalizeSurvey(json) {
+  const items = [];
+  const toNum = v => (typeof v === 'number' ? v : Number(v ?? 0));
+
+  const walk = obj => {
+    if (!obj) return;
+    if (Array.isArray(obj)) {
+      obj.forEach(walk);
+      return;
+    }
+    if (typeof obj !== 'object') return;
+
+    if (Array.isArray(obj.items)) {
+      obj.items.forEach(walk);
+      return;
+    }
+
+    const hasKey = obj.key || obj.id || obj.name || obj.label;
+    const hasRating = obj.rating ?? obj.score ?? obj.value;
+    if (hasKey && hasRating !== undefined) {
+      items.push({
+        key: obj.key ?? obj.id ?? obj.name ?? obj.label,
+        rating: toNum(obj.rating ?? obj.score ?? obj.value)
+      });
+      return;
+    }
+
+    for (const [k, v] of Object.entries(obj)) {
+      if (typeof v === 'number' || typeof v === 'string') {
+        items.push({ key: k, rating: toNum(v) });
+      } else if (v && typeof v === 'object') {
+        if ('rating' in v || 'score' in v || 'value' in v) {
+          items.push({ key: k, rating: toNum(v.rating ?? v.score ?? v.value) });
+        } else {
+          walk(v);
+        }
+      }
+    }
+  };
+
+  if (json && typeof json === 'object') walk(json);
+  return { items };
+}
+
+function surveyToLookup(survey) {
+  const out = {};
+  if (!survey || !Array.isArray(survey.items)) return out;
+  survey.items.forEach(it => {
+    const key = normalize(it.key ?? it.id ?? it.label ?? it.name);
+    if (key) out[key] = Number(it.rating ?? it.score ?? it.value ?? 0);
+  });
+  return out;
+}
+
 async function handlePartnerAUpload(file) {
   const json = await file.text();
   let parsed = {};
   try { parsed = JSON.parse(json); } catch (e) { alert('Invalid JSON'); return; }
-  const normalized = {};
-  Object.keys(parsed).forEach(k => { normalized[normalize(k)] = parsed[k]; });
-  window.partnerASurvey = window.surveyA = normalized;
+  const survey = normalizeSurvey(parsed);
+  const lookup = surveyToLookup(survey);
+  window.partnerASurvey = window.surveyA = survey;
   if (typeof updateComparison === 'function') updateComparison();
   ensurePartnerACol();
   setTimeout(() => {
-    const matched = fillPartnerA(normalized);
+    const matched = fillPartnerA(lookup);
     if (!matched) {
       console.warn('[Partner A] No values found yet — will attempt to annotate and refill.');
       if (window.__compatMismatch) setTimeout(window.__compatMismatch, 300);
@@ -101,4 +157,4 @@ if (typeof document !== 'undefined') {
   });
 }
 
-export {}; // ensure module context
+export { handlePartnerAUpload, normalizeSurvey, surveyToLookup };

--- a/test/partnerALoader.test.js
+++ b/test/partnerALoader.test.js
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { normalizeSurvey, surveyToLookup } from '../js/partnerALoader.js';
+
+test('normalize flat key-value object', () => {
+  const survey = normalizeSurvey({ Bondage: 4 });
+  const lookup = surveyToLookup(survey);
+  assert.deepStrictEqual(lookup, { bondage: 4 });
+});
+
+test('normalize items array', () => {
+  const survey = normalizeSurvey({ items: [{ key: 'Bondage', rating: 5 }] });
+  const lookup = surveyToLookup(survey);
+  assert.deepStrictEqual(lookup, { bondage: 5 });
+});


### PR DESCRIPTION
## Summary
- Support Partner A uploads with item arrays or nested category objects
- Build normalized lookup and populate table cells from survey data
- Test normalization for flat objects and `items` array formats

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a7c24c3b8832cb57d685532677bd3