### PR TITLE
Use RGB colors for match bar labels

### DIFF
--- a/js/compatibilityReportHelpers.js
+++ b/js/compatibilityReportHelpers.js
@@ -2,10 +2,10 @@
 
 // Determine the font color used for the match percentage
 function getFontColor(percentage) {
-  if (percentage === null || percentage === undefined) return 'black';
-  if (percentage >= 90) return 'green';
-  if (percentage >= 60) return 'yellow';
-  return 'red';
+  if (percentage === null || percentage === undefined) return [0, 0, 0];
+  if (percentage >= 90) return [0, 128, 0];
+  if (percentage >= 60) return [255, 255, 0];
+  return [255, 0, 0];
 }
 
 // Flag logic
@@ -37,7 +37,7 @@ export function drawMatchBar(
 
   // Label centered inside the bar
   doc.setFontSize(7);
-  doc.setTextColor(textColor);
+  doc.setTextColor(...textColor);
   doc.text(label, x + width / 2, y + height / 2 + 1.8, { align: 'center' });
 
   // Reset text color for subsequent drawing

--- a/test/compatibilityReportHelpers.test.js
+++ b/test/compatibilityReportHelpers.test.js
@@ -36,7 +36,7 @@ const fillColorCall = doc.calls.find(c => c[0] === 'setFillColor');
 assert.deepStrictEqual(fillColorCall, ['setFillColor', [255, 255, 255]]);
 
 const colorCalls = doc.calls.filter(c => c[0] === 'setTextColor');
-assert.deepStrictEqual(colorCalls[0], ['setTextColor', ['red']]);
+assert.deepStrictEqual(colorCalls[0], ['setTextColor', [255, 0, 0]]);
 assert.deepStrictEqual(colorCalls[colorCalls.length - 1], ['setTextColor', ['black']]);
 
   const textCall = doc.calls.find(c => c[0] === 'text' && c[1][0] === '50%');


### PR DESCRIPTION
## Summary
- return RGB arrays from getFontColor
- render match bar text using RGB colors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab8d562d20832cab026cbd35e056a9