### PR TITLE
fix: mark compatibility table root

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -103,7 +103,7 @@
       <div id="pdf-container">
         <div id="compatibility-wrapper" class="compatibility-wrapper">
           <div id="comparisonResult"></div>
-          <div id="compatibility-report" class="pdf-export-area"></div>
+          <div id="compatibility-report" class="pdf-export-area" data-compat-root></div>
           <div id="print-card-list" class="print-only"></div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- mark the comparison table container with `data-compat-root` so Partner A/B scripts find it correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bcbd344f4832ca55b6d204ccfbc5c