### PR TITLE
Add dark theme compatibility report PDF export snippet

### DIFF
--- a/snippet-compatibility-report-dark-pdf-export-row-fix.html
+++ b/snippet-compatibility-report-dark-pdf-export-row-fix.html
@@ -1,0 +1,162 @@
+<!-- COPY/PASTE THIS WHOLE BLOCK just before </body> on your page (or paste into DevTools console). 
+It renders a DARK themed “Talk Kink • Compatibility Report” with white text and thick white grid lines.
+If a PDF showed only the title before, it’s because no rows were being collected — this fixes row extraction. -->
+
+<script>
+(async function TKPDF_DARK_EXPORT() {
+  /* ============== tiny logger ============== */
+  const log = (...a) => console.log("TK Log✕", ...a);
+
+  /* ============== loader ============== */
+  const JS_LOCAL   = "/js/vendor/jspdf.umd.min.js";
+  const AT_LOCAL   = "/js/vendor/jspdf.plugin.autotable.min.js";
+  const JS_CDNS = [
+    "https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js",
+    "https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"
+  ];
+  const AT_CDNS = [
+    "https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.8.3/jspdf.plugin.autotable.min.js",
+    "https://cdn.jsdelivr.net/npm/jspdf-autotable@3.8.3/dist/jspdf.plugin.autotable.min.js"
+  ];
+  const load = (src) => new Promise((res, rej) => {
+    if (document.querySelector(`script[src="${src}"]`)) return res();
+    const s = document.createElement("script");
+    s.src = src; s.async = true;
+    s.onload = res; s.onerror = () => rej(new Error("load fail " + src));
+    document.head.appendChild(s);
+  });
+  async function ensureJsPDF() {
+    if (!(window.jspdf && window.jspdf.jsPDF)) {
+      try { await load(JS_LOCAL); } catch {}
+      if (!(window.jspdf && window.jspdf.jsPDF)) {
+        for (const u of JS_CDNS) { try { await load(u); if (window.jspdf && window.jspdf.jsPDF) break; } catch {} }
+      }
+    }
+    if (!(window.jspdf && window.jspdf.jsPDF)) throw new Error("jsPDF missing");
+    window.jsPDF = window.jspdf.jsPDF; // expose for plugin
+  }
+  async function ensureAutoTable() {
+    let ok = (window.jspdf && window.jspdf.autoTable) || (window.jsPDF && window.jsPDF.API && window.jsPDF.API.autoTable);
+    if (ok) return;
+    try { await load(AT_LOCAL); } catch {}
+    ok = (window.jspdf && window.jspdf.autoTable) || (window.jsPDF && window.jsPDF.API && window.jsPDF.API.autoTable);
+    if (!ok) {
+      for (const u of AT_CDNS) { try { await load(u); ok = (window.jspdf && window.jspdf.autoTable) || (window.jsPDF && window.jsPDF.API && window.jsPDF.API.autoTable); if (ok) break; } catch {} }
+    }
+    if (!ok) throw new Error("AutoTable missing");
+  }
+
+  /* ============== extract rows from the on-page table ============== */
+  const tidy = (s) => (s || "").replace(/\s+/g, " ").trim();
+  const toNum = (v) => { const n = Number(String(v ?? "").replace(/[^\d.-]/g, "")); return Number.isFinite(n) ? n : null; };
+  const clamp2 = (s, perLine = 60) => {
+    const t = tidy(s); if (!t) return "—";
+    if (t.length <= perLine) return t;
+    const a = t.slice(0, perLine).trim(), b = t.slice(perLine).trim();
+    return a + "\n" + (b.length > perLine ? (b.slice(0, perLine - 1).trim() + "…") : b);
+  };
+  function findTable() {
+    return (
+      document.querySelector("#compatibilityTable") ||
+      document.querySelector(".results-table.compat") ||
+      document.querySelector("table")
+    );
+  }
+  function collectRows() {
+    const table = findTable();
+    if (!table) return [];
+    // Skip header rows; use any rows with TDs
+    const trs = [...table.querySelectorAll("tr")].filter(tr => tr.querySelectorAll("td").length > 0 && tr.querySelectorAll("th").length === 0);
+    return trs.map(tr => {
+      const cells = [...tr.querySelectorAll("td")].map(td => tidy(td.textContent));
+      const cat = cells[0] || "—";
+      const nums = cells.map(toNum).filter(n => n !== null);
+      const A = nums.length ? nums[0] : null;
+      const B = nums.length ? nums[nums.length - 1] : null;
+      let pct = cells.find(c => /%$/.test(c)) || null;
+      if (!pct && A != null && B != null) {
+        const p = Math.round(100 - (Math.abs(A - B) / 5) * 100);
+        pct = `${Math.max(0, Math.min(100, p))}%`;
+      }
+      return [clamp2(cat, 60), A ?? "—", pct ?? "—", B ?? "—"];
+    });
+  }
+
+  /* ============== render dark PDF ============== */
+  try {
+    log("Export: start");
+    await ensureJsPDF();
+    await ensureAutoTable();
+
+    const body = collectRows();
+    if (!body.length) {
+      alert("No rows found in the on-page table. Scroll the page until the table is visible, then try again.");
+      return;
+    }
+
+    const { jsPDF } = window.jspdf;
+    const doc = new jsPDF({ orientation: "landscape", unit: "pt", format: "a4" });
+    const pageW = doc.internal.pageSize.getWidth();
+    const pageH = doc.internal.pageSize.getHeight();
+
+    // Paint BLACK background before each page draws:
+    const paintBg = () => { doc.setFillColor(0,0,0); doc.rect(0,0,pageW,pageH,"F"); doc.setTextColor(255,255,255); };
+
+    // Title
+    paintBg();
+    doc.setFontSize(28);
+    doc.text("Talk Kink • Compatibility Report", pageW / 2, 55, { align: "center" });
+
+    const marginLR = 30;
+    const usable = pageW - marginLR * 2;
+    const Awidth = 90, Mwidth = 100, Bwidth = 90;
+    const CatWidth = Math.max(220, usable - (Awidth + Mwidth + Bwidth));
+
+    const runAT = (opts) =>
+      (typeof doc.autoTable === "function") ? doc.autoTable(opts) :
+      (window.jspdf && typeof window.jspdf.autoTable === "function") ? window.jspdf.autoTable(doc, opts) :
+      (() => { throw new Error("AutoTable API not found"); })();
+
+    runAT({
+      head: [["Category", "Partner A", "Match %", "Partner B"]],
+      body,
+      startY: 80,
+      margin: { left: marginLR, right: marginLR, top: 80, bottom: 40 },
+      styles: {
+        fontSize: 11,
+        cellPadding: 6,
+        textColor: [255,255,255],  // white text
+        fillColor: [0,0,0],        // black cells
+        lineColor: [255,255,255],  // white grid
+        lineWidth: 0.9,            // THICK lines
+        overflow: "linebreak",
+        halign: "center",
+        valign: "middle"
+      },
+      headStyles: {
+        fontStyle: "bold",
+        fillColor: [0,0,0],
+        textColor: [255,255,255],
+        lineColor: [255,255,255],
+        lineWidth: 1.2,
+        halign: "center",
+        valign: "middle"
+      },
+      columnStyles: {
+        0: { cellWidth: CatWidth, halign: "left"   }, // Category
+        1: { cellWidth: Awidth,   halign: "center" }, // Partner A
+        2: { cellWidth: Mwidth,   halign: "center" }, // Match %
+        3: { cellWidth: Bwidth,   halign: "center" }  // Partner B
+      },
+      tableWidth: usable,
+      willDrawPage: paintBg   // CRUCIAL: paint bg BEFORE the table on each page
+    });
+
+    doc.save("compatibility-dark.pdf");
+    log("Export: saved compatibility-dark.pdf");
+  } catch (err) {
+    console.error("TK Log✕ Export error", err);
+    alert("PDF export failed: " + (err?.message || err));
+  }
+})();
+</script>


### PR DESCRIPTION
## Summary
- add snippet for dark-themed compatibility PDF export with row extraction fix

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0eb744038832c98611b55b2c7983f