### PR TITLE
fix: robust jsPDF fallback

### DIFF
--- a/js/pdfDownload.js
+++ b/js/pdfDownload.js
@@ -22,7 +22,11 @@ function _loadScript(src) {
 }
 
 function _getJsPDF() {
-  return (window.jspdf && window.jspdf.jsPDF) || (window.jsPDF && window.jsPDF.jsPDF);
+  return (
+    (window.jspdf && window.jspdf.jsPDF) ||
+    window.jsPDF ||
+    (window.jsPDF && window.jsPDF.jsPDF)
+  );
 }
 
 async function _ensurePdfLibs() {
@@ -107,8 +111,8 @@ export async function downloadCompatibilityPDF({
     return;
   }
 
-  const { jsPDF } = window.jspdf;
-  const doc = new jsPDF({ orientation, unit: 'pt', format });
+  const JsPDF = _getJsPDF();
+  const doc = new JsPDF({ orientation, unit: 'pt', format });
 
   const pageW = doc.internal.pageSize.getWidth();
   const pageH = doc.internal.pageSize.getHeight();


### PR DESCRIPTION
## Summary
- prevent pdf exports from failing when `window.jspdf` is missing by checking other global jsPDF constructors
- use unified helper to construct jsPDF, avoiding undefined destructuring errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aaa2c1794c832c8be47737bd625abb