### PR TITLE
Hide duplicate Talk Kink heading after PDF button

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -30,3 +30,8 @@
 }
 
 
+/* Hide heading after the Download PDF button */
+#downloadBtn + h1 {
+  display: none;
+}
+


### PR DESCRIPTION
## Summary
- Hide heading that follows the Download PDF button with CSS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d1d068014832cb724aecf1747a8c6