### PR TITLE
Make PDF dark mode opt-in

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -3013,18 +3013,24 @@ body {
     display: none !important;
   }
 }
-/* Set universal black background and text color for PDF */
+/* Optional dark mode for PDFs */
+.pdf-dark-mode {
+  --pdf-bg: #000;
+  --pdf-color: #fff;
+}
+
+/* Configure print colors using CSS variables so they can be overridden */
 @media print {
   html, body {
     margin: 0;
     padding: 0;
-    background: #000 !important;
-    color: white !important;
+    background: var(--pdf-bg, #fff) !important;
+    color: var(--pdf-color, #000) !important;
   }
 
   .compatibility-wrapper {
-    background: #000 !important;
-    color: white !important;
+    background: var(--pdf-bg, #fff) !important;
+    color: var(--pdf-color, #000) !important;
     width: 100% !important;
     max-width: 100% !important;
     margin: 0 auto !important;


### PR DESCRIPTION
## Summary
- Replace hard-coded print colors with CSS variables
- Add `.pdf-dark-mode` class to opt into dark PDF exports

## Testing
- `npm test`
- `apt-get update` *(failed: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aa50313f88832cbf782f01097710b1