### PR TITLE
fix: add conflict marker guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "test:coverage": "node --test --experimental-test-coverage",
     "generate-token": "node scripts/generateToken.js",
     "generate:tokens": "node generateTokens.js",
-    "generate-pdf:landscape": "node --input-type=module -e \"globalThis.window={};await import('./js/vendor/jspdf.umd.min.js');await (await import('./js/compatibilityPdf.js')).generateCompatibilityPDFLandscape({categories: []})\""
+    "generate-pdf:landscape": "node --input-type=module -e \"globalThis.window={};await import('./js/vendor/jspdf.umd.min.js');await (await import('./js/compatibilityPdf.js')).generateCompatibilityPDFLandscape({categories: []})\"",
+    "check:conflicts": "node scripts/check-conflicts.js",
+    "precommit": "npm run check:conflicts"
   },
   "keywords": [],
   "author": "",

--- a/scripts/check-conflicts.js
+++ b/scripts/check-conflicts.js
@@ -1,0 +1,37 @@
+import { spawnSync } from "node:child_process";
+
+const args = [
+  "grep",
+  "-n",
+  "-e",
+  "^<<<<<<<",
+  "-e",
+  "^=======$",
+  "-e",
+  "^>>>>>>>",
+  "--",
+  ".",
+  ":!node_modules",
+  ":!.git",
+];
+
+const result = spawnSync("git", args, { encoding: "utf8" });
+
+if (result.status === 0) {
+  const output = result.stdout.trim();
+  if (output) {
+    console.error(`\n❌ Conflict markers found:\n${output}\n`);
+    process.exit(1);
+  }
+  console.log("✅ No conflict markers");
+  process.exit(0);
+}
+
+if (result.status === 1) {
+  console.log("✅ No conflict markers");
+  process.exit(0);
+}
+
+const message = result.stderr?.toString().trim() || result.error?.message || "Unknown error";
+console.error(`check failed: ${message}`);
+process.exit(result.status ?? 2);


### PR DESCRIPTION
## Summary
- add a git conflict marker check script that looks for real markers at the start of lines
- wire the check into npm scripts so it can run via `npm run check:conflicts` and precommit

## Testing
- npm run check:conflicts

------
https://chatgpt.com/codex/tasks/task_e_68c9eb2ec458832cab6e4d370e56b8dd