### PR TITLE
fix: detect AutoTable plugin correctly

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -538,7 +538,8 @@ Optional later:
   function downloadCompatibilityPDF(){
     // Simple lib checks
     const jsPDFctor = window.jspdf?.jsPDF;
-    if (!jsPDFctor || !window.jspdf?.autoTable){
+    const hasAutoTable = jsPDFctor?.API?.autoTable;
+    if (!jsPDFctor || !hasAutoTable){
       alert('Missing jsPDF and/or AutoTable. Keep the two CDN <script> tags above this block.');
       return;
     }


### PR DESCRIPTION
## Summary
- Ensure AutoTable plugin is detected by checking jsPDF API

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689ffaadb604832c945a88e2c5860c87