### PR TITLE
Refine merge conflict detection in safe bootstrap script

### DIFF
--- a/appearance-play-table.html
+++ b/appearance-play-table.html
@@ -103,13 +103,14 @@
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    const MERGE_MARKERS = [
-      "<".repeat(7),
-      "=".repeat(7),
-      ">".repeat(7),
-    ];
-    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
-      console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+    const HEAD = '<'.repeat(7);
+    const SEP = '='.repeat(7);
+    const TAIL = '>'.repeat(7);
+    if (html.includes(HEAD) && html.includes(SEP) && html.includes(TAIL)) {
+      const conflictPattern = new RegExp(`${HEAD}[\s\S]*?${SEP}[\s\S]*?${TAIL}`);
+      if (conflictPattern.test(html)) {
+        console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+      }
     }
   } catch (_) {}
 

--- a/auto-pdf.html
+++ b/auto-pdf.html
@@ -104,13 +104,14 @@
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    const MERGE_MARKERS = [
-      "<".repeat(7),
-      "=".repeat(7),
-      ">".repeat(7),
-    ];
-    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
-      console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+    const HEAD = '<'.repeat(7);
+    const SEP = '='.repeat(7);
+    const TAIL = '>'.repeat(7);
+    if (html.includes(HEAD) && html.includes(SEP) && html.includes(TAIL)) {
+      const conflictPattern = new RegExp(`${HEAD}[\s\S]*?${SEP}[\s\S]*?${TAIL}`);
+      if (conflictPattern.test(html)) {
+        console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+      }
     }
   } catch (_) {}
 

--- a/basic-survey.html
+++ b/basic-survey.html
@@ -301,13 +301,14 @@
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    const MERGE_MARKERS = [
-      "<".repeat(7),
-      "=".repeat(7),
-      ">".repeat(7),
-    ];
-    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
-      console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+    const HEAD = '<'.repeat(7);
+    const SEP = '='.repeat(7);
+    const TAIL = '>'.repeat(7);
+    if (html.includes(HEAD) && html.includes(SEP) && html.includes(TAIL)) {
+      const conflictPattern = new RegExp(`${HEAD}[\s\S]*?${SEP}[\s\S]*?${TAIL}`);
+      if (conflictPattern.test(html)) {
+        console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+      }
     }
   } catch (_) {}
 

--- a/compat-upload.html
+++ b/compat-upload.html
@@ -530,13 +530,14 @@ console.log(`TalkKink Test Plan:
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    const MERGE_MARKERS = [
-      "<".repeat(7),
-      "=".repeat(7),
-      ">".repeat(7),
-    ];
-    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
-      console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+    const HEAD = '<'.repeat(7);
+    const SEP = '='.repeat(7);
+    const TAIL = '>'.repeat(7);
+    if (html.includes(HEAD) && html.includes(SEP) && html.includes(TAIL)) {
+      const conflictPattern = new RegExp(`${HEAD}[\s\S]*?${SEP}[\s\S]*?${TAIL}`);
+      if (conflictPattern.test(html)) {
+        console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+      }
     }
   } catch (_) {}
 

--- a/compatibility.html
+++ b/compatibility.html
@@ -689,13 +689,14 @@ RESULT
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    const MERGE_MARKERS = [
-      "<".repeat(7),
-      "=".repeat(7),
-      ">".repeat(7),
-    ];
-    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
-      console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+    const HEAD = '<'.repeat(7);
+    const SEP = '='.repeat(7);
+    const TAIL = '>'.repeat(7);
+    if (html.includes(HEAD) && html.includes(SEP) && html.includes(TAIL)) {
+      const conflictPattern = new RegExp(`${HEAD}[\s\S]*?${SEP}[\s\S]*?${TAIL}`);
+      if (conflictPattern.test(html)) {
+        console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+      }
     }
   } catch (_) {}
 

--- a/data-tools.html
+++ b/data-tools.html
@@ -160,13 +160,14 @@
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    const MERGE_MARKERS = [
-      "<".repeat(7),
-      "=".repeat(7),
-      ">".repeat(7),
-    ];
-    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
-      console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+    const HEAD = '<'.repeat(7);
+    const SEP = '='.repeat(7);
+    const TAIL = '>'.repeat(7);
+    if (html.includes(HEAD) && html.includes(SEP) && html.includes(TAIL)) {
+      const conflictPattern = new RegExp(`${HEAD}[\s\S]*?${SEP}[\s\S]*?${TAIL}`);
+      if (conflictPattern.test(html)) {
+        console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+      }
     }
   } catch (_) {}
 

--- a/index.html
+++ b/index.html
@@ -46,13 +46,14 @@
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    const MERGE_MARKERS = [
-      "<".repeat(7),
-      "=".repeat(7),
-      ">".repeat(7),
-    ];
-    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
-      console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+    const HEAD = '<'.repeat(7);
+    const SEP = '='.repeat(7);
+    const TAIL = '>'.repeat(7);
+    if (html.includes(HEAD) && html.includes(SEP) && html.includes(TAIL)) {
+      const conflictPattern = new RegExp(`${HEAD}[\s\S]*?${SEP}[\s\S]*?${TAIL}`);
+      if (conflictPattern.test(html)) {
+        console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+      }
     }
   } catch (_) {}
 

--- a/individualkinkanalysis.html
+++ b/individualkinkanalysis.html
@@ -591,13 +591,14 @@ Otherwise, safe fallbacks included below will run.
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    const MERGE_MARKERS = [
-      "<".repeat(7),
-      "=".repeat(7),
-      ">".repeat(7),
-    ];
-    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
-      console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+    const HEAD = '<'.repeat(7);
+    const SEP = '='.repeat(7);
+    const TAIL = '>'.repeat(7);
+    if (html.includes(HEAD) && html.includes(SEP) && html.includes(TAIL)) {
+      const conflictPattern = new RegExp(`${HEAD}[\s\S]*?${SEP}[\s\S]*?${TAIL}`);
+      if (conflictPattern.test(html)) {
+        console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+      }
     }
   } catch (_) {}
 

--- a/js/tk-safe-bootstrap.js
+++ b/js/tk-safe-bootstrap.js
@@ -5,13 +5,14 @@
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    const MERGE_MARKERS = [
-      "<".repeat(7),
-      "=".repeat(7),
-      ">".repeat(7),
-    ];
-    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
-      console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+    const HEAD = '<'.repeat(7);
+    const SEP = '='.repeat(7);
+    const TAIL = '>'.repeat(7);
+    if (html.includes(HEAD) && html.includes(SEP) && html.includes(TAIL)) {
+      const conflictPattern = new RegExp(`${HEAD}[\s\S]*?${SEP}[\s\S]*?${TAIL}`);
+      if (conflictPattern.test(html)) {
+        console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+      }
     }
   } catch (_) {}
 

--- a/kink-list.html
+++ b/kink-list.html
@@ -275,13 +275,14 @@
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    const MERGE_MARKERS = [
-      "<".repeat(7),
-      "=".repeat(7),
-      ">".repeat(7),
-    ];
-    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
-      console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+    const HEAD = '<'.repeat(7);
+    const SEP = '='.repeat(7);
+    const TAIL = '>'.repeat(7);
+    if (html.includes(HEAD) && html.includes(SEP) && html.includes(TAIL)) {
+      const conflictPattern = new RegExp(`${HEAD}[\s\S]*?${SEP}[\s\S]*?${TAIL}`);
+      if (conflictPattern.test(html)) {
+        console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+      }
     }
   } catch (_) {}
 

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -991,13 +991,14 @@ How to use
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    const MERGE_MARKERS = [
-      "<".repeat(7),
-      "=".repeat(7),
-      ">".repeat(7),
-    ];
-    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
-      console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+    const HEAD = '<'.repeat(7);
+    const SEP = '='.repeat(7);
+    const TAIL = '>'.repeat(7);
+    if (html.includes(HEAD) && html.includes(SEP) && html.includes(TAIL)) {
+      const conflictPattern = new RegExp(`${HEAD}[\s\S]*?${SEP}[\s\S]*?${TAIL}`);
+      if (conflictPattern.test(html)) {
+        console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+      }
     }
   } catch (_) {}
 

--- a/pdf-download-test.html
+++ b/pdf-download-test.html
@@ -135,13 +135,14 @@ document.addEventListener("DOMContentLoaded", setupPDFExport);
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    const MERGE_MARKERS = [
-      "<".repeat(7),
-      "=".repeat(7),
-      ">".repeat(7),
-    ];
-    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
-      console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+    const HEAD = '<'.repeat(7);
+    const SEP = '='.repeat(7);
+    const TAIL = '>'.repeat(7);
+    if (html.includes(HEAD) && html.includes(SEP) && html.includes(TAIL)) {
+      const conflictPattern = new RegExp(`${HEAD}[\s\S]*?${SEP}[\s\S]*?${TAIL}`);
+      if (conflictPattern.test(html)) {
+        console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+      }
     }
   } catch (_) {}
 

--- a/simple-compatibility.html
+++ b/simple-compatibility.html
@@ -452,13 +452,14 @@ Paste this WHOLE block at the very end of the page (after your table renders).
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    const MERGE_MARKERS = [
-      "<".repeat(7),
-      "=".repeat(7),
-      ">".repeat(7),
-    ];
-    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
-      console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+    const HEAD = '<'.repeat(7);
+    const SEP = '='.repeat(7);
+    const TAIL = '>'.repeat(7);
+    if (html.includes(HEAD) && html.includes(SEP) && html.includes(TAIL)) {
+      const conflictPattern = new RegExp(`${HEAD}[\s\S]*?${SEP}[\s\S]*?${TAIL}`);
+      if (conflictPattern.test(html)) {
+        console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+      }
     }
   } catch (_) {}
 

--- a/snippet-category-panel.html
+++ b/snippet-category-panel.html
@@ -185,13 +185,14 @@ document.getElementById('deselectAll').addEventListener('click', () => {
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    const MERGE_MARKERS = [
-      "<".repeat(7),
-      "=".repeat(7),
-      ">".repeat(7),
-    ];
-    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
-      console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+    const HEAD = '<'.repeat(7);
+    const SEP = '='.repeat(7);
+    const TAIL = '>'.repeat(7);
+    if (html.includes(HEAD) && html.includes(SEP) && html.includes(TAIL)) {
+      const conflictPattern = new RegExp(`${HEAD}[\s\S]*?${SEP}[\s\S]*?${TAIL}`);
+      if (conflictPattern.test(html)) {
+        console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+      }
     }
   } catch (_) {}
 

--- a/snippet-clean-match.html
+++ b/snippet-clean-match.html
@@ -78,13 +78,14 @@ tkRefreshAll();
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    const MERGE_MARKERS = [
-      "<".repeat(7),
-      "=".repeat(7),
-      ">".repeat(7),
-    ];
-    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
-      console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+    const HEAD = '<'.repeat(7);
+    const SEP = '='.repeat(7);
+    const TAIL = '>'.repeat(7);
+    if (html.includes(HEAD) && html.includes(SEP) && html.includes(TAIL)) {
+      const conflictPattern = new RegExp(`${HEAD}[\s\S]*?${SEP}[\s\S]*?${TAIL}`);
+      if (conflictPattern.test(html)) {
+        console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+      }
     }
   } catch (_) {}
 

--- a/snippet-compatibility-report-dark.html
+++ b/snippet-compatibility-report-dark.html
@@ -214,13 +214,14 @@ Notes
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    const MERGE_MARKERS = [
-      "<".repeat(7),
-      "=".repeat(7),
-      ">".repeat(7),
-    ];
-    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
-      console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+    const HEAD = '<'.repeat(7);
+    const SEP = '='.repeat(7);
+    const TAIL = '>'.repeat(7);
+    if (html.includes(HEAD) && html.includes(SEP) && html.includes(TAIL)) {
+      const conflictPattern = new RegExp(`${HEAD}[\s\S]*?${SEP}[\s\S]*?${TAIL}`);
+      if (conflictPattern.test(html)) {
+        console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+      }
     }
   } catch (_) {}
 

--- a/snippet-compatibility-report-pdf-export-fix.html
+++ b/snippet-compatibility-report-pdf-export-fix.html
@@ -13,13 +13,14 @@ HOW TO USE:
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    const MERGE_MARKERS = [
-      "<".repeat(7),
-      "=".repeat(7),
-      ">".repeat(7),
-    ];
-    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
-      console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+    const HEAD = '<'.repeat(7);
+    const SEP = '='.repeat(7);
+    const TAIL = '>'.repeat(7);
+    if (html.includes(HEAD) && html.includes(SEP) && html.includes(TAIL)) {
+      const conflictPattern = new RegExp(`${HEAD}[\s\S]*?${SEP}[\s\S]*?${TAIL}`);
+      if (conflictPattern.test(html)) {
+        console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+      }
     }
   } catch (_) {}
 

--- a/snippet-compatibility-report.html
+++ b/snippet-compatibility-report.html
@@ -207,13 +207,14 @@ If your table rows use <td data-cell="A">…</td> and <td data-cell="B">…</td>
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    const MERGE_MARKERS = [
-      "<".repeat(7),
-      "=".repeat(7),
-      ">".repeat(7),
-    ];
-    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
-      console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+    const HEAD = '<'.repeat(7);
+    const SEP = '='.repeat(7);
+    const TAIL = '>'.repeat(7);
+    if (html.includes(HEAD) && html.includes(SEP) && html.includes(TAIL)) {
+      const conflictPattern = new RegExp(`${HEAD}[\s\S]*?${SEP}[\s\S]*?${TAIL}`);
+      if (conflictPattern.test(html)) {
+        console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+      }
     }
   } catch (_) {}
 

--- a/snippet-individual-kink-analysis.html
+++ b/snippet-individual-kink-analysis.html
@@ -85,13 +85,14 @@
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    const MERGE_MARKERS = [
-      "<".repeat(7),
-      "=".repeat(7),
-      ">".repeat(7),
-    ];
-    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
-      console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+    const HEAD = '<'.repeat(7);
+    const SEP = '='.repeat(7);
+    const TAIL = '>'.repeat(7);
+    if (html.includes(HEAD) && html.includes(SEP) && html.includes(TAIL)) {
+      const conflictPattern = new RegExp(`${HEAD}[\s\S]*?${SEP}[\s\S]*?${TAIL}`);
+      if (conflictPattern.test(html)) {
+        console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+      }
     }
   } catch (_) {}
 

--- a/talk-kink-module.html
+++ b/talk-kink-module.html
@@ -328,13 +328,14 @@
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    const MERGE_MARKERS = [
-      "<".repeat(7),
-      "=".repeat(7),
-      ">".repeat(7),
-    ];
-    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
-      console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+    const HEAD = '<'.repeat(7);
+    const SEP = '='.repeat(7);
+    const TAIL = '>'.repeat(7);
+    if (html.includes(HEAD) && html.includes(SEP) && html.includes(TAIL)) {
+      const conflictPattern = new RegExp(`${HEAD}[\s\S]*?${SEP}[\s\S]*?${TAIL}`);
+      if (conflictPattern.test(html)) {
+        console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+      }
     }
   } catch (_) {}
 

--- a/token.html
+++ b/token.html
@@ -63,13 +63,14 @@
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    const MERGE_MARKERS = [
-      "<".repeat(7),
-      "=".repeat(7),
-      ">".repeat(7),
-    ];
-    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
-      console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+    const HEAD = '<'.repeat(7);
+    const SEP = '='.repeat(7);
+    const TAIL = '>'.repeat(7);
+    if (html.includes(HEAD) && html.includes(SEP) && html.includes(TAIL)) {
+      const conflictPattern = new RegExp(`${HEAD}[\s\S]*?${SEP}[\s\S]*?${TAIL}`);
+      if (conflictPattern.test(html)) {
+        console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+      }
     }
   } catch (_) {}
 

--- a/training-plan.html
+++ b/training-plan.html
@@ -34,13 +34,14 @@
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    const MERGE_MARKERS = [
-      "<".repeat(7),
-      "=".repeat(7),
-      ">".repeat(7),
-    ];
-    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
-      console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+    const HEAD = '<'.repeat(7);
+    const SEP = '='.repeat(7);
+    const TAIL = '>'.repeat(7);
+    if (html.includes(HEAD) && html.includes(SEP) && html.includes(TAIL)) {
+      const conflictPattern = new RegExp(`${HEAD}[\s\S]*?${SEP}[\s\S]*?${TAIL}`);
+      if (conflictPattern.test(html)) {
+        console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+      }
     }
   } catch (_) {}
 

--- a/villain-quote.html
+++ b/villain-quote.html
@@ -38,13 +38,14 @@
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    const MERGE_MARKERS = [
-      "<".repeat(7),
-      "=".repeat(7),
-      ">".repeat(7),
-    ];
-    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
-      console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+    const HEAD = '<'.repeat(7);
+    const SEP = '='.repeat(7);
+    const TAIL = '>'.repeat(7);
+    if (html.includes(HEAD) && html.includes(SEP) && html.includes(TAIL)) {
+      const conflictPattern = new RegExp(`${HEAD}[\s\S]*?${SEP}[\s\S]*?${TAIL}`);
+      if (conflictPattern.test(html)) {
+        console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+      }
     }
   } catch (_) {}
 

--- a/your-roles.html
+++ b/your-roles.html
@@ -153,13 +153,14 @@
   /* A. QUICK SANITY CHECKS — find & warn about merge markers (these often lock pages) */
   try {
     const html = document.documentElement.innerHTML;
-    const MERGE_MARKERS = [
-      "<".repeat(7),
-      "=".repeat(7),
-      ">".repeat(7),
-    ];
-    if (MERGE_MARKERS.some((marker) => html.includes(marker))) {
-      console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+    const HEAD = '<'.repeat(7);
+    const SEP = '='.repeat(7);
+    const TAIL = '>'.repeat(7);
+    if (html.includes(HEAD) && html.includes(SEP) && html.includes(TAIL)) {
+      const conflictPattern = new RegExp(`${HEAD}[\s\S]*?${SEP}[\s\S]*?${TAIL}`);
+      if (conflictPattern.test(html)) {
+        console.warn("[TK-SAFE] Merge conflict markers detected in DOM. Remove them to avoid broken JS/CSS.");
+      }
     }
   } catch (_) {}
 


### PR DESCRIPTION
## Summary
- update the TalkKink Safe Bootstrap script to only warn when a full merge conflict pattern is present
- mirror the refined detection logic across all HTML copies of the bootstrap helper to prevent console noise

## Testing
- npm run check:conflicts

------
https://chatgpt.com/codex/tasks/task_e_68ca04be4e18832ca47b4fdbe2cf064f