### PR TITLE
chore: unify key normalization

### DIFF
--- a/js/compatNormalizeKey.js
+++ b/js/compatNormalizeKey.js
@@ -1,14 +1,16 @@
-export function compatNormalizeKey(s){
-  return String(s || '')
-    .replace(/[\u2018\u2019\u2032]/g,"'")
-    .replace(/[\u201C\u201D\u2033]/g,'"')
-    .replace(/[\u2013\u2014]/g,'-')
-    .replace(/\u2026/g,'')
-    .replace(/\s*\.\.\.\s*$/,'')
-    .replace(/\s+/g,' ')
+export function normalizeKey(s) {
+  return (s || '')
+    .toString()
+    .toLowerCase()
+    .replace(/[\s\-_]+/g, ' ')
     .trim()
-    .toLowerCase();
+    .replace(/[^\p{L}\p{N} ]/gu, '')
+    .replace(/\s+/g, ' ');
 }
 
-if (typeof window !== 'undefined') window.compatNormalizeKey = compatNormalizeKey;
+// Backward-compatible named export
+export { normalizeKey as compatNormalizeKey };
+
+// Expose for non-module scripts
+if (typeof window !== 'undefined') window.compatNormalizeKey = normalizeKey;
 

--- a/js/partnerALoader.js
+++ b/js/partnerALoader.js
@@ -1,3 +1,5 @@
+import { normalizeKey } from './compatNormalizeKey.js';
+
 // Partner A Loader: attaches JSON upload handler and PDF download guard
 // Auto-generated based on provided snippet.
 
@@ -13,40 +15,7 @@ const CFG = {
 
 const $one = (sel, ctx = document) => ctx.querySelector(sel);
 const $all = (sel, ctx = document) => [...ctx.querySelectorAll(sel)];
-// --- normalize (reuse if already defined elsewhere) ---
-const __compatNormalize =
-  (typeof window !== 'undefined' && window.__compatNormalize)
-    ? window.__compatNormalize
-    : (str =>
-        (str || '')
-          .trim()
-          .replace(/[“”]/g, '"')
-          .replace(/[‘’]/g, "'")
-          .replace(/[\u2013\u2014]/g, '-')      // – — -> -
-          .replace(/\u2026/g, '...')            // … -> ...
-          .replace(/\s+/g, ' ')
-          .toLowerCase()
-      );
-
-// Optionally cache on window for other scripts
-if (typeof window !== 'undefined' && !window.__compatNormalize) {
-  window.__compatNormalize = __compatNormalize;
-}
-
-// --- __compatDump (browser-only helper) ---
-if (typeof window !== 'undefined') {
-  window.__compatDump = () => {
-    console.log('Headers:', getHeaders());
-    console.log(
-      'Row samples:',
-      $all(`${CFG.tableContainer} tr`).slice(0, 5).map(r => ({
-        label: __compatNormalize(r.dataset.key || r.cells[0]?.textContent || ''),
-        dataKey: r.dataset.key || '',
-        partnerA: r.querySelector(CFG.partnerACellSelector)?.textContent
-      }))
-    );
-  };
-}
+const normalize = normalizeKey;
 
 function getHeaders() {
   const headerRow = $one(`${CFG.tableContainer} thead tr`) || $one(`${CFG.tableContainer} tr`);
@@ -180,14 +149,6 @@ if (typeof document !== 'undefined') {
   });
 }
 
-// Keep normalize function from codex branch
-const normalize = str => (str || '').trim()
-  .replace(/[“”]/g, '"')
-  .replace(/[‘’]/g, "'")
-  .replace(/\s+/g, ' ')
-  .toLowerCase();
-
-// Keep __compatDump from main branch but using normalize above
 if (typeof window !== 'undefined') {
   window.__compatDump = () => {
     console.log('Headers:', getHeaders());

--- a/js/pdfDownload.js
+++ b/js/pdfDownload.js
@@ -36,6 +36,8 @@
  *        • renders a multi-page, true-black PDF without seams
  */
 
+import { normalizeKey } from './compatNormalizeKey.js';
+
 /* ================================ CONFIG ================================== */
 const IDS = {
   uploadA: '#uploadSurveyA, [data-upload-a]',
@@ -138,11 +140,6 @@ function normalizeSurvey(json) {
 
 /* ========================== TABLE SANITY/HELPERS ========================== */
 const wait = ms => new Promise(r => setTimeout(r, ms));
-
-function normalizeKey(s) {
-  return (s||'').toString().toLowerCase().replace(/[\s\-_]+/g,' ').trim()
-    .replace(/[^\p{L}\p{N} ]/gu,'').replace(/\s+/g,' ');
-}
 
 function findPartnerAIndexByHeader(table){
   const tr = table.querySelector('thead tr'); if(!tr) return -1;

--- a/test/compatNormalizeKey.test.js
+++ b/test/compatNormalizeKey.test.js
@@ -1,31 +1,24 @@
 import assert from 'node:assert';
 import test from 'node:test';
-import { compatNormalizeKey } from '../js/compatNormalizeKey.js';
+import { normalizeKey } from '../js/compatNormalizeKey.js';
 
-test('normalizes typographic quotes', () => {
-  const curlyDouble = '“Fancy” test';
-  const straightDouble = '"Fancy" test';
-  const curlySingle = '‘single’ test';
-  const straightSingle = "'single' test";
-  assert.strictEqual(compatNormalizeKey(curlyDouble), compatNormalizeKey(straightDouble));
-  assert.strictEqual(compatNormalizeKey(curlySingle), compatNormalizeKey(straightSingle));
+test('strips punctuation and normalizes case/spacing', () => {
+  const input = '  “Bondage-Play_Extra”  ';
+  const expected = 'bondage play extra';
+  assert.strictEqual(normalizeKey(input), expected);
 });
 
-test('normalizes dashes', () => {
-  const enDash = 'dash – test';
-  const emDash = 'dash — test';
-  const plainDash = 'dash - test';
-  const normalized = compatNormalizeKey(plainDash);
-  assert.strictEqual(compatNormalizeKey(enDash), normalized);
-  assert.strictEqual(compatNormalizeKey(emDash), normalized);
+test('removes symbols and collapsing spaces', () => {
+  const input = 'Toys & Gadgets!';
+  const expected = 'toys gadgets';
+  assert.strictEqual(normalizeKey(input), expected);
 });
 
-test('removes trailing ellipses', () => {
+test('handles ellipsis', () => {
   const dots = 'more...';
   const unicode = 'more\u2026';
-  const plain = 'more';
-  const normalized = compatNormalizeKey(plain);
-  assert.strictEqual(compatNormalizeKey(dots), normalized);
-  assert.strictEqual(compatNormalizeKey(unicode), normalized);
+  const expected = 'more';
+  assert.strictEqual(normalizeKey(dots), expected);
+  assert.strictEqual(normalizeKey(unicode), expected);
 });
 

--- a/test/partnerALoader.test.js
+++ b/test/partnerALoader.test.js
@@ -139,16 +139,16 @@ const handlePartnerAUpload =
 
 // 1) normalize flat key-value object
 test('normalize flat key-value object', () => {
-  const survey = normalizeSurvey({ Bondage: 4 });
+  const survey = normalizeSurvey({ 'Bondage-Play': 4 });
   const lookup = surveyToLookup(survey);
-  assert.deepStrictEqual(lookup, { bondage: 4 });
+  assert.deepStrictEqual(lookup, { 'bondage play': 4 });
 });
 
 // 2) normalize items array
 test('normalize items array', () => {
-  const survey = normalizeSurvey({ items: [{ key: 'Bondage', rating: 5 }] });
+  const survey = normalizeSurvey({ items: [{ key: 'Bondage_Play', rating: 5 }] });
   const lookup = surveyToLookup(survey);
-  assert.deepStrictEqual(lookup, { bondage: 5 });
+  assert.deepStrictEqual(lookup, { 'bondage play': 5 });
 });
 
 // 3) Partner A column inserted and populated (DOM integration)
@@ -171,8 +171,8 @@ test('Partner A column inserted and populated', async () => {
 
   const tbody = document.createElement('tbody');
   const row = document.createElement('tr');
-  row.dataset.key = 'affection';
-  const c1 = document.createElement('td'); c1.textContent = 'Affection';
+  row.dataset.key = 'Affection Level';
+  const c1 = document.createElement('td'); c1.textContent = 'Affection Level';
   const c2 = document.createElement('td'); c2.className = 'pb'; c2.textContent = '3';
   row.appendChild(c1); row.appendChild(c2);
   tbody.appendChild(row);
@@ -189,7 +189,7 @@ test('Partner A column inserted and populated', async () => {
   // Simulate uploading JSON and ensure value is written
   const realSetTimeout = global.setTimeout;
   global.setTimeout = (fn) => { fn(); return 0; }; // run immediately for test determinism
-  const file = { text: async () => JSON.stringify({ affection: 7 }) };
+  const file = { text: async () => JSON.stringify({ affection_level: 7 }) };
   await handlePartnerAUpload(file);
   global.setTimeout = realSetTimeout;
 


### PR DESCRIPTION
## Summary
- centralize key normalization in `normalizeKey`
- use shared normalization in partner A loader and PDF download
- expand tests for punctuation/spacing normalization

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689bad188da0832c928d6d572aa2a589