### PR TITLE
Add dark PDF exporter with auto-binding

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -442,103 +442,72 @@
 document.addEventListener('DOMContentLoaded', () => setTimeout(runFill, 250));
 })();
 </script>
+<!-- DARK PDF EXPORT (black page, white text & thick white grid)
+Copy this whole block right before </body>. It auto-binds #downloadBtn
+and exposes TKPDF_forceDark() for the console. -->
 <script>
-/* -----------------------------------------------------------
-   TK PDF — remove log panel + export true-black dark PDF
-   ----------------------------------------------------------- */
+(() => {
+  const LOG = (...a) => console.log('[TK-PDF]', ...a);
+  const USE_WILL = false;
 
-(function () {
-  /* -------- 0) REMOVE “TK Log” PANEL (permanent/instant) ------- */
-  function removeTKLog() {
-    // hide any existing debug/log panel
-    const sels = [
-      '#tk-log', '#tklog', '.tk-log', '[data-tklog]',
-      '.tk-debug-panel', '.tk-pdf-log', '.tkpdf-log'
-    ];
-    for (const sel of sels) {
-      document.querySelectorAll(sel).forEach(el => el.remove());
+  async function loadOneOf(srcs){
+    for(const src of srcs){
+      if(document.querySelector(`script[src="${src}"]`)) return src;
+      try{
+        await new Promise((res,rej)=>{
+          const s=document.createElement('script');
+          s.src=src; s.async=true; s.onload=()=>res(); s.onerror=()=>rej();
+          document.head.appendChild(s);
+        });
+        return src;
+      }catch(_){/* try next */}
     }
-    // if any helper buttons were injected earlier, remove them too
-    const maybeBtns = Array.from(document.querySelectorAll('button,a')).filter(b => {
-      const t = (b.textContent || '').toLowerCase();
-      return /run pdf|rebind download|tk log|tkpdf/.test(t);
-    });
-    maybeBtns.forEach(b => b.remove());
-
-    // also prevent future log panels via CSS (in case another script tries)
-    const css = document.createElement('style');
-    css.textContent = `
-      #tk-log, #tklog, .tk-log, [data-tklog], .tk-debug-panel, .tk-pdf-log, .tkpdf-log { display:none !important; }
-    `;
-    document.head.appendChild(css);
-  }
-  removeTKLog();
-
-  /* -------- 1) LIGHTWEIGHT LOADER (jsPDF + AutoTable) ---------- */
-  const CDN_JSPDF = [
-    '/js/vendor/jspdf.umd.min.js',
-    'https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js',
-    'https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js'
-  ];
-  const CDN_AT = [
-    '/js/vendor/jspdf.plugin.autotable.min.js',
-    'https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.8.3/jspdf.plugin.autotable.min.js',
-    'https://cdn.jsdelivr.net/npm/jspdf-autotable@3.8.3/dist/jspdf.plugin.autotable.min.js'
-  ];
-
-  function loadScript(src) {
-    return new Promise((resolve, reject) => {
-      if (document.querySelector(`script[src="${src}"]`)) return resolve();
-      const s = document.createElement('script');
-      s.src = src;
-      s.onload = resolve;
-      s.onerror = () => reject(new Error('Failed to load ' + src));
-      document.head.appendChild(s);
-    });
+    throw new Error('All script sources failed: '+srcs.join(', '));
   }
 
-  async function ensureLibs() {
-    // jsPDF
-    if (!(window.jspdf && window.jspdf.jsPDF)) {
-      let ok = false;
-      for (const url of CDN_JSPDF) {
-        try { await loadScript(url); ok = !!(window.jspdf && window.jspdf.jsPDF); if (ok) break; } catch {}
-      }
-      if (!ok) throw new Error('jsPDF failed to load');
+  async function ensureLibs(){
+    if(!(window.jspdf && window.jspdf.jsPDF)){
+      LOG('loading jsPDF…');
+      await loadOneOf([
+        '/js/vendor/jspdf.umd.min.js',
+        'https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js',
+        'https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js'
+      ]);
     }
-    // expose jsPDF when using UMD
-    if (!window.jsPDF && window.jspdf && window.jspdf.jsPDF) {
+    if(!window.jsPDF && window.jspdf && window.jspdf.jsPDF){
       window.jsPDF = window.jspdf.jsPDF;
     }
-    // AutoTable
-    const hasAT = !!((window.jspdf && window.jspdf.autoTable) || (window.jsPDF && window.jsPDF.API && window.jsPDF.API.autoTable));
-    if (!hasAT) {
-      let ok = false;
-      for (const url of CDN_AT) {
-        try { await loadScript(url);
-              ok = !!((window.jspdf && window.jspdf.autoTable) || (window.jsPDF && window.jsPDF.API && window.jsPDF.API.autoTable));
-              if (ok) break;
-        } catch {}
-      }
-      if (!ok) throw new Error('jsPDF-AutoTable failed to load');
+    const hasAT =
+      (window.jspdf && window.jspdf.autoTable) ||
+      (window.jsPDF && window.jsPDF.API && window.jsPDF.API.autoTable);
+    if(!hasAT){
+      LOG('loading AutoTable…');
+      await loadOneOf([
+        '/js/vendor/jspdf.plugin.autotable.min.js',
+        'https://cdn.jsdelivr.net/npm/jspdf-autotable@3.8.3/dist/jspdf.plugin.autotable.min.js',
+        'https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.8.3/jspdf.plugin.autotable.min.js'
+      ]);
     }
+    const ok =
+      (window.jspdf && window.jspdf.jsPDF) &&
+      ((window.jspdf && window.jspdf.autoTable) || (window.jsPDF && window.jsPDF.API && window.jsPDF.API.autoTable));
+    if(!ok) throw new Error('jsPDF-AutoTable failed to load');
   }
 
-  /* -------- 2) TABLE PARSE (Category | A | Match % | B) -------- */
-  const tidy = s => (s || '').replace(/\s+/g, ' ').trim();
+  const tidy = s => (s||'').replace(/\s+/g,' ').trim();
   const toNum = v => {
-    const n = Number(String(v ?? '').replace(/[^\d.-]/g, ''));
+    const n = Number(String(v ?? '').replace(/[^\d.-]/g,''));
     return Number.isFinite(n) ? n : null;
   };
   const clampTwo = (s, perLine=60) => {
-    const t = tidy(s); if (!t) return '—';
-    if (t.length <= perLine) return t;
-    const a = t.slice(0, perLine).trim();
-    const b = t.slice(perLine).trim();
-    return a + '\n' + (b.length > perLine ? b.slice(0, perLine-1).trim() + '…' : b);
+    const t = tidy(s); if(!t) return '—';
+    if(t.length<=perLine) return t;
+    const a=t.slice(0,perLine).trim();
+    const rest=t.slice(perLine).trim();
+    return a+'\n'+(rest.length>perLine ? rest.slice(0,perLine-1).trim()+'…' : rest);
   };
 
-  function findTable() {
+  function findTable(){
     return (
       document.querySelector('#compatibilityTable') ||
       document.querySelector('.results-table.compat') ||
@@ -546,130 +515,98 @@ document.addEventListener('DOMContentLoaded', () => setTimeout(runFill, 250));
     );
   }
 
-  function getRows() {
-    const table = findTable();
-    if (!table) return [];
-    const trs = [...table.querySelectorAll('tr')]
-      .filter(tr => tr.querySelectorAll('th').length === 0 && tr.querySelectorAll('td').length > 0);
-
-    const rows = [];
-    for (const tr of trs) {
-      const cells = [...tr.querySelectorAll('td')].map(td => tidy(td.textContent));
-      if (!cells.length) continue;
-
-      const cat = cells[0] || '—';
-      const nums = cells.map(toNum).filter(n => n !== null);
-      const A = nums.length ? nums[0] : null;
-      const B = nums.length ? nums[nums.length - 1] : null;
-
-      let pct = cells.find(c => /%$/.test(c));
-      if (!pct && A != null && B != null) {
-        const p = Math.round(100 - (Math.abs(A - B) / 5) * 100);
-        pct = `${Math.max(0, Math.min(100, p))}%`;
+  function extractRows(){
+    const table=findTable();
+    if(!table) return [];
+    const trs=[...table.querySelectorAll('tr')]
+      .filter(tr => tr.querySelectorAll('th').length===0 && tr.querySelectorAll('td').length>0);
+    return trs.map(tr=>{
+      const cells=[...tr.querySelectorAll('td')].map(td=>tidy(td.textContent));
+      const cat=cells[0]||'—';
+      const numsIdx=cells.map((c,i)=>toNum(c)!==null?i:-1).filter(i=>i>=0);
+      const A = numsIdx.length ? toNum(cells[numsIdx[0]]) : null;
+      const B = numsIdx.length ? toNum(cells[numsIdx[numsIdx.length-1]]) : null;
+      let pct=cells.find(c=>/%$/.test(c))||null;
+      if(!pct && A!=null && B!=null){
+        const p=Math.round(100 - (Math.abs(A-B)/5)*100);
+        pct=`${Math.max(0,Math.min(100,p))}%`;
       }
-
-      rows.push([clampTwo(cat, 60), A ?? '—', pct ?? '—', B ?? '—']);
-    }
-    return rows;
-  }
-
-  /* -------- 3) DARK PDF (full black page, white lines/text) ---- */
-  async function TKPDF_dark() {
-    await ensureLibs();
-
-    const body = getRows();
-    if (!body.length) {
-      alert('No rows found to export.');
-      return;
-    }
-
-    const jsPDFCtor = (window.jspdf && window.jspdf.jsPDF) ? window.jspdf.jsPDF : window.jsPDF;
-    const doc = new jsPDFCtor({ orientation: 'landscape', unit: 'pt', format: 'a4' });
-
-    const pageW = doc.internal.pageSize.getWidth();
-    const pageH = doc.internal.pageSize.getHeight();
-
-    // Paint the ENTIRE page black (overscan a little to avoid faint edges)
-    function paintPageBlack(d) {
-      d.setFillColor(0, 0, 0);
-      d.rect(-5, -5, pageW + 10, pageH + 10, 'F');
-      d.setTextColor(255, 255, 255);
-    }
-
-    // Title (we draw it after painting bg on first page)
-    paintPageBlack(doc);
-    doc.setFontSize(28);
-    doc.text('Talk Kink • Compatibility Report', pageW / 2, 48, { align: 'center' });
-
-    const marginLR = 40;
-    const usable = pageW - marginLR * 2;
-    const Awidth = 90, Mwidth = 100, Bwidth = 90;
-    const reserved = Awidth + Mwidth + Bwidth;
-    const CatWidth = Math.max(240, usable - reserved);
-
-    // prefer native doc.autoTable when present
-    const runAT = (opts) => (typeof doc.autoTable === 'function')
-      ? doc.autoTable(opts)
-      : (window.jspdf && typeof window.jspdf.autoTable === 'function')
-        ? window.jspdf.autoTable(doc, opts)
-        : (() => { throw new Error('AutoTable not available'); })();
-
-    runAT({
-      head: [['Category', 'Partner A', 'Match %', 'Partner B']],
-      body,
-      startY: 70,
-      margin: { left: marginLR, right: marginLR, top: 70, bottom: 40 },
-      // Theme grid but force all fills to pure black; thick white strokes
-      styles: {
-        fontSize: 12,
-        fontStyle: 'normal',
-        cellPadding: 7,
-        textColor: [255, 255, 255],
-        fillColor: [0, 0, 0],
-        lineColor: [255, 255, 255],
-        lineWidth: 1.2,
-        overflow: 'linebreak',
-        halign: 'center',
-        valign: 'middle'
-      },
-      headStyles: {
-        fillColor: [0, 0, 0],
-        textColor: [255, 255, 255],
-        fontStyle: 'bold',
-        lineColor: [255, 255, 255],
-        lineWidth: 1.4,
-        halign: 'center',
-        valign: 'middle'
-      },
-      bodyStyles: {
-        fillColor: [0, 0, 0],
-        textColor: [255, 255, 255]
-      },
-      alternateRowStyles: { fillColor: [0, 0, 0] }, // no zebra
-      tableLineColor: [255, 255, 255],
-      tableLineWidth: 1.4,
-      theme: 'grid',
-      columnStyles: {
-        0: { cellWidth: CatWidth, halign: 'left'   }, // Category
-        1: { cellWidth: Awidth,   halign: 'center' }, // Partner A
-        2: { cellWidth: Mwidth,   halign: 'center' }, // Match %
-        3: { cellWidth: Bwidth,   halign: 'center' }  // Partner B
-      },
-      tableWidth: usable,
-      // Draw black page before anything on every page
-      willDrawPage: () => paintPageBlack(doc)
+      return [clampTwo(cat,60), A??'—', pct??'—', B??'—'];
     });
-
-    doc.save('compatibility-dark.pdf');
   }
 
-  // Expose a manual trigger for you
-  window.TKPDF_forceDark = TKPDF_dark;
+  async function TKPDF_export(){
+    try{
+      await ensureLibs();
+      const { jsPDF } = window.jspdf || window;
+      const doc = new jsPDF({orientation:'landscape', unit:'pt', format:'a4'});
+      const pageW = doc.internal.pageSize.getWidth();
+      const pageH = doc.internal.pageSize.getHeight();
+      const rows = extractRows();
+      if(!rows.length){ alert('No rows found to export.'); return; }
+      const paintBg = () => {
+        doc.setFillColor(0,0,0);
+        doc.rect(0,0,pageW,pageH,'F');
+        doc.setTextColor(255,255,255);
+      };
+      paintBg();
+      doc.setFontSize(28);
+      doc.text('Talk Kink • Compatibility Report', pageW/2, 52, {align:'center'});
+      const useAT = (opts)=>{
+        if(typeof doc.autoTable==='function') return doc.autoTable(opts);
+        if(window.jspdf && typeof window.jspdf.autoTable==='function') return window.jspdf.autoTable(doc, opts);
+        throw new Error('AutoTable not available');
+      };
+      const marginLR=36, usable=pageW-marginLR*2;
+      const wA=96, wM=110, wB=96, wCat=Math.max(260, usable-(wA+wM+wB));
+      const hooks = USE_WILL ? { willDrawPage: paintBg } : { didDrawPage: paintBg };
+      useAT({
+        head: [['Category','Partner A','Match %','Partner B']],
+        body: rows,
+        startY: 76,
+        margin: { left: marginLR, right: marginLR, top: 76, bottom: 40 },
+        styles: {
+          fontSize: 12,
+          cellPadding: 6,
+          textColor: [255,255,255],
+          fillColor: [0,0,0],
+          lineColor: [255,255,255],
+          lineWidth: 1.25,
+          overflow: 'linebreak',
+          halign: 'center',
+          valign: 'middle'
+        },
+        headStyles: {
+          fillColor: [0,0,0],
+          textColor: [255,255,255],
+          fontStyle: 'bold',
+          lineColor: [255,255,255],
+          lineWidth: 1.5,
+          halign: 'center'
+        },
+        columnStyles: {
+          0:{cellWidth:wCat, halign:'left'},
+          1:{cellWidth:wA,  halign:'center'},
+          2:{cellWidth:wM,  halign:'center'},
+          3:{cellWidth:wB,  halign:'center'}
+        },
+        tableWidth: usable,
+        ...hooks
+      });
+      doc.save('compatibility-dark.pdf');
+    }catch(err){
+      console.error('[TK-PDF] Export failed:', err);
+      alert('PDF export failed: ' + (err?.message || err));
+    }
+  }
 
-  // Bind button if present
+  window.TKPDF_forceDark = TKPDF_export;
   const btn = document.querySelector('#downloadBtn');
-  if (btn) {
-    btn.onclick = (e) => { e.preventDefault(); TKPDF_dark(); };
+  if(btn){
+    btn.addEventListener('click', e => { e.preventDefault(); TKPDF_export(); });
+    LOG('Bound Download PDF');
+  }else{
+    LOG('No #downloadBtn found; use TKPDF_forceDark() from console.');
   }
 })();
 </script>

--- a/snippet-compatibility-report-dark-pdf-export-drop-in.html
+++ b/snippet-compatibility-report-dark-pdf-export-drop-in.html
@@ -1,113 +1,69 @@
-<!--
-DROP-IN DARK PDF EXPORTER (Talk Kink • Compatibility Report)
-============================================================
-
-How to use (copy/paste this whole <script> block just before </body>):
-
-1) Make sure your page renders the table you want to export.
-   The script will look for (in this order):
-     - #compatibilityTable
-     - .results-table.compat
-     - the first <table> on the page
-
-2) Optional: add a button with id="downloadBtn" to trigger the export:
-     <button id="downloadBtn">Download PDF</button>
-
-3) That’s it. The script will:
-   • Auto-load jsPDF + AutoTable (local /js/vendor first, then CDN fallbacks)
-   • Build a landscape A4 PDF with a solid BLACK background
-   • Draw WHITE text and THICK WHITE grid lines
-   • Keep Category | Partner A | Match % | Partner B column order
-   • Bind the button automatically
-   • Expose a console helper: TKPDF_forceDark()
-
-If you don’t want a button, open DevTools and run:
-   TKPDF_forceDark();
-
-------------------------------------------------------------------------
--->
+<!-- DARK PDF EXPORT (black page, white text & thick white grid)
+Copy this whole block right before </body>. It auto-binds #downloadBtn
+and exposes TKPDF_forceDark() for the console. -->
 <script>
 (() => {
-  // ---------- Tiny console logger ----------
   const LOG = (...a) => console.log('[TK-PDF]', ...a);
+  const USE_WILL = false;
 
-  // ---------- Robust loader with local+CDN fallbacks ----------
-  async function loadOneOf(urls) {
-    for (const src of urls) {
-      if (document.querySelector(`script[src="${src}"]`)) {
-        await new Promise(r => setTimeout(r, 0)); // already in DOM
-        return src;
-      }
-      try {
-        await new Promise((resolve, reject) => {
-          const s = document.createElement('script');
-          s.src = src;
-          s.async = true;
-          s.onload = () => resolve();
-          s.onerror = () => reject(new Error('load failed: ' + src));
+  async function loadOneOf(srcs){
+    for(const src of srcs){
+      if(document.querySelector(`script[src="${src}"]`)) return src;
+      try{
+        await new Promise((res,rej)=>{
+          const s=document.createElement('script');
+          s.src=src; s.async=true; s.onload=()=>res(); s.onerror=()=>rej();
           document.head.appendChild(s);
         });
         return src;
-      } catch (_) {
-        // try next url
-      }
+      }catch(_){/* try next */}
     }
-    throw new Error('All sources failed: ' + urls.join(', '));
+    throw new Error('All script sources failed: '+srcs.join(', '));
   }
 
-  async function ensureLibs() {
-    // 1) jsPDF (UMD)
-    const jsPDFUrls = [
-      '/js/vendor/jspdf.umd.min.js',
-      'https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js',
-      'https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js'
-    ];
-    if (!(window.jspdf && window.jspdf.jsPDF)) {
-      const used = await loadOneOf(jsPDFUrls);
-      LOG('loaded', used);
+  async function ensureLibs(){
+    if(!(window.jspdf && window.jspdf.jsPDF)){
+      LOG('loading jsPDF…');
+      await loadOneOf([
+        '/js/vendor/jspdf.umd.min.js',
+        'https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js',
+        'https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js'
+      ]);
     }
-    // bridge for the plugin if it expects window.jsPDF
-    if (!window.jsPDF && window.jspdf && window.jspdf.jsPDF) {
+    if(!window.jsPDF && window.jspdf && window.jspdf.jsPDF){
       window.jsPDF = window.jspdf.jsPDF;
     }
-
-    // 2) AutoTable plugin
-    const atUrls = [
-      '/js/vendor/jspdf.plugin.autotable.min.js',
-      'https://cdn.jsdelivr.net/npm/jspdf-autotable@3.8.3/dist/jspdf.plugin.autotable.min.js',
-      'https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.8.3/jspdf.plugin.autotable.min.js'
-    ];
     const hasAT =
       (window.jspdf && window.jspdf.autoTable) ||
       (window.jsPDF && window.jsPDF.API && window.jsPDF.API.autoTable);
-    if (!hasAT) {
-      const used = await loadOneOf(atUrls);
-      LOG('loaded', used);
+    if(!hasAT){
+      LOG('loading AutoTable…');
+      await loadOneOf([
+        '/js/vendor/jspdf.plugin.autotable.min.js',
+        'https://cdn.jsdelivr.net/npm/jspdf-autotable@3.8.3/dist/jspdf.plugin.autotable.min.js',
+        'https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.8.3/jspdf.plugin.autotable.min.js'
+      ]);
     }
-
     const ok =
-      (window.jspdf && window.jspdf.jsPDF &&
-       ((window.jspdf.autoTable) || (window.jsPDF && window.jsPDF.API && window.jsPDF.API.autoTable)));
-    if (!ok) throw new Error('jsPDF-AutoTable failed to load');
+      (window.jspdf && window.jspdf.jsPDF) &&
+      ((window.jspdf && window.jspdf.autoTable) || (window.jsPDF && window.jsPDF.API && window.jsPDF.API.autoTable));
+    if(!ok) throw new Error('jsPDF-AutoTable failed to load');
   }
 
-  // ---------- Table discovery & extraction ----------
-  const tidy = (s) => (s || '').replace(/\s+/g, ' ').trim();
-  const toNum = (v) => {
-    const n = Number(String(v ?? '').replace(/[^\d.-]/g, ''));
+  const tidy = s => (s||'').replace(/\s+/g,' ').trim();
+  const toNum = v => {
+    const n = Number(String(v ?? '').replace(/[^\d.-]/g,''));
     return Number.isFinite(n) ? n : null;
   };
-  const clampTwo = (s, perLine = 60) => {
-    const t = tidy(s);
-    if (!t) return '—';
-    if (t.length <= perLine) return t;
-    const a = t.slice(0, perLine).trim();
-    const bFull = t.slice(perLine).trim();
-    const b = bFull.length > perLine ? (bFull.slice(0, perLine - 1).trim() + '…') : bFull;
-    return a + '\n' + b;
+  const clampTwo = (s, perLine=60) => {
+    const t = tidy(s); if(!t) return '—';
+    if(t.length<=perLine) return t;
+    const a=t.slice(0,perLine).trim();
+    const rest=t.slice(perLine).trim();
+    return a+'\n'+(rest.length>perLine ? rest.slice(0,perLine-1).trim()+'…' : rest);
   };
 
-  function findTable() {
+  function findTable(){
     return (
       document.querySelector('#compatibilityTable') ||
       document.querySelector('.results-table.compat') ||
@@ -115,137 +71,99 @@ If you don’t want a button, open DevTools and run:
     );
   }
 
-  function extractRows() {
-    const table = findTable();
-    if (!table) return [];
-    const trs = [...table.querySelectorAll('tr')]
-      .filter(tr => tr.querySelectorAll('th').length === 0 && tr.querySelectorAll('td').length > 0);
-
-    const out = [];
-    trs.forEach(tr => {
-      const cells = [...tr.querySelectorAll('td')].map(td => tidy(td.textContent));
-      if (!cells.length) return;
-
-      const cat = cells[0] || '—';
-
-      // Numeric detection anywhere in row
-      const numsIdx = cells
-        .map((c, i) => (toNum(c) !== null ? i : -1))
-        .filter(i => i >= 0);
-
+  function extractRows(){
+    const table=findTable();
+    if(!table) return [];
+    const trs=[...table.querySelectorAll('tr')]
+      .filter(tr => tr.querySelectorAll('th').length===0 && tr.querySelectorAll('td').length>0);
+    return trs.map(tr=>{
+      const cells=[...tr.querySelectorAll('td')].map(td=>tidy(td.textContent));
+      const cat=cells[0]||'—';
+      const numsIdx=cells.map((c,i)=>toNum(c)!==null?i:-1).filter(i=>i>=0);
       const A = numsIdx.length ? toNum(cells[numsIdx[0]]) : null;
-      const B = numsIdx.length ? toNum(cells[numsIdx[numsIdx.length - 1]]) : null;
-
-      // Match % from an explicit cell or compute from A/B (0..5 scale)
-      let pctCell = cells.find(c => /%$/.test(c)) || null;
-      if (!pctCell && A != null && B != null) {
-        const p = Math.round(100 - (Math.abs(A - B) / 5) * 100);
-        pctCell = `${Math.max(0, Math.min(100, p))}%`;
+      const B = numsIdx.length ? toNum(cells[numsIdx[numsIdx.length-1]]) : null;
+      let pct=cells.find(c=>/%$/.test(c))||null;
+      if(!pct && A!=null && B!=null){
+        const p=Math.round(100 - (Math.abs(A-B)/5)*100);
+        pct=`${Math.max(0,Math.min(100,p))}%`;
       }
-      if (!pctCell) pctCell = '—';
-
-      out.push([clampTwo(cat, 60), A ?? '—', pctCell, B ?? '—']);
+      return [clampTwo(cat,60), A??'—', pct??'—', B??'—'];
     });
-    return out;
   }
 
-  // ---------- Core export ----------
-  async function TKPDF_export() {
-    try {
+  async function TKPDF_export(){
+    try{
       await ensureLibs();
-
-      const { jsPDF } = window.jspdf || window; // UMD
-      const doc = new jsPDF({ orientation: 'landscape', unit: 'pt', format: 'a4' });
-
+      const { jsPDF } = window.jspdf || window;
+      const doc = new jsPDF({orientation:'landscape', unit:'pt', format:'a4'});
       const pageW = doc.internal.pageSize.getWidth();
       const pageH = doc.internal.pageSize.getHeight();
-
-      const body = extractRows();
-      if (!body.length) {
-        alert('No rows found to export.');
-        return;
-      }
-
-      // Paint black background + white text for each page (BEFORE table draw)
+      const rows = extractRows();
+      if(!rows.length){ alert('No rows found to export.'); return; }
       const paintBg = () => {
-        doc.setFillColor(0, 0, 0);
-        doc.rect(0, 0, pageW, pageH, 'F');
-        doc.setTextColor(255, 255, 255);
+        doc.setFillColor(0,0,0);
+        doc.rect(0,0,pageW,pageH,'F');
+        doc.setTextColor(255,255,255);
       };
-
-      // Title
       paintBg();
       doc.setFontSize(28);
-      doc.text('Talk Kink • Compatibility Report', pageW / 2, 52, { align: 'center' });
-
-      // AutoTable (use willDrawPage so bg is painted first per page)
-      const useAutoTable = (opts) => {
-        if (typeof doc.autoTable === 'function') return doc.autoTable(opts);
-        if (window.jspdf && typeof window.jspdf.autoTable === 'function') {
-          return window.jspdf.autoTable(doc, opts);
-        }
+      doc.text('Talk Kink • Compatibility Report', pageW/2, 52, {align:'center'});
+      const useAT = (opts)=>{
+        if(typeof doc.autoTable==='function') return doc.autoTable(opts);
+        if(window.jspdf && typeof window.jspdf.autoTable==='function') return window.jspdf.autoTable(doc, opts);
         throw new Error('AutoTable not available');
       };
-
-      // Column widths that *fit* the page to avoid “could not fit page”
-      const marginLR = 36;              // generous left/right margin
-      const usable   = pageW - marginLR * 2;
-      const wA = 96, wM = 110, wB = 96; // narrow numeric columns
-      const wCat = Math.max(260, usable - (wA + wM + wB));
-
-      useAutoTable({
-        head: [['Category', 'Partner A', 'Match %', 'Partner B']],
-        body,
+      const marginLR=36, usable=pageW-marginLR*2;
+      const wA=96, wM=110, wB=96, wCat=Math.max(260, usable-(wA+wM+wB));
+      const hooks = USE_WILL ? { willDrawPage: paintBg } : { didDrawPage: paintBg };
+      useAT({
+        head: [['Category','Partner A','Match %','Partner B']],
+        body: rows,
         startY: 76,
         margin: { left: marginLR, right: marginLR, top: 76, bottom: 40 },
         styles: {
           fontSize: 12,
           cellPadding: 6,
-          textColor: [255, 255, 255],   // WHITE text
-          fillColor: [0, 0, 0],         // BLACK cell fill
-          lineColor: [255, 255, 255],   // WHITE grid lines
-          lineWidth: 1.25,              // THICK lines
+          textColor: [255,255,255],
+          fillColor: [0,0,0],
+          lineColor: [255,255,255],
+          lineWidth: 1.25,
           overflow: 'linebreak',
           halign: 'center',
           valign: 'middle'
         },
         headStyles: {
-          fillColor: [0, 0, 0],
-          textColor: [255, 255, 255],
+          fillColor: [0,0,0],
+          textColor: [255,255,255],
           fontStyle: 'bold',
-          lineColor: [255, 255, 255],
+          lineColor: [255,255,255],
           lineWidth: 1.5,
           halign: 'center'
         },
         columnStyles: {
-          0: { cellWidth: wCat, halign: 'left'   }, // Category
-          1: { cellWidth: wA,   halign: 'center' }, // Partner A
-          2: { cellWidth: wM,   halign: 'center' }, // Match %
-          3: { cellWidth: wB,   halign: 'center' }  // Partner B
+          0:{cellWidth:wCat, halign:'left'},
+          1:{cellWidth:wA,  halign:'center'},
+          2:{cellWidth:wM,  halign:'center'},
+          3:{cellWidth:wB,  halign:'center'}
         },
         tableWidth: usable,
-        willDrawPage: paintBg
+        ...hooks
       });
-
       doc.save('compatibility-dark.pdf');
-    } catch (err) {
+    }catch(err){
       console.error('[TK-PDF] Export failed:', err);
-      alert('PDF export failed: ' + (err && err.message ? err.message : err));
+      alert('PDF export failed: ' + (err?.message || err));
     }
   }
 
-  // ---------- Public hook & button binding ----------
   window.TKPDF_forceDark = TKPDF_export;
-
   const btn = document.querySelector('#downloadBtn');
-  if (btn) {
-    btn.onclick = (e) => {
-      e.preventDefault();
-      TKPDF_export();
-    };
+  if(btn){
+    btn.addEventListener('click', e => { e.preventDefault(); TKPDF_export(); });
     LOG('Bound Download PDF');
-  } else {
-    LOG('No #downloadBtn found; use TKPDF_forceDark() in console.');
+  }else{
+    LOG('No #downloadBtn found; use TKPDF_forceDark() from console.');
   }
 })();
 </script>
+

--- a/snippet-compatibility-report-dark-pdf-export.html
+++ b/snippet-compatibility-report-dark-pdf-export.html
@@ -1,125 +1,169 @@
-<!-- ================== TALK KINK DARK PDF EXPORT ==================
-This script makes your compatibility table export to a dark-mode PDF:
-- Black background
-- White text
-- Thick white grid lines
-- Landscape A4
-=============================================================== -->
-
-<!-- 1. Make sure you have a table with either:
-     id="compatibilityTable", or class="results-table compat", or any <table> -->
-<!-- 2. Add a button with id="downloadBtn" if you want a clickable export -->
-<!-- 3. Place this script just before </body>, or paste into DevTools console -->
-
+<!-- DARK PDF EXPORT (black page, white text & thick white grid)
+Copy this whole block right before </body>. It auto-binds #downloadBtn
+and exposes TKPDF_forceDark() for the console. -->
 <script>
-(async function () {
-  console.log("[TK-PDF] Export script initializing...");
+(() => {
+  const LOG = (...a) => console.log('[TK-PDF]', ...a);
+  const USE_WILL = false;
 
-  // ---- Ensure libraries (jsPDF + AutoTable) ----
-  async function loadScript(src) {
-    return new Promise((resolve, reject) => {
-      if (document.querySelector(`script[src="${src}"]`)) return resolve();
-      const s = document.createElement("script");
-      s.src = src;
-      s.onload = resolve;
-      s.onerror = () => reject(new Error("Failed to load " + src));
-      document.head.appendChild(s);
-    });
+  async function loadOneOf(srcs){
+    for(const src of srcs){
+      if(document.querySelector(`script[src="${src}"]`)) return src;
+      try{
+        await new Promise((res,rej)=>{
+          const s=document.createElement('script');
+          s.src=src; s.async=true; s.onload=()=>res(); s.onerror=()=>rej();
+          document.head.appendChild(s);
+        });
+        return src;
+      }catch(_){/* try next */}
+    }
+    throw new Error('All script sources failed: '+srcs.join(', '));
   }
 
-  if (!(window.jspdf && window.jspdf.jsPDF)) {
-    await loadScript("https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js");
-  }
-  if (!((window.jspdf && window.jspdf.autoTable) || (window.jsPDF && window.jsPDF.API && window.jsPDF.API.autoTable))) {
-    await loadScript("https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.8.3/jspdf.plugin.autotable.min.js");
+  async function ensureLibs(){
+    if(!(window.jspdf && window.jspdf.jsPDF)){
+      LOG('loading jsPDF…');
+      await loadOneOf([
+        '/js/vendor/jspdf.umd.min.js',
+        'https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js',
+        'https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js'
+      ]);
+    }
+    if(!window.jsPDF && window.jspdf && window.jspdf.jsPDF){
+      window.jsPDF = window.jspdf.jsPDF;
+    }
+    const hasAT =
+      (window.jspdf && window.jspdf.autoTable) ||
+      (window.jsPDF && window.jsPDF.API && window.jsPDF.API.autoTable);
+    if(!hasAT){
+      LOG('loading AutoTable…');
+      await loadOneOf([
+        '/js/vendor/jspdf.plugin.autotable.min.js',
+        'https://cdn.jsdelivr.net/npm/jspdf-autotable@3.8.3/dist/jspdf.plugin.autotable.min.js',
+        'https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.8.3/jspdf.plugin.autotable.min.js'
+      ]);
+    }
+    const ok =
+      (window.jspdf && window.jspdf.jsPDF) &&
+      ((window.jspdf && window.jspdf.autoTable) || (window.jsPDF && window.jsPDF.API && window.jsPDF.API.autoTable));
+    if(!ok) throw new Error('jsPDF-AutoTable failed to load');
   }
 
-  const { jsPDF } = window.jspdf || window;
+  const tidy = s => (s||'').replace(/\s+/g,' ').trim();
+  const toNum = v => {
+    const n = Number(String(v ?? '').replace(/[^\d.-]/g,''));
+    return Number.isFinite(n) ? n : null;
+  };
+  const clampTwo = (s, perLine=60) => {
+    const t = tidy(s); if(!t) return '—';
+    if(t.length<=perLine) return t;
+    const a=t.slice(0,perLine).trim();
+    const rest=t.slice(perLine).trim();
+    return a+'\n'+(rest.length>perLine ? rest.slice(0,perLine-1).trim()+'…' : rest);
+  };
 
-  // ---- Find table rows ----
-  function findTable() {
+  function findTable(){
     return (
-      document.querySelector("#compatibilityTable") ||
-      document.querySelector(".results-table.compat") ||
-      document.querySelector("table")
+      document.querySelector('#compatibilityTable') ||
+      document.querySelector('.results-table.compat') ||
+      document.querySelector('table')
     );
   }
 
-  function extractRows(table) {
-    const tidy = (s) => (s || "").replace(/\s+/g, " ").trim();
-    const trs = [...table.querySelectorAll("tr")]
-      .filter(tr => tr.querySelectorAll("th").length === 0 && tr.querySelectorAll("td").length > 0);
-
-    return trs.map(tr => {
-      const cells = [...tr.querySelectorAll("td")].map(td => tidy(td.textContent));
-      return [cells[0] || "—", cells[1] || "—", cells[2] || "—", cells[3] || "—"];
+  function extractRows(){
+    const table=findTable();
+    if(!table) return [];
+    const trs=[...table.querySelectorAll('tr')]
+      .filter(tr => tr.querySelectorAll('th').length===0 && tr.querySelectorAll('td').length>0);
+    return trs.map(tr=>{
+      const cells=[...tr.querySelectorAll('td')].map(td=>tidy(td.textContent));
+      const cat=cells[0]||'—';
+      const numsIdx=cells.map((c,i)=>toNum(c)!==null?i:-1).filter(i=>i>=0);
+      const A = numsIdx.length ? toNum(cells[numsIdx[0]]) : null;
+      const B = numsIdx.length ? toNum(cells[numsIdx[numsIdx.length-1]]) : null;
+      let pct=cells.find(c=>/%$/.test(c))||null;
+      if(!pct && A!=null && B!=null){
+        const p=Math.round(100 - (Math.abs(A-B)/5)*100);
+        pct=`${Math.max(0,Math.min(100,p))}%`;
+      }
+      return [clampTwo(cat,60), A??'—', pct??'—', B??'—'];
     });
   }
 
-  // ---- Paint full black background ----
-  function paintBg(doc) {
-    const pageW = doc.internal.pageSize.getWidth();
-    const pageH = doc.internal.pageSize.getHeight();
-    doc.setFillColor(0, 0, 0);
-    doc.rect(0, 0, pageW, pageH, "F");
-    doc.setTextColor(255, 255, 255);
+  async function TKPDF_export(){
+    try{
+      await ensureLibs();
+      const { jsPDF } = window.jspdf || window;
+      const doc = new jsPDF({orientation:'landscape', unit:'pt', format:'a4'});
+      const pageW = doc.internal.pageSize.getWidth();
+      const pageH = doc.internal.pageSize.getHeight();
+      const rows = extractRows();
+      if(!rows.length){ alert('No rows found to export.'); return; }
+      const paintBg = () => {
+        doc.setFillColor(0,0,0);
+        doc.rect(0,0,pageW,pageH,'F');
+        doc.setTextColor(255,255,255);
+      };
+      paintBg();
+      doc.setFontSize(28);
+      doc.text('Talk Kink • Compatibility Report', pageW/2, 52, {align:'center'});
+      const useAT = (opts)=>{
+        if(typeof doc.autoTable==='function') return doc.autoTable(opts);
+        if(window.jspdf && typeof window.jspdf.autoTable==='function') return window.jspdf.autoTable(doc, opts);
+        throw new Error('AutoTable not available');
+      };
+      const marginLR=36, usable=pageW-marginLR*2;
+      const wA=96, wM=110, wB=96, wCat=Math.max(260, usable-(wA+wM+wB));
+      const hooks = USE_WILL ? { willDrawPage: paintBg } : { didDrawPage: paintBg };
+      useAT({
+        head: [['Category','Partner A','Match %','Partner B']],
+        body: rows,
+        startY: 76,
+        margin: { left: marginLR, right: marginLR, top: 76, bottom: 40 },
+        styles: {
+          fontSize: 12,
+          cellPadding: 6,
+          textColor: [255,255,255],
+          fillColor: [0,0,0],
+          lineColor: [255,255,255],
+          lineWidth: 1.25,
+          overflow: 'linebreak',
+          halign: 'center',
+          valign: 'middle'
+        },
+        headStyles: {
+          fillColor: [0,0,0],
+          textColor: [255,255,255],
+          fontStyle: 'bold',
+          lineColor: [255,255,255],
+          lineWidth: 1.5,
+          halign: 'center'
+        },
+        columnStyles: {
+          0:{cellWidth:wCat, halign:'left'},
+          1:{cellWidth:wA,  halign:'center'},
+          2:{cellWidth:wM,  halign:'center'},
+          3:{cellWidth:wB,  halign:'center'}
+        },
+        tableWidth: usable,
+        ...hooks
+      });
+      doc.save('compatibility-dark.pdf');
+    }catch(err){
+      console.error('[TK-PDF] Export failed:', err);
+      alert('PDF export failed: ' + (err?.message || err));
+    }
   }
 
-  // ---- Export function ----
-  async function TKPDF_exportDark() {
-    const table = findTable();
-    if (!table) { alert("No table found."); return; }
-    const body = extractRows(table);
-    if (!body.length) { alert("No rows to export."); return; }
-
-    const doc = new jsPDF({ orientation: "landscape", unit: "pt", format: "a4" });
-    const pageW = doc.internal.pageSize.getWidth();
-
-    paintBg(doc);
-    doc.setFontSize(24);
-    doc.text("Talk Kink • Compatibility Report", pageW / 2, 40, { align: "center" });
-
-    doc.autoTable({
-      head: [["Category", "Partner A", "Match %", "Partner B"]],
-      body,
-      startY: 60,
-      styles: {
-        fontSize: 12,
-        textColor: [255, 255, 255],
-        fillColor: [0, 0, 0],
-        lineColor: [255, 255, 255],
-        lineWidth: 1.2,
-      },
-      headStyles: {
-        fontStyle: "bold",
-        fillColor: [0, 0, 0],
-        textColor: [255, 255, 255],
-        lineColor: [255, 255, 255],
-        lineWidth: 1.5,
-      },
-      columnStyles: {
-        0: { cellWidth: 400, halign: "left" },
-        1: { cellWidth: 80, halign: "center" },
-        2: { cellWidth: 90, halign: "center" },
-        3: { cellWidth: 80, halign: "center" }
-      },
-      willDrawPage: () => paintBg(doc),
-    });
-
-    doc.save("compatibility-dark.pdf");
-  }
-
-  // ---- Bind button and console alias ----
-  window.TKPDF_forceDark = TKPDF_exportDark;
-  const btn = document.querySelector("#downloadBtn");
-  if (btn) {
-    btn.addEventListener("click", (e) => {
-      e.preventDefault();
-      TKPDF_exportDark();
-    });
-    console.log("[TK-PDF] Bound Download PDF button");
-  } else {
-    console.log("[TK-PDF] No button found. Use TKPDF_forceDark() in console.");
+  window.TKPDF_forceDark = TKPDF_export;
+  const btn = document.querySelector('#downloadBtn');
+  if(btn){
+    btn.addEventListener('click', e => { e.preventDefault(); TKPDF_export(); });
+    LOG('Bound Download PDF');
+  }else{
+    LOG('No #downloadBtn found; use TKPDF_forceDark() from console.');
   }
 })();
 </script>
+


### PR DESCRIPTION
## Summary
- replace compatibility page's PDF exporter with robust dark-theme script
- add shareable snippet scripts that auto-load jsPDF & AutoTable and bind #downloadBtn

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3ef618e08832c8175a3efdfb19315