### PR TITLE
Fix PDF generation in Node environment

### DIFF
--- a/js/compatibilityPdf.js
+++ b/js/compatibilityPdf.js
@@ -2,7 +2,7 @@ import { getFlagEmoji } from './matchFlag.js';
 import { buildLayout, drawMatchBar, getMatchPercentage } from './compatibilityReportHelpers.js';
 const DEBUG = typeof process !== 'undefined' && process.env?.NODE_ENV !== 'production';
 
-export function generateCompatibilityPDF(data = { categories: [] }) {
+export async function generateCompatibilityPDF(data = { categories: [] }) {
   if (DEBUG) {
     console.log('PDF function triggered');
   }
@@ -142,7 +142,7 @@ export function generateCompatibilityPDF(data = { categories: [] }) {
     });
   });
 
-  doc.save('compatibility_report.pdf');
+  await doc.save('compatibility_report.pdf');
 }
 
 if (typeof document !== 'undefined') {
@@ -163,7 +163,7 @@ if (typeof document !== 'undefined') {
   }
 }
 
-export function generateCompatibilityPDFLandscape(data) {
+export async function generateCompatibilityPDFLandscape(data) {
   const categories = Array.isArray(data) ? data : data?.categories || [];
   const { jsPDF } = window.jspdf;
   const doc = new jsPDF({ orientation: 'landscape', unit: 'mm', format: 'a4' });
@@ -204,7 +204,7 @@ export function generateCompatibilityPDFLandscape(data) {
     }
   });
 
-  doc.save('compatibility_report_landscape.pdf');
+  await doc.save('compatibility_report_landscape.pdf');
 }
 
 function drawTitle(doc, pageWidth) {

--- a/js/vendor/jspdf.umd.min.js
+++ b/js/vendor/jspdf.umd.min.js
@@ -27,7 +27,7 @@
     addPage() {}
 
     // Very small PDF generator – supports text output only
-    save(filename = 'document.pdf') {
+    async save(filename = 'document.pdf') {
       const esc = (s) =>
         (s || '').replace(/([\\()\n\r])/g, (r) => ({
           '\\': '\\\\',
@@ -63,6 +63,12 @@
         body += off.toString().padStart(10, '0') + ' 00000 n \n';
       });
       body += `trailer\n<< /Size ${objects.length + 1} /Root ${objects.length} 0 R >>\nstartxref\n${xref}\n%%EOF`;
+
+      if (typeof document === 'undefined') {
+        const fs = await import('node:fs');
+        fs.writeFileSync(filename, body);
+        return;
+      }
 
       const blob = new Blob([body], { type: 'application/pdf' });
       const a = document.createElement('a');

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test:coverage": "node --test --experimental-test-coverage",
     "generate-token": "node scripts/generateToken.js",
     "generate:tokens": "node generateTokens.js",
-    "generate-pdf:landscape": "node --input-type=module -e \"globalThis.window={};await import('./js/vendor/jspdf.umd.min.js');(await import('./js/compatibilityPdf.js')).generateCompatibilityPDFLandscape({categories: []})\""
+    "generate-pdf:landscape": "node --input-type=module -e \"globalThis.window={};await import('./js/vendor/jspdf.umd.min.js');await (await import('./js/compatibilityPdf.js')).generateCompatibilityPDFLandscape({categories: []})\""
   },
   "keywords": [],
   "author": "",

--- a/test/compatibilityPdfZero.test.js
+++ b/test/compatibilityPdfZero.test.js
@@ -33,7 +33,7 @@ test('renders zero scores for both partners', async () => {
   };
 
   const { generateCompatibilityPDF } = await import('../js/compatibilityPdf.js');
-  generateCompatibilityPDF(data);
+  await generateCompatibilityPDF(data);
 
   // Ensure zeros are printed and no N/A appears
   const texts = textCalls.map(c => c[0]);

--- a/test/generateCompatibilityPDF.test.js
+++ b/test/generateCompatibilityPDF.test.js
@@ -38,7 +38,7 @@ test('generates PDF with score columns and percent', async () => {
     ]
   };
 
-  generateCompatibilityPDF(data);
+  await generateCompatibilityPDF(data);
 
   assert.ok(rectCalls.length > 0);
   assert.ok(textCalls.some(c => c[0] === 'Kink Compatibility Report'));
@@ -85,7 +85,7 @@ test('shows N/A bar when scores missing', async () => {
     ]
   };
 
-  generateCompatibilityPDF(data);
+  await generateCompatibilityPDF(data);
 
   assert.ok(textCalls.some(c => c[0] === 'N/A'));
   assert.ok(!textCalls.some(c => /\d+%/.test(c[0])));
@@ -115,6 +115,6 @@ test('renders compatibility history section when history data present', async ()
     categories: [],
     history: [{ score: 85, date: '2024-01-01T00:00:00Z' }]
   };
-  generateCompatibilityPDF(data);
+  await generateCompatibilityPDF(data);
   assert.ok(textCalls.some(c => c[0] === 'Compatibility History'));
 });


### PR DESCRIPTION
## Summary
- allow the jsPDF stub to write files directly when no DOM is available
- make compatibility PDF generators async and await `doc.save` for Node support
- ensure the `generate-pdf:landscape` script waits for PDF creation

## Testing
- `npm test`
- `npm run generate-pdf:landscape`


------
https://chatgpt.com/codex/tasks/task_e_68a7ada2a9c8832c8abb361566b318f0