### PR TITLE
fix: ensure PDF table uses white text on black background

### DIFF
--- a/js/compatTbodyPdf.js
+++ b/js/compatTbodyPdf.js
@@ -150,6 +150,7 @@
         head: [["Category","Partner A","Match","Flag","Partner B"]],
         body: rows,
         startY: 20,
+        theme: 'plain',
         styles: {
           fontSize: 10,
           cellWidth: 'wrap',
@@ -166,6 +167,10 @@
           2:{ cellWidth:20 },
           3:{ cellWidth:15 },
           4:{ cellWidth:20 }
+        },
+        didParseCell: data => {
+          data.cell.styles.fillColor = [0,0,0];
+          data.cell.styles.textColor = [255,255,255];
         }
       });
 


### PR DESCRIPTION
## Summary
- preserve white text in generated compatibility PDFs by forcing plain theme and cell styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9335f4a50832c881aff5400fa065d