### PR TITLE
Handle empty partner data in PDF export

### DIFF
--- a/test/pdfDownloadNoData.test.js
+++ b/test/pdfDownloadNoData.test.js
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert';
+
+test('alerts and aborts when both partners have no data', async () => {
+  const originalGlobals = {
+    window: globalThis.window,
+    document: globalThis.document,
+    alert: globalThis.alert,
+  };
+  try {
+    let alertMsg = '';
+    let jsPdfCalled = false;
+
+    globalThis.alert = msg => { alertMsg = msg; };
+    globalThis.window = {
+      html2canvas: () => {},
+      jspdf: { jsPDF: class { constructor(){ jsPdfCalled = true; } save(){} } },
+    };
+    globalThis.document = {
+      readyState: 'complete',
+      querySelector: () => null,
+      querySelectorAll: () => [],
+      head: { appendChild: () => {} },
+      createElement: () => ({ setAttribute: () => {}, textContent: '', appendChild: () => {}, style: {} }),
+    };
+
+    const mod = await import('../js/pdfDownload.js?no-data-test');
+    await mod.downloadCompatibilityPDF();
+
+    assert.strictEqual(jsPdfCalled, false);
+    assert.match(alertMsg, /no data/i);
+  } finally {
+    if (originalGlobals.window) globalThis.window = originalGlobals.window; else delete globalThis.window;
+    if (originalGlobals.document) globalThis.document = originalGlobals.document; else delete globalThis.document;
+    if (originalGlobals.alert) globalThis.alert = originalGlobals.alert; else delete globalThis.alert;
+  }
+});
+


### PR DESCRIPTION
## Summary
- detect Partner B column data with new `partnerBHasData`
- abort PDF export when both partners lack data
- skip row pruning when no partner data
- add test ensuring export warns and skips when data absent

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a52de408d8832c86f6b2260963d823