### PR TITLE
Ensure dark PDF exports use uniform black cells

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -580,15 +580,19 @@ A PDF called compatibility-dark.pdf will be downloaded.
           lineColor: [255, 255, 255],
           lineWidth: 1.6,
         },
+        bodyStyles: {
+          fillColor: [0, 0, 0],
+          textColor: [255, 255, 255],
+        },
+        alternateRowStyles: {
+          fillColor: [0, 0, 0],
+          textColor: [255, 255, 255],
+        },
         columnStyles: {
           0: { cellWidth: CatWidth, halign: "left" },
           1: { cellWidth: Awidth, halign: "center" },
           2: { cellWidth: Mwidth, halign: "center" },
           3: { cellWidth: Bwidth, halign: "center" },
-        },
-        didParseCell: (data) => {
-          data.cell.styles.fillColor = [0, 0, 0];
-          data.cell.styles.textColor = [255, 255, 255];
         },
         willDrawPage: paintBg,
       });

--- a/js/downloadCompatibilityPDF.ts
+++ b/js/downloadCompatibilityPDF.ts
@@ -123,6 +123,10 @@ export async function downloadCompatibilityPDF(): Promise<void> {
         lineColor: [255, 255, 255],
         lineWidth: 1.6,
       },
+      bodyStyles: {
+        fillColor: [0, 0, 0],
+        textColor: [255, 255, 255],
+      },
       alternateRowStyles: {
         fillColor: [0, 0, 0],
         textColor: [255, 255, 255],

--- a/js/pdfDownload.js
+++ b/js/pdfDownload.js
@@ -242,6 +242,14 @@ export async function downloadCompatibilityPDF({
       lineColor: [255, 255, 255],
       lineWidth: 0.5
     },
+    bodyStyles: {
+      fillColor: [0, 0, 0],
+      textColor: [255, 255, 255]
+    },
+    alternateRowStyles: {
+      fillColor: [0, 0, 0],
+      textColor: [255, 255, 255]
+    },
     columnStyles: {
       0: { cellWidth: 520, halign: 'left'   }, // Category
       1: { cellWidth:  80, halign: 'center' }, // Partner A

--- a/snippet-compatibility-report-dark-pdf-export-drop-in.html
+++ b/snippet-compatibility-report-dark-pdf-export-drop-in.html
@@ -136,15 +136,19 @@ A PDF called compatibility-dark.pdf will be downloaded.
           lineColor: [255, 255, 255],
           lineWidth: 1.6,
         },
+        bodyStyles: {
+          fillColor: [0, 0, 0],
+          textColor: [255, 255, 255],
+        },
+        alternateRowStyles: {
+          fillColor: [0, 0, 0],
+          textColor: [255, 255, 255],
+        },
         columnStyles: {
           0: { cellWidth: CatWidth, halign: "left" },
           1: { cellWidth: Awidth, halign: "center" },
           2: { cellWidth: Mwidth, halign: "center" },
           3: { cellWidth: Bwidth, halign: "center" },
-        },
-        didParseCell: (data) => {
-          data.cell.styles.fillColor = [0, 0, 0];
-          data.cell.styles.textColor = [255, 255, 255];
         },
         willDrawPage: paintBg,
       });

--- a/snippet-compatibility-report-dark-pdf-export.html
+++ b/snippet-compatibility-report-dark-pdf-export.html
@@ -136,15 +136,19 @@ A PDF called compatibility-dark.pdf will be downloaded.
           lineColor: [255, 255, 255],
           lineWidth: 1.6,
         },
+        bodyStyles: {
+          fillColor: [0, 0, 0],
+          textColor: [255, 255, 255],
+        },
+        alternateRowStyles: {
+          fillColor: [0, 0, 0],
+          textColor: [255, 255, 255],
+        },
         columnStyles: {
           0: { cellWidth: CatWidth, halign: "left" },
           1: { cellWidth: Awidth, halign: "center" },
           2: { cellWidth: Mwidth, halign: "center" },
           3: { cellWidth: Bwidth, halign: "center" },
-        },
-        didParseCell: (data) => {
-          data.cell.styles.fillColor = [0, 0, 0];
-          data.cell.styles.textColor = [255, 255, 255];
         },
         willDrawPage: paintBg,
       });


### PR DESCRIPTION
## Summary
- force AutoTable to fill all body rows with black to prevent white stripes in dark PDF exports
- add matching `bodyStyles` and `alternateRowStyles` to snippets and modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb687ca964832ca66b2b8497fe052e