### PR TITLE
Fail fast when html2canvas is unavailable

### DIFF
--- a/test/pdfDownloadFailsWithoutHtml2canvas.test.js
+++ b/test/pdfDownloadFailsWithoutHtml2canvas.test.js
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert';
+
+// Ensure downloadCompatibilityPDF aborts when html2canvas cannot be loaded
+
+test('fails fast when html2canvas is unavailable', async () => {
+  const originalGlobals = {
+    window: globalThis.window,
+    document: globalThis.document,
+    alert: globalThis.alert
+  };
+  try {
+    let alertMsg = '';
+    globalThis.alert = msg => { alertMsg = msg; };
+    globalThis.window = {};
+    globalThis.document = {
+      readyState: 'complete',
+      querySelector: () => null,
+      querySelectorAll: () => [],
+      head: {
+        appendChild: el => {
+          if (el && 'src' in el) {
+            // simulate script load failure
+            setTimeout(() => el.onerror && el.onerror(new Error('fail')), 0);
+          }
+        }
+      },
+      createElement: tag => {
+        if (tag === 'script') {
+          return { onload: null, onerror: null, src: '', setAttribute: () => {}, textContent: '', appendChild: () => {}, style: {} };
+        }
+        return { setAttribute: () => {}, textContent: '', appendChild: () => {}, style: {} };
+      }
+    };
+
+    const mod = await import('../js/pdfDownload.js');
+    await mod.downloadCompatibilityPDF();
+    assert.match(alertMsg, /html2canvas/i);
+  } finally {
+    if (originalGlobals.window) globalThis.window = originalGlobals.window; else delete globalThis.window;
+    if (originalGlobals.document) globalThis.document = originalGlobals.document; else delete globalThis.document;
+    if (originalGlobals.alert) globalThis.alert = originalGlobals.alert; else delete globalThis.alert;
+  }
+});


### PR DESCRIPTION
## Summary
- Abort PDF export when html2canvas cannot be loaded and alert the user
- Test that export fails quickly without html2canvas

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a11b1317f8832cac0a25e446d957dc