### PR TITLE
fix: tighten conflict guard and bump sw cache

### DIFF
--- a/greenlight/sw.js
+++ b/greenlight/sw.js
@@ -1,5 +1,5 @@
 // Bump the cache name to force clients to fetch the latest assets
-const CACHE = 'greenlight-v6';
+const CACHE = 'greenlight-v7';
 const FILES = [
   './',
   './index.html',


### PR DESCRIPTION
## Summary
- update the conflict marker guard to detect only true merge markers while still blocking commits when they appear
- bump the greenlight service worker cache key so browsers fetch the refreshed assets

## Testing
- npm run check:conflicts

------
https://chatgpt.com/codex/tasks/task_e_68c9edaf3f24832c969c066fe285d998