### PR TITLE
Add loading spinner helpers for slow compatibility operations

### DIFF
--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -20,6 +20,21 @@ const RATING_LABELS = {
   5: 'Love / Core Interest'
 };
 
+function showSpinner() {
+  const overlay = document.querySelector('.loading-overlay');
+  if (overlay) overlay.style.display = 'flex';
+}
+
+function hideSpinner() {
+  const overlay = document.querySelector('.loading-overlay');
+  if (overlay) overlay.style.display = 'none';
+}
+
+if (typeof window !== 'undefined') {
+  window.showSpinner = showSpinner;
+  window.hideSpinner = hideSpinner;
+}
+
 // ----- Compatibility history helpers -----
 function loadHistory() {
   try {
@@ -287,6 +302,7 @@ function buildKinkBreakdown(surveyA, surveyB = {}) {
 
 function loadFileA(file) {
   if (!file) return;
+  showSpinner();
   const reader = new FileReader();
   reader.onload = ev => {
     try {
@@ -300,8 +316,11 @@ function loadFileA(file) {
     } catch (err) {
       console.warn('Failed to load Survey A:', err);
       alert('Invalid JSON for Survey A.\nPlease upload the unmodified JSON file exported from this site.');
+    } finally {
+      hideSpinner();
     }
   };
+  reader.onerror = () => hideSpinner();
   reader.readAsText(file);
 }
 
@@ -310,6 +329,7 @@ function loadFileB(file) {
   if (!confirm('Have you reviewed consent with your partner?')) {
     return;
   }
+  showSpinner();
   const reader = new FileReader();
   reader.onload = ev => {
     try {
@@ -323,8 +343,11 @@ function loadFileB(file) {
     } catch (err) {
       console.warn('Failed to load Survey B:', err);
       alert('Invalid JSON for Survey B.\nPlease upload the unmodified JSON file exported from this site.');
+    } finally {
+      hideSpinner();
     }
   };
+  reader.onerror = () => hideSpinner();
   reader.readAsText(file);
 }
 
@@ -553,15 +576,20 @@ function downloadBlob(blob, filename) {
 async function exportPNG() {
   const element = document.getElementById('pdf-container');
   if (!element) return;
-  const canvas = await html2canvas(element, {
-    backgroundColor: '#fff',
-    scale: 2,
-    useCORS: true
-  });
-  const link = document.createElement('a');
-  link.download = 'kink-survey.png';
-  link.href = canvas.toDataURL('image/png');
-  link.click();
+  showSpinner();
+  try {
+    const canvas = await html2canvas(element, {
+      backgroundColor: '#fff',
+      scale: 2,
+      useCORS: true
+    });
+    const link = document.createElement('a');
+    link.download = 'kink-survey.png';
+    link.href = canvas.toDataURL('image/png');
+    link.click();
+  } finally {
+    hideSpinner();
+  }
 }
 
 function exportHTML() {

--- a/js/compatibilityPdf.js
+++ b/js/compatibilityPdf.js
@@ -135,7 +135,14 @@ if (typeof document !== 'undefined') {
   const attachHandler = () => {
     const button = document.getElementById('downloadPdfBtn');
     if (button) {
-      button.addEventListener('click', () => generateCompatibilityPDF(window.compatibilityData));
+      button.addEventListener('click', async () => {
+        try {
+          if (typeof window.showSpinner === 'function') window.showSpinner();
+          await generateCompatibilityPDF(window.compatibilityData);
+        } finally {
+          if (typeof window.hideSpinner === 'function') window.hideSpinner();
+        }
+      });
     } else {
       console.error('Download button not found');
     }


### PR DESCRIPTION
## Summary
- Add `showSpinner`/`hideSpinner` utilities to toggle the loading overlay
- Wrap survey file parsing, PNG export, and PDF generation with spinner visibility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aba78896b4832cb0ca525f88a3f21a