### PR TITLE
Use pdf-container id for compatibility output

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -12,7 +12,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <style>
-  #compat-container {
+  #pdf-container {
     width: 100%;
     max-width: 100%;
   }
@@ -100,7 +100,7 @@
 
     <div id="comparisonResults">
       <div id="loading-spinner" class="loading-overlay"><div class="spinner"></div></div>
-      <div id="compat-container" class="compat-root" data-compat-root></div>
+      <div id="pdf-container" class="compat-root" data-compat-root></div>
       <div class="print-footer"></div>
     </div>
   </div>

--- a/css/auto-pdf.css
+++ b/css/auto-pdf.css
@@ -19,7 +19,7 @@ body {
   padding: 20px;
 }
 
-#compat-container {
+#pdf-container, #compat-container {
   background-color: #000;
   display: block;
   width: 100vw;

--- a/css/style.css
+++ b/css/style.css
@@ -2801,7 +2801,7 @@ body {
     font-family: 'Segoe UI', 'Helvetica Neue', Arial, sans-serif !important;
   }
 
-  #compat-container {
+  #compat-container, #pdf-container {
     margin: 0 auto !important;
     padding: 0 !important;
     background-color: #000 !important;
@@ -2821,7 +2821,7 @@ body {
 }
 
 /* Centered PDF export containers */
-#compat-container {
+#compat-container, #pdf-container {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -2839,7 +2839,7 @@ body {
 }
 
 @media print {
-  body, #compat-container, #compatibility-wrapper {
+  body, #compat-container, #pdf-container, #compatibility-wrapper {
     background: #000 !important;
     color: #fff !important;
     margin: 0 !important;

--- a/js/compat-pdf.js
+++ b/js/compat-pdf.js
@@ -116,7 +116,7 @@ function stripProblemImages(root){
 
 function makeClone(){
   const src=document.getElementById('pdf-container');
-  if(!src) throw new Error('#compat-container not found');
+  if(!src) throw new Error('#pdf-container not found');
   const r=src.getBoundingClientRect();
   diag('container', { width:r.width, height:r.height, scrollW:src.scrollWidth, scrollH:src.scrollHeight });
 

--- a/js/compatPdfFixes.js
+++ b/js/compatPdfFixes.js
@@ -7,30 +7,30 @@ export function applyCompatLayoutAndFlags(root = document.getElementById('pdf-co
     style.id = 'compat-pdf-fixes';
     style.textContent = `
   /* Dark theme + reliable widths */
-  #compat-container { background:#000; color:#fff; }
-  #compat-container table.compat { width:100%; table-layout:fixed; border-collapse:collapse; color:#fff; background:#000; }
-  #compat-container table.compat th,
-  #compat-container table.compat td { padding:10px 12px; vertical-align:top; word-break:break-word; }
+  #pdf-container { background:#000; color:#fff; }
+  #pdf-container table.compat { width:100%; table-layout:fixed; border-collapse:collapse; color:#fff; background:#000; }
+  #pdf-container table.compat th,
+  #pdf-container table.compat td { padding:10px 12px; vertical-align:top; word-break:break-word; }
 
   /* Even column widths: [Label | A | Match | Flag | B] */
-  #compat-container table.compat col.label { width:52%; }
-  #compat-container table.compat col.pa    { width:12%; }
-  #compat-container table.compat col.match { width:8%;  }
-  #compat-container table.compat col.flag  { width:8%;  }
-  #compat-container table.compat col.pb    { width:12%; }
+  #pdf-container table.compat col.label { width:52%; }
+  #pdf-container table.compat col.pa    { width:12%; }
+  #pdf-container table.compat col.match { width:8%;  }
+  #pdf-container table.compat col.flag  { width:8%;  }
+  #pdf-container table.compat col.pb    { width:12%; }
 
   /* Remove the "Kink" header label cell text */
-  #compat-container table.compat thead th:first-child { color:transparent; }
+  #pdf-container table.compat thead th:first-child { color:transparent; }
 
   /* Category title row (spans all columns) */
-  #compat-container .category-title {
+  #pdf-container .category-title {
     font-weight:800; font-size:1.2rem;
     border-top:2px solid #333; border-bottom:2px solid #333;
     padding:14px 12px !important;
   }
 
   /* Keep a whole category (title + items) together on one page */
-  #compat-container tbody.category-block { break-inside:avoid; page-break-inside:avoid; }
+  #pdf-container tbody.category-block { break-inside:avoid; page-break-inside:avoid; }
 
   /* Print: keep true black background */
   @media print {

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -355,7 +355,7 @@ function renderFlags(root = document) {
 }
 
 function markPartnerALoaded() {
-  const table = document.querySelector('#compat-container table');
+  const table = document.querySelector('#pdf-container table');
   if (!table) return;
 
   const ths = Array.from(table.querySelectorAll('thead th'));

--- a/js/pdfDownload.js
+++ b/js/pdfDownload.js
@@ -29,7 +29,7 @@
  *      and call your existing updateComparison() so the table shows Partner A in Column A.
  *    - (Optional) Upload Partner B; updateComparison() will redraw with both partners.
  *    - Click “Download PDF”. This script:
- *        • clones #compat-container (web stays untouched)
+ *        • clones #pdf-container (web stays untouched)
  *        • ensures 5 columns: Category | Partner A | Match | Flag | Partner B
  *        • fills Flag:  ⭐ when Match ≥ 90; 🚩 when Match ≤ 50 OR (A is 4/5 while B is empty) OR vice-versa
  *        • spaces categories (no title cut) + keeps table rows intact across pages
@@ -43,7 +43,7 @@ const IDS = {
   uploadA: '#uploadSurveyA, [data-upload-a]',
   uploadB: '#uploadSurveyB, [data-upload-b]',
   downloadBtn: '#downloadBtn',
-  container: '#compat-container'
+  container: '#pdf-container, #compat-container'
 };
 const PDF_ORIENTATION = 'landscape';  // 'portrait' | 'landscape'
 const STAR_MIN = 90;                   // ⭐ threshold (Match %)
@@ -448,7 +448,7 @@ function partnerAHasData(){
 /* 1) Build safe clone (web page remains untouched) */
 function makeClone(){
   const src = document.querySelector(IDS.container);
-  if (!src) throw new Error('#compat-container not found');
+  if (!src) throw new Error('#pdf-container not found');
 
   const shell = document.createElement('div');
   Object.assign(shell.style,{background:'#000',color:'#fff',margin:0,padding:0,width:'100%',minHeight:'100vh',overflow:'auto'});

--- a/js/pdfExportAdjustments.js
+++ b/js/pdfExportAdjustments.js
@@ -1,5 +1,5 @@
 export class CompatibilityPDFExporter {
-  constructor(containerSelector = '#compat-container') {
+  constructor(containerSelector = '#pdf-container, #compat-container') {
     this.containerSelector = containerSelector;
     this.styleAttr = 'data-pdf-fix';
     this.categoryShortMap = {
@@ -242,6 +242,6 @@ export class CompatibilityPDFExporter {
 }
 
 /* Usage:
-const exporter = new CompatibilityPDFExporter('#compat-container');
+const exporter = new CompatibilityPDFExporter('#pdf-container');
 exporter.generate();
 */

--- a/js/theme.js
+++ b/js/theme.js
@@ -135,7 +135,7 @@ export const pdfStyles = `
       color: #fbc02d !important; /* yellow */
     }
 
-    #compat-container {
+    #pdf-container, #compat-container {
       font-size: 11pt;
       line-height: 1.6;
       padding: 1.5em;


### PR DESCRIPTION
## Summary
- Replace `compat-container` with `pdf-container` in compatibility page markup
- Update JS and CSS to reference the new container id
- Ensure PDF tooling looks for `#pdf-container`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689fdeb27f68832cbfea6d255b64379a