### PR TITLE
feat: ignore header-like rows when extracting table data

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -493,6 +493,7 @@ A PDF called compatibility-dark.pdf will be downloaded.
     const n = Number(String(v ?? "").replace(/[^\d.-]/g, ""));
     return Number.isFinite(n) ? n : null;
   };
+  const isValidScore = (n) => Number.isInteger(n) && n >= 1 && n <= 5;
 
   function findTable() {
     return (
@@ -503,22 +504,44 @@ A PDF called compatibility-dark.pdf will be downloaded.
   }
 
   function extractRows(table) {
+    // rows that have <td> cells (some sites use <td> for headers)
     const trs = [...table.querySelectorAll("tr")].filter(
-      (tr) => tr.querySelectorAll("th").length === 0 && tr.querySelectorAll("td").length > 0
+      (tr) => tr.querySelectorAll("td").length > 0
     );
-    return trs.map((tr) => {
+
+    const isHeaderLike = (cellTexts) => {
+      const first = (cellTexts[0] || "").toLowerCase();
+      const joined = cellTexts.map((t) => (t || "").toLowerCase()).join(" | ");
+      if (first === "category") return true;
+      if (/partner a|partner b|match/.test(joined)) return true;
+      if (!cellTexts.some((t) => /\S/.test(t))) return true;
+      return false;
+    };
+
+    const rows = [];
+    for (const tr of trs) {
       const cells = [...tr.querySelectorAll("td")].map((td) => tidy(td.textContent));
+      if (!cells.length) continue;
+      if (isHeaderLike(cells)) continue;
+
       const category = cells[0] || "—";
-      const nums = cells.map(toNum).filter((n) => n !== null);
-      const A = nums.length ? nums[0] : null;
-      const B = nums.length ? nums[nums.length - 1] : null;
+      const numeric = cells.map(toNum).filter((n) => n !== null);
+      const Araw = numeric.length ? numeric[0] : null;
+      const Braw = numeric.length ? numeric[numeric.length - 1] : null;
+
+      const aValid = isValidScore(Araw);
+      const bValid = isValidScore(Braw);
+
       let pct = cells.find((c) => /%$/.test(c)) || null;
-      if (!pct && A != null && B != null) {
-        const p = Math.round(100 - (Math.abs(A - B) / 5) * 100);
+      if (!pct && aValid && bValid) {
+        const p = Math.round(100 - (Math.abs(Araw - Braw) / 5) * 100);
         pct = `${Math.max(0, Math.min(100, p))}%`;
       }
-      return [category, A ?? "—", pct ?? "—", B ?? "—"];
-    });
+      if (!pct) pct = "—";
+
+      rows.push([category, aValid ? Araw : "—", pct, bValid ? Braw : "—"]);
+    }
+    return rows;
   }
 
   async function TKPDF_exportDark() {

--- a/snippet-compatibility-report-dark-pdf-export-click.html
+++ b/snippet-compatibility-report-dark-pdf-export-click.html
@@ -83,6 +83,7 @@ This snippet:
     const n = Number(String(v ?? '').replace(/[^\d.-]/g, ''));
     return Number.isFinite(n) ? n : null;
   };
+  const isValidScore = (n) => Number.isInteger(n) && n >= 1 && n <= 5;
   function clampTwoLines(s, perLine = 60) {
     const t = tidy(s);
     if (!t) return '—';
@@ -105,26 +106,48 @@ This snippet:
     const table = findTable();
     if (!table) return [];
     const trs = [...table.querySelectorAll('tr')]
-      .filter(tr => tr.querySelectorAll('th').length === 0 && tr.querySelectorAll('td').length > 0);
+      .filter(tr => tr.querySelectorAll('td').length > 0);
 
-    return trs.map(tr => {
+    const isHeaderLike = (cellTexts) => {
+      const first = (cellTexts[0] || '').toLowerCase();
+      const joined = cellTexts.map(t => (t || '').toLowerCase()).join(' | ');
+      if (first === 'category') return true;
+      if (/partner a|partner b|match/.test(joined)) return true;
+      if (!cellTexts.some(t => /\S/.test(t))) return true;
+      return false;
+    };
+
+    const rows = [];
+    for (const tr of trs) {
       const cells = [...tr.querySelectorAll('td')].map(td => tidy(td.textContent));
+      if (!cells.length) continue;
+      if (isHeaderLike(cells)) continue;
       const cat = cells[0] || '—';
 
-      // Identify first and last numeric cells for A/B
       const nums = cells.map(toNum);
-      const idx = nums.map((n, i) => (n !== null ? i : -1)).filter(i => i >= 0);
-      const A = idx.length ? nums[idx[0]] : null;
-      const B = idx.length ? nums[idx[idx.length - 1]] : null;
+      const numeric = nums.filter(n => n !== null);
+      const Araw = numeric.length ? numeric[0] : null;
+      const Braw = numeric.length ? numeric[numeric.length - 1] : null;
 
-      // Match % from row OR compute if A/B present
+      const aValid = isValidScore(Araw);
+      const bValid = isValidScore(Braw);
+
       let pct = cells.find(c => /%$/.test(c)) || null;
-      if (!pct && A != null && B != null) {
-        const p = Math.round(100 - (Math.abs(A - B) / 5) * 100);
+      if (!pct && aValid && bValid) {
+        const p = Math.round(100 - (Math.abs(Araw - Braw) / 5) * 100);
         pct = `${Math.max(0, Math.min(100, p))}%`;
       }
-      return [clampTwoLines(cat, 60), A ?? '—', pct ?? '—', B ?? '—'];
-    });
+      if (!pct) pct = '—';
+
+      rows.push([
+        clampTwoLines(cat, 60),
+        aValid ? Araw : '—',
+        pct,
+        bValid ? Braw : '—'
+      ]);
+    }
+
+    return rows;
   }
 
   /* ------------------------------- PDF export ------------------------------ */

--- a/snippet-compatibility-report-dark-pdf-export-configurable.html
+++ b/snippet-compatibility-report-dark-pdf-export-configurable.html
@@ -32,6 +32,11 @@
   // ---------------- utilities ----------------
   const log = (...a)=>console.log("[TK-DARK]", ...a);
   const tidy = s => (s||"").replace(/\s+/g," ").trim();
+  const toNum = v => {
+    const n = Number(String(v ?? "").replace(/[^\d.-]/g,""));
+    return Number.isFinite(n) ? n : null;
+  };
+  const isValidScore = n => Number.isInteger(n) && n >= 1 && n <= 5;
 
   function loadScript(src){
     return new Promise((res,rej)=>{
@@ -76,24 +81,45 @@
   }
 
   function extractRows(table){
-    // use only TRs with TDs and no THs
-    const trs = [...table.querySelectorAll("tr")]
-      .filter(tr => tr.querySelectorAll("td").length && tr.querySelectorAll("th").length===0);
+    // rows that have <td> cells (some sites use <td> for headers)
+    const trs = [...table.querySelectorAll("tr")] 
+      .filter(tr => tr.querySelectorAll("td").length > 0);
 
-    const rows = trs.map(tr => {
+    const isHeaderLike = (cellTexts) => {
+      const first = (cellTexts[0] || "").toLowerCase();
+      const joined = cellTexts.map(t => (t || "").toLowerCase()).join(" | ");
+      if (first === "category") return true;
+      if (/partner a|partner b|match/.test(joined)) return true;
+      if (!cellTexts.some(t => /\S/.test(t))) return true;
+      return false;
+    };
+
+    const rows = [];
+    for (const tr of trs){
       const tds = [...tr.querySelectorAll("td")].map(td => tidy(td.textContent));
+      if (!tds.length) continue;
+      if (isHeaderLike(tds)) continue;
+
       const cat = tds[0] ?? "—";
+      const numeric = tds.map(toNum).filter(n => n !== null);
+      const Araw = numeric.length ? numeric[0] : null;
+      const Braw = numeric.length ? numeric[numeric.length-1] : null;
 
-      // try to infer Partner A / B as first/last numbers
-      const nums = tds.map((v,i)=>({i, n: Number(String(v).replace(/[^\d.-]/g,""))}))
-                      .filter(x=>Number.isFinite(x.n));
-      const a = nums.length ? String(nums[0].n) : "—";
-      const b = nums.length ? String(nums[nums.length-1].n) : "—";
+      const aValid = isValidScore(Araw);
+      const bValid = isValidScore(Braw);
 
-      // match % cell if present
-      const m = tds.find(v=>/%$/.test(v)) || "—";
-      return [cat, a, m, b];
-    });
+      const a = aValid && Araw !== null ? String(Araw) : "—";
+      const b = bValid && Braw !== null ? String(Braw) : "—";
+
+      let m = tds.find(v=>/%$/.test(v)) || null;
+      if (!m && aValid && bValid){
+        const p = Math.round(100 - (Math.abs(Araw - Braw) / 5) * 100);
+        m = `${Math.max(0, Math.min(100, p))}%`;
+      }
+      if (!m) m = "—";
+
+      rows.push([cat, a, m, b]);
+    }
 
     return rows;
   }

--- a/snippet-compatibility-report-dark-pdf-export-drop-in.html
+++ b/snippet-compatibility-report-dark-pdf-export-drop-in.html
@@ -49,6 +49,7 @@ A PDF called compatibility-dark.pdf will be downloaded.
     const n = Number(String(v ?? "").replace(/[^\d.-]/g, ""));
     return Number.isFinite(n) ? n : null;
   };
+  const isValidScore = (n) => Number.isInteger(n) && n >= 1 && n <= 5;
 
   function findTable() {
     return (
@@ -59,22 +60,45 @@ A PDF called compatibility-dark.pdf will be downloaded.
   }
 
   function extractRows(table) {
+    // rows that have <td> cells (some sites use <td> for headers)
     const trs = [...table.querySelectorAll("tr")].filter(
-      (tr) => tr.querySelectorAll("th").length === 0 && tr.querySelectorAll("td").length > 0
+      (tr) => tr.querySelectorAll("td").length > 0
     );
-    return trs.map((tr) => {
+
+    const isHeaderLike = (cellTexts) => {
+      const first = (cellTexts[0] || "").toLowerCase();
+      const joined = cellTexts.map((t) => (t || "").toLowerCase()).join(" | ");
+      if (first === "category") return true;
+      if (/partner a|partner b|match/.test(joined)) return true;
+      if (!cellTexts.some((t) => /\S/.test(t))) return true;
+      return false;
+    };
+
+    const rows = [];
+    for (const tr of trs) {
       const cells = [...tr.querySelectorAll("td")].map((td) => tidy(td.textContent));
+      if (!cells.length) continue;
+      if (isHeaderLike(cells)) continue;
+
       const category = cells[0] || "—";
-      const nums = cells.map(toNum).filter((n) => n !== null);
-      const A = nums.length ? nums[0] : null;
-      const B = nums.length ? nums[nums.length - 1] : null;
+      const numeric = cells.map(toNum).filter((n) => n !== null);
+      const Araw = numeric.length ? numeric[0] : null;
+      const Braw = numeric.length ? numeric[numeric.length - 1] : null;
+
+      const aValid = isValidScore(Araw);
+      const bValid = isValidScore(Braw);
+
       let pct = cells.find((c) => /%$/.test(c)) || null;
-      if (!pct && A != null && B != null) {
-        const p = Math.round(100 - (Math.abs(A - B) / 5) * 100);
+      if (!pct && aValid && bValid) {
+        const p = Math.round(100 - (Math.abs(Araw - Braw) / 5) * 100);
         pct = `${Math.max(0, Math.min(100, p))}%`;
       }
-      return [category, A ?? "—", pct ?? "—", B ?? "—"];
-    });
+      if (!pct) pct = "—";
+
+      rows.push([category, aValid ? Araw : "—", pct, bValid ? Braw : "—"]);
+    }
+
+    return rows;
   }
 
   async function TKPDF_exportDark() {

--- a/snippet-compatibility-report-dark-pdf-export-keep-layout.html
+++ b/snippet-compatibility-report-dark-pdf-export-keep-layout.html
@@ -57,28 +57,35 @@ How to use:
 
   // Parse table rows into structured objects
   function extractRows(table) {
-    const trs = [...table.querySelectorAll("tr")].filter(tr => {
-      const ths = tr.querySelectorAll("th").length;
-      const tds = tr.querySelectorAll("td").length;
-      return ths === 0 && tds > 0;
-    });
+    // rows that have <td> cells (some sites use <td> for headers)
+    const trs = [...table.querySelectorAll("tr")].filter(tr =>
+      tr.querySelectorAll("td").length > 0
+    );
+
+    const isHeaderLike = (cellTexts) => {
+      const first = (cellTexts[0] || "").toLowerCase();
+      const joined = cellTexts.map(t => (t || "").toLowerCase()).join(" | ");
+      if (first === "category") return true;
+      if (/partner a|partner b|match/.test(joined)) return true;
+      if (!cellTexts.some(t => /\S/.test(t))) return true;
+      return false;
+    };
 
     const rows = [];
     for (const tr of trs) {
       const cells = [...tr.querySelectorAll("td")].map(td => tidy(td.textContent));
       if (!cells.length) continue;
+      if (isHeaderLike(cells)) continue;
 
       const category = cells[0] || "—";
 
-      // locate numeric answers (not strictly “columns 2 & 4” — we scan)
-      const nums = cells.map(toNum).filter(n => n !== null);
-      const Araw = nums[0] ?? null;
-      const Braw = nums.length ? nums[nums.length - 1] : null;
+      const numeric = cells.map(toNum).filter(n => n !== null);
+      const Araw = numeric.length ? numeric[0] : null;
+      const Braw = numeric.length ? numeric[numeric.length - 1] : null;
 
       const aValid = isValidScore(Araw);
       const bValid = isValidScore(Braw);
 
-      // existing percent cell or compute if both valid
       let pct = cells.find(c => /%$/.test(c)) || null;
       if (!pct && aValid && bValid) {
         const p = Math.round(100 - (Math.abs(Araw - Braw) / 5) * 100);
@@ -90,7 +97,8 @@ How to use:
         category,
         A: aValid ? Araw : null,   // null if invalid/blank/0
         B: bValid ? Braw : null,
-        aValid, bValid,
+        aValid,
+        bValid,
         pct
       });
     }

--- a/snippet-compatibility-report-dark-pdf-export.html
+++ b/snippet-compatibility-report-dark-pdf-export.html
@@ -49,6 +49,7 @@ A PDF called compatibility-dark.pdf will be downloaded.
     const n = Number(String(v ?? "").replace(/[^\d.-]/g, ""));
     return Number.isFinite(n) ? n : null;
   };
+  const isValidScore = (n) => Number.isInteger(n) && n >= 1 && n <= 5;
 
   function findTable() {
     return (
@@ -59,22 +60,45 @@ A PDF called compatibility-dark.pdf will be downloaded.
   }
 
   function extractRows(table) {
+    // rows that have <td> cells (some sites use <td> for headers)
     const trs = [...table.querySelectorAll("tr")].filter(
-      (tr) => tr.querySelectorAll("th").length === 0 && tr.querySelectorAll("td").length > 0
+      (tr) => tr.querySelectorAll("td").length > 0
     );
-    return trs.map((tr) => {
+
+    const isHeaderLike = (cellTexts) => {
+      const first = (cellTexts[0] || "").toLowerCase();
+      const joined = cellTexts.map((t) => (t || "").toLowerCase()).join(" | ");
+      if (first === "category") return true;
+      if (/partner a|partner b|match/.test(joined)) return true;
+      if (!cellTexts.some((t) => /\S/.test(t))) return true;
+      return false;
+    };
+
+    const rows = [];
+    for (const tr of trs) {
       const cells = [...tr.querySelectorAll("td")].map((td) => tidy(td.textContent));
+      if (!cells.length) continue;
+      if (isHeaderLike(cells)) continue;
+
       const category = cells[0] || "—";
-      const nums = cells.map(toNum).filter((n) => n !== null);
-      const A = nums.length ? nums[0] : null;
-      const B = nums.length ? nums[nums.length - 1] : null;
+      const numeric = cells.map(toNum).filter((n) => n !== null);
+      const Araw = numeric.length ? numeric[0] : null;
+      const Braw = numeric.length ? numeric[numeric.length - 1] : null;
+
+      const aValid = isValidScore(Araw);
+      const bValid = isValidScore(Braw);
+
       let pct = cells.find((c) => /%$/.test(c)) || null;
-      if (!pct && A != null && B != null) {
-        const p = Math.round(100 - (Math.abs(A - B) / 5) * 100);
+      if (!pct && aValid && bValid) {
+        const p = Math.round(100 - (Math.abs(Araw - Braw) / 5) * 100);
         pct = `${Math.max(0, Math.min(100, p))}%`;
       }
-      return [category, A ?? "—", pct ?? "—", B ?? "—"];
-    });
+      if (!pct) pct = "—";
+
+      rows.push([category, aValid ? Araw : "—", pct, bValid ? Braw : "—"]);
+    }
+
+    return rows;
   }
 
   async function TKPDF_exportDark() {

--- a/snippet-compatibility-report-pdf-export-fix.html
+++ b/snippet-compatibility-report-pdf-export-fix.html
@@ -113,14 +113,53 @@ or
   }
 
   // === Method 2: DATA EXPORT (AutoTable, vector text, faster) ===
+  const tidy = (s) => (s || '').replace(/\s+/g, ' ').trim();
+  const toNum = (v) => {
+    const n = Number(String(v ?? '').replace(/[^\d.-]/g, ''));
+    return Number.isFinite(n) ? n : null;
+  };
+  const isValidScore = (n) => Number.isInteger(n) && n >= 1 && n <= 5;
   function extractRows() {
     const table = document.querySelector('#compatibilityTable')
                || document.querySelector('table.results-table.compat')
                || document.querySelector('table');
     if (!table) return [];
     const trs = [...table.querySelectorAll('tr')]
-      .filter(tr => tr.querySelectorAll('th').length === 0 && tr.querySelectorAll('td').length > 0);
-    return trs.map(tr => [...tr.querySelectorAll('td')].map(td => td.textContent.trim()));
+      .filter(tr => tr.querySelectorAll('td').length > 0);
+
+    const isHeaderLike = (cellTexts) => {
+      const first = (cellTexts[0] || '').toLowerCase();
+      const joined = cellTexts.map(t => (t || '').toLowerCase()).join(' | ');
+      if (first === 'category') return true;
+      if (/partner a|partner b|match/.test(joined)) return true;
+      if (!cellTexts.some(t => /\S/.test(t))) return true;
+      return false;
+    };
+
+    const rows = [];
+    for (const tr of trs) {
+      const cells = [...tr.querySelectorAll('td')].map(td => tidy(td.textContent));
+      if (!cells.length) continue;
+      if (isHeaderLike(cells)) continue;
+
+      const category = cells[0] || '—';
+      const numeric = cells.map(toNum).filter(n => n !== null);
+      const Araw = numeric.length ? numeric[0] : null;
+      const Braw = numeric.length ? numeric[numeric.length - 1] : null;
+
+      const aValid = isValidScore(Araw);
+      const bValid = isValidScore(Braw);
+
+      let pct = cells.find(c => /%$/.test(c)) || null;
+      if (!pct && aValid && bValid) {
+        const p = Math.round(100 - (Math.abs(Araw - Braw) / 5) * 100);
+        pct = `${Math.max(0, Math.min(100, p))}%`;
+      }
+      if (!pct) pct = '—';
+
+      rows.push([category, aValid ? Araw : '—', pct, bValid ? Braw : '—']);
+    }
+    return rows;
   }
 
   async function downloadCompatibilityPDF({


### PR DESCRIPTION
## Summary
- skip header-like rows when extracting compatibility data
- validate scores before computing match percentages
- update PDF download helpers and demos

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bb8b60fc1c832ca5da0dcc9d6acb43