### PR TITLE
Add completion screen to guided survey

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -459,6 +459,7 @@ async function startNewSurvey() {
   if (panelContainer) panelContainer.style.display = 'none';
   surveyContainer.style.display = 'none';
   finalScreen.style.display = 'none';
+  if (exportControls) exportControls.style.display = 'none';
   progressBanner.style.display = 'none';
   const initialize = data => initializeSurvey(data);
 
@@ -649,6 +650,7 @@ function showKinks(category) {
   }
   surveyContainer.style.display = 'block';
   finalScreen.style.display = 'none';
+  if (exportControls) exportControls.style.display = 'none';
   const categoryData = surveyA[category];
   updateProgress();
   const items = getUnifiedItems(categoryData).filter(shouldDisplayItem);
@@ -734,6 +736,7 @@ function nextCategory() {
     currentCategory = null;
     surveyContainer.style.display = 'none';
     finalScreen.style.display = 'flex';
+    if (exportControls) exportControls.style.display = 'flex';
     progressBanner.style.display = 'none';
     setTimeout(() => {
       downloadPDF();
@@ -808,6 +811,7 @@ function buildPanelLayout() {
   panelContainer.style.display = 'block';
   surveyContainer.style.display = 'none';
   finalScreen.style.display = 'none';
+  if (exportControls) exportControls.style.display = 'none';
   progressBanner.style.display = 'none';
   const lastOpen = localStorage.getItem('lastPanel');
   categoryOrder.forEach((cat, idx) => {

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -85,7 +85,19 @@
       <button id="skipCategoryBtn" class="themed-button">Skip Category</button>
       <button id="nextCategoryBtn" class="themed-button">Next Category</button>
     </div>
-    <div id="exportControls" style="display:none; margin-top: 30px; text-align: center;">
+  </div>
+
+  <div
+    id="finalScreen"
+    class="final-screen"
+    style="display:none; align-items:center; justify-content:center; flex-direction:column; gap:1.5rem; text-align:center; margin:40px auto 0;"
+  >
+    <h2>Survey complete!</h2>
+    <p>
+      You've reviewed every selected category. Download your answers to compare with a partner or continue to the
+      data tools for your next steps.
+    </p>
+    <div id="exportControls" style="display:none; gap:1rem; justify-content:center; flex-wrap:wrap;">
       <button id="exportAndCompareBtn" class="themed-button">Download & Compare</button>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add a dedicated final screen to the kinks survey page so the user sees a completion message once the last category is finished
- ensure the guided survey logic hides the export controls until completion and shows them alongside the new message

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb5a39fb0c832c92bd3c529a101b9a