### PR TITLE
Allow custom PDF background color

### DIFF
--- a/js/pdfDownload.js
+++ b/js/pdfDownload.js
@@ -689,7 +689,7 @@ function keepRowsIntact(clone, pageHeightCss, topPad = ROW_TOP_PAD) {
   }
 }
 
-async function renderMultiPagePDF({ clone, jsPDFCtor, orientation=PDF_ORIENTATION, jpgQuality=0.95, firstPageHeader=FIRST_PAGE_HEADER }) {
+export async function renderMultiPagePDF({ clone, jsPDFCtor, orientation=PDF_ORIENTATION, jpgQuality=0.95, firstPageHeader=FIRST_PAGE_HEADER, bgColor=null }) {
   const pdf = new jsPDFCtor({ unit:'pt', format:'letter', orientation });
   const pdfW = pdf.internal.pageSize.getWidth();
   const pdfH = pdf.internal.pageSize.getHeight();
@@ -716,7 +716,7 @@ async function renderMultiPagePDF({ clone, jsPDFCtor, orientation=PDF_ORIENTATIO
     const sliceYOffsetCss = page === 0 ? headerTopPadCss : 0;
     const sliceH = Math.min(pageHeightCss - sliceYOffsetCss, totalCssHeight - y);
     const canvas = await html2canvas(clone, {
-      backgroundColor:'#000', scale, useCORS:true, allowTaint:true,
+      backgroundColor:bgColor, scale, useCORS:true, allowTaint:true,
       scrollX:0, scrollY:0, windowWidth:cssWidth, windowHeight:sliceH, height:sliceH, y: y + sliceYOffsetCss
     });
     const img = canvas.toDataURL('image/jpeg', jpgQuality);
@@ -742,7 +742,7 @@ async function renderMultiPagePDF({ clone, jsPDFCtor, orientation=PDF_ORIENTATIO
 }
 
 /* ============================== EXPORT ENTRY ============================== */
-export async function downloadCompatibilityPDF() {
+export async function downloadCompatibilityPDF({ bgColor=null } = {}) {
   try { await ensureLibs(); } catch (e) { console.error(e); alert(e.message); return; }
 
   const aHas = partnerAHasData();
@@ -770,7 +770,7 @@ export async function downloadCompatibilityPDF() {
 
   try {
     const jsPDFCtor = getJsPDF();
-    const pdf = await renderMultiPagePDF({ clone: shell, jsPDFCtor, orientation: PDF_ORIENTATION, jpgQuality: 0.95, firstPageHeader: '' });
+    const pdf = await renderMultiPagePDF({ clone: shell, jsPDFCtor, orientation: PDF_ORIENTATION, jpgQuality: 0.95, firstPageHeader: '', bgColor });
     pdf.save('kink-compatibility.pdf');
   } catch (err) {
     console.error('[pdf] render error:', err);

--- a/test/pdfDownloadBackgroundColor.test.js
+++ b/test/pdfDownloadBackgroundColor.test.js
@@ -1,0 +1,66 @@
+import test from 'node:test';
+import assert from 'node:assert';
+
+// Verify html2canvas background color defaults to null (no forced black)
+
+test('renderMultiPagePDF passes null backgroundColor when none supplied', async () => {
+  const original = {
+    document: globalThis.document,
+    html2canvas: globalThis.html2canvas,
+    window: globalThis.window,
+  };
+
+  try {
+    let capturedBg;
+    globalThis.html2canvas = async (el, opts) => {
+      capturedBg = opts.backgroundColor;
+      return { toDataURL: () => '' };
+    };
+
+    globalThis.document = {
+      readyState: 'complete',
+      addEventListener: () => {},
+      documentElement: { clientWidth: 100 },
+      createElement: () => ({
+        setAttribute: () => {},
+        textContent: '',
+        appendChild: () => {},
+        style: {},
+      }),
+      querySelector: () => null,
+      querySelectorAll: () => [],
+      head: { appendChild: () => {} },
+    };
+    globalThis.window = {};
+
+    const clone = {
+      scrollWidth: 100,
+      scrollHeight: 100,
+      getBoundingClientRect: () => ({ width: 100, height: 100, top: 0 }),
+      querySelectorAll: () => [],
+    };
+
+    class FakePDF {
+      constructor() {
+        this.internal = { pageSize: { getWidth: () => 612, getHeight: () => 792 } };
+      }
+      addPage() {}
+      addImage() {}
+      setFillColor() {}
+      rect() {}
+      setTextColor() {}
+      setFont() {}
+      setFontSize() {}
+      text() {}
+    }
+
+    const { renderMultiPagePDF } = await import('../js/pdfDownload.js');
+    await renderMultiPagePDF({ clone, jsPDFCtor: FakePDF, firstPageHeader: '' });
+
+    assert.strictEqual(capturedBg, null);
+  } finally {
+    if (original.document) globalThis.document = original.document; else delete globalThis.document;
+    if (original.html2canvas) globalThis.html2canvas = original.html2canvas; else delete globalThis.html2canvas;
+    if (original.window) globalThis.window = original.window; else delete globalThis.window;
+  }
+});


### PR DESCRIPTION
## Summary
- Make `renderMultiPagePDF` accept an optional `bgColor` and forward it to `html2canvas` so the computed page background is used when no color is supplied
- Pass through `bgColor` from `downloadCompatibilityPDF` to control PDF background color
- Add unit test confirming `html2canvas` receives `null` background when no color is provided

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa502c0bdc832ca357a2950e3137de