### PR TITLE
fix(kinks): add base href and live verifier

### DIFF
--- a/kinks/index.html
+++ b/kinks/index.html
@@ -1,26 +1,24 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- TK-HOTFIX START -->
-<link rel="stylesheet" href="/css/style.css" id="tk-style-root"/>
-<link rel="stylesheet" href="/css/theme.css" id="tk-theme-root"/>
-<style id="tk-fallback">
-  :root{ --tk-fg:#e6f2ff; --tk-accent:#00e6ff; }
-  body{ background:#000; color:var(--fg, var(--tk-fg)); }
-  .themed-title,.category-panel,.themed-text{ color:var(--fg, var(--tk-fg)); }
-  .themed-button{ background:var(--accent, var(--tk-accent)); color:#000; }
-</style>
-<script type="module" id="tk-theme-module">
-  import { initTheme, applyThemeColors } from '/js/theme.js';
-  try{ initTheme(); window.applyThemeColors = applyThemeColors; }catch(e){ console.error('[TK-theme]', e); }
-</script>
-<!-- TK-HOTFIX END -->
-
+  <!-- TK-HOTFIX START -->
+  <base href="/" />
+  <!-- TK-HOTFIX END -->
+  <!-- TK-HOTFIX START -->
+  <link rel="stylesheet" href="/css/style.css?v=1730846400000" id="tk-style-root"/>
+  <link rel="stylesheet" href="/css/theme.css?v=1730846400000" id="tk-theme-root"/>
+  <!-- readable fallback so black text can't disappear on black bg -->
+  <style id="tk-fallback">
+    :root{ --tk-fg:#e6f2ff; --tk-accent:#00e6ff; }
+    body{ background:#000; color:var(--fg, var(--tk-fg)); }
+    .themed-title,.category-panel,.themed-text{ color:var(--fg, var(--tk-fg)); }
+    .themed-button{ background:var(--accent, var(--tk-accent)); color:#000; }
+  </style>
+  <script type="module" id="tk-theme-module" src="/js/theme.js?v=1730846400000"></script>
+  <!-- TK-HOTFIX END -->
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Talk Kink</title>
-  <link rel="stylesheet" href="../css/style.css" />
-  <link rel="stylesheet" href="../css/theme.css" />
   <link href="https://fonts.googleapis.com/css2?family=Fredoka+One&family=EB+Garamond&display=swap" rel="stylesheet">
 </head>
 <body class="theme-dark has-category-panel">
@@ -122,7 +120,7 @@
 
   <!-- Theme & Survey Logic -->
   <script type="module">
-    import { initTheme, applyThemeColors } from '../js/theme.js';
+    import { initTheme, applyThemeColors } from '/js/theme.js?v=1730846400000';
 
     initTheme();
     window.applyThemeColors = applyThemeColors;
@@ -965,24 +963,21 @@ How to use
 <script id="tk-diag">
 (function(){
   function show(msg){
-    let diag = document.getElementById('kinksDiagnostics');
-    if(!diag){ diag = document.createElement('div'); diag.id='kinksDiagnostics'; document.body.prepend(diag); }
-    diag.hidden = false;
-    diag.style.cssText = "background:#111;color:#fff;padding:8px;border:1px solid #444;margin:8px 0";
-    diag.textContent = msg;
+    var d = document.getElementById('kinksDiagnostics');
+    if(!d){ d = document.createElement('div'); d.id='kinksDiagnostics'; document.body.prepend(d); }
+    d.hidden = false;
+    d.style.cssText = "background:#111;color:#fff;padding:8px;border:1px solid #444;margin:8px 0";
+    d.textContent = msg;
   }
-  // Only run if page didn't already boot data
-  if(!window.__TK_BOOT_RAN){
-    window.__TK_BOOT_RAN = true;
-    (async () => {
-      try{
-        const r = await fetch('/data/kinks.json', { cache:'no-store' });
-        if(!r.ok) throw new Error('kinks.json ' + r.status);
-        const data = await r.json();
-        if (typeof window.KINKS_boot === 'function') { window.KINKS_boot(data); }
-      }catch(e){ show('Data bootstrap failed: ' + e.message); }
-    })();
-  }
+  // Try the canonical JSON from root (works under /kinks/)
+  (async () => {
+    try {
+      const r = await fetch('/data/kinks.json?v=1730846400000', { cache:'no-store' });
+      if(!r.ok) throw new Error('kinks.json ' + r.status);
+      const data = await r.json();
+      if (typeof window.KINKS_boot === 'function') { window.KINKS_boot(data); }
+    } catch (e) { show('Data bootstrap failed: ' + e.message); }
+  })();
 })();
 </script>
 <!-- TK-HOTFIX END -->

--- a/scripts/verify_live.mjs
+++ b/scripts/verify_live.mjs
@@ -1,0 +1,33 @@
+const base = (process.argv[2] || "https://talkkink.org").replace(/\/+$/,"");
+const stamp = Date.now();
+const urls = [
+  `${base}/kinks/`,
+  `${base}/css/style.css?v=${stamp}`,
+  `${base}/css/theme.css?v=${stamp}`,
+  `${base}/js/theme.js?v=${stamp}`,
+  `${base}/data/kinks.json?v=${stamp}`
+];
+
+async function check(u){
+  try{
+    const r = await fetch(u, { cache: "no-store" });
+    return { url: u, status: r.status, ok: r.ok, type: r.headers.get("content-type") || "" };
+  }catch(e){
+    return { url: u, status: "FETCH_FAIL", ok: false, type: String(e) };
+  }
+}
+
+(async () => {
+  const results = await Promise.all(urls.map(check));
+  const pad = (s,n)=>String(s).padEnd(n);
+  console.log("Checking", base);
+  console.log(pad("STATUS",10), pad("OK",4), pad("TYPE",24), "URL");
+  for (const r of results) console.log(pad(r.status,10), pad(r.ok,4), pad(r.type,24), r.url);
+  // helper: print a hint if /kinks/ HTML doesn’t include the hotfix markers
+  try{
+    const html = await (await fetch(`${base}/kinks/?t=${stamp}`, { cache: "no-store" })).text();
+    const hasBase = /<base href="\/"/i.test(html);
+    const hasHotfix = /TK-HOTFIX/.test(html);
+    console.log("\nHotfix markers — base tag:", hasBase, "hotfix blocks:", hasHotfix);
+  }catch{}
+})();


### PR DESCRIPTION
## Summary
- add a <base href="/"> hotfix block that forces root-absolute asset loading with cache-busting URLs and fallback styling
- switch the in-page theme loader to the cache-busted root module path and ensure JSON diagnostics fetches the root data with cache control
- add a scripts/verify_live.mjs helper to confirm live assets, CSS, JS, and hotfix markers after deployment

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ccd0035a58832c86eb329a079dc30b