### PR TITLE
Recompute match values for compatibility PDF export

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -467,178 +467,75 @@ How to apply
 ============================================================================================== -->
 
 <script>
-(function(){
-  /* ====== TUNABLES ====== */
-  const PDF_TITLE   = 'Talk Kink';
-  const PDF_FONT    = 'helvetica';
-  const TITLE_Y     = 84;   // move DOWN by increasing; UP by decreasing
-  const TITLE_SIZE  = 54;   // title font size
-  const TABLE_GAP   = 34;   // distance from title to table
-  const MARGIN_LR   = 36;   // left/right margins
-  /* ====================== */
-
-  const NBSP = '\u00A0'; // non-breaking space
-
-  const norm = s => String(s||'').replace(/\s+/g,' ').trim().toLowerCase();
-
-  // Simple Title-Case for Category text
-  function toTitleCase(str){
-    const small = new Set(['a','an','and','as','at','but','by','for','from','in','into','of','on','or','the','to','with','up','via','vs','etc','e.g.','i.e.']);
-    const words = String(str||'').toLowerCase().split(/\s+/);
-    return words.map((w,i) => {
-      const keepLower = i>0 && small.has(w);
-      if (keepLower) return w;
-      // keep punctuation at the end (e.g., “50s)”)
-      const m = w.match(/^([(\[{"']?)(.+?)([)\]"'}]?)$/) || [];
-      const lead = m[1] || '', core = m[2] || w, trail = m[3] || '';
-      return lead + core.charAt(0).toUpperCase() + core.slice(1) + trail;
-    }).join(' ');
+/* ===== PDF Export: compute % + icon, never numbers in Flag =====
+   Requires jsPDF + jsPDF-AutoTable (same as before). */
+(function installPDFExport(){
+  // helper: parse number or return null
+  function n(v){ const x=Number(String(v??"").trim()); return Number.isFinite(x)?x:null; }
+  function percent(a,b){
+    const A=n(a), B=n(b);
+    if (A==null || B==null) return null;
+    return Math.round(100 - (Math.abs(A-B)/5)*100);
+  }
+  function flagIcon(pct){
+    if (pct==null) return "";         // no match yet
+    if (pct >= 90) return "★";        // high
+    if (pct >= 60) return "⚑";        // medium
+    return "";                        // low → blank (change to "❗" if you prefer)
   }
 
-  // Find the first visible comparison table
-  function findComparisonTable(){
-    const selectors = [
-      '#compat-container table:where(:not([hidden]))',
-      '#pdf-container table:where(:not([hidden]))',
-      'table:where(:not([hidden]))'
-    ];
-    for (const q of selectors){
-      const el = document.querySelector(q);
-      if (el) return el;
+  // NEW exporter (replaces any old one bound to the button)
+  async function exportCompatibilityPDF(){
+    if (!(window.jspdf && window.jspdf.jsPDF && window.jspdf.autoTable)) {
+      alert("PDF export needs jsPDF + jsPDF-AutoTable on the page.");
+      return;
     }
-    return null;
-  }
+    const { jsPDF } = window.jspdf;
 
-  // Extract rows as arrays: [Category, Partner A, Match, Flag, Partner B]
-  function extractRows(table){
-    const WANT = ['category','partner a','match','flag','partner b'];
+    // Build rows from the DOM, but recompute Match/Flag instead of reading them
+    const rows = [];
+    document.querySelectorAll('tbody tr[data-kink-id]').forEach(tr=>{
+      const category = tr.cells?.[0]?.textContent?.trim() ?? tr.getAttribute('data-kink-id');
+      const aTxt = tr.querySelector('td[data-cell="A"]')?.textContent ?? "";
+      const bTxt = tr.querySelector('td[data-cell="B"]')?.textContent ?? "";
 
-    // Map headers by text (case-insensitive)
-    const headerRow = table.querySelector('thead tr')
-      || Array.from(table.querySelectorAll('tr')).find(r => r.querySelector('th'));
-    const map = {};
-    if (headerRow){
-      Array.from(headerRow.querySelectorAll('th')).forEach((th, i) => {
-        const label = norm(th.innerText || th.textContent);
-        if (WANT.includes(label)) map[label] = i;
-      });
-    }
+      const A = n(aTxt), B = n(bTxt);
+      const pct = percent(A,B);
+      const pctTxt = (pct==null ? "–" : `${pct}%`);
+      const flag = flagIcon(pct);
 
-    // Prefer <tbody> rows; else any <tr> with <td>
-    const bodyRows = Array.from(table.querySelectorAll('tbody tr')).filter(r => r.querySelectorAll('td').length);
-    const rows = bodyRows.length ? bodyRows
-      : Array.from(table.querySelectorAll('tr')).filter(r => r.querySelectorAll('td').length);
-
-    // Positional fallbacks if some headers weren’t found
-    const idx = {
-      category:  ('category' in map)   ? map['category']   : 0,
-      a:         ('partner a' in map)  ? map['partner a']  : 1,
-      match:     ('match' in map)      ? map['match']      : 2,
-      flag:      ('flag' in map)       ? map['flag']       : 3,
-      b:         ('partner b' in map)  ? map['partner b']  : 4
-    };
-
-    return rows.map(tr => {
-      const cells = Array.from(tr.querySelectorAll('td'));
-      const read  = i => (cells[i]?.innerText || cells[i]?.textContent || '').trim();
-      const flagCell  = cells[idx.flag];
-      const flagAttr  = flagCell?.getAttribute?.('data-flag') || ''; // prefer explicit data-flag if present
-      const flagValue = flagAttr || read(idx.flag);
-
-      // Title-case Category column here
-      const catTitle = toTitleCase(read(idx.category));
-
-      return [ catTitle, read(idx.a), read(idx.match), flagValue, read(idx.b) ];
+      // Only A & B are numeric in the PDF; Match is %, Flag is icon
+      rows.push([category, (A??"–"), pctTxt, flag, (B??"–")]);
     });
-  }
 
-  function downloadCompatibilityPDF(){
-    const jsPDFctor = window.jspdf?.jsPDF;
-    if (!jsPDFctor || !jsPDFctor.API?.autoTable){
-      alert('Missing jsPDF and/or AutoTable. Keep the two CDN <script> tags above this block.');
-      return;
-    }
+    const doc = new jsPDF({ orientation:"landscape", unit:"pt", format:"a4" });
+    doc.setFontSize(18);
+    doc.text("Talk Kink • Compatibility Report", 40, 48);
 
-    // Locate table
-    const table = findComparisonTable();
-    if (!table){
-      alert('Could not find the comparison table on this page.');
-      return;
-    }
-
-    // Snapshot current table content
-    const body = extractRows(table);
-
-    // Use non-breaking spaces to stop header wrap
-    const HEAD = ['Category','Partner'+NBSP+'A','Match','Flag','Partner'+NBSP+'B'];
-
-    // Build PDF (Letter, landscape), white text on black background
-    const doc = new jsPDFctor({ orientation: 'landscape', unit: 'pt', format: 'letter' });
-    const pageW = doc.internal.pageSize.getWidth();
-    const pageH = doc.internal.pageSize.getHeight();
-
-    // Paint full black background
-    doc.setFillColor(0,0,0);
-    doc.rect(0,0,pageW,pageH,'F');
-
-    // Title: single, centered, not touching the top
-    doc.setFont(PDF_FONT,'bold');
-    doc.setFontSize(TITLE_SIZE);
-    doc.setTextColor(255,255,255);
-    doc.text(PDF_TITLE, pageW/2, TITLE_Y, { align: 'center' });
-
-    // Dynamic column widths — give A/Match/Flag/B a slightly larger minimum to avoid wraps
-    const availW = pageW - (MARGIN_LR*2);
-    const minEach = 100;                 // bumped up to prevent header overhang
-    const catW   = Math.max(380, availW - minEach*4);
-    const eachW  = Math.max(minEach, (availW - catW) / 4);
-
-    const startY = TITLE_Y + TABLE_GAP;
-
-    doc.autoTable({
-      head: [HEAD],
-      body,
-      startY,
-      theme: 'plain',
-      margin: { left: MARGIN_LR, right: MARGIN_LR },
-      styles: {
-        font: PDF_FONT,
-        fontSize: 12,
-        textColor: [255,255,255],
-        fillColor: [0,0,0],
-        lineWidth: 0,
-        cellPadding: { top: 5, right: 6, bottom: 5, left: 6 },
-        overflow: 'linebreak'   // wrap long Category text
-      },
-      headStyles: {
-        fontStyle: 'bold',
-        fontSize: 16,           // big but we keep it on one line with NBSP + wider cols
-        textColor: [255,255,255],
-        fillColor: [0,0,0],
-        overflow: 'hidden'      // never wrap headers
-      },
+    window.jspdf.autoTable(doc, {
+      head: [["Category","Partner A","Match","Flag","Partner B"]],
+      body: rows,
+      startY: 70,
+      styles: { fontSize: 10, cellPadding: 6, overflow: "linebreak" },
       columnStyles: {
-        0: { cellWidth: catW,  halign: 'left'   }, // Category
-        1: { cellWidth: eachW, halign: 'center' }, // Partner A
-        2: { cellWidth: eachW, halign: 'center' }, // Match
-        3: { cellWidth: eachW, halign: 'center' }, // Flag
-        4: { cellWidth: eachW, halign: 'center' }  // Partner B
+        1: { halign: "center" },  // A
+        2: { halign: "center" },  // Match %
+        3: { halign: "center" },  // Flag icon
+        4: { halign: "center" },  // Partner B
       },
-      didParseCell: (data) => {
-        // Ensure header cells don’t break on space
-        if (data.section === 'head') data.cell.styles.overflow = 'hidden';
-      }
+      headStyles: { fillColor: [0,0,0] }
     });
 
-    doc.save('kink-compatibility.pdf');
+    doc.save("compatibility-report.pdf");
   }
 
-  // Expose globally & wire button if present
-  window.downloadCompatibilityPDF = downloadCompatibilityPDF;
-  document.addEventListener('DOMContentLoaded', () => {
-    const btn = document.getElementById('downloadBtn') || document.querySelector('[data-download-pdf]');
-    if (btn) btn.addEventListener('click', downloadCompatibilityPDF);
-  });
+  const btn = document.getElementById("downloadBtn") || document.querySelector('[data-download-pdf]');
+  if (btn){
+    btn.onclick = exportCompatibilityPDF;  // override any previous click listener
+  } else {
+    // Fallback: expose globally if you trigger it elsewhere
+    window.downloadCompatibilityPDF = exportCompatibilityPDF;
+  }
 })();
 </script>
 


### PR DESCRIPTION
## Summary
- replace legacy PDF export script with version that recalculates match percentage and flag icons
- wire download button to new exporter

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a4eef4a4d8832c8c3468b2df1113fa