### PR TITLE
Default PDF exports to light theme and vector workflow

### DIFF
--- a/js/compatPdfFixes.js
+++ b/js/compatPdfFixes.js
@@ -113,10 +113,10 @@ export function applyCompatLayoutAndFlags(root = document.getElementById('pdf-co
     }
   });
 
-  // 4) Ensure container is full-width black
+  // 4) Ensure container is full-width with light background
   Object.assign(root.style, {
-    backgroundColor: '#000',
-    color: '#fff',
+    backgroundColor: '#fff',
+    color: '#000',
     width: '100%',
     maxWidth: '100%',
     margin: '0',

--- a/js/compatTbodyPdf.js
+++ b/js/compatTbodyPdf.js
@@ -139,10 +139,10 @@
       const { jsPDF } = window.jspdf;
       const doc = new jsPDF();
 
-      // Full-page black background with white text
-      doc.setFillColor(0,0,0);
+      // Light page background with dark text
+      doc.setFillColor(255,255,255);
       doc.rect(0,0,doc.internal.pageSize.width,doc.internal.pageSize.height,'F');
-      doc.setTextColor(255,255,255);
+      doc.setTextColor(0,0,0);
       doc.setFontSize(16);
       doc.text("Talk Kink • Compatibility Report", 14, 15);
 
@@ -156,11 +156,11 @@
           cellWidth: 'wrap',
           halign: 'center',
           valign: 'middle',
-          fillColor: [0,0,0],
-          textColor: [255,255,255],
+          fillColor: [255,255,255],
+          textColor: [0,0,0],
           fontStyle: 'normal'
         },
-        headStyles: { fillColor:[0,0,0], textColor:[255,255,255], fontStyle:'bold' },
+        headStyles: { fillColor:[255,255,255], textColor:[0,0,0], fontStyle:'bold' },
         columnStyles: {
           0:{ cellWidth:70, halign:'left' },
           1:{ cellWidth:20 },
@@ -168,10 +168,7 @@
           3:{ cellWidth:15 },
           4:{ cellWidth:20 }
         },
-        didParseCell: data => {
-          data.cell.styles.fillColor = [0,0,0];
-          data.cell.styles.textColor = [255,255,255];
-        }
+        didParseCell: data => {}
       });
 
       doc.save("compatibility_report.pdf");

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -554,7 +554,7 @@ async function exportPNG() {
   const element = document.getElementById('pdf-container');
   if (!element) return;
   const canvas = await html2canvas(element, {
-    backgroundColor: '#000000',
+    backgroundColor: '#fff',
     scale: 2,
     useCORS: true
   });

--- a/js/compatibilityReportHelpers.js
+++ b/js/compatibilityReportHelpers.js
@@ -2,7 +2,7 @@
 
 // Determine the font color used for the match percentage
 function getFontColor(percentage) {
-  if (percentage === null || percentage === undefined) return 'white';
+  if (percentage === null || percentage === undefined) return 'black';
   if (percentage >= 90) return 'green';
   if (percentage >= 60) return 'yellow';
   return 'red';
@@ -26,13 +26,13 @@ export function drawMatchBar(
   width,
   height,
   percentage,
-  resetColor = 'white'
+  resetColor = 'black'
 ) {
   const label = percentage !== null && percentage !== undefined ? `${percentage}%` : 'N/A';
   const textColor = getFontColor(percentage);
 
-  // Black background
-  doc.setFillColor(0, 0, 0);
+  // Light background to avoid solid black fills
+  doc.setFillColor(255, 255, 255);
   doc.rect(x, y, width, height, 'F');
 
   // Label centered inside the bar
@@ -45,7 +45,7 @@ export function drawMatchBar(
 }
 
 // Render the category header at the provided coordinates
-function renderCategoryHeader(doc, x, y, category, textColor = 'white') {
+function renderCategoryHeader(doc, x, y, category, textColor = 'black') {
   doc.setFontSize(13);
   doc.setTextColor(textColor);
   doc.text(category, x, y);
@@ -88,7 +88,7 @@ export function getMatchPercentage(a, b) {
 }
 
 // Helper: draw one row of the kink table
-function drawKinkRow(doc, layout, y, label, aScore, bScore, match, textColor = 'white') {
+function drawKinkRow(doc, layout, y, label, aScore, bScore, match, textColor = 'black') {
   const { colLabel, colA, colBar, colFlag, colB, barWidth, barHeight } = layout;
   const aNorm = normalizeScore(aScore);
   const bNorm = normalizeScore(bScore);
@@ -119,7 +119,7 @@ function drawKinkRow(doc, layout, y, label, aScore, bScore, match, textColor = '
 }
 
 // Render an entire category section including column headers
-export function renderCategorySection(doc, categoryLabel, items, layout, startY, textColor = 'white') {
+export function renderCategorySection(doc, categoryLabel, items, layout, startY, textColor = 'black') {
   const { colLabel, colA, colBar, colFlag, colB, barWidth } = layout;
 
   renderCategoryHeader(doc, colLabel, startY, categoryLabel, textColor);

--- a/js/compatibilityTablePdf.js
+++ b/js/compatibilityTablePdf.js
@@ -95,9 +95,9 @@
     const BODY_FS = 12;
     const CAT_FS  = 16;
 
-    // black page
-    doc.setFillColor(0,0,0); doc.rect(0,0,W,H,"F");
-    doc.setTextColor(255,255,255);
+    // light page background
+    doc.setFillColor(255,255,255); doc.rect(0,0,W,H,'F');
+    doc.setTextColor(0,0,0);
     doc.setFontSize(28);
     doc.text("Talk Kink • Compatibility Report", W/2, 42, {align:"center"});
 
@@ -114,14 +114,14 @@
         cellPadding: 8,
         halign: "center",
         valign: "middle",
-        textColor: [255,255,255],
-        fillColor: [0,0,0],
+        textColor: [0,0,0],
+        fillColor: [255,255,255],
       },
       headStyles: {
         fontSize: 14,
         fontStyle: "bold",
-        textColor: [255,255,255],
-        fillColor: [0,0,0],
+        textColor: [0,0,0],
+        fillColor: [255,255,255],
         halign: "center",
       },
       columnStyles: {
@@ -132,10 +132,6 @@
         4: { cellWidth: wB,     halign: "center"},
       },
       didParseCell: data => {
-        // enforce black fill & white text everywhere
-        data.cell.styles.fillColor = [0,0,0];
-        data.cell.styles.textColor = [255,255,255];
-
         // clamp Category to TWO lines, larger font
         if(data.section==="body" && data.column.index===0){
           const clean = tidy(Array.isArray(data.cell.text)?data.cell.text.join(" "):data.cell.text);
@@ -145,11 +141,6 @@
           data.cell.styles.fontSize = CAT_FS;
           data.cell.styles.lineHeight = 1.18;
         }
-      },
-      willDrawCell: (data) => {
-        const c = data.cell;
-        data.doc.setFillColor(0,0,0);
-        data.doc.rect(c.x, c.y, c.width, c.height, "F");
       },
       // prevent AutoTable from auto-squeezing widths (keeps alignment)
       horizontalPageBreak: true

--- a/js/pdfExportAdjustments.js
+++ b/js/pdfExportAdjustments.js
@@ -1,3 +1,4 @@
+// Legacy html2canvas-based exporter. Prefer using downloadCompatibilityPDF from pdfDownload.js.
 export class CompatibilityPDFExporter {
   constructor(containerSelector = '#pdf-container, #compat-container') {
     this.containerSelector = containerSelector;
@@ -223,7 +224,7 @@ export class CompatibilityPDFExporter {
 
     try {
       const canvas = await html2canvas(clone, {
-        backgroundColor: '#000',
+        backgroundColor: '#fff',
         scale: 2,
         useCORS: true,
         scrollX: 0,
@@ -231,9 +232,9 @@ export class CompatibilityPDFExporter {
         windowWidth: cssWidth,
         windowHeight: Math.ceil(clone.getBoundingClientRect().height)
       });
-      const img = canvas.toDataURL('image/jpeg', 0.95);
+      const img = canvas.toDataURL('image/png');
       const ratio = canvas.height / canvas.width;
-      pdf.addImage(img, 'JPEG', 0, 0, pdfW, pdfW * ratio, undefined, 'FAST');
+      pdf.addImage(img, 'PNG', 0, 0, pdfW, pdfW * ratio, undefined, 'FAST');
       pdf.save('kink-compatibility.pdf');
     } finally {
       document.body.removeChild(clone);

--- a/js/rawSurveyPdf.js
+++ b/js/rawSurveyPdf.js
@@ -86,8 +86,8 @@ function drawCategorySection(title, items, layout, startY, doc, theme) {
 
 export function generateCompatibilityPDF(partnerAData, partnerBData, doc, theme = {}) {
   const {
-    bgColor = '#000000',
-    textColor = '#ffffff',
+    bgColor = '#ffffff',
+    textColor = '#000000',
     barFillColor = '#000000',
     barTextColor = '#ffffff',
     font = 'helvetica'

--- a/js/script.js
+++ b/js/script.js
@@ -880,66 +880,14 @@ if (downloadBtn) downloadBtn.addEventListener('click', exportSurvey);
 
 function downloadPDF() {
   document.body.classList.add('exporting');
-  const current = localStorage.getItem('theme') || 'dark';
-  applyPrintStyles(current);
-
-  const element = document.getElementById('export-target') || document.getElementById('surveyContainer');
-  if (!element) return;
-  window.scrollTo(0, 0);
-  element.style.paddingBottom = '100px';
-
-  // Inject minimal styles to ensure full-width dark export
-  const style = document.createElement('style');
-  style.textContent = `
-    .pdf-wrapper {
-      background: #000 !important;
-      color: #fff !important;
-      padding: 0 !important;
-      margin: 0 !important;
-      width: 100vw;
-      min-height: 100vh;
-      box-sizing: border-box;
-    }
-
-    html, body {
-      margin: 0 !important;
-      padding: 0 !important;
-      background: #000 !important;
-    }
-
-    * {
-      box-sizing: border-box !important;
-      -webkit-print-color-adjust: exact !important;
-      print-color-adjust: exact !important;
-    }
-  `;
-  document.head.appendChild(style);
-
-  element.classList.add('pdf-wrapper');
-
-  const opt = {
-    margin: 40,
-    filename: 'kink-compatibility-results.pdf',
-    image: { type: 'jpeg', quality: 1 },
-    html2canvas: {
-      scale: 2,
-      useCORS: true,
-      backgroundColor: '#000',
-      scrollX: 0,
-      scrollY: 0,
-      windowWidth: element.scrollWidth,
-      windowHeight: element.scrollHeight
-    },
-    jsPDF: {
-      unit: 'px',
-      format: 'a4',
-      orientation: 'portrait',
-    },
-  };
-
-  html2pdf().set(opt).from(element).save().then(() => {
+  if (typeof window.downloadCompatibilityPDF === 'function') {
+    window.downloadCompatibilityPDF().finally(() => {
+      document.body.classList.remove('exporting');
+    });
+  } else {
+    console.error('downloadCompatibilityPDF not available');
     document.body.classList.remove('exporting');
-  });
+  }
 }
 
 

--- a/test/compatibilityReportHelpers.test.js
+++ b/test/compatibilityReportHelpers.test.js
@@ -24,7 +24,7 @@ function createDocMock() {
   };
 }
 
-test('drawMatchBar renders black bar with colored text and resets color', () => {
+test('drawMatchBar renders white bar with colored text and resets color', () => {
   const doc = createDocMock();
   drawMatchBar(doc, 10, 10, 100, 8, 50);
   doc.text('after', 0, 0); // simulate subsequent drawing
@@ -33,17 +33,17 @@ test('drawMatchBar renders black bar with colored text and resets color', () => 
   assert.deepStrictEqual(rectCalls[0], ['rect', [10, 10, 100, 8, 'F']]);
 // ✅ Final merged version
 const fillColorCall = doc.calls.find(c => c[0] === 'setFillColor');
-assert.deepStrictEqual(fillColorCall, ['setFillColor', [0, 0, 0]]);
+assert.deepStrictEqual(fillColorCall, ['setFillColor', [255, 255, 255]]);
 
 const colorCalls = doc.calls.filter(c => c[0] === 'setTextColor');
 assert.deepStrictEqual(colorCalls[0], ['setTextColor', ['red']]);
-assert.deepStrictEqual(colorCalls[colorCalls.length - 1], ['setTextColor', ['white']]);
+assert.deepStrictEqual(colorCalls[colorCalls.length - 1], ['setTextColor', ['black']]);
 
   const textCall = doc.calls.find(c => c[0] === 'text' && c[1][0] === '50%');
   assert.ok(textCall, 'percentage label should be rendered');
 });
 
-test('flag and partner B columns render in white after drawMatchBar', () => {
+test('flag and partner B columns render in black after drawMatchBar', () => {
   const doc = createDocMock();
   const items = [{ label: 'Test', partnerA: 4, partnerB: 0 }]; // results in a 🚩 flag
   const margin = 5;
@@ -53,11 +53,11 @@ test('flag and partner B columns render in white after drawMatchBar', () => {
 
   const flagIndex = doc.calls.findIndex(c => c[0] === 'text' && c[1][0] === '🚩');
   const lastColorBeforeFlag = doc.calls.slice(0, flagIndex).filter(c => c[0] === 'setTextColor').pop();
-  assert.deepStrictEqual(lastColorBeforeFlag, ['setTextColor', ['white']]);
+  assert.deepStrictEqual(lastColorBeforeFlag, ['setTextColor', ['black']]);
 
   const partnerBIndex = doc.calls.findIndex(c => c[0] === 'text' && c[1][0] === '0');
   const lastColorBeforePartnerB = doc.calls.slice(0, partnerBIndex).filter(c => c[0] === 'setTextColor').pop();
-  assert.deepStrictEqual(lastColorBeforePartnerB, ['setTextColor', ['white']]);
+  assert.deepStrictEqual(lastColorBeforePartnerB, ['setTextColor', ['black']]);
 });
 
 test('renderCategorySection renders each item and returns final y', () => {

--- a/your-roles.html
+++ b/your-roles.html
@@ -74,7 +74,7 @@
       if (!element) return;
 
       // Force background color for PDF rendering
-      element.style.backgroundColor = "#000"; // pure black background
+      element.style.backgroundColor = "#fff";
 
       document.body.classList.add('exporting');
       element.classList.add('pdf-export');
@@ -82,10 +82,10 @@
         .set({
           margin: 0,
           filename: 'kink-compatibility-results.pdf',
-          image: { type: 'jpeg', quality: 1 },
+          image: { type: 'png', quality: 1 },
           html2canvas: {
             scale: 2,
-            backgroundColor: '#000',
+            backgroundColor: '#fff',
             useCORS: true
           },
           jsPDF: { unit: 'in', format: 'letter', orientation: 'portrait' },


### PR DESCRIPTION
## Summary
- ensure html2canvas-based exporters render on white and emit PNG snapshots
- drop black page fills in PDF generators and default helpers to light colors
- route download buttons through vector-based `downloadCompatibilityPDF`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa73d1f038832c89c09f753e013ab4