### PR TITLE
fix: ensure pdf columns fit within page

### DIFF
--- a/snippet-compatibility-report-dark.html
+++ b/snippet-compatibility-report-dark.html
@@ -17,95 +17,175 @@
 </table>
 -->
 
-<!-- === TalkKink Compatibility Report Export ===
-STEPS:
-1. Paste this <script> block just before </body>.
-2. Ensure your table has id="compatibilityTable".
-3. Add a button with id="downloadBtn" (or #downloadPdfBtn / [data-download-pdf]).
-   If you don’t, this script creates one for you.
-4. Click the button to export a full-width, black-background, white-text PDF.
+<!--
+TALK KINK • COMPATIBILITY REPORT (fix “cut off on the right”)
+
+WHAT THIS DOES
+• Auto-loads jsPDF + AutoTable.
+• Reads your on-page table (id="compatibilityTable" or first <table>).
+• Exports a LANDSCAPE A4 PDF with a solid black page, white text.
+• Uses calculated column widths that ALWAYS fit inside the printable area,
+  with line-wrapping in the Category column so nothing is cut off.
+
+HOW TO USE
+1) Paste this whole <script> block right before </body>.
+2) Make sure a table exists (ideally id="compatibilityTable").
+3) Have a button with id="downloadBtn" (or #downloadPdfBtn / [data-download-pdf]).
+   If none exists, this script creates one.
+4) Reload page → click the button. You can also call window.exportCompatibilityPDF() in the console.
 -->
 
 <script>
 (function () {
-  async function inject(src){
+  /* ---------- load libs ---------- */
+  function inject(src){
     return new Promise((res,rej)=>{
-      if(document.querySelector(`script[src="${src}"]`))return res();
-      const s=document.createElement("script");s.src=src;s.onload=res;s.onerror=()=>rej();document.head.appendChild(s);
+      if (document.querySelector(`script[src="${src}"]`)) return res();
+      const s=document.createElement("script");
+      s.src=src; s.async=true; s.onload=res; s.onerror=()=>rej(new Error("Failed to load "+src));
+      document.head.appendChild(s);
     });
   }
   async function ensureLibs(){
-    if(!(window.jspdf&&window.jspdf.jsPDF)){
-      await inject("https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js");
-    }
-    if(!((window.jspdf&&window.jspdf.autoTable)||(window.jsPDF&&window.jsPDF.API&&window.jsPDF.API.autoTable))){
+    await inject("https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js");
+    if (!((window.jspdf && window.jspdf.jsPDF))) throw new Error("jsPDF not ready");
+    if (!((window.jspdf && window.jspdf.autoTable) || (window.jsPDF && window.jsPDF.API && window.jsPDF.API.autoTable))){
       await inject("https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.8.3/jspdf.plugin.autotable.min.js");
     }
   }
-  function runAutoTable(doc,opts){
-    if(typeof doc.autoTable==="function") return doc.autoTable(opts);
-    return window.jspdf.autoTable(doc,opts);
+  function runAutoTable(doc, opts){
+    if (typeof doc.autoTable === "function") return doc.autoTable(opts);
+    return window.jspdf.autoTable(doc, opts);
   }
 
-  function getRows(){
-    const table=document.getElementById("compatibilityTable")||document.querySelector("table");
-    if(!table)return[];
-    const trs=[...table.querySelectorAll("tbody tr")];
+  /* ---------- helpers ---------- */
+  const tidy = s => (s||"").replace(/\s+/g," ").trim();
+
+  function getTable(){
+    return document.getElementById("compatibilityTable")
+        || document.querySelector('table[aria-label*="compatibility" i]')
+        || document.querySelector("table");
+  }
+  function getRowsFromTable(){
+    const table=getTable();
+    if(!table) return [];
+    let trs=[...table.querySelectorAll("tbody tr")];
+    if(!trs.length) trs=[...table.querySelectorAll("tr")].filter(tr=>tr.querySelectorAll("td").length);
     const out=[];
-    for(const tr of trs){
-      const tds=[...tr.querySelectorAll("td")];if(!tds.length)continue;
-      out.push(tds.map(td=>td.textContent.trim()));
+    for (const tr of trs){
+      const tds=[...tr.querySelectorAll("td")];
+      if(!tds.length) continue;
+      out.push(tds.map(td=>tidy(td.textContent)));
     }
     return out;
   }
+  function getOrCreateButton(){
+    const btn = document.querySelector("#downloadBtn,#downloadPdfBtn,[data-download-pdf]");
+    if (btn) return btn;
+    const b=document.createElement("button");
+    b.id="downloadBtn";
+    b.textContent="Download Compatibility PDF";
+    b.style.cssText="margin:16px 0;padding:10px 14px;font-size:14px;border-radius:8px;border:1px solid #0ff;background:#001014;color:#0ff;cursor:pointer;";
+    (getTable()?.parentElement || document.body).appendChild(b);
+    return b;
+  }
 
-  async function exportPDF(){
+  /* ---------- export ---------- */
+  async function exportCompatibilityPDF(){
     await ensureLibs();
-    const { jsPDF }=window.jspdf;
-    const doc=new jsPDF({orientation:"landscape",unit:"pt",format:"a4"});
+    const { jsPDF } = window.jspdf;
+    const rows = getRowsFromTable();
+    if (!rows.length){ alert("No rows to export."); return; }
 
-    const rows=getRows();
-    if(!rows.length){alert("No rows to export.");return;}
+    const doc = new jsPDF({ orientation:"landscape", unit:"pt", format:"a4" });
 
+    // page metrics
+    const pageW = doc.internal.pageSize.getWidth ? doc.internal.pageSize.getWidth() : doc.internal.pageSize.width;
+    const pageH = doc.internal.pageSize.getHeight ? doc.internal.pageSize.getHeight() : doc.internal.pageSize.height;
+
+    // margins & inner width (we base column widths on THIS so nothing overflows)
+    const M_LEFT  = 60;
+    const M_RIGHT = 60;
+    const INNER_W = pageW - M_LEFT - M_RIGHT;
+
+    // column widths as proportions of INNER_W (must sum to 1.00)
+    const COL_CAT   = INNER_W * 0.52; // Category (wide, left aligned, wraps)
+    const COL_A     = INNER_W * 0.10; // Partner A
+    const COL_MATCH = INNER_W * 0.14; // Match
+    const COL_FLAG  = INNER_W * 0.08; // Flag
+    const COL_B     = INNER_W * 0.16; // Partner B
+
+    // paint full black background
     doc.setFillColor(0,0,0);
-    doc.rect(0,0,doc.internal.pageSize.width,doc.internal.pageSize.height,"F");
-    doc.setTextColor(255,255,255);
-    doc.setFontSize(24);
-    doc.text("Talk Kink • Compatibility Report", doc.internal.pageSize.width/2, 50, {align:"center"});
+    doc.rect(0,0,pageW,pageH,"F");
 
-    runAutoTable(doc,{
-      head:[["Category","Partner A","Match","Flag","Partner B"]],
-      body:rows,
-      startY:80,
-      theme:"plain",
-      styles:{fontSize:12,fillColor:[0,0,0],textColor:[255,255,255],halign:"center",valign:"middle"},
-      headStyles:{fillColor:[0,0,0],textColor:[255,255,255],fontStyle:"bold"},
-      tableWidth:"auto",
-      columnStyles:{
-        0:{cellWidth:doc.internal.pageSize.width*0.5,halign:"left",fontStyle:"bold"},
-        1:{cellWidth:doc.internal.pageSize.width*0.12},
-        2:{cellWidth:doc.internal.pageSize.width*0.12},
-        3:{cellWidth:doc.internal.pageSize.width*0.1},
-        4:{cellWidth:doc.internal.pageSize.width*0.12}
+    // title
+    doc.setTextColor(255,255,255);
+    doc.setFontSize(32);
+    doc.text("Talk Kink • Compatibility Report", pageW/2, 64, { align:"center" });
+
+    // table
+    runAutoTable(doc, {
+      head: [["Category","Partner A","Match","Flag","Partner B"]],
+      body: rows,
+      startY: 96,
+      theme: "plain",                 // let us control all paint
+      tableWidth: INNER_W,            // hard-fit inside margins
+      margin: { left: M_LEFT, right: M_RIGHT },
+
+      styles: {
+        fontSize: 14,
+        cellPadding: 8,
+        overflow: "linebreak",        // WRAP long category labels
+        halign: "center",
+        valign: "middle",
+        textColor: [255,255,255],
+        fillColor: [0,0,0]
       },
-      margin:{left:40,right:40}
+      headStyles: {
+        fontStyle: "bold",
+        textColor: [255,255,255],
+        fillColor: [0,0,0],
+        halign: "center"
+      },
+      columnStyles: {
+        0: { cellWidth: COL_CAT,   halign: "left",  fontStyle: "bold" },
+        1: { cellWidth: COL_A,     halign: "center" },
+        2: { cellWidth: COL_MATCH, halign: "center" },
+        3: { cellWidth: COL_FLAG,  halign: "center" },
+        4: { cellWidth: COL_B,     halign: "center" }
+      },
+
+      // Force *every* cell to render black/white (no zebra/stripes)
+      didParseCell: data => {
+        data.cell.styles.fillColor = [0,0,0];
+        data.cell.styles.textColor = [255,255,255];
+      },
+      willDrawCell: data => {
+        const { cell } = data;
+        doc.setFillColor(0,0,0);
+        doc.rect(cell.x, cell.y, cell.width, cell.height, "F");
+      }
     });
 
     doc.save("compatibility-report.pdf");
   }
 
+  // bind
   function bind(){
-    let btn=document.querySelector("#downloadBtn,#downloadPdfBtn,[data-download-pdf]");
-    if(!btn){
-      btn=document.createElement("button");
-      btn.id="downloadBtn";
-      btn.textContent="Download Compatibility PDF";
-      document.body.appendChild(btn);
-    }
-    btn.onclick=exportPDF;
+    const btn=getOrCreateButton();
+    btn.removeEventListener("click", exportCompatibilityPDF);
+    btn.addEventListener("click", exportCompatibilityPDF);
+    // also expose globally for manual triggering
+    window.exportCompatibilityPDF = exportCompatibilityPDF;
   }
-  if(document.readyState==="loading")document.addEventListener("DOMContentLoaded",bind);else bind();
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", bind);
+  } else {
+    bind();
+  }
 })();
 </script>
 </body>
 </html>
+


### PR DESCRIPTION
## Summary
- adjust dark compatibility report snippet to compute column widths within printable area so nothing gets cut off
- auto-load jsPDF/AutoTable and ensure a download button exists on the page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a901d58400832c98e28eb0aa44c5f2