### PR TITLE
Handle UTF-16 encoded survey uploads

### DIFF
--- a/js/auto-pdf.js
+++ b/js/auto-pdf.js
@@ -55,7 +55,10 @@ const PAGE_BREAK_CATEGORIES = new Set([
 ]);
 
 function parseSurveyJSON(text) {
-  const clean = text.replace(/^\uFEFF/, '').trim();
+  const clean = text
+    .replace(/^\uFEFF/, '')
+    .replace(/\u0000/g, '')
+    .trim();
   try {
     return JSON.parse(clean);
   } catch {

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -44,7 +44,10 @@ if (typeof window !== 'undefined') {
 }
 
 function parseSurveyJSON(text) {
-  const clean = text.replace(/^\uFEFF/, '').trim();
+  const clean = text
+    .replace(/^\uFEFF/, '')
+    .replace(/\u0000/g, '')
+    .trim();
   try {
     return JSON.parse(clean);
   } catch {

--- a/js/script.js
+++ b/js/script.js
@@ -53,7 +53,10 @@ const HIGH_INTENSITY_WARNING =
   'The High-Intensity Kinks category includes intense but SSC-aware kink options that require strong negotiation, emotional readiness, and safe aftercare. Only explore if you feel prepared.';
 
 function parseSurveyJSON(text) {
-  const clean = text.replace(/^\uFEFF/, '').trim();
+  const clean = text
+    .replace(/^\uFEFF/, '')
+    .replace(/\u0000/g, '')
+    .trim();
   try {
     return JSON.parse(clean);
   } catch {


### PR DESCRIPTION
## Summary
- Strip null characters when parsing uploaded surveys to avoid bogus "Invalid JSON" errors
- Apply fix across compatibility, auto PDF, and script helpers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1232f4974832c9d57135a79d63678