### PR TITLE
feat: add dark PDF export

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -442,15 +442,32 @@
 document.addEventListener('DOMContentLoaded', () => setTimeout(runFill, 250));
 })();
 </script>
-<!-- DROP-IN: Dark-mode PDF export with section headers + "Unanswered (0 or blank)" summary.
-     Paste this whole block just before </body> on compatibility.html. -->
+<!--
+TALK KINK • COMPATIBILITY REPORT — DARK PDF (ALL CELLS BLACK) + "UNANSWERED" LIST
+Copy/paste this WHOLE box into **compatibility.html** right before </body>.
+
+WHAT THIS DOES
+1) Loads jsPDF + jsPDF-AutoTable from CDN only if missing.
+2) Finds your results table (#compatibilityTable, .results-table.compat, or the first <table>).
+3) Exports a landscape A4, **pure black** table (white text, thick white grid).
+4) Treats scores 1–5 as valid. Anything 0 or blank = “unanswered”.
+5) Adds a second table at the end: **Unanswered Categories**, marking who skipped (✖) for Partner A/B.
+6) Binds to #downloadBtn automatically OR call TKPDF_forceDark() from the console.
+
+HOW TO USE
+- Ensure the results table is visible in the DOM.
+- Click the button with id="downloadBtn", or run TKPDF_forceDark() in the console.
+- A file named **compatibility-dark.pdf** will download.
+
+SAFETY
+- This only reads visible table text; no server calls, no external data writes.
+-->
 
 <script>
 (function () {
-  /* ========= Utilities ========= */
   const LOG = (...a) => console.log('[TK-PDF]', ...a);
 
-  // Load a script once (from CDN)
+  // --- loader helpers -------------------------------------------------------
   function loadScript(src) {
     return new Promise((resolve, reject) => {
       if (document.querySelector(`script[src="${src}"]`)) return resolve();
@@ -461,27 +478,17 @@ document.addEventListener('DOMContentLoaded', () => setTimeout(runFill, 250));
       document.head.appendChild(s);
     });
   }
-
   async function ensureLibs() {
-    // jsPDF UMD
     if (!(window.jspdf && window.jspdf.jsPDF)) {
       await loadScript('https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js');
     }
-    // AutoTable (works with UMD)
-    const hasAT =
-      (window.jspdf && window.jspdf.jsPDF && window.jspdf.jsPDF.API && window.jspdf.jsPDF.API.autoTable) ||
-      (window.jspdf && window.jspdf.autoTable);
-    if (!hasAT) {
+    // AutoTable available on jspdf.jsPDF.API.autoTable in UMD usage
+    if (!((window.jspdf && window.jspdf.jsPDF && window.jspdf.jsPDF.API && window.jspdf.jsPDF.API.autoTable))) {
       await loadScript('https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.8.3/jspdf.plugin.autotable.min.js');
     }
-    if (!(window.jspdf && window.jspdf.jsPDF)) throw new Error('jsPDF missing');
-    if (
-      !((window.jspdf && window.jspdf.jsPDF && window.jspdf.jsPDF.API && window.jspdf.jsPDF.API.autoTable) ||
-        (window.jspdf && window.jspdf.autoTable))
-    ) throw new Error('AutoTable missing');
   }
 
-  // Find the results table
+  // --- table discovery -------------------------------------------------------
   function findTable() {
     return (
       document.querySelector('#compatibilityTable') ||
@@ -490,259 +497,165 @@ document.addEventListener('DOMContentLoaded', () => setTimeout(runFill, 250));
     );
   }
 
-  // Text helpers
+  // --- small utils -----------------------------------------------------------
   const tidy = (s) => (s || '').replace(/\s+/g, ' ').trim();
-
-  // If entire string is exactly two identical halves (e.g. "CumCum", "BloodBlood", "Tears/cryingTears/crying")
-  function collapseExactDouble(str) {
-    const t = tidy(str);
-    if (!t) return t;
-    const mid = Math.floor(t.length / 2);
-    if (t.length % 2 === 0 && t.slice(0, mid) === t.slice(mid)) return t.slice(0, mid);
-    return t;
-  }
-
-  function fixCommonTypos(s) {
-    let t = s;
-    t = t.replace(/\bChosing\b/gi, 'Choosing');
-    t = t.replace(/\bbones?\b/gi, 'bonnets'); // very rough (seen "bonets")
-    t = t.replace(/\bhods?\b/gi, 'hoods');    // very rough (seen "hods")
-    t = t.replace(/\bloks?\b/gi, 'looks');    // "loks" -> "looks"
-    t = t.replace(/\bmod\b/gi, 'mood');
-    return t;
-  }
-
-  function normalizeLabel(s) {
-    let t = collapseExactDouble(tidy(s));
-    t = fixCommonTypos(t);
-    // Rename single-word "Cum" to "Cum Play"
-    if (/^cum$/i.test(t)) t = 'Cum Play';
-    return t;
-  }
-
-  function toNum(v) {
+  const toNum = (v) => {
     const n = Number(String(v ?? '').replace(/[^\d.-]/g, ''));
     return Number.isFinite(n) ? n : null;
-  }
-
+  };
   const isValidScore = (n) => n != null && Number.isInteger(n) && n >= 1 && n <= 5;
   const isZeroOrBlank = (n) => n == null || n === 0;
 
-  /* ========= Extraction with Section Headers ========= */
-  function extractBySections(table) {
-    const sections = []; // [{ name, rows: [[label,a,match,b]], missing: [{label, missA, missB}] }]
-    let current = { name: 'Category', rows: [], missing: [] };
-    sections.push(current);
+  // Optional: light de-dupe/fixes for repeated labels like "BloodBlood", "Cum" -> "Cum Play"
+  function cleanLabel(s) {
+    let t = tidy(s);
+    t = t.replace(/\b([A-Za-z/’'-]+)\1\b/g, '$1');   // "BloodBlood" => "Blood"
+    t = t.replace(/\bCum\b/g, 'Cum Play');
+    return t;
+  }
 
-    const trs = [...table.querySelectorAll('tr')].filter(tr => tr.querySelectorAll('td').length > 0);
+  // --- extract rows + track unanswered --------------------------------------
+  function extractRows(table) {
+    const trs = [...table.querySelectorAll('tr')];
+    const rows = [];
+    const missing = [];
 
     for (const tr of trs) {
       const tds = [...tr.querySelectorAll('td')];
-      const texts = tds.map(td => tidy(td.textContent));
+      if (!tds.length) continue;
 
-      // Heuristic: a section header row if it has only 1 meaningful cell (or the other cells are blank/whitespace)
-      const nonEmptyCount = texts.filter(x => x).length;
-      const looksLikeHeader = (tds.length === 1) ||
-                              (nonEmptyCount === 1 && tidy(texts[0]) && texts.slice(1).every(x => !tidy(x)));
+      const texts = tds.map(td => cleanLabel(td.textContent));
 
-      if (looksLikeHeader) {
-        const sectionName = normalizeLabel(texts[0] || current.name || 'Category');
-        current = { name: sectionName, rows: [], missing: [] };
-        sections.push(current);
+      // Section header row (one meaningful cell spanning the row)
+      if (tds.length === 1 || (texts[0] && texts.slice(1).every(x => !x))) {
+        rows.push([{
+          content: texts[0],
+          colSpan: 4,
+          styles: { fontStyle: 'bold', halign: 'left', fillColor: [0, 0, 0], textColor: [255, 255, 255] }
+        }]);
         continue;
       }
 
-      // Normal data row
-      const rawLabel = texts[0] || '—';
-      const label = normalizeLabel(rawLabel);
+      // Normal row: Category | Partner A | Match % | Partner B
+      const category = cleanLabel(texts[0] || '—');
 
-      // Find numeric cells (scores), and a percent cell for match
       const nums = texts.map(toNum);
       const numericIdx = nums.map((n, i) => (n !== null ? i : -1)).filter(i => i >= 0);
       const a = numericIdx.length ? nums[numericIdx[0]] : null;
       const b = numericIdx.length ? nums[numericIdx[numericIdx.length - 1]] : null;
 
-      let match = texts.find(c => /%$/.test(c)) || null;
+      let match = texts.find(c => /%$/.test(c)) || '—';
       if (!match && isValidScore(a) && isValidScore(b)) {
         const pct = Math.round(100 - (Math.abs(a - b) / 5) * 100);
         match = `${Math.max(0, Math.min(100, pct))}%`;
       }
-      if (!match) match = '—';
 
-      // Track missing answers (0 or blank)
       const missA = isZeroOrBlank(a);
       const missB = isZeroOrBlank(b);
       if (missA || missB) {
-        current.missing.push({ label, missA, missB });
+        missing.push([category, missA ? '✖' : '—', missB ? '✖' : '—']);
       }
 
-      // Push into rated rows ONLY if at least one partner has a valid (1-5) score
-      if (isValidScore(a) || isValidScore(b)) {
-        current.rows.push([
-          label,
-          isValidScore(a) ? String(a) : '—',
-          match,
-          isValidScore(b) ? String(b) : '—'
-        ]);
-      }
+      rows.push([
+        { content: category, styles: { fillColor: [0, 0, 0], textColor: [255, 255, 255] } },
+        { content: isValidScore(a) ? String(a) : '—', styles: { fillColor: [0, 0, 0], textColor: [255, 255, 255] } },
+        { content: match, styles: { fillColor: [0, 0, 0], textColor: [255, 255, 255] } },
+        { content: isValidScore(b) ? String(b) : '—', styles: { fillColor: [0, 0, 0], textColor: [255, 255, 255] } }
+      ]);
     }
 
-    // Prune any empty (no rows + no missing) sections that slipped in
-    return sections.filter(s => s.rows.length || s.missing.length);
+    return { rows, missing };
   }
 
-  /* ========= PDF Export ========= */
-  function runAutoTable(doc, opts) {
-    if (typeof doc.autoTable === 'function') return doc.autoTable(opts);
-    if (window.jspdf && typeof window.jspdf.autoTable === 'function') return window.jspdf.autoTable(doc, opts);
-    throw new Error('AutoTable not available');
-  }
-
+  // --- export (dark mode) ----------------------------------------------------
   async function TKPDF_export() {
     try {
       await ensureLibs();
-
-      const table = findTable();
-      if (!table) { alert('No table found on the page.'); return; }
-
-      const sections = extractBySections(table);
-      if (!sections.length) { alert('No data found to export.'); return; }
-
       const { jsPDF } = window.jspdf;
+      const table = findTable();
+      if (!table) return alert('No table found on the page.');
+
+      const { rows, missing } = extractRows(table);
+
       const doc = new jsPDF({ orientation: 'landscape', unit: 'pt', format: 'a4' });
       const pageW = doc.internal.pageSize.getWidth();
       const pageH = doc.internal.pageSize.getHeight();
+      const paintBg = () => { doc.setFillColor(0,0,0); doc.rect(0,0, pageW, pageH, 'F'); doc.setTextColor(255,255,255); };
 
-      // Dark background painter (called for each page)
-      const paintBg = () => {
-        doc.setFillColor(0, 0, 0);
-        doc.rect(0, 0, pageW, pageH, 'F');
-        doc.setTextColor(255, 255, 255);
-      };
-
-      // Title
       paintBg();
-      doc.setFontSize(26);
-      doc.text('Talk Kink • Compatibility Report', pageW / 2, 46, { align: 'center' });
+      doc.setFontSize(24);
+      doc.text('Talk Kink • Compatibility Report', pageW / 2, 42, { align: 'center' });
 
       const marginLR = 30;
       const usable = pageW - marginLR * 2;
-      const Awidth = 90;
-      const Mwidth = 110;
-      const Bwidth = 90;
-      const CatWidth = Math.max(240, usable - (Awidth + Mwidth + Bwidth));
+      const Awidth = 90, Mwidth = 110, Bwidth = 90;
+      const CatWidth = usable - (Awidth + Mwidth + Bwidth);
 
-      let startY = 68;
+      doc.autoTable({
+        head: [['Category', 'Partner A', 'Match %', 'Partner B']],
+        body: rows,
+        startY: 64,
+        margin: { left: marginLR, right: marginLR },
+        styles: {
+          fontSize: 11,
+          cellPadding: 6,
+          textColor: [255, 255, 255],
+          fillColor: [0, 0, 0],            // <- EVERY CELL BLACK
+          lineColor: [255, 255, 255],
+          lineWidth: 1.2,
+          halign: 'center',
+          valign: 'middle',
+          overflow: 'linebreak'
+        },
+        headStyles: {
+          fillColor: [0, 0, 0],
+          textColor: [255, 255, 255],
+          fontStyle: 'bold',
+          lineColor: [255, 255, 255],
+          lineWidth: 1.4
+        },
+        columnStyles: {
+          0: { cellWidth: CatWidth, halign: 'left' },
+          1: { cellWidth: Awidth },
+          2: { cellWidth: Mwidth },
+          3: { cellWidth: Bwidth }
+        },
+        willDrawPage: paintBg
+      });
 
-      // Render each section as its own table so the left header shows the actual section name
-      sections.forEach(sec => {
-        if (!sec.rows.length) return; // skip sections with only missing rows
-
-        runAutoTable(doc, {
-          head: [[sec.name, 'Partner A', 'Match %', 'Partner B']],
-          body: sec.rows,
-          startY,
-          margin: { left: marginLR, right: marginLR, top: startY, bottom: 40 },
+      if (missing.length) {
+        doc.autoTable({
+          head: [['Unanswered Categories (0 or blank)', 'Partner A', 'Partner B']],
+          body: missing.map(r => r.map(c => ({ content: c, styles: { fillColor: [0,0,0], textColor: [255,255,255] } }))),
+          startY: doc.lastAutoTable.finalY + 20,
+          margin: { left: marginLR, right: marginLR },
           styles: {
             fontSize: 11,
             cellPadding: 6,
             textColor: [255, 255, 255],
-            fillColor: [0, 0, 0],
+            fillColor: [0, 0, 0],          // unanswered table also black
             lineColor: [255, 255, 255],
-            lineWidth: 1.2,
-            halign: 'center',
-            valign: 'middle',
-            overflow: 'linebreak'
+            lineWidth: 1.2
           },
-          headStyles: {
-            fillColor: [0, 0, 0],
-            textColor: [255, 255, 255],
-            fontStyle: 'bold',
-            lineColor: [255, 255, 255],
-            lineWidth: 1.6
-          },
-          columnStyles: {
-            0: { cellWidth: CatWidth, halign: 'left' },
-            1: { cellWidth: Awidth, halign: 'center' },
-            2: { cellWidth: Mwidth, halign: 'center' },
-            3: { cellWidth: Bwidth, halign: 'center' }
-          },
-          tableWidth: usable,
-          willDrawPage: paintBg
-        });
-
-        startY = (doc.lastAutoTable?.finalY || startY) + 20;
-      });
-
-      // Build global "Unanswered (0 or blank)" table
-      const missingRows = [];
-      sections.forEach(sec => {
-        sec.missing.forEach(m => {
-          missingRows.push([
-            `${sec.name} • ${m.label}`,
-            m.missA ? '✖' : '—',
-            m.missB ? '✖' : '—'
-          ]);
-        });
-      });
-
-      if (missingRows.length) {
-        if (startY > pageH - 120) {
-          doc.addPage();
-          paintBg();
-          startY = 40;
-        }
-
-        runAutoTable(doc, {
-          head: [['Unanswered (0 or blank)', 'Partner A', 'Partner B']],
-          body: missingRows,
-          startY,
-          margin: { left: marginLR, right: marginLR, top: startY, bottom: 40 },
-          styles: {
-            fontSize: 11,
-            cellPadding: 6,
-            textColor: [255, 255, 255],
-            fillColor: [0, 0, 0],
-            lineColor: [255, 255, 255],
-            lineWidth: 1.2,
-            halign: 'left',
-            valign: 'middle',
-            overflow: 'linebreak'
-          },
-          headStyles: {
-            fillColor: [0, 0, 0],
-            textColor: [255, 255, 255],
-            fontStyle: 'bold',
-            lineColor: [255, 255, 255],
-            lineWidth: 1.6
-          },
-          columnStyles: {
-            0: { cellWidth: usable - 180, halign: 'left' },
-            1: { cellWidth: 90, halign: 'center' },
-            2: { cellWidth: 90, halign: 'center' }
-          },
-          tableWidth: usable,
+          headStyles: { fillColor: [0,0,0], textColor: [255,255,255], fontStyle: 'bold' },
+          columnStyles: { 0: { cellWidth: usable - 180 }, 1: { cellWidth: 90 }, 2: { cellWidth: 90 } },
           willDrawPage: paintBg
         });
       }
 
       doc.save('compatibility-dark.pdf');
-      LOG('Export complete.');
+      LOG('Export complete');
     } catch (err) {
       console.error('[TK-PDF] Export failed:', err);
       alert('PDF export failed: ' + (err?.message || err));
     }
   }
 
-  // Expose & bind
+  // Expose + bind
   window.TKPDF_forceDark = TKPDF_export;
   const btn = document.querySelector('#downloadBtn');
-  if (btn) {
-    btn.addEventListener('click', (e) => { e.preventDefault(); TKPDF_export(); });
-    LOG('Bound Download PDF');
-  } else {
-    LOG('Download button not found; call TKPDF_forceDark() from console.');
-  }
+  if (btn) btn.addEventListener('click', e => { e.preventDefault(); TKPDF_export(); });
+  LOG('Bound Download PDF');
 })();
 </script>
 


### PR DESCRIPTION
## Summary
- add dark PDF export snippet to `compatibility.html`
- generate a black-background PDF and log unanswered categories

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c081bef130832ca98df60c8c7723f1