### PR TITLE
Handle section headers in PDF export

### DIFF
--- a/test/categoryNormalization.test.js
+++ b/test/categoryNormalization.test.js
@@ -46,7 +46,10 @@ test('extractRows normalizes category labels', async () => {
     const mod = await import('../js/pdfDownload.js');
     await mod.downloadCompatibilityPDF();
 
-    assert.deepStrictEqual(capturedBody.map(r => r[0]), ['Cum', 'Cum Play', 'Tears/cryingTears/crying']);
+    assert.deepStrictEqual(
+      capturedBody.map(r => r[0]),
+      ['Cum Play', 'Cum Play', 'Tears/cryingTears/crying']
+    );
   } finally {
     if (originalGlobals.window) globalThis.window = originalGlobals.window; else delete globalThis.window;
     if (originalGlobals.document) globalThis.document = originalGlobals.document; else delete globalThis.document;


### PR DESCRIPTION
## Summary
- Enhance PDF row extraction to detect section headers and fix duplicate category labels.
- Build AutoTable body with bold header rows and normalized categories.
- Update unit test for new category normalization behavior.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb9498880c832c89baa9c0a00e99d7