### PR TITLE
Stop redirecting unauthenticated kink survey users

### DIFF
--- a/kinks/index.html
+++ b/kinks/index.html
@@ -820,7 +820,7 @@
     fetch("/check-session", { credentials: "include" })
       .then(res => {
         if (res.status === 401) {
-          window.location.href = "/token.html";
+          console.info("Session check: unauthenticated user", res);
         }
       })
       .catch(err => console.error("Session check failed:", err));


### PR DESCRIPTION
## Summary
- remove the redirect to /token.html from the inline /check-session guard so anonymous visitors can use the survey

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cb57e39854832ca17e8a84a5dc62f1