### PR TITLE
Handle missing data in PDF download without alert

### DIFF
--- a/js/pdfDownload.js
+++ b/js/pdfDownload.js
@@ -107,7 +107,10 @@ export async function downloadCompatibilityPDF({
 
   const rows = _extractRows();
   if (!rows.length) {
-    alert('No data rows found to export.');
+    console.warn('[pdf] No data rows found to export.');
+    document
+      .querySelectorAll('#downloadBtn, #downloadPdfBtn, [data-download-pdf]')
+      .forEach(btn => _setBtnState(btn, false));
     return;
   }
 


### PR DESCRIPTION
## Summary
- Replace alert with console warning when no data rows exist for PDF export
- Disable download button when data is missing and update no-data unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ab8d50fa1c832c93a6bcb48f10ea2a