### PR TITLE
style: add header border styling to dark PDF

### DIFF
--- a/pdf-download-test.html
+++ b/pdf-download-test.html
@@ -101,7 +101,9 @@ async function setupPDFExport() {
       headStyles: {
         fillColor: [0, 0, 0],
         textColor: [255, 255, 255],
-        fontStyle: "bold"
+        fontStyle: "bold",
+        lineColor: [255, 255, 255],   // white header borders
+        lineWidth: 0.5
       },
       columnStyles: {
         0: { cellWidth: 420, halign: "left" },


### PR DESCRIPTION
## Summary
- ensure dark compatibility report PDF has white header borders by setting lineColor and lineWidth

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa89770a70832c96e553f2ce0d375c