### PR TITLE
Embed template survey fallback

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -438,7 +438,7 @@ if (roleDefinitionsBtn) roleDefinitionsBtn.addEventListener('click', showRolePan
 if (closeRoleDefinitionsBtn) closeRoleDefinitionsBtn.addEventListener('click', hideRolePanel);
 if (roleDefinitionsOverlay) roleDefinitionsOverlay.addEventListener('click', hideRolePanel);
 
-function startNewSurvey() {
+async function startNewSurvey() {
   guidedMode = true;
   if (surveyIntro) surveyIntro.style.display = 'none';
   if (newSurveyBtn) newSurveyBtn.style.display = 'none';
@@ -460,20 +460,20 @@ function startNewSurvey() {
   const initialize = data => initializeSurvey(data);
 
   if (location.protocol.startsWith('http')) {
-    fetch('../template-survey.json', { cache: 'no-store' })
-      .then(res => res.json())
-      .then(data => {
-        window.templateSurvey = normalizeSurveyFormat(data);
+    try {
+      const res = await fetch('../template-survey.json', { cache: 'no-store' });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      window.templateSurvey = normalizeSurveyFormat(data);
+      initialize(JSON.parse(JSON.stringify(window.templateSurvey)));
+    } catch (err) {
+      if (window.templateSurvey) {
+        console.warn('Failed to load template, using embedded copy:', err);
         initialize(JSON.parse(JSON.stringify(window.templateSurvey)));
-      })
-      .catch(err => {
-        if (window.templateSurvey) {
-          console.warn('Failed to load template, using embedded copy:', err);
-          initialize(JSON.parse(JSON.stringify(window.templateSurvey)));
-        } else {
-          alert('Failed to load template: ' + err.message);
-        }
-      });
+      } else {
+        alert('Failed to load template: ' + err.message);
+      }
+    }
   } else if (window.templateSurvey) {
     // When opened directly from the file system, use the embedded template
     initialize(JSON.parse(JSON.stringify(window.templateSurvey)));

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -93,6 +93,7 @@
   <!-- Panel Container (still hidden until needed) -->
   <div id="panelContainer" class="panel-container" style="display:none;"></div>
 
+  <script src="/js/template-survey.js"></script>
   <!-- Theme Handling -->
   <script type="module">
     import { initTheme, applyThemeColors } from '../js/theme.js';
@@ -204,7 +205,27 @@
     }
 
     async function renderSurvey(selectedNames) {
-      const allData = await fetch('../template-survey.json').then(res => res.json());
+      let allData;
+      if (location.protocol.startsWith('http')) {
+        try {
+          const res = await fetch('../template-survey.json', { cache: 'no-store' });
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          allData = await res.json();
+        } catch (err) {
+          if (window.templateSurvey) {
+            console.warn('Failed to load template, using embedded copy:', err);
+            allData = window.templateSurvey;
+          } else {
+            alert('Failed to load template: ' + err.message);
+            return;
+          }
+        }
+      } else if (window.templateSurvey) {
+        allData = window.templateSurvey;
+      } else {
+        alert('Failed to load template: unsupported protocol');
+        return;
+      }
       surveyCategories = selectedNames.map(name => ({
         name,
         kinks: [


### PR DESCRIPTION
## Summary
- Load template-survey.js in kinks survey page for an embedded template
- Fall back to embedded survey template when fetching template-survey.json fails

## Testing
- `npm test`
- Attempted to run a jsdom-based simulation for HTTP/file loading, but jsdom installation was forbidden (E403)


------
https://chatgpt.com/codex/tasks/task_e_68a11b16a6a4832cade715bd92386b30