### PR TITLE
Add compatibility auto-fill utilities

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -100,10 +100,10 @@
 
     <div id="comparisonResults">
       <div id="loading-spinner" class="loading-overlay"><div class="spinner"></div></div>
-      <div id="pdf-container">
+      <div id="pdf-container" data-compat-root>
         <div id="compatibility-wrapper" class="compatibility-wrapper">
           <div id="comparisonResult"></div>
-          <div id="compatibility-report" class="pdf-export-area" data-compat-root></div>
+          <div id="compatibility-report" class="pdf-export-area"></div>
           <div id="print-card-list" class="print-only"></div>
         </div>
       </div>
@@ -1022,5 +1022,136 @@ window.__compatDump = () => {
   }
 })();
 </script>
+  <script>
+  (function(){
+    // ---------- Robust normalizer ----------
+    const norm = s => String(s||'')
+      .replace(/[\u2018\u2019\u2032]/g,"'")
+      .replace(/[\u201C\u201D\u2033]/g,'"')
+      .replace(/[\u2013\u2014]/g,'-')
+      .replace(/\u2026/g,'')
+      .replace(/\s*\.\.\.\s*$/,'')
+      .replace(/\s+/g,' ')
+      .trim().toLowerCase();
+
+    // ---------- Build lookup from: flat object OR {items:[{name|label|key|id, rating|score|value}]} ----------
+    function toLookup(json){
+      const map = new Map();
+      if (!json || typeof json !== 'object') return map;
+
+      // flat object case
+      if (!Array.isArray(json) && !json.items && !json.survey) {
+        for (const [k,v] of Object.entries(json)) {
+          const n = Number(v);
+          if (Number.isFinite(n)) map.set(norm(k), n);
+        }
+        return map;
+      }
+
+      // items array case (your logs show {items: Array(35)})
+      const items = Array.isArray(json.items) ? json.items : [];
+      for (const it of items){
+        const k = norm(it?.name ?? it?.label ?? it?.key ?? it?.id ?? '');
+        const n = Number(it?.rating ?? it?.score ?? it?.value);
+        if (k && Number.isFinite(n)) map.set(k, n);
+      }
+      return map;
+    }
+
+    // ---------- Root detection (prefers data-compat-root) ----------
+    function getRoot(){
+      return document.querySelector('[data-compat-root]') ||
+             document.querySelector('#pdf-container') ||
+             document.body;
+    }
+
+    // ---------- Annotate rows with stable keys (works for true tables) ----------
+    function annotateRows(root){
+      root.querySelectorAll('table tbody tr').forEach(tr=>{
+        if ((tr.getAttribute('data-key')||'').trim()) return;
+        const first = tr.querySelector('td:first-child, th:first-child');
+        const label =
+          tr.getAttribute('data-full') || tr.getAttribute('data-label') ||
+          (first && (first.getAttribute('data-full') || first.getAttribute('data-label'))) ||
+          tr.getAttribute('title') || tr.getAttribute('aria-label') ||
+          (first && (first.getAttribute('title') || first.getAttribute('aria-label'))) ||
+          (first ? first.textContent : '');
+        tr.setAttribute('data-key', norm(label));
+      });
+    }
+
+    // ---------- Tag Partner A/B columns by reading THEAD ----------
+    function tagPartnerColumns(root){
+      root.querySelectorAll('table').forEach(table=>{
+        const tr = table.querySelector('thead tr');
+        if (!tr) return;
+        const ths = Array.from(tr.children);
+        const idxA = ths.findIndex(th => norm(th.textContent) === 'partner a');
+        const idxB = ths.findIndex(th => norm(th.textContent) === 'partner b');
+        if (idxA >= 0) table.querySelectorAll('tbody tr').forEach(r=>{ const td = r.children[idxA]; if (td) td.classList.add('pa'); });
+        if (idxB >= 0) table.querySelectorAll('tbody tr').forEach(r=>{ const td = r.children[idxB]; if (td) td.classList.add('pb'); });
+      });
+    }
+
+    // ---------- Fill a given partner column ('A' or 'B') ----------
+    function fillPartner(root, partner, json){
+      const map = toLookup(json);
+      if (!map.size) return 0;
+      const cls = partner === 'A' ? 'pa' : 'pb';
+      let wrote = 0;
+
+      root.querySelectorAll('table tbody tr').forEach(tr=>{
+        const td = tr.querySelector('td.'+cls);
+        if (!td) return;
+        const curr = (td.textContent||'').trim();
+        if (curr && !/^[-–—]$/.test(curr)) return;  // don't overwrite real values
+        const key = tr.getAttribute('data-key') || tr.getAttribute('data-id') || '';
+        if (!key) return;
+        const val = map.get(norm(key));
+        if (val == null) return;
+        td.textContent = String(val);
+        wrote++;
+      });
+      return wrote;
+    }
+
+    // ---------- Public console helpers ----------
+    window.__compatFindRoot = function(){
+      const root = getRoot();
+      const rows = root.querySelectorAll('tbody tr').length;
+      console.log('[compat] root =', root, 'rows =', rows);
+      return root;
+    };
+
+    window.__compatForceAFill = function(){
+      const root = getRoot();
+      annotateRows(root);
+      tagPartnerColumns(root);
+      const a = fillPartner(root, 'A', window.partnerASurvey || window.surveyA);
+      const b = fillPartner(root, 'B', window.partnerBSurvey || window.surveyB);
+      if (typeof window.populateFlags === 'function') window.populateFlags();
+      console.log(`[compat] filled A=${a} B=${b}`);
+      return {A:a, B:b};
+    };
+
+    // ---------- Auto-fill after uploads (id or data- attributes) ----------
+    document.addEventListener('change', e=>{
+      const isA = e.target && e.target.matches('#uploadSurveyA,[data-upload-a]');
+      const isB = e.target && e.target.matches('#uploadSurveyB,[data-upload-b]');
+      if (!(isA || isB)) return;
+
+      // give the page a moment to render rows, then fill
+      setTimeout(()=>{
+        const root = getRoot();
+        annotateRows(root);
+        tagPartnerColumns(root);
+        const resA = isA ? fillPartner(root, 'A', window.partnerASurvey || window.surveyA) : 0;
+        const resB = isB ? fillPartner(root, 'B', window.partnerBSurvey || window.surveyB) : 0;
+        if (typeof window.populateFlags === 'function') window.populateFlags();
+        console.log(`[compat] auto-fill A=${resA} B=${resB}`);
+      }, 150);
+    });
+  })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- mark pdf container with `data-compat-root`
- add script to auto-fill Partner A/B columns and expose helper functions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bcdffd470832c9edc9f8651b7542e