### PR TITLE
Fix TK-SAFE merge marker warning on compatibility page

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -181,7 +181,7 @@
   </script>
 
 <script>
-/* ===================== COMPAT: Robust A/B Fill (markup-agnostic) ===================== *
+/* ==== COMPAT: Robust A/B Fill (markup-agnostic) ==== *
  * Supports three table shapes:
  *  1) Cells with data-partner-a / data-partner-b attributes             (preferred)
  *  2) Cells with .pa / .pb classes                                      (legacy)


### PR DESCRIPTION
## Summary
- adjust the compatibility helper banner comment to avoid the "=======" sequence detected as merge markers by TK-SAFE

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca03bb42e4832cbf66a6c17a0c02e9