### PR TITLE
Bind compatibility PDF export to existing button

### DIFF
--- a/js/compatTbodyPdf.js
+++ b/js/compatTbodyPdf.js
@@ -1,88 +1,83 @@
 (function () {
-  /* ---------------- 0) Loader ---------------- */
-  function loadScript(src){return new Promise((res,rej)=>{const s=document.createElement('script');s.src=src;s.crossOrigin="anonymous";s.referrerPolicy="no-referrer";s.onload=res;s.onerror=()=>rej(new Error("Failed to load "+src));document.head.appendChild(s);});}
-  async function ensureLibs(){
-    if(!(window.jspdf && window.jspdf.jsPDF)){
-      console.log("[PDF] Loading jsPDF…");
-      await loadScript("https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js");
-    }
-    const hasAuto = (window.jspdf && window.jspdf.autoTable) || (window.jsPDF && window.jsPDF.API && window.jsPDF.API.autoTable);
-    if(!hasAuto){
-      console.log("[PDF] Loading jsPDF-AutoTable…");
-      await loadScript("https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.8.3/jspdf.plugin.autotable.min.js");
-    }
-    console.log("[PDF] Libraries ready");
-  }
+  /* ---------- CONFIG ---------- */
+  const BTN_SELECTORS = ["#downloadBtn", "#downloadPdfBtn", "[data-download-pdf]"];
+  const TBODY_SELECTOR = "#compatTbody";
+  const THRESH = { star: 90, flag: 60, low: 30 };
+  const ICON   = { star: "★", flag: "⚑", low: "🚩", blank: "" }; // Unicode, NOT HTML entities
 
-  /* ---------------- 1) Helpers ---------------- */
-  const THRESH={star:90,flag:60,low:30};
-  const ICON={star:"★",flag:"⚑",low:"🚩",blank:""};
-  const toNum=v=>{const n=Number(String(v??"").trim());return Number.isFinite(n)?n:null;};
-  const matchPct=(a,b)=>{const A=toNum(a),B=toNum(b);if(A==null||B==null)return null;return Math.round(100-(Math.abs(A-B)/5)*100);};
-  const iconFor=p=>p==null?ICON.blank:(p>=THRESH.star?ICON.star:(p>=THRESH.flag?ICON.flag:(p<=THRESH.low?ICON.low:ICON.blank)));
-  const scaleOf=arr=>{const vals=(arr||[]).map(x=>x?.score).filter(x=>typeof x==="number");if(!vals.length)return 1;const mx=Math.max(...vals),mn=Math.min(...vals);if(mx<=5&&mn>=0)return 1;if(mx<=1&&mn>=0)return 5;if(mx<=7)return 5/7;if(mx<=10)return 5/10;if(mx<=100)return 5/100;return 5/Math.max(5,mx);};
+  /* ---------- helpers ---------- */
+  const N = v => { const x = Number(String(v ?? "").trim()); return Number.isFinite(x) ? x : null; };
+  const pct = (a,b) => { const A=N(a), B=N(b); if (A==null||B==null) return null; return Math.round(100 - (Math.abs(A-B)/5)*100); };
+  const icon = p => p==null ? ICON.blank : (p>=THRESH.star?ICON.star : (p>=THRESH.flag?ICON.flag : (p<=THRESH.low?ICON.low:ICON.blank)));
+  const scaleOf = arr => {
+    const vals=(arr||[]).map(x=>x?.score).filter(x=>typeof x==="number");
+    if(!vals.length) return 1;
+    const mx=Math.max(...vals), mn=Math.min(...vals);
+    if(mx<=5&&mn>=0) return 1;
+    if(mx<=1&&mn>=0) return 5;
+    if(mx<=7)  return 5/7;
+    if(mx<=10) return 5/10;
+    if(mx<=100)return 5/100;
+    return 5/Math.max(5,mx);
+  };
 
-  /* ---------------- 2) Collect rows ---------------- */
+  /* ---------- rows from DOM (#compatTbody) ---------- */
   function rowsFromTbody(){
-    const tbody = document.querySelector("#compatTbody");
-    if(!tbody){ console.warn("[PDF] #compatTbody not found"); return []; }
+    const tbody=document.querySelector(TBODY_SELECTOR);
+    if(!tbody) return [];
     const out=[];
     for(const tr of tbody.querySelectorAll("tr")){
       const tds=tr.querySelectorAll("td"); if(!tds.length) continue;
       const cat = tds[0]?.textContent?.trim() || tr.getAttribute("data-kink-id") || "";
-      const aTxt = tr.querySelector('td[data-cell="A"]')?.textContent ?? tds[1]?.textContent ?? "";
-      const bTxt = tr.querySelector('td[data-cell="B"]')?.textContent ?? tds[tds.length-1]?.textContent ?? "";
-      const A=toNum(aTxt), B=toNum(bTxt), P=matchPct(A,B);
-      out.push([cat||"—", (A??"—"), (P==null?"—":`${P}%`), iconFor(P), (B??"—")]);
+      const aTxt= tr.querySelector('td[data-cell="A"]')?.textContent ?? tds[1]?.textContent ?? "";
+      const bTxt= tr.querySelector('td[data-cell="B"]')?.textContent ?? tds[tds.length-1]?.textContent ?? "";
+      const A=N(aTxt), B=N(bTxt), P=pct(A,B);
+      out.push([cat||"—", (A??"—"), (P==null?"—":`${P}%`), icon(P), (B??"—")]);
     }
-    console.log("[PDF] rowsFromTbody:", out.length);
     return out;
   }
 
+  /* ---------- rows from memory (partnerAData/partnerBData) ---------- */
   function rowsFromMemory(){
     const A=(window.partnerAData?.items)||(Array.isArray(window.partnerAData)?window.partnerAData:null);
     const B=(window.partnerBData?.items)||(Array.isArray(window.partnerBData)?window.partnerBData:null);
-    if(!A&&!B){ console.warn("[PDF] partnerAData/partnerBData missing"); return []; }
+    if(!A&&!B) return [];
     const sA=scaleOf(A||[]), sB=scaleOf(B||[]);
     const mA=new Map((A||[]).map(i=>[(i.id||i.label),i]));
     const mB=new Map((B||[]).map(i=>[(i.id||i.label),i]));
-    const union=new Map(); (A||[]).forEach(i=>union.set(i.id||i.label,i.label||i.id)); (B||[]).forEach(i=>union.set(i.id||i.label,i.label||i.id));
+    const keys=new Map(); (A||[]).forEach(i=>keys.set(i.id||i.label,i.label||i.id)); (B||[]).forEach(i=>keys.set(i.id||i.label,i.label||i.id));
     const out=[];
-    for(const [id,label] of union){
+    for(const [id,label] of keys){
       const a=mA.get(id), b=mB.get(id);
-      const Ar=(typeof a?.score==="number")?a.score:null;
-      const Br=(typeof b?.score==="number")?b.score:null;
-      const P=(Ar==null||Br==null)?null:matchPct(Ar*sA,Br*sB);
-      out.push([label||id||"—",(Ar??"—"),(P==null?"—":`${P}%`),iconFor(P),(Br??"—")]);
+      const Ar=typeof a?.score==="number"?a.score:null;
+      const Br=typeof b?.score==="number"?b.score:null;
+      const P=(Ar==null||Br==null)?null:pct(Ar*sA,Br*sB);
+      out.push([label||id||"—",(Ar??"—"),(P==null?"—":`${P}%`),icon(P),(Br??"—")]);
     }
-    console.log("[PDF] rowsFromMemory:", out.length);
     return out;
   }
 
-  function selfTestRows(){
-    console.warn("[PDF] SELF-TEST MODE — exporting demo rows so you can verify downloads.");
-    return [
-      ["Choosing outfit for a scene", 5, "100%", "★", 5],
-      ["Styling hair (braiding, etc.)", 1, "100%", "★", 1],
-      ["Creating themed looks", 0, "100%", "★", 0]
-    ];
-  }
-
+  /* ---------- AutoTable wrapper ---------- */
   function runAutoTable(doc, opts){
     if (typeof doc.autoTable === "function") return doc.autoTable(opts);
     if (window.jspdf && typeof window.jspdf.autoTable === "function") return window.jspdf.autoTable(doc, opts);
-    throw new Error("AutoTable not available");
+    throw new Error("jsPDF-AutoTable not available. Include the plugin before this script.");
   }
 
-  /* ---------------- 3) Exporter ---------------- */
-  async function exportPDF(ev){
-    ev?.preventDefault?.();
+  /* ---------- export ---------- */
+  function exportPDF(e){
+    e?.preventDefault?.();
     try{
-      await ensureLibs();
+      if(!(window.jspdf && window.jspdf.jsPDF)){ alert("jsPDF not loaded."); return; }
 
       let rows = rowsFromTbody();
       if(!rows.length) rows = rowsFromMemory();
-      if(!rows.length) rows = selfTestRows();
+
+      if(!rows.length){
+        console.warn("[PDF] No rows found in DOM or memory.");
+        alert("No data rows found to export. Load both surveys first.");
+        return;
+      }
 
       const { jsPDF } = window.jspdf;
       const doc = new jsPDF({orientation:"landscape", unit:"pt", format:"a4"});
@@ -95,57 +90,45 @@
         body: rows,
         startY: 70,
         styles: { fontSize: 11, cellPadding: 6, overflow: "linebreak" },
-        headStyles: { fillColor: [0,0,0], textColor: [255,255,255], fontStyle: "bold" },
+        headStyles: { fillColor:[0,0,0], textColor:[255,255,255], fontStyle:"bold" },
         columnStyles: {
-          0: { halign:"left",   cellWidth: 560 },
-          1: { halign:"center", cellWidth: 80  },
-          2: { halign:"center", cellWidth: 90  },
-          3: { halign:"center", cellWidth: 60  },
-          4: { halign:"center", cellWidth: 80  }
+          0:{ halign:"left",   cellWidth: 560 },
+          1:{ halign:"center", cellWidth: 80  },
+          2:{ halign:"center", cellWidth: 90  },
+          3:{ halign:"center", cellWidth: 60  },
+          4:{ halign:"center", cellWidth: 80  }
         }
       });
 
       doc.save("compatibility-report.pdf");
     }catch(err){
       console.error("[PDF] Export failed:", err);
-      alert("PDF export failed: "+err.message);
+      alert("PDF export failed: " + err.message);
     }
   }
 
-  /* ---------------- 4) Button binding (creates one if missing) ---------------- */
-  function getOrCreateButton(){
-    const candidates=[
-      "#downloadBtn","#downloadPdfBtn","[data-download-pdf]",
-      'button[aria-label="Download PDF"]','a[role="button"][href="#download-pdf"]'
-    ];
-    for(const sel of candidates){ const el=document.querySelector(sel); if(el) return el; }
-    // create button if none
-    const btn=document.createElement("button");
-    btn.id="downloadBtn";
-    btn.textContent="Download Compatibility Report (PDF)";
-    btn.style.cssText="position:fixed;right:16px;bottom:16px;z-index:999999;padding:.6rem 1rem;border-radius:.5rem";
-    document.body.appendChild(btn);
-    console.warn("[PDF] No download button found; created one (#downloadBtn) at bottom-right.");
-    return btn;
-  }
-
-  function bind(){
-    const btn = getOrCreateButton();
-    btn.removeEventListener("click", exportPDF);
-    btn.addEventListener("click", exportPDF, { passive: true });
-    console.log("[PDF] Exporter bound →", btn);
+  /* ---------- bind to YOUR existing button ---------- */
+  function bindOnce(){
+    for (const sel of BTN_SELECTORS){
+      const btn = document.querySelector(sel);
+      if (btn){
+        btn.removeEventListener("click", exportPDF); // avoid double-binding
+        btn.addEventListener("click", exportPDF);
+        console.log("[PDF] Bound to", sel);
+        return true;
+      }
+    }
+    console.warn("[PDF] Download button not found. Expecting one of:", BTN_SELECTORS.join(", "));
+    return false;
   }
 
   if (document.readyState === "loading") {
-    document.addEventListener("DOMContentLoaded", bind);
+    document.addEventListener("DOMContentLoaded", bindOnce);
   } else {
-    bind();
+    bindOnce();
   }
 
-  // Rebind if the app re-renders DOM
-  const mo = new MutationObserver(() => bind());
-  mo.observe(document.documentElement, { childList: true, subtree: true });
-
-  // Manual trigger if you want to call from dev console
-  window.downloadCompatibilityPDF = exportPDF;
+  // In case your app re-renders the header/buttons, keep the binding alive.
+  const mo = new MutationObserver(() => bindOnce());
+  mo.observe(document.body || document.documentElement, { childList:true, subtree:true });
 })();


### PR DESCRIPTION
## Summary
- simplify compatTbodyPdf to use existing download button selectors
- generate PDF rows from DOM or memory and recompute match/flag icons

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7c5679b98832cb77e50d2a01ce677