### PR TITLE
Handle session check failures

### DIFF
--- a/kinks/index.html
+++ b/kinks/index.html
@@ -395,7 +395,8 @@
         if (res.status === 401) {
           window.location.href = "/token.html";
         }
-      });
+      })
+      .catch(err => console.error("Session check failed:", err));
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- log errors when `/check-session` fails on the kink survey page so missing sessions don't stall the page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aba5de2a7c832cb168abb804060cd4