### PR TITLE
fix: use relative path for template-survey script

### DIFF
--- a/kinks/index.html
+++ b/kinks/index.html
@@ -93,7 +93,7 @@
   <!-- Panel Container (still hidden until needed) -->
   <div id="panelContainer" class="panel-container" style="display:none;"></div>
 
-  <script src="/js/template-survey.js"></script>
+  <script src="../js/template-survey.js"></script>
   <!-- Theme Handling -->
   <script type="module">
     import { initTheme, applyThemeColors } from '../js/theme.js';


### PR DESCRIPTION
## Summary
- fix incorrect path to `template-survey.js` in kinks page so it loads from the filesystem as well

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aba5de03a8832c88383a232ff447e0