### PR TITLE
Ensure jsPDF exposes global for AutoTable

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -450,16 +450,16 @@ document.addEventListener('DOMContentLoaded', () => setTimeout(runFill, 250));
   const FILE  = "compatibility-dark.pdf";
 
   const JSPDF_CDNS = [
+    "/js/vendor/jspdf.umd.min.js",
     "https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js",
     "https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js",
-    "https://unpkg.com/jspdf@2.5.1/dist/jspdf.umd.min.js",
-    "/js/vendor/jspdf.umd.min.js"
+    "https://unpkg.com/jspdf@2.5.1/dist/jspdf.umd.min.js"
   ];
   const AT_CDNS = [
+    "/js/vendor/jspdf.plugin.autotable.min.js",
     "https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.8.3/jspdf.plugin.autotable.min.js",
     "https://cdn.jsdelivr.net/npm/jspdf-autotable@3.8.3/dist/jspdf.plugin.autotable.min.js",
-    "https://unpkg.com/jspdf-autotable@3.8.3/dist/jspdf.plugin.autotable.min.js",
-    "/js/vendor/jspdf.plugin.autotable.min.js"
+    "https://unpkg.com/jspdf-autotable@3.8.3/dist/jspdf.plugin.autotable.min.js"
   ];
 
   // small on-page logger (minimally invasive)
@@ -507,12 +507,18 @@ document.addEventListener('DOMContentLoaded', () => setTimeout(runFill, 250));
   }
 
   async function ensureJsPDF(){
-    if (window.jspdf && window.jspdf.jsPDF) return;
+    if (window.jspdf && window.jspdf.jsPDF) {
+      window.jsPDF = window.jspdf.jsPDF; // expose for plugins
+      return;
+    }
     for (const u of JSPDF_CDNS){
       try {
         await loadScript(u);
         for (let i=0;i<40;i++){
-          if (window.jspdf && window.jspdf.jsPDF) return;
+          if (window.jspdf && window.jspdf.jsPDF) {
+            window.jsPDF = window.jspdf.jsPDF; // expose for plugins
+            return;
+          }
           await new Promise(r=>setTimeout(r,50));
         }
       } catch (e){ log(e.message); }

--- a/js/helpers/pdfCanvasSnapshot.js
+++ b/js/helpers/pdfCanvasSnapshot.js
@@ -30,6 +30,9 @@ async function ensureLibs() {
     try { await loadScript('/lib/jspdf.umd.min.js'); }
     catch { await loadScript('https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js'); }
   }
+  if (window.jspdf && window.jspdf.jsPDF) {
+    window.jsPDF = window.jspdf.jsPDF; // expose for plugins
+  }
   if (!getJsPDF()) throw new Error('jsPDF failed to load.');
 }
 

--- a/js/loadJsPDF.js
+++ b/js/loadJsPDF.js
@@ -14,7 +14,7 @@ export async function loadJsPDF() {
   if (!window.jspdf || !window.jspdf.jsPDF) {
     throw new Error('jsPDF failed to load');
   }
-
+  window.jsPDF = window.jspdf.jsPDF; // expose global constructor for plugins
   jsPDFLib = window.jspdf.jsPDF;
   return jsPDFLib;
 }

--- a/js/pdfDownload.js
+++ b/js/pdfDownload.js
@@ -44,6 +44,10 @@ async function _ensurePdfLibs() {
     }
   }
 
+  if (window.jspdf && window.jspdf.jsPDF) {
+    window.jsPDF = window.jspdf.jsPDF; // expose for plugins
+  }
+
   let hasAT =
     (window.jspdf && window.jspdf.autoTable) ||
     (window.jsPDF && window.jsPDF.API && window.jsPDF.API.autoTable);


### PR DESCRIPTION
## Summary
- Prioritize local jsPDF and AutoTable sources and expose jsPDF constructor globally
- Update PDF download helpers to set `window.jsPDF` for plugin compatibility
- Adjust jsPDF loader utilities to surface global constructor

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0ddc7c530832cacb075a945ad1b46