### PR TITLE
Load saved survey into comparison view on page load

### DIFF
--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -151,6 +151,7 @@ function loadSavedSurvey() {
     mergeSurveyWithTemplate(surveyA, window.templateSurvey);
     normalizeRatings(surveyA);
     filterGeneralOptions(surveyA);
+    updateComparison();
   } catch (err) {
     console.warn('Failed to parse saved survey:', err);
   }
@@ -627,4 +628,5 @@ function exportJSON() {
 document.addEventListener('DOMContentLoaded', () => {
   initTheme();
   loadSavedSurvey();
+  updateComparison();
 });


### PR DESCRIPTION
## Summary
- Invoke `updateComparison` after parsing saved survey so stored answers render immediately
- Call `updateComparison` after `loadSavedSurvey` on DOMContentLoaded to display cached data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aba786718c832c81684bfa4d78b6e2