### PR TITLE
Block legacy PDF listeners to eliminate false export errors

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -989,9 +989,15 @@ Permanent Codex version
     const btn = document.querySelector('#downloadBtn')
             || document.querySelector('#downloadPdfBtn')
             || document.querySelector('[data-download-pdf]');
-    if (btn) {
-      btn.removeEventListener('click', downloadDarkCompatibilityPDF);
-      btn.addEventListener('click', (e) => { e.preventDefault(); downloadDarkCompatibilityPDF(); });
+    if (btn && !btn.dataset.tkPdfBound) {
+      // remove any inline handler and intercept clicks before other listeners fire
+      btn.onclick = null;
+      btn.addEventListener('click', (e) => {
+        e.stopImmediatePropagation();
+        e.preventDefault();
+        downloadDarkCompatibilityPDF();
+      }, true); // capture phase to block previous handlers
+      btn.dataset.tkPdfBound = 'true';
       console.log('[TK-PDF] Bound Download PDF');
     }
     // optional: remove any "Run Export (manual)" control

--- a/js/pdfDownload.js
+++ b/js/pdfDownload.js
@@ -210,15 +210,18 @@ export function bindPdfButton() {
   const btn = BTN_SELECTORS.map(sel => document.querySelector(sel)).find(Boolean);
   if (!btn || btn.hasAttribute(BOUND_ATTR)) return;
 
+  // Clear any inline onclick and intercept early to block previous handlers
+  btn.onclick = null;
   btn.addEventListener('click', ev => {
+    ev.stopImmediatePropagation();
+    ev.preventDefault();
     const ready = btn.getAttribute(READY_ATTR) === 'true';
     if (!ready) {
-      ev.preventDefault();
       console.warn('[pdf] Not ready: load both surveys before exporting.');
       return;
     }
     downloadCompatibilityPDF();
-  });
+  }, true);
 
   btn.setAttribute(BOUND_ATTR, 'true');
 


### PR DESCRIPTION
## Summary
- Stop leftover click handlers from firing during PDF download to avoid erroneous `jsPDF-AutoTable` alerts
- Guard PDF download bindings with capture-phase listener and inline handler removal

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab94ade7cc832cb79b6a9dc7eaa4a5