### PR TITLE
Fix partner B survey upload handling

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -412,7 +412,10 @@
       // If your upload handlers already parse JSON and set window.partnerASurvey/window.partnerBSurvey,
       // runFill will use them. If not, attempt quick inline parsing:
       const f = e.target.files && e.target.files[0];
-      if (f && !window.partnerASurvey && !window.partnerBSurvey){
+      if (f && (
+        (e.target.matches('#uploadSurveyA,[data-upload-a]') && !window.partnerASurvey) ||
+        (e.target.matches('#uploadSurveyB,[data-upload-b]') && !window.partnerBSurvey)
+      )){
         try {
           const json = JSON.parse(await f.text());
           if (e.target.matches('#uploadSurveyA,[data-upload-a]')) window.partnerASurvey = json;


### PR DESCRIPTION
## Summary
- Parse each survey upload independently so Partner B JSON files populate correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a276560628832c80bb794995e88197