### PR TITLE
Add dark PDF export to compatibility page

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -686,5 +686,182 @@ document.addEventListener('DOMContentLoaded', () => setTimeout(runFill, 250));
 </script>
 
 
+<!--
+PASTE THIS WHOLE BLOCK near the end of compatibility.html (right before </body>).
+It guarantees a BLACK page background, WHITE text, and THICK WHITE grid lines
+for the exported PDF—regardless of site CSS. It also loads jsPDF + AutoTable
+in the correct order and binds the existing #downloadBtn.
+
+If you want the export to run immediately (no button), call TKPDF_exportDark()
+at the very end.
+-->
+<script>
+(() => {
+  const LOG = (...a) => console.log('[TK-PDF]', ...a);
+
+  // --- tiny loader (guarantees order) ---------------------------------------
+  function loadScript(src) {
+    return new Promise((resolve, reject) => {
+      if (document.querySelector(`script[src="${src}"]`)) return resolve();
+      const s = document.createElement('script');
+      s.src = src;
+      s.onload = resolve;
+      s.onerror = () => reject(new Error('Failed to load ' + src));
+      document.head.appendChild(s);
+    });
+  }
+
+  async function ensureLibs() {
+    // 1) jsPDF UMD
+    if (!(window.jspdf && window.jspdf.jsPDF)) {
+      await loadScript('https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js');
+    }
+    // expose jsPDF globally for AutoTable
+    if (!window.jsPDF && window.jspdf && window.jspdf.jsPDF) {
+      window.jsPDF = window.jspdf.jsPDF;
+    }
+    // 2) AutoTable plugin
+    if (!(window.jsPDF && window.jsPDF.API && window.jsPDF.API.autoTable)) {
+      await loadScript('https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.8.3/jspdf.plugin.autotable.min.js');
+    }
+    if (!(window.jsPDF && window.jsPDF.API && window.jsPDF.API.autoTable)) {
+      throw new Error('AutoTable still missing after load');
+    }
+  }
+
+  // --- helpers ---------------------------------------------------------------
+  const tidy = (s) => (s || '').replace(/\s+/g, ' ').trim();
+  const toNum = (v) => {
+    const n = Number(String(v ?? '').replace(/[^\d.-]/g, ''));
+    return Number.isFinite(n) ? n : null;
+  };
+  function clampTwoLines(s, perLine = 60) {
+    const t = tidy(s); if (!t) return '—';
+    if (t.length <= perLine) return t;
+    const a = t.slice(0, perLine).trim();
+    const rest = t.slice(perLine).trim();
+    const b = rest.length > perLine ? rest.slice(0, perLine - 1).trim() + '…' : rest;
+    return a + '\n' + b;
+  }
+  function findTable() {
+    return (
+      document.querySelector('#compatibilityTable') ||
+      document.querySelector('.results-table.compat') ||
+      document.querySelector('table')
+    );
+  }
+  function extractRows() {
+    const table = findTable();
+    if (!table) return [];
+    const trs = [...table.querySelectorAll('tr')]
+      .filter(tr => tr.querySelectorAll('th').length === 0 && tr.querySelectorAll('td').length > 0);
+
+    return trs.map(tr => {
+      const cells = [...tr.querySelectorAll('td')].map(td => tidy(td.textContent));
+      const cat = cells[0] || '—';
+
+      const nums = cells.map(toNum);
+      const numericIdx = nums.map((n, i) => (n !== null ? i : -1)).filter(i => i >= 0);
+      const A = numericIdx.length ? nums[numericIdx[0]] : null;
+      const B = numericIdx.length ? nums[numericIdx[numericIdx.length - 1]] : null;
+
+      let pct = cells.find(c => /%$/.test(c)) || null;
+      if (!pct && A != null && B != null) {
+        const p = Math.round(100 - (Math.abs(A - B) / 5) * 100);
+        pct = `${Math.max(0, Math.min(100, p))}%`;
+      }
+      return [clampTwoLines(cat), A ?? '—', pct ?? '—', B ?? '—'];
+    });
+  }
+
+  // --- DARK export (black page, white text/lines) ----------------------------
+  async function TKPDF_exportDark() {
+    try {
+      await ensureLibs();
+
+      const body = extractRows();
+      if (!body.length) {
+        alert('No rows found to export.');
+        return;
+      }
+
+      const { jsPDF } = window.jspdf || {};
+      const doc = new jsPDF({ orientation: 'landscape', unit: 'pt', format: 'a4' });
+      const pageW = doc.internal.pageSize.getWidth();
+      const pageH = doc.internal.pageSize.getHeight();
+
+      // PAINT BLACK BACKGROUND on every page BEFORE drawing table/content
+      const paintBg = () => {
+        doc.setFillColor(0, 0, 0);
+        doc.rect(0, 0, pageW, pageH, 'F');
+        doc.setTextColor(255, 255, 255);
+      };
+
+      paintBg();
+      doc.setFontSize(26);
+      doc.text('Talk Kink • Compatibility Report', pageW / 2, 44, { align: 'center' });
+
+      // widths: make sure the total fits the page so nothing overflows
+      const marginLR = 30;
+      const usable = pageW - marginLR * 2;
+      const Awidth = 80, Mwidth = 90, Bwidth = 80;
+      const CatWidth = Math.max(200, usable - (Awidth + Mwidth + Bwidth));
+
+      doc.autoTable({
+        head: [['Category', 'Partner A', 'Match %', 'Partner B']],
+        body,
+        startY: 66,
+        margin: { left: marginLR, right: marginLR, top: 66, bottom: 40 },
+        styles: {
+          fontSize: 11,
+          cellPadding: 6,
+          textColor: [255, 255, 255],    // WHITE text
+          fillColor: [0, 0, 0],          // BLACK cells
+          lineColor: [255, 255, 255],    // WHITE grid
+          lineWidth: 1,                  // THICK lines
+          halign: 'center',
+          valign: 'middle',
+          overflow: 'linebreak'
+        },
+        headStyles: {
+          fillColor: [0, 0, 0],
+          textColor: [255, 255, 255],
+          fontStyle: 'bold',
+          lineColor: [255, 255, 255],
+          lineWidth: 1.5
+        },
+        columnStyles: {
+          0: { cellWidth: CatWidth, halign: 'left' },
+          1: { cellWidth: Awidth },
+          2: { cellWidth: Mwidth },
+          3: { cellWidth: Bwidth }
+        },
+        willDrawPage: paintBg // <-- critical: keeps every page BLACK
+      });
+
+      doc.save('compatibility-dark.pdf');
+    } catch (err) {
+      console.error('[TK-PDF] Export failed:', err);
+      alert('PDF export failed: ' + (err?.message || err));
+    }
+  }
+
+  // Bind to your existing button
+  const btn = document.querySelector('#downloadBtn');
+  if (btn) {
+    btn.addEventListener('click', (e) => {
+      e.preventDefault();
+      TKPDF_exportDark();
+    });
+    LOG('Bound Download PDF');
+  } else {
+    LOG('Download button not found; call TKPDF_exportDark() manually if needed.');
+  }
+
+  // Expose for manual trigger if desired
+  window.TKPDF_exportDark = TKPDF_exportDark;
+})();
+</script>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure compatibility table exports to a dark-themed PDF with white text and grid lines

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b397d12638832c8c2f2ca5af6ac4e1