### PR TITLE
Persist compatibility data for PDF export

### DIFF
--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -413,16 +413,25 @@ function updateComparison() {
   }
 
   const mergedKinkData = [];
+  const aItems = [];
+  const bItems = [];
   Object.entries(lastResult).forEach(([category, items]) => {
     items.forEach(it => {
+      const aScore = maxRating(it.you);
+      const bScore = surveyB ? maxRating(it.partner) : null;
       mergedKinkData.push({
         category,
         name: it.name,
-        partnerA: maxRating(it.you),
-        partnerB: surveyB ? maxRating(it.partner) : null
+        partnerA: aScore,
+        partnerB: bScore
       });
+      const key = compatNormalizeKey(it.name);
+      if (aScore != null) aItems.push({ id: key, label: it.name, score: aScore });
+      if (bScore != null) bItems.push({ id: key, label: it.name, score: bScore });
     });
   });
+  window.partnerAData = { items: aItems };
+  window.partnerBData = { items: bItems };
 
   const groupedData = groupKinksByCategory(mergedKinkData);
 


### PR DESCRIPTION
## Summary
- Track survey A and B ratings when comparison table is built
- Expose normalized data via `window.partnerAData`/`window.partnerBData` for PDF generation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a54360a580832c9df0e1c31f83f335