### PR TITLE
Fix TK-SAFE merge marker detection false positives

### DIFF
--- a/appearance-play-table.html
+++ b/appearance-play-table.html
@@ -103,7 +103,12 @@
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    if (html.includes("<<<<<<<") || html.includes("=======") || html.includes(">>>>>>>")) {
+    const MERGE_MARKERS = [
+      "<".repeat(7),
+      "=".repeat(7),
+      ">".repeat(7),
+    ];
+    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
       console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
     }
   } catch (_) {}

--- a/auto-pdf.html
+++ b/auto-pdf.html
@@ -104,7 +104,12 @@
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    if (html.includes("<<<<<<<") || html.includes("=======") || html.includes(">>>>>>>")) {
+    const MERGE_MARKERS = [
+      "<".repeat(7),
+      "=".repeat(7),
+      ">".repeat(7),
+    ];
+    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
       console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
     }
   } catch (_) {}

--- a/basic-survey.html
+++ b/basic-survey.html
@@ -301,7 +301,12 @@
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    if (html.includes("<<<<<<<") || html.includes("=======") || html.includes(">>>>>>>")) {
+    const MERGE_MARKERS = [
+      "<".repeat(7),
+      "=".repeat(7),
+      ">".repeat(7),
+    ];
+    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
       console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
     }
   } catch (_) {}

--- a/compat-upload.html
+++ b/compat-upload.html
@@ -530,7 +530,12 @@ console.log(`TalkKink Test Plan:
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    if (html.includes("<<<<<<<") || html.includes("=======") || html.includes(">>>>>>>")) {
+    const MERGE_MARKERS = [
+      "<".repeat(7),
+      "=".repeat(7),
+      ">".repeat(7),
+    ];
+    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
       console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
     }
   } catch (_) {}

--- a/compatibility.html
+++ b/compatibility.html
@@ -689,7 +689,12 @@ RESULT
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    if (html.includes("<<<<<<<") || html.includes("=======") || html.includes(">>>>>>>")) {
+    const MERGE_MARKERS = [
+      "<".repeat(7),
+      "=".repeat(7),
+      ">".repeat(7),
+    ];
+    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
       console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
     }
   } catch (_) {}

--- a/data-tools.html
+++ b/data-tools.html
@@ -160,7 +160,12 @@
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    if (html.includes("<<<<<<<") || html.includes("=======") || html.includes(">>>>>>>")) {
+    const MERGE_MARKERS = [
+      "<".repeat(7),
+      "=".repeat(7),
+      ">".repeat(7),
+    ];
+    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
       console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
     }
   } catch (_) {}

--- a/index.html
+++ b/index.html
@@ -46,7 +46,12 @@
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    if (html.includes("<<<<<<<") || html.includes("=======") || html.includes(">>>>>>>")) {
+    const MERGE_MARKERS = [
+      "<".repeat(7),
+      "=".repeat(7),
+      ">".repeat(7),
+    ];
+    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
       console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
     }
   } catch (_) {}

--- a/individualkinkanalysis.html
+++ b/individualkinkanalysis.html
@@ -591,7 +591,12 @@ Otherwise, safe fallbacks included below will run.
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    if (html.includes("<<<<<<<") || html.includes("=======") || html.includes(">>>>>>>")) {
+    const MERGE_MARKERS = [
+      "<".repeat(7),
+      "=".repeat(7),
+      ">".repeat(7),
+    ];
+    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
       console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
     }
   } catch (_) {}

--- a/js/tk-safe-bootstrap.js
+++ b/js/tk-safe-bootstrap.js
@@ -5,7 +5,12 @@
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    if (html.includes("<<<<<<<") || html.includes("=======") || html.includes(">>>>>>>")) {
+    const MERGE_MARKERS = [
+      "<".repeat(7),
+      "=".repeat(7),
+      ">".repeat(7),
+    ];
+    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
       console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
     }
   } catch (_) {}

--- a/kink-list.html
+++ b/kink-list.html
@@ -275,7 +275,12 @@
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    if (html.includes("<<<<<<<") || html.includes("=======") || html.includes(">>>>>>>")) {
+    const MERGE_MARKERS = [
+      "<".repeat(7),
+      "=".repeat(7),
+      ">".repeat(7),
+    ];
+    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
       console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
     }
   } catch (_) {}

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -843,7 +843,12 @@ How to use
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    if (html.includes("<<<<<<<") || html.includes("=======") || html.includes(">>>>>>>")) {
+    const MERGE_MARKERS = [
+      "<".repeat(7),
+      "=".repeat(7),
+      ">".repeat(7),
+    ];
+    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
       console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
     }
   } catch (_) {}

--- a/pdf-download-test.html
+++ b/pdf-download-test.html
@@ -135,7 +135,12 @@ document.addEventListener("DOMContentLoaded", setupPDFExport);
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    if (html.includes("<<<<<<<") || html.includes("=======") || html.includes(">>>>>>>")) {
+    const MERGE_MARKERS = [
+      "<".repeat(7),
+      "=".repeat(7),
+      ">".repeat(7),
+    ];
+    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
       console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
     }
   } catch (_) {}

--- a/simple-compatibility.html
+++ b/simple-compatibility.html
@@ -452,7 +452,12 @@ Paste this WHOLE block at the very end of the page (after your table renders).
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    if (html.includes("<<<<<<<") || html.includes("=======") || html.includes(">>>>>>>")) {
+    const MERGE_MARKERS = [
+      "<".repeat(7),
+      "=".repeat(7),
+      ">".repeat(7),
+    ];
+    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
       console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
     }
   } catch (_) {}

--- a/snippet-category-panel.html
+++ b/snippet-category-panel.html
@@ -185,7 +185,12 @@ document.getElementById('deselectAll').addEventListener('click', () => {
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    if (html.includes("<<<<<<<") || html.includes("=======") || html.includes(">>>>>>>")) {
+    const MERGE_MARKERS = [
+      "<".repeat(7),
+      "=".repeat(7),
+      ">".repeat(7),
+    ];
+    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
       console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
     }
   } catch (_) {}

--- a/snippet-clean-match.html
+++ b/snippet-clean-match.html
@@ -78,7 +78,12 @@ tkRefreshAll();
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    if (html.includes("<<<<<<<") || html.includes("=======") || html.includes(">>>>>>>")) {
+    const MERGE_MARKERS = [
+      "<".repeat(7),
+      "=".repeat(7),
+      ">".repeat(7),
+    ];
+    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
       console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
     }
   } catch (_) {}

--- a/snippet-compatibility-report-dark.html
+++ b/snippet-compatibility-report-dark.html
@@ -214,7 +214,12 @@ Notes
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    if (html.includes("<<<<<<<") || html.includes("=======") || html.includes(">>>>>>>")) {
+    const MERGE_MARKERS = [
+      "<".repeat(7),
+      "=".repeat(7),
+      ">".repeat(7),
+    ];
+    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
       console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
     }
   } catch (_) {}

--- a/snippet-compatibility-report-pdf-export-fix.html
+++ b/snippet-compatibility-report-pdf-export-fix.html
@@ -13,7 +13,12 @@ HOW TO USE:
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    if (html.includes("<<<<<<<") || html.includes("=======") || html.includes(">>>>>>>")) {
+    const MERGE_MARKERS = [
+      "<".repeat(7),
+      "=".repeat(7),
+      ">".repeat(7),
+    ];
+    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
       console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
     }
   } catch (_) {}

--- a/snippet-compatibility-report.html
+++ b/snippet-compatibility-report.html
@@ -207,7 +207,12 @@ If your table rows use <td data-cell="A">…</td> and <td data-cell="B">…</td>
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    if (html.includes("<<<<<<<") || html.includes("=======") || html.includes(">>>>>>>")) {
+    const MERGE_MARKERS = [
+      "<".repeat(7),
+      "=".repeat(7),
+      ">".repeat(7),
+    ];
+    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
       console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
     }
   } catch (_) {}

--- a/snippet-individual-kink-analysis.html
+++ b/snippet-individual-kink-analysis.html
@@ -85,7 +85,12 @@
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    if (html.includes("<<<<<<<") || html.includes("=======") || html.includes(">>>>>>>")) {
+    const MERGE_MARKERS = [
+      "<".repeat(7),
+      "=".repeat(7),
+      ">".repeat(7),
+    ];
+    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
       console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
     }
   } catch (_) {}

--- a/talk-kink-module.html
+++ b/talk-kink-module.html
@@ -328,7 +328,12 @@
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    if (html.includes("<<<<<<<") || html.includes("=======") || html.includes(">>>>>>>")) {
+    const MERGE_MARKERS = [
+      "<".repeat(7),
+      "=".repeat(7),
+      ">".repeat(7),
+    ];
+    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
       console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
     }
   } catch (_) {}

--- a/token.html
+++ b/token.html
@@ -63,7 +63,12 @@
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    if (html.includes("<<<<<<<") || html.includes("=======") || html.includes(">>>>>>>")) {
+    const MERGE_MARKERS = [
+      "<".repeat(7),
+      "=".repeat(7),
+      ">".repeat(7),
+    ];
+    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
       console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
     }
   } catch (_) {}

--- a/training-plan.html
+++ b/training-plan.html
@@ -34,7 +34,12 @@
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    if (html.includes("<<<<<<<") || html.includes("=======") || html.includes(">>>>>>>")) {
+    const MERGE_MARKERS = [
+      "<".repeat(7),
+      "=".repeat(7),
+      ">".repeat(7),
+    ];
+    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
       console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
     }
   } catch (_) {}

--- a/villain-quote.html
+++ b/villain-quote.html
@@ -38,7 +38,12 @@
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    if (html.includes("<<<<<<<") || html.includes("=======") || html.includes(">>>>>>>")) {
+    const MERGE_MARKERS = [
+      "<".repeat(7),
+      "=".repeat(7),
+      ">".repeat(7),
+    ];
+    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
       console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
     }
   } catch (_) {}

--- a/your-roles.html
+++ b/your-roles.html
@@ -153,7 +153,12 @@
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    if (html.includes("<<<<<<<") || html.includes("=======") || html.includes(">>>>>>>")) {
+    const MERGE_MARKERS = [
+      "<".repeat(7),
+      "=".repeat(7),
+      ">".repeat(7),
+    ];
+    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
       console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
     }
   } catch (_) {}


### PR DESCRIPTION
## Summary
- update the TK-SAFE bootstrap snippet (shared via js/tk-safe-bootstrap.js and inline copies) to generate merge marker strings at runtime
- prevent the safety script from flagging itself for merge conflict markers while retaining the existing warning for real conflicts

## Testing
- npm run check:conflicts

------
https://chatgpt.com/codex/tasks/task_e_68c9eeff52b4832ca899d7231dfc5639