### PR TITLE
Add AutoTable PDF export to compatibility page

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -688,5 +688,237 @@ document.addEventListener('DOMContentLoaded', () => setTimeout(runFill, 250));
 })();
 </script>
 
+<!--
+TALK KINK • “Perfect PDF” (AutoTable version you had before)
+- Dark theme: black background, white text, thick white borders
+- Columns (exact order): Category | Partner A | Match % | Partner B
+- Category wraps to TWO lines max
+- Uses jsPDF + jsPDF-AutoTable (loads both from CDN)
+- Binds to your existing Download button: #downloadBtn / #downloadPdfBtn / [data-download-pdf]
+Paste this near the end of compatibility.html (just before </body>).
+-->
+<script>
+(function () {
+  const TITLE='Talk Kink • Compatibility Report';
+  const FILE ='compatibility-report.pdf';
+
+  // Layout
+  const MARGIN_LR = 30, TOP = 70, BOTTOM = 40;
+  const FONT_SIZE = 11, LINE_H = 14, PAD = 6;
+  const THICK = 1.5; // thick white borders
+  const NUM_A = 80, NUM_M = 90, NUM_B = 80; // widths for A / Match % / B
+
+  // ---------------- Load libs (jsPDF + AutoTable) ----------------
+  const CDN = {
+    jspdf: [
+      'https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js',
+      'https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js',
+      'https://unpkg.com/jspdf@2.5.1/dist/jspdf.umd.min.js'
+    ],
+    autotable: [
+      'https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.8.3/jspdf.plugin.autotable.min.js',
+      'https://cdn.jsdelivr.net/npm/jspdf-autotable@3.8.3/dist/jspdf.plugin.autotable.min.js',
+      'https://unpkg.com/jspdf-autotable@3.8.3/dist/jspdf.plugin.autotable.min.js'
+    ]
+  };
+  function loadScript(src){
+    return new Promise((res,rej)=>{
+      if (document.querySelector(`script[src="${src}"]`)) return res();
+      const s=document.createElement('script'); s.src=src; s.async=true;
+      s.onload=res; s.onerror=()=>rej(new Error('Failed to load '+src));
+      document.head.appendChild(s);
+    });
+  }
+  async function ensureJsPDF(){
+    if ((window.jspdf&&window.jspdf.jsPDF)) return;
+    for (const src of CDN.jspdf){
+      try{
+        await loadScript(src);
+        for (let i=0;i<60;i++){
+          if (window.jspdf&&window.jspdf.jsPDF) return;
+          await new Promise(r=>setTimeout(r,50));
+        }
+      }catch{}
+    }
+    throw new Error('jsPDF failed to load');
+  }
+  async function ensureAutoTable(){
+    if ((window.jspdf && window.jspdf.autoTable) ||
+        (window.jsPDF && window.jsPDF.API && window.jsPDF.API.autoTable)) return;
+    for (const src of CDN.autotable){
+      try{
+        await loadScript(src);
+        for (let i=0;i<60;i++){
+          if ((window.jspdf && window.jspdf.autoTable) ||
+              (window.jsPDF && window.jsPDF.API && window.jsPDF.API.autoTable)) return;
+          await new Promise(r=>setTimeout(r,50));
+        }
+      }catch{}
+    }
+    throw new Error('jsPDF-AutoTable failed to load');
+  }
+  function runAT(doc, opts){
+    if (typeof doc.autoTable === 'function') return doc.autoTable(opts);
+    if (window.jspdf && typeof window.jspdf.autoTable === 'function') return window.jspdf.autoTable(doc, opts);
+    throw new Error('jsPDF-AutoTable not available');
+  }
+
+  // ---------------- Helpers ----------------
+  const tidy=s=>(s||'').replace(/\s+/g,' ').trim();
+  const toNum=v=>{ const n=Number(String(v??'').replace(/[^\d.-]/g,'')); return Number.isFinite(n)?n:null; };
+  const pct=(a,b)=>{ if(a==null||b==null) return null; const p=Math.round(100-(Math.abs(a-b)/5)*100); return Math.max(0,Math.min(100,p)); };
+
+  function clampTwoLines(str, maxCharsPerLine){
+    const t = tidy(str);
+    if (!t) return '—';
+    if (t.length <= maxCharsPerLine) return t;
+    const a = t.slice(0, maxCharsPerLine).trim();
+    const rest = t.slice(maxCharsPerLine).trim();
+    const b = rest.length > maxCharsPerLine ? rest.slice(0, maxCharsPerLine-1).trim() + '…' : rest;
+    return a + '\n' + b;
+  }
+
+  // Collect rows: [Category, Partner A, Match %, Partner B]
+  function rowsFromDOM(){
+    const out=[];
+    document.querySelectorAll('tbody').forEach(tb=>{
+      tb.querySelectorAll('tr').forEach(tr=>{
+        const tds=[...tr.querySelectorAll('td')];
+        if(!tds.length) return;
+        const aCell=tr.querySelector('td[data-cell="A"]');
+        const bCell=tr.querySelector('td[data-cell="B"]');
+        const category = tidy(tds[0]?.textContent) || tr.getAttribute('data-kink-id') || '';
+        const aTxt = tidy((aCell?aCell.textContent:tds[1]?.textContent) || '');
+        const bTxt = tidy((bCell?bCell.textContent:tds[tds.length-1]?.textContent) || '');
+        if (!category && !aTxt && !bTxt) return;
+        const A=toNum(aTxt), B=toNum(bTxt);
+        const pctCell = tds.map(td=>tidy(td.textContent)).find(t=>/%$/.test(t));
+        const P = pctCell ? pctCell : (()=>{ const pv=pct(A,B); return pv==null?'—':(pv+'%'); })();
+        out.push([category||'—', (A==null?'—':A), P, (B==null?'—':B)]);
+      });
+    });
+    return out;
+  }
+  function rowsFromMemory(){
+    const A=(window.partnerAData?.items)||(Array.isArray(window.partnerAData)?window.partnerAData:null);
+    const B=(window.partnerBData?.items)||(Array.isArray(window.partnerBData)?window.partnerBData:null);
+    if(!A && !B) return [];
+    const mA=new Map((A||[]).map(i=>[(i.id||i.label),i]));
+    const mB=new Map((B||[]).map(i=>[(i.id||i.label),i]));
+    const keys=new Map();
+    (A||[]).forEach(i=>keys.set(i.id||i.label, i.label||i.id));
+    (B||[]).forEach(i=>keys.set(i.id||i.label, i.label||i.id));
+    const out=[];
+    for (const [id,label] of keys){
+      const a=mA.get(id), b=mB.get(id);
+      const Av=toNum(a?.score), Bv=toNum(b?.score);
+      const p = pct(Av,Bv);
+      out.push([label||id||'—', (Av==null?'—':Av), (p==null?'—':(p+'%')), (Bv==null?'—':Bv)]);
+    }
+    return out;
+  }
+  async function collectRows(max=6){
+    for (let i=0;i<max;i++){
+      const rows = rowsFromDOM().filter(r=>r.some(v=>v!=='' && v!=='—'));
+      if (rows.length) return rows;
+      if (typeof window.updateComparison==='function'){ try{ window.updateComparison(); }catch{} }
+      await new Promise(r=>setTimeout(r,150));
+    }
+    return rowsFromMemory();
+  }
+
+  // ---------------- Export (AutoTable) ----------------
+  async function exportPDF(){
+    await ensureJsPDF();
+    await ensureAutoTable();
+
+    const { jsPDF } = window.jspdf;
+    const doc = new jsPDF({ orientation:'landscape', unit:'pt', format:'a4' });
+
+    const pageW = doc.internal.pageSize.getWidth();
+    const pageH = doc.internal.pageSize.getHeight();
+    const usable = pageW - MARGIN_LR*2;
+    const catWidth = Math.max(220, usable - (NUM_A + NUM_M + NUM_B));
+
+    const rows = await collectRows();
+    if (!rows.length){ alert('No rows found to export.'); return; }
+
+    // Paint black background BEFORE table on every page
+    function paintBg(d){
+      d.setFillColor(0,0,0);
+      d.rect(0,0,pageW,pageH,'F');
+      d.setTextColor(255,255,255);
+    }
+
+    // Title on first page
+    paintBg(doc);
+    doc.setFontSize(28);
+    doc.text(TITLE, pageW/2, 48, { align:'center' });
+
+    runAT(doc, {
+      head: [['Category','Partner A','Match %','Partner B']],
+      body: rows.map(r=>{
+        // force Category to 2 lines max by characters; AutoTable will honor \n
+        const clamped = clampTwoLines(r[0], 60);
+        return [clamped, r[1], r[2], r[3]];
+      }),
+      startY: TOP,
+      margin: { left: MARGIN_LR, right: MARGIN_LR, top: TOP, bottom: BOTTOM },
+      styles: {
+        fontSize: FONT_SIZE,
+        cellPadding: PAD,
+        textColor: [255,255,255],    // white text
+        fillColor: [0,0,0],          // black cells
+        lineColor: [255,255,255],    // white borders
+        lineWidth: THICK,
+        overflow: 'linebreak',
+        valign: 'middle',
+        halign: 'center'
+      },
+      headStyles: {
+        fontStyle: 'bold',
+        fillColor: [0,0,0],
+        textColor: [255,255,255],
+        lineColor: [255,255,255],
+        lineWidth: THICK
+      },
+      columnStyles: {
+        0: { cellWidth: catWidth, halign:'left'   }, // Category
+        1: { cellWidth: NUM_A,   halign:'center' }, // Partner A
+        2: { cellWidth: NUM_M,   halign:'center' }, // Match %
+        3: { cellWidth: NUM_B,   halign:'center' }  // Partner B
+      },
+      tableWidth: 'wrap',
+      // CRITICAL: background BEFORE table on each page; prevents “all black overlay”
+      willDrawPage: () => paintBg(doc)
+    });
+
+    doc.save(FILE);
+  }
+
+  // ---------------- Bind to existing button ----------------
+  const SELECTORS = '#downloadBtn, #downloadPdfBtn, [data-download-pdf]';
+  function bind(){
+    const btn = document.querySelector(SELECTORS);
+    if (!btn) return;
+    // Replace node to drop old listeners; bind our AutoTable exporter
+    const clone = btn.cloneNode(true);
+    btn.replaceWith(clone);
+    clone.addEventListener('click', (e)=>{ e.preventDefault(); exportPDF().catch(err=>{
+      console.error('[TK-PDF] Export failed:', err);
+      alert('PDF export failed: ' + (err?.message||err));
+    }); }, true);
+    console.log('[TK-PDF] Bound Download PDF (AutoTable version)');
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', bind, { once:true });
+  } else {
+    bind();
+  }
+  new MutationObserver(bind).observe(document.documentElement, { childList:true, subtree:true });
+})();
+</script>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary
- integrate AutoTable-based PDF exporter into `compatibility.html`
- load jsPDF and AutoTable from CDN and bind to download button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68abab7718cc832ca900786a6c5de98a