### PR TITLE
Fix category toggles failing on kink survey

### DIFF
--- a/kinks/index.html
+++ b/kinks/index.html
@@ -242,13 +242,19 @@
     function selectAllCategories() {
       document.querySelectorAll('#categorySurveyPanel input[type="checkbox"]').forEach(cb => cb.checked = true);
       document.getElementById('warning').textContent = '';
-      document.getElementById('startSurveyBtn').disabled = false;
+      const startButton = document.getElementById('startSurveyBtn');
+      if (startButton) {
+        startButton.disabled = false;
+      }
     }
 
     function deselectAllCategories() {
       document.querySelectorAll('#categorySurveyPanel input[type="checkbox"]').forEach(cb => cb.checked = false);
       document.getElementById('warning').textContent = '';
-      document.getElementById('startSurveyBtn').disabled = true;
+      const startButton = document.getElementById('startSurveyBtn');
+      if (startButton) {
+        startButton.disabled = true;
+      }
     }
 
     function togglePanel() {
@@ -267,11 +273,25 @@
 
     document.addEventListener('DOMContentLoaded', () => {
       const startBtn = document.getElementById('startSurveyBtn');
-      document.getElementById('selectAll').addEventListener('click', selectAllCategories);
-      document.getElementById('deselectAll').addEventListener('click', deselectAllCategories);
-      document.getElementById('panelToggle').addEventListener('click', togglePanel);
+      const selectAllBtn = document.getElementById('selectAll') || document.getElementById('selectAllBtn');
+      const deselectAllBtn = document.getElementById('deselectAll') || document.getElementById('deselectAllBtn');
+      const panelToggleBtn = document.getElementById('panelToggle');
 
-      startBtn.addEventListener('click', startSurvey);
+      if (selectAllBtn) {
+        selectAllBtn.addEventListener('click', selectAllCategories);
+      }
+
+      if (deselectAllBtn) {
+        deselectAllBtn.addEventListener('click', deselectAllCategories);
+      }
+
+      if (panelToggleBtn) {
+        panelToggleBtn.addEventListener('click', togglePanel);
+      }
+
+      if (startBtn) {
+        startBtn.addEventListener('click', startSurvey);
+      }
 
       document.querySelectorAll('#categorySurveyPanel .category-list label').forEach(label => {
         label.setAttribute('title', label.textContent.trim());
@@ -280,11 +300,15 @@
       document.querySelectorAll('.category-checkbox').forEach(cb => {
         cb.addEventListener('change', () => {
           document.getElementById('warning').textContent = '';
-          startBtn.disabled = !document.querySelector('.category-checkbox:checked');
+          if (startBtn) {
+            startBtn.disabled = !document.querySelector('.category-checkbox:checked');
+          }
         });
       });
 
-      startBtn.disabled = !document.querySelector('.category-checkbox:checked');
+      if (startBtn) {
+        startBtn.disabled = !document.querySelector('.category-checkbox:checked');
+      }
 
       document.getElementById('trackCategoryBtn').addEventListener('click', () => {
         const remaining = surveyCategories.length - currentCategoryIndex;


### PR DESCRIPTION
## Summary
- allow the kink survey select/deselect controls to bind to either legacy or new button ids
- guard start button state toggles so the category helpers keep working even if the button is missing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9c6355b7c832cae630e93217edcc0