### PR TITLE
fix: remove AutoTable dependency in dark PDF export snippet

### DIFF
--- a/snippet-compatibility-report-dark-pdf-export-robust.html
+++ b/snippet-compatibility-report-dark-pdf-export-robust.html
@@ -1,219 +1,234 @@
 <!-- DROP THIS <script> AT THE END OF YOUR PAGE (before </body>) -->
 <script>
-/**
- * Robust DARK MODE PDF export
- * - Fixes: "Cannot destructure property 'jsPDF' of 'window.jspdf' as it is undefined."
- * - Always uses black background, white text, thick white borders
- * - Works whether jsPDF exposes window.jspdf.jsPDF or window.jsPDF
- */
+/* FIX: “PDF export failed: jsPDF-AutoTable failed to load”
+   This bypasses AutoTable entirely and forces a PURE jsPDF export.
+   It also intercepts the Download button click (capture phase) to stop
+   any old handlers that try to use AutoTable.
+
+   Result: Dark PDF (black bg), white text, thick white borders.
+   Columns: Category | Partner A | Match % | Partner B
+*/
 
 (function () {
-  const TITLE        = 'Talk Kink • Compatibility Report';
-  const FILE_NAME    = 'compatibility-dark.pdf';
-  const LINE_W       = 1.4;   // white grid thickness
-  const CAT_PER_LINE = 60;    // category wrap per line
+  const TITLE='Talk Kink • Compatibility Report';
+  const FILE ='compatibility-dark.pdf';
 
-  /* ----------------- Safe loaders ----------------- */
-  function loadScript(src) {
-    return new Promise((resolve, reject) => {
-      if (document.querySelector(`script[src="${src}"]`)) return resolve();
-      const s = document.createElement('script');
-      s.src = src;
-      s.async = true;
-      s.onload = resolve;
-      s.onerror = () => reject(new Error('Failed to load ' + src));
+  // Layout
+  const GRID=1.4, FONT_SIZE=11, LINE_H=14, PAD_X=6, PAD_Y=8;
+  const MARGIN_LR=30, TOP_Y=70, BOTTOM=40;
+
+  // --- Load jsPDF only (NO AutoTable) ---
+  const CDNS=[
+    'https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js',
+    'https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js',
+    'https://unpkg.com/jspdf@2.5.1/dist/jspdf.umd.min.js'
+  ];
+  function loadScript(src){
+    return new Promise((res,rej)=>{
+      if (document.querySelector(`script[src="${src}"]`)) return res();
+      const s=document.createElement('script'); s.src=src; s.async=true;
+      s.onload=res; s.onerror=()=>rej(new Error('load fail '+src));
       document.head.appendChild(s);
     });
   }
-
-  function getJsPDFCtor() {
-    // Prefer UMD (window.jspdf.jsPDF). Fallbacks for older bundles.
-    return (window.jspdf && window.jspdf.jsPDF)
-        || window.jsPDF
-        || window.jspPDF         // very old
-        || null;
-  }
-
-  function hasAutoTable() {
-    return (window.jspdf && window.jspdf.autoTable)
-        || (window.jsPDF && window.jsPDF.API && window.jsPDF.API.autoTable)
-        || null;
-  }
-
-  async function ensureLibs() {
-    // jsPDF
-    if (!getJsPDFCtor()) {
-      await loadScript('https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js');
-      // wait up to ~3s for UMD to attach
-      await new Promise((resolve) => {
-        let tries = 0;
-        const iv = setInterval(() => {
-          if (getJsPDFCtor() || ++tries > 60) { clearInterval(iv); resolve(); }
-        }, 50);
-      });
+  async function ensureJsPDF(){
+    if ((window.jspdf&&window.jspdf.jsPDF)||window.jsPDF||window.jspPDF) return;
+    for (const src of CDNS){
+      try{
+        await loadScript(src);
+        for (let i=0;i<80;i++){
+          if ((window.jspdf&&window.jspdf.jsPDF)||window.jsPDF||window.jspPDF) return;
+          await new Promise(r=>setTimeout(r,50));
+        }
+      }catch{}
     }
-    if (!getJsPDFCtor()) throw new Error('jsPDF failed to load');
+    throw new Error('jsPDF failed to load');
+  }
+  const getJsPDF=()=> (window.jspdf&&window.jspdf.jsPDF)||window.jsPDF||window.jspPDF;
 
-    // AutoTable
-    if (!hasAutoTable()) {
-      await loadScript('https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.8.3/jspdf.plugin.autotable.min.js');
-      await new Promise((resolve) => {
-        let tries = 0;
-        const iv = setInterval(() => {
-          if (hasAutoTable() || ++tries > 60) { clearInterval(iv); resolve(); }
-        }, 50);
-      });
+  // --- Helpers ---
+  const tidy=s=>(s||'').replace(/\s+/g,' ').trim();
+  const toNum=v=>{const n=Number(String(v??'').replace(/[^\d.-]/g,''));return Number.isFinite(n)?n:null;};
+  const pctMatch=(a,b)=>{if(a==null||b==null)return null;const p=Math.round(100-(Math.abs(a-b)/5)*100);return Math.max(0,Math.min(100,p));};
+
+  function wrapToTwoLines(doc,text,maxW){
+    doc.setFontSize(FONT_SIZE);
+    const raw=String(text??''); if(!raw) return ['—'];
+    const words=raw.split(/\s+/); const lines=[]; let cur='';
+    for(const w of words){
+      const trial=cur?cur+' '+w:w;
+      if(doc.getTextWidth(trial)<=maxW) cur=trial;
+      else{ if(cur) lines.push(cur); else lines.push(w); cur=w; }
+      if(lines.length===2) break;
     }
-    if (!hasAutoTable()) throw new Error('jsPDF-AutoTable failed to load');
+    if(cur && lines.length<2) lines.push(cur);
+    if(!lines.length) lines.push('—');
+    if((lines.join(' ').length)<raw.length){
+      let last=lines[lines.length-1];
+      while(doc.getTextWidth(last+'…')>maxW && last.length) last=last.slice(0,-1);
+      lines[lines.length-1]=last+'…';
+    }
+    return lines.slice(0,2);
   }
 
-  /* ----------------- Data extraction ----------------- */
-  const tidy = (s) => (s || '').replace(/\s+/g, ' ').trim();
-  const toNum = (v) => {
-    const n = Number(String(v ?? '').replace(/[^\d.-]/g, ''));
-    return Number.isFinite(n) ? n : null;
-  };
-  const clampTwo = (s, perLine) => {
-    const t = tidy(s);
-    if (!t) return '—';
-    if (t.length <= perLine) return t;
-    const a = t.slice(0, perLine).trim();
-    const bFull = t.slice(perLine).trim();
-    const b = bFull.length > perLine ? bFull.slice(0, perLine - 1).trim() + '…' : bFull;
-    return a + '\n' + b;
-  };
+  function drawCell(doc,x,y,w,h,text,align){
+    doc.setDrawColor(255,255,255);
+    doc.setLineWidth(GRID);
+    doc.rect(x,y,w,h);
+    doc.setTextColor(255,255,255);
+    doc.setFontSize(FONT_SIZE);
+    const innerW=w-PAD_X*2;
+    const lines = Array.isArray(text) ? text
+      : (typeof text==='string' && text.includes('\n')) ? text.split('\n').slice(0,2)
+      : wrapToTwoLines(doc,text,innerW);
+    const needed=Math.max(LINE_H, lines.length*LINE_H);
+    let tx=x+PAD_X, ty=y+(h-needed)/2+LINE_H-2;
+    if(align==='center') tx=x+w/2;
+    if(align==='right')  tx=x+w-PAD_X;
+    for(let i=0;i<lines.length;i++){
+      const opts={baseline:'alphabetic'};
+      if(align==='center') opts.align='center';
+      if(align==='right')  opts.align='right';
+      doc.text(lines[i], tx, ty+i*LINE_H, opts);
+    }
+  }
 
-  function getRows() {
-    const table = document.getElementById('compatibilityTable')
-               || document.querySelector('table.results-table.compat')
-               || document.querySelector('table');
-    if (!table) return [];
-    const trs = [...table.querySelectorAll('tr')].filter(tr =>
-      tr.querySelectorAll('th').length === 0 && tr.querySelectorAll('td').length > 0
-    );
+  function computeLayout(doc){
+    const pageW=doc.internal.pageSize.getWidth();
+    const usable=pageW - MARGIN_LR*2;
+    const A=80, M=90, B=80;
+    const Cat=Math.max(220, usable-(A+M+B));
+    return {Cat,A,M,B,pageW};
+  }
 
-    return trs.map(tr => {
-      const cells = [...tr.querySelectorAll('td')].map(td => tidy(td.textContent));
-      const cat = cells[0] || '—';
-      const nums = cells.map(toNum).filter(n => n !== null);
-      const A = nums.length ? nums[0] : null;
-      const B = nums.length ? nums[nums.length - 1] : null;
-
-      let pct = cells.find(c => /%$/.test(c)) || null;
-      if (!pct && A != null && B != null) {
-        const p = Math.round(100 - (Math.abs(A - B) / 5) * 100);
-        pct = `${Math.max(0, Math.min(100, p))}%`;
+  // --- Row collectors ---
+  function rowsFromAnyTable(){
+    const tbodies=[...document.querySelectorAll('tbody')];
+    const out=[];
+    for(const tb of tbodies){
+      for(const tr of tb.querySelectorAll('tr')){
+        const tds=[...tr.querySelectorAll('td')];
+        if(!tds.length) continue;
+        const aCell=tr.querySelector('td[data-cell="A"]');
+        const bCell=tr.querySelector('td[data-cell="B"]');
+        const category=tidy(tds[0]?.textContent)||tr.getAttribute('data-kink-id')||'';
+        const aTxt=tidy((aCell?aCell.textContent:tds[1]?.textContent)||'');
+        const bTxt=tidy((bCell?bCell.textContent:tds[tds.length-1]?.textContent)||'');
+        if(!category && !aTxt && !bTxt) continue;
+        const A=toNum(aTxt), B=toNum(bTxt);
+        const pctCell = tds.map(td=>tidy(td.textContent)).find(t=>/%$/.test(t));
+        const P = pctCell ? pctCell : (()=>{const p=pctMatch(A,B);return p==null?'—':(p+'%');})();
+        out.push([category||'—', (A==null?'—':A), P, (B==null?'—':B)]);
       }
-      return [clampTwo(cat, CAT_PER_LINE), A ?? '—', pct ?? '—', B ?? '—'];
-    });
+    }
+    return out;
+  }
+  function rowsFromMemory(){
+    const A=(window.partnerAData?.items)||(Array.isArray(window.partnerAData)?window.partnerAData:null);
+    const B=(window.partnerBData?.items)||(Array.isArray(window.partnerBData)?window.partnerBData:null);
+    if(!A && !B) return [];
+    const mA=new Map((A||[]).map(i=>[(i.id||i.label),i]));
+    const mB=new Map((B||[]).map(i=>[(i.id||i.label),i]));
+    const keys=new Map();
+    (A||[]).forEach(i=>keys.set(i.id||i.label,i.label||i.id));
+    (B||[]).forEach(i=>keys.set(i.id||i.label,i.label||i.id));
+    const out=[];
+    for(const [id,label] of keys){
+      const a=mA.get(id), b=mB.get(id);
+      const Av=toNum(a?.score), Bv=toNum(b?.score);
+      const p=pctMatch(Av,Bv);
+      out.push([label||id||'—', (Av==null?'—':Av), (p==null?'—':(p+'%')), (Bv==null?'—':Bv)]);
+    }
+    return out;
+  }
+  async function collectRowsWithRetries(max=6){
+    for(let i=0;i<max;i++){
+      let rows=rowsFromAnyTable().filter(r=>r.some(v=>v!=='' && v!=='—'));
+      if(rows.length) return rows;
+      if(typeof window.updateComparison==='function'){ try{ window.updateComparison(); }catch{} }
+      await new Promise(r=>setTimeout(r,150));
+    }
+    return rowsFromMemory();
   }
 
-  /* ----------------- Export ----------------- */
-  async function downloadDarkCompatibilityPDF() {
-    try {
-      await ensureLibs();
+  // --- Exporter (manual, no AutoTable) ---
+  async function exportPDF(){
+    try{
+      await ensureJsPDF();
+      const JsPDF=getJsPDF();
+      const doc = new JsPDF({orientation:'landscape', unit:'pt', format:'a4'});
 
-      const rows = getRows();
-      if (!rows.length) { alert('No rows found to export.'); return; }
+      const {Cat,A,M,B,pageW}=computeLayout(doc);
+      const pageH=doc.internal.pageSize.getHeight();
+      const paintBg=()=>{doc.setFillColor(0,0,0);doc.rect(0,0,pageW,pageH,'F');doc.setTextColor(255,255,255);};
 
-      const JsPDFCtor = getJsPDFCtor();
-      const doc = new JsPDFCtor({ orientation: 'landscape', unit: 'pt', format: 'a4' });
+      const rows=await collectRowsWithRetries();
+      if(!rows.length){ alert('No rows found to export. Ensure your table/surveys are loaded.'); return; }
 
-      const pageW = doc.internal.pageSize.getWidth();
-      const pageH = doc.internal.pageSize.getHeight();
-
-      const paintBg = () => {
-        doc.setFillColor(0, 0, 0);
-        doc.rect(0, 0, pageW, pageH, 'F');
-        doc.setTextColor(255, 255, 255);
-      };
-
+      // Title + bg
       paintBg();
       doc.setFontSize(28);
-      doc.text(TITLE, pageW / 2, 48, { align: 'center' });
+      doc.text(TITLE, pageW/2, 48, {align:'center'});
 
-      const runAT = (opts) => {
-        if (typeof doc.autoTable === 'function') return doc.autoTable(opts);
-        if (window.jspdf && typeof window.jspdf.autoTable === 'function') return window.jspdf.autoTable(doc, opts);
-        throw new Error('AutoTable is not available on doc');
-      };
+      const x0=MARGIN_LR; let y=TOP_Y;
 
-      const marginLR = 30;
-      const usable   = pageW - marginLR * 2;
-      const Awidth   = 80, Mwidth = 90, Bwidth = 80;
-      const reserved = Awidth + Mwidth + Bwidth;
-      const CatWidth = Math.max(220, usable - reserved);
+      function newPageIfNeeded(h){
+        if(y+h+BOTTOM>pageH){
+          doc.addPage(); paintBg();
+          doc.setFontSize(28);
+          doc.text(TITLE, pageW/2, 48, {align:'center'});
+          y=TOP_Y; drawHeader();
+        }
+      }
+      function drawHeader(){
+        const h=PAD_Y*2+LINE_H;
+        let x=x0;
+        drawCell(doc,x,y,Cat,h,'Category','left'); x+=Cat;
+        drawCell(doc,x,y,A,h,'Partner A','center'); x+=A;
+        drawCell(doc,x,y,M,h,'Match %','center');   x+=M;
+        drawCell(doc,x,y,B,h,'Partner B','center');
+        y+=h;
+      }
 
-      runAT({
-        head: [['Category', 'Partner A', 'Match %', 'Partner B']],
-        body: rows,
-        theme: 'grid',
-        startY: 70,
-        margin: { left: marginLR, right: marginLR, top: 70, bottom: 40 },
+      drawHeader();
 
-        styles: {
-          fontSize: 11,
-          cellPadding: 6,
-          textColor: [255,255,255],
-          fillColor: [0,0,0],
-          lineColor: [255,255,255],
-          lineWidth: LINE_W,
-          halign: 'center',
-          valign: 'middle',
-          overflow: 'linebreak'
-        },
-        headStyles: { fillColor: [0,0,0], textColor: [255,255,255], fontStyle: 'bold', lineColor: [255,255,255], lineWidth: LINE_W },
-        bodyStyles: { fillColor: [0,0,0], textColor: [255,255,255], lineColor: [255,255,255], lineWidth: LINE_W },
-        footStyles: { fillColor: [0,0,0], textColor: [255,255,255], lineColor: [255,255,255], lineWidth: LINE_W },
-        alternateRowStyles: { fillColor: [0,0,0], textColor: [255,255,255] },
+      for(const [category,a,pct,b] of rows){
+        const catLines=wrapToTwoLines(doc, category, Cat-PAD_X*2);
+        const rowH=Math.max(PAD_Y*2 + catLines.length*LINE_H, PAD_Y*2 + LINE_H);
+        newPageIfNeeded(rowH);
+        let x=x0;
+        drawCell(doc,x,y,Cat,rowH,catLines,'left'); x+=Cat;
+        drawCell(doc,x,y,A,rowH,String(a??'—'),'center'); x+=A;
+        drawCell(doc,x,y,M,rowH,String(pct??'—'),'center'); x+=M;
+        drawCell(doc,x,y,B,rowH,String(b??'—'),'center');
+        y+=rowH;
+      }
 
-        didParseCell: (data) => {
-          const s = data.cell.styles;
-          s.fillColor = [0,0,0];
-          s.textColor = [255,255,255];
-          s.lineColor = [255,255,255];
-          s.lineWidth = LINE_W;
-        },
-
-        columnStyles: {
-          0: { cellWidth: CatWidth, halign: 'left'   },
-          1: { cellWidth: Awidth,   halign: 'center' },
-          2: { cellWidth: Mwidth,   halign: 'center' },
-          3: { cellWidth: Bwidth,   halign: 'center' }
-        },
-
-        // IMPORTANT: background must be painted BEFORE table draws
-        willDrawPage: () => paintBg()
-      });
-
-      doc.save(FILE_NAME);
-    } catch (err) {
-      console.error('[TK-PDF] Export failed:', err);
-      alert('PDF export failed: ' + (err && err.message ? err.message : err));
+      doc.save(FILE);
+    }catch(err){
+      console.error('[TK-PDF] Export failed (pure):', err);
+      alert('PDF export failed: '+(err?.message||err));
     }
   }
 
-  // Bind button(s)
-  function bindButton() {
-    const btn = document.querySelector('#downloadBtn')
-            || document.querySelector('#downloadPdfBtn')
-            || document.querySelector('[data-download-pdf]');
-    if (btn) {
-      btn.removeEventListener('click', downloadDarkCompatibilityPDF);
-      btn.addEventListener('click', (e) => { e.preventDefault(); downloadDarkCompatibilityPDF(); });
-      console.log('[TK-PDF] Bound Download PDF');
-    }
-    // Remove any manual export button if present
-    const manual = [...document.querySelectorAll('button, a')]
-      .find(el => /run export \(manual\)/i.test(el.textContent || ''));
-    if (manual) manual.remove();
+  // --- Intercept the button to stop AutoTable handlers and use PURE export ---
+  const SELECTORS = '#downloadBtn, #downloadPdfBtn, [data-download-pdf]';
+  function bindPure(){
+    const btn=document.querySelector(SELECTORS);
+    if(!btn) return;
+    // Remove inline onclick and capture-phase intercept to block other listeners
+    btn.onclick=null;
+    btn.addEventListener('click', function onCap(e){
+      e.stopImmediatePropagation(); // stop any previous handlers that trigger AutoTable
+      e.preventDefault();
+      exportPDF();
+    }, true); // capture phase
+    console.log('[TK-PDF] Bound Download PDF (PURE, AutoTable bypassed)');
   }
 
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', bindButton);
-  } else {
-    bindButton();
-  }
-  new MutationObserver(bindButton).observe(document.documentElement, { childList: true, subtree: true });
+  // Expose and bind
+  window.TKPDF_export_pure = exportPDF;
+  if(document.readyState==='loading') document.addEventListener('DOMContentLoaded', bindPure, {once:true}); else bindPure();
+  new MutationObserver(bindPure).observe(document.documentElement,{childList:true,subtree:true});
 })();
 </script>


### PR DESCRIPTION
## Summary
- reimplement dark-mode PDF export snippet using pure jsPDF
- intercept Download button to bypass AutoTable handlers

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab91d2d424832caee3de34273e2378