### PR TITLE
Add PDF exporter fallbacks and nginx config

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -452,12 +452,14 @@ document.addEventListener('DOMContentLoaded', () => setTimeout(runFill, 250));
   const JSPDF_CDNS = [
     "https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js",
     "https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js",
-    "https://unpkg.com/jspdf@2.5.1/dist/jspdf.umd.min.js"
+    "https://unpkg.com/jspdf@2.5.1/dist/jspdf.umd.min.js",
+    "/js/vendor/jspdf.umd.min.js"
   ];
   const AT_CDNS = [
     "https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.8.3/jspdf.plugin.autotable.min.js",
     "https://cdn.jsdelivr.net/npm/jspdf-autotable@3.8.3/dist/jspdf.plugin.autotable.min.js",
-    "https://unpkg.com/jspdf-autotable@3.8.3/dist/jspdf.plugin.autotable.min.js"
+    "https://unpkg.com/jspdf-autotable@3.8.3/dist/jspdf.plugin.autotable.min.js",
+    "/js/vendor/jspdf.plugin.autotable.min.js"
   ];
 
   // small on-page logger (minimally invasive)
@@ -491,12 +493,15 @@ document.addEventListener('DOMContentLoaded', () => setTimeout(runFill, 250));
 
   function loadScript(src, timeout=8000){
     return new Promise((res, rej)=>{
-      if (document.querySelector(`script[src="${src}"]`)) return res("cached");
+      if (document.querySelector(`script[src="${src}"]`)) {
+        log("script cached", src);
+        return res("cached");
+      }
       const s=document.createElement("script");
       s.src=src; s.async=true;
       const t=setTimeout(()=>{ s.remove(); rej(new Error("Timeout "+src)); }, timeout);
-      s.onload=()=>{ clearTimeout(t); res("ok"); };
-      s.onerror=()=>{ clearTimeout(t); rej(new Error("Load error "+src)); };
+      s.onload=()=>{ clearTimeout(t); log("loaded", src); res("ok"); };
+      s.onerror=()=>{ clearTimeout(t); log("load error", src); rej(new Error("Load error "+src)); };
       document.head.appendChild(s);
     });
   }
@@ -516,6 +521,7 @@ document.addEventListener('DOMContentLoaded', () => setTimeout(runFill, 250));
   }
 
   async function ensureAutoTable(){
+    await ensureJsPDF();
     if ((window.jspdf && window.jspdf.autoTable) || (window.jsPDF && window.jsPDF.API && window.jsPDF.API.autoTable)) return;
     for (const u of AT_CDNS){
       try {

--- a/js/vendor/jspdf.plugin.autotable.min.js
+++ b/js/vendor/jspdf.plugin.autotable.min.js
@@ -1,0 +1,15 @@
+/*
+ Placeholder for jsPDF AutoTable plugin.
+ Actual library could not be fetched in this environment.
+ Replace with the real plugin from the official source when building for production.
+*/
+(function(global){
+  global = global || (typeof window !== 'undefined' ? window : this);
+  if (!global.jspdf) global.jspdf = {};
+  global.jspdf.autoTable = function(){
+    console.warn('AutoTable plugin placeholder: real library missing.');
+  };
+  if (global.jsPDF && global.jsPDF.API){
+    global.jsPDF.API.autoTable = global.jspdf.autoTable;
+  }
+})(this);

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,31 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index compatibility.html;
+
+    # Serve compatibility.html for root or missing files
+    location / {
+        try_files $uri $uri/ /compatibility.html;
+    }
+
+    # Cache static assets aggressively
+    location ~* \.(js|css|woff2?|ttf|otf)$ {
+        add_header Cache-Control "public, max-age=31536000, immutable";
+    }
+
+    # Explicit MIME types matching server.mjs
+    types {
+        text/html  html htm;
+        application/javascript  js mjs;
+        text/css  css;
+        application/json json;
+        image/png png;
+        image/jpeg jpg jpeg;
+        image/svg+xml svg;
+        image/x-icon ico;
+        application/pdf pdf;
+        text/plain txt;
+    }
+    default_type application/octet-stream;
+}


### PR DESCRIPTION
## Summary
- ensure jsPDF and AutoTable load with local fallbacks and logging
- add placeholder AutoTable plugin for offline builds
- provide nginx config using compatibility.html as default and caching static assets

## Testing
- `npm test`
- `node server.mjs`

------
https://chatgpt.com/codex/tasks/task_e_68ad0ed9bed8832c827d454155ecdefd