### PR TITLE
fallback root lookup for PDF comparison

### DIFF
--- a/js/pdfDownload.js
+++ b/js/pdfDownload.js
@@ -159,7 +159,9 @@ window.updateComparison = function(partnerAData = window.partnerAData, partnerBD
     bLookup[normalizeLabel(label)] = score;
   });
 
-  const root = document.querySelector('[data-compat-root]');
+  const root =
+    document.querySelector('[data-compat-root]') ||
+    document.querySelector('#pdf-container');
   if (!root) {
     console.warn('[compat] No root container found.');
     return;


### PR DESCRIPTION
## Summary
- extend comparison root lookup to fall back to `#pdf-container` when `data-compat-root` is absent

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a014652210832ca36d697dad05d582