### PR TITLE
Add dark-mode PDF exporter with unanswered summary

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -443,27 +443,23 @@ document.addEventListener('DOMContentLoaded', () => setTimeout(runFill, 250));
 })();
 </script>
 <!--
-Talk Kink — Compatibility Report • Dark-Mode PDF Exporter
-=========================================================
-Steps to use:
-1. Place this <script> block right before </body> in compatibility.html.
-2. Ensure your results table is present in the DOM (#compatibilityTable, .results-table.compat, or the first <table>).
-3. Add a button with id="downloadBtn" to trigger export (or run TKPDF_forceDark() in console).
-4. Click "Download PDF" — a dark-themed PDF will download as compatibility-dark.pdf.
+Talk Kink — Compatibility Report • Dark-Mode PDF Exporter with Unanswered Summary
+Paste this whole block right before </body> on compatibility.html
 
-Features:
-- Loads jsPDF + AutoTable dynamically from CDN.
-- Deduplicates repeated words (e.g. "CumCum" → "Cum Play", "BloodBlood" → "Blood").
-- Uses section headers (like "Appearance Play") instead of generic "Category".
-- Dark background, white text, bold white lines.
-- At the bottom, adds a table of unanswered/zero entries, showing who missed (Partner A, Partner B, Both).
+What it does:
+- Loads jsPDF + AutoTable from CDN if not already loaded
+- Finds the results table (#compatibilityTable, .results-table.compat, or first <table>)
+- Cleans labels (dedupes repeats, fixes typos, renames "Cum" → "Cum Play")
+- Exports dark-themed PDF (black background, white text, thick white lines)
+- Main table = answered rows
+- Extra table at bottom = categories where Partner A, B, or both left blank or rated 0
+- Binds to #downloadBtn OR call TKPDF_forceDark() from console
 -->
 <script>
 (async function () {
   const LOG = (...a) => console.log("[TK-PDF]", ...a);
 
-  // Load jsPDF + AutoTable
-  function loadScript(src) {
+  async function loadScript(src) {
     return new Promise((res, rej) => {
       if (document.querySelector(`script[src="${src}"]`)) return res();
       const s = document.createElement("script");
@@ -473,16 +469,35 @@ Features:
       document.head.appendChild(s);
     });
   }
+
   async function ensureLibs() {
     if (!(window.jspdf && window.jspdf.jsPDF)) {
       await loadScript("https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js");
     }
-    if (!(window.jspdf.jsPDF.API.autoTable)) {
+    const hasAT =
+      (window.jspdf && window.jspdf.autoTable) ||
+      (window.jspdf && window.jspdf.jsPDF && window.jspdf.jsPDF.API && window.jspdf.jsPDF.API.autoTable);
+    if (!hasAT) {
       await loadScript("https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.8.3/jspdf.plugin.autotable.min.js");
     }
   }
 
-  // Find table
+  const tidy = (s) => (s || "").replace(/\s+/g, " ").trim();
+  const toNum = (v) => {
+    const n = Number(String(v ?? "").replace(/[^\d.-]/g, ""));
+    return Number.isFinite(n) ? n : null;
+  };
+
+  function cleanLabel(label) {
+    let t = tidy(label);
+    t = t.replace(/\b(Cum|CumCum)\b/gi, "Cum Play");
+    t = t.replace(/\b(\w+)\s+\1\b/gi, "$1");
+    t = t.replace(/\bChosing\b/gi, "Choosing")
+         .replace(/\bmod\b/gi, "mood")
+         .replace(/\bhoks\b/gi, "hoods");
+    return t;
+  }
+
   function findTable() {
     return (
       document.querySelector("#compatibilityTable") ||
@@ -491,125 +506,166 @@ Features:
     );
   }
 
-  // Helpers
-  const tidy = (s) => (s || "").replace(/\s+/g, " ").trim();
-  function dedupeWords(str) {
-    if (!str) return str;
-    let t = tidy(str);
-    t = t.replace(/\b([A-Za-z/'’\-]+)\s*\1\b/g, "$1"); // remove doubled words
-    if (/^cum$/i.test(t)) t = "Cum Play"; // normalize Cum
-    return t;
-  }
-  const toScore = (v) => {
-    const n = Number(String(v ?? "").replace(/[^\d.-]/g, ""));
-    return Number.isInteger(n) && n >= 1 && n <= 5 ? n : null;
-  };
-
-  // Extract rows
   function extractRows(table) {
-    const trs = [...table.querySelectorAll("tr")].filter((tr) => tr.querySelectorAll("td").length > 0);
-    let firstSectionHeader = null;
+    const trs = [...table.querySelectorAll("tr")].filter(
+      (tr) => tr.querySelectorAll("th").length === 0 && tr.querySelectorAll("td").length > 0
+    );
 
-    const rows = trs.map((tr) => {
-      const tds = [...tr.querySelectorAll("td")];
-      const cells = tds.map((td) => dedupeWords(td.textContent));
+    const out = [];
+    trs.forEach((tr) => {
+      const cells = [...tr.querySelectorAll("td")].map((td) => tidy(td.textContent));
+      const category = cleanLabel(cells[0] || "—");
+      const nums = cells.map(toNum);
+      const A = nums.length ? nums[0] : null;
+      const B = nums.length > 1 ? nums[nums.length - 1] : null;
 
-      const numeric = cells.filter((c) => /^-?\d+%?$/.test(c));
-      const looksLikeHeader = numeric.length === 0 && cells.slice(1).every((c) => !c);
-      if (looksLikeHeader) {
-        if (!firstSectionHeader) firstSectionHeader = cells[0];
-        return { type: "header", category: cells[0] };
+      let pct = cells.find((c) => /%$/.test(c)) || null;
+      if (!pct && A != null && B != null) {
+        const p = Math.round(100 - (Math.abs(A - B) / 5) * 100);
+        pct = `${Math.max(0, Math.min(100, p))}%`;
       }
 
-      const A = toScore(cells[1]);
-      const B = toScore(cells[cells.length - 1]);
-      let pct = cells.find((c) => /%$/.test(c)) || "—";
-      return { type: "row", category: cells[0], A, pct, B };
+      out.push({ category, A, B, pct });
     });
-    return { rows, firstSectionHeader };
+    return out;
   }
 
-  // Exporter
-  async function TKPDF_forceDark() {
-    await ensureLibs();
-    const { jsPDF } = window.jspdf;
-    const table = findTable();
-    if (!table) return alert("No table found.");
+  async function TKPDF_exportDark() {
+    try {
+      await ensureLibs();
+      const { jsPDF } = window.jspdf;
+      const table = findTable();
+      if (!table) return alert("No table found.");
 
-    const { rows, firstSectionHeader } = extractRows(table);
-    const body = [];
-    const unanswered = [];
-    const firstColHeader = firstSectionHeader || "Category";
+      const rows = extractRows(table);
+      if (!rows.length) return alert("No rows to export.");
 
-    rows.forEach((r) => {
-      if (r.type === "header") {
-        body.push([{ content: r.category, colSpan: 4, styles: { fontStyle: "bold", halign: "left" } }]);
-      } else {
-        body.push([r.category, r.A ?? "—", r.pct, r.B ?? "—"]);
-        if (r.A == null || r.B == null || r.A === 0 || r.B === 0) {
-          unanswered.push({
-            category: r.category,
-            who: (r.A == null || r.A === 0) && (r.B == null || r.B === 0)
-              ? "Both"
-              : (r.A == null || r.A === 0)
-              ? "Partner A"
-              : "Partner B",
-          });
+      const rated = [];
+      const missing = [];
+
+      rows.forEach((r) => {
+        const validA = r.A >= 1 && r.A <= 5;
+        const validB = r.B >= 1 && r.B <= 5;
+        if (validA || validB) {
+          rated.push([r.category, validA ? r.A : "—", r.pct || "—", validB ? r.B : "—"]);
+        } else {
+          let who = [];
+          if (!validA) who.push("Partner A");
+          if (!validB) who.push("Partner B");
+          missing.push([r.category, who.length ? who.join(" & ") : "Both"]);
         }
-      }
-    });
+      });
 
-    const doc = new jsPDF({ orientation: "landscape", unit: "pt", format: "a4" });
-    const pageW = doc.internal.pageSize.getWidth();
-    const pageH = doc.internal.pageSize.getHeight();
-    const paintBg = () => {
-      doc.setFillColor(0, 0, 0);
-      doc.rect(0, 0, pageW, pageH, "F");
-      doc.setTextColor(255, 255, 255);
-    };
-    paintBg();
-    doc.setFontSize(24);
-    doc.text("Talk Kink • Compatibility Report", pageW / 2, 42, { align: "center" });
+      const doc = new jsPDF({ orientation: "landscape", unit: "pt", format: "a4" });
+      const pageW = doc.internal.pageSize.getWidth();
+      const pageH = doc.internal.pageSize.getHeight();
 
-    const marginLR = 30;
-    const runAT = (opts) => doc.autoTable(opts);
+      const paintBg = () => {
+        doc.setFillColor(0, 0, 0);
+        doc.rect(0, 0, pageW, pageH, "F");
+        doc.setTextColor(255, 255, 255);
+      };
 
-    // Main table
-    runAT({
-      head: [[firstColHeader, "Partner A", "Match %", "Partner B"]],
-      body,
-      startY: 64,
-      margin: { left: marginLR, right: marginLR, bottom: 40 },
-      styles: { fontSize: 11, cellPadding: 6, textColor: [255, 255, 255], fillColor: [0, 0, 0], lineColor: [255, 255, 255], lineWidth: 1.2 },
-      headStyles: { fillColor: [0, 0, 0], textColor: [255, 255, 255], fontStyle: "bold" },
-      willDrawPage: paintBg,
-    });
+      paintBg();
+      doc.setFontSize(24);
+      doc.text("Talk Kink • Compatibility Report", pageW / 2, 42, { align: "center" });
 
-    // Unanswered section
-    if (unanswered.length) {
-      const y = doc.lastAutoTable.finalY + 22;
-      doc.setFontSize(16);
-      doc.text("Unanswered (0 or blank)", marginLR, y - 8);
+      const marginLR = 30;
+      const usable = pageW - marginLR * 2;
+      const Awidth = 90, Mwidth = 110, Bwidth = 90;
+      const CatWidth = Math.max(220, usable - (Awidth + Mwidth + Bwidth));
+
+      const runAT = (opts) => {
+        if (typeof doc.autoTable === "function") return doc.autoTable(opts);
+        if (window.jspdf && typeof window.jspdf.autoTable === "function") return window.jspdf.autoTable(doc, opts);
+        throw new Error("AutoTable not available");
+      };
+
       runAT({
-        head: [[firstColHeader, "Who missed"]],
-        body: unanswered.map((u) => [u.category, u.who]),
-        startY: y,
-        margin: { left: marginLR, right: marginLR, bottom: 40 },
-        styles: { fontSize: 11, cellPadding: 6, textColor: [255, 255, 255], fillColor: [0, 0, 0], lineColor: [255, 255, 255] },
-        headStyles: { fillColor: [0, 0, 0], textColor: [255, 255, 255], fontStyle: "bold" },
+        head: [["Category", "Partner A", "Match %", "Partner B"]],
+        body: rated,
+        startY: 64,
+        margin: { left: marginLR, right: marginLR, top: 64, bottom: 40 },
+        styles: {
+          fontSize: 11,
+          cellPadding: 6,
+          textColor: [255, 255, 255],
+          fillColor: [0, 0, 0],
+          lineColor: [255, 255, 255],
+          lineWidth: 1.2,
+          halign: "center",
+          valign: "middle",
+          overflow: "linebreak",
+        },
+        headStyles: {
+          fillColor: [0, 0, 0],
+          textColor: [255, 255, 255],
+          fontStyle: "bold",
+          lineColor: [255, 255, 255],
+          lineWidth: 1.6,
+        },
+        columnStyles: {
+          0: { cellWidth: CatWidth, halign: "left" },
+          1: { cellWidth: Awidth, halign: "center" },
+          2: { cellWidth: Mwidth, halign: "center" },
+          3: { cellWidth: Bwidth, halign: "center" },
+        },
+        tableWidth: usable,
         willDrawPage: paintBg,
       });
-    }
 
-    doc.save("compatibility-dark.pdf");
-    LOG("Export complete.");
+      if (missing.length) {
+        runAT({
+          head: [["Unanswered (0 or blank)", "Missing"]],
+          body: missing,
+          startY: doc.lastAutoTable.finalY + 40,
+          margin: { left: marginLR, right: marginLR },
+          styles: {
+            fontSize: 11,
+            cellPadding: 6,
+            textColor: [255, 255, 255],
+            fillColor: [0, 0, 0],
+            lineColor: [255, 255, 255],
+            lineWidth: 1.2,
+            halign: "center",
+            valign: "middle",
+            overflow: "linebreak",
+          },
+          headStyles: {
+            fillColor: [0, 0, 0],
+            textColor: [255, 255, 255],
+            fontStyle: "bold",
+            lineColor: [255, 255, 255],
+            lineWidth: 1.6,
+          },
+          columnStyles: {
+            0: { cellWidth: CatWidth, halign: "left" },
+            1: { cellWidth: 200, halign: "center" },
+          },
+          willDrawPage: paintBg,
+        });
+      }
+
+      doc.save("compatibility-dark.pdf");
+      LOG("Export complete.");
+    } catch (err) {
+      console.error("[TK-PDF] Export failed:", err);
+      alert("PDF export failed: " + (err?.message || err));
+    }
   }
 
-  // Bind button
-  window.TKPDF_forceDark = TKPDF_forceDark;
+  window.TKPDF_forceDark = TKPDF_exportDark;
+
   const btn = document.querySelector("#downloadBtn");
-  if (btn) btn.addEventListener("click", (e) => { e.preventDefault(); TKPDF_forceDark(); });
+  if (btn) {
+    btn.addEventListener("click", (e) => {
+      e.preventDefault();
+      TKPDF_exportDark();
+    });
+    LOG("Bound Download PDF button");
+  }
 })();
 </script>
+
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add script to compatibility page that exports dark-themed PDF and lists unanswered categories

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbc556e630832c8f9a5810196ce584