### PR TITLE
feat: improve Partner A loader with row annotation

### DIFF
--- a/js/compatNormalizeKey.js
+++ b/js/compatNormalizeKey.js
@@ -1,6 +1,10 @@
 export function normalizeKey(s) {
-  return (s || '')
-    .toString()
+  return String(s || '')
+    .replace(/[\u2018\u2019\u2032]/g, "'")
+    .replace(/[\u201C\u201D\u2033]/g, '"')
+    .replace(/[\u2013\u2014]/g, '-')
+    .replace(/\u2026/g, '')
+    .replace(/\s*\.\.\.\s*$/, '')
     .toLowerCase()
     .replace(/[\s\-_]+/g, ' ')
     .trim()


### PR DESCRIPTION
## Summary
- normalize survey keys by trimming ellipses and curly punctuation
- auto-annotate comparison rows and refill Partner A values on DOM changes
- cover nested survey exports and data-full row matching in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bb4b46250832ca3bb17cebd3c9471