### PR TITLE
Fix compatibility PDF download check

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -547,7 +547,7 @@ How to apply
 
   function downloadCompatibilityPDF(){
     const jsPDFctor = window.jspdf?.jsPDF;
-    if (!jsPDFctor || !window.jspdf?.autoTable){
+    if (!jsPDFctor || !jsPDFctor.API?.autoTable){
       alert('Missing jsPDF and/or AutoTable. Keep the two CDN <script> tags above this block.');
       return;
     }


### PR DESCRIPTION
## Summary
- ensure compatibility report detects jsPDF AutoTable plugin via API property

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a005e71298832c927f2d9ca6b7b7d2