### PR TITLE
Add white border around table in dark PDF export

### DIFF
--- a/pdf-download-test.html
+++ b/pdf-download-test.html
@@ -111,6 +111,8 @@ async function setupPDFExport() {
         2: { cellWidth: 90, halign: "center" },
         3: { cellWidth: 80, halign: "center" }
       },
+      tableLineColor: [255, 255, 255],
+      tableLineWidth: 0.5,
       didDrawPage: paintPage
     });
 


### PR DESCRIPTION
## Summary
- Ensure generated PDF tables draw a white outline using `tableLineColor` and `tableLineWidth`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa8b419c0c832c866c0b909e4b6201