### PR TITLE
Add CI wrapper and E2E scripts for kinks

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,11 @@
   "dependencies": {
     "dotenv": "^16.4.5",
     "express": "^4.19.2"
-  }
+  },
+  "directories": {
+    "doc": "docs",
+    "lib": "lib",
+    "test": "test"
+  },
+  "devDependencies": {}
 }

--- a/scripts/kinks_ci.mjs
+++ b/scripts/kinks_ci.mjs
@@ -1,0 +1,62 @@
+import http from "node:http";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+import { spawn } from "node:child_process";
+
+function log(...a){ console.log("[CI]", ...a); }
+
+async function head(u){
+  try { const r = await fetch(u,{method:"HEAD"}); return {ok:r.ok, status:r.status}; }
+  catch { return {ok:false, status:"FAIL"}; }
+}
+
+async function liveOK(){
+  const { ok, status } = await head("https://talkkink.org/kinks/");
+  log("live probe:", status);
+  return ok && status===200;
+}
+
+// Minimal static server (no deps)
+function serve(dir, port=8080){
+  const mimes = { ".html":"text/html",".css":"text/css",".js":"application/javascript",".json":"application/json",".png":"image/png",".svg":"image/svg+xml",".ico":"image/x-icon" };
+  const srv = http.createServer((req,res)=>{
+    try{
+      let p = decodeURI(req.url.split("?")[0]);
+      if (p.endsWith("/")) p += "index.html";
+      const file = path.join(dir, p);
+      if (!file.startsWith(path.resolve(dir))) { res.writeHead(403); return res.end("Forbidden"); }
+      if (!fs.existsSync(file)) { res.writeHead(404); return res.end("Not found"); }
+      const ext = path.extname(file).toLowerCase();
+      res.writeHead(200, {"Content-Type": mimes[ext] || "application/octet-stream"});
+      fs.createReadStream(file).pipe(res);
+    }catch(e){ res.writeHead(500); res.end("Server error"); }
+  });
+  return new Promise(resolve => srv.listen(port, "127.0.0.1", ()=>resolve(srv)));
+}
+
+async function main(){
+  let base = "https://talkkink.org/kinks/";
+  let srv = null;
+
+  if (!(await liveOK())) {
+    // fallback to local
+    const root = fs.existsSync("docs/kinks/index.html") ? "docs" :
+                 fs.existsSync("kinks/index.html")      ? "."   : null;
+    if (!root) { console.error("Cannot find kinks/index.html in docs/ or repo root."); process.exit(2); }
+    srv = await serve(root, 8080);
+    base = "http://127.0.0.1:8080/kinks/";
+    log("serving local:", path.resolve(root), "→", base);
+  } else {
+    log("using live:", base);
+  }
+
+  // run E2E against the chosen base
+  const env = { ...process.env, KINKS_BASE: base };
+  const p = spawn(process.execPath, ["scripts/kinks_e2e.mjs"], { stdio:"inherit", env });
+  const code = await new Promise(res => p.on("close", res));
+
+  if (srv) srv.close();
+  process.exit(code);
+}
+main();

--- a/scripts/kinks_e2e.mjs
+++ b/scripts/kinks_e2e.mjs
@@ -7,134 +7,71 @@ const ART = "artifacts";
 await fs.mkdir(ART, { recursive: true });
 
 let hadConsoleError = false;
-
-const browser = await chromium.launch({ headless: true });
-const ctx = await browser.newContext({
-  acceptDownloads: true,
-  ignoreHTTPSErrors: true,
-  viewport: { width: 1440, height: 900 }
-});
+const browser = await chromium.launch({ headless:true });
+const ctx = await browser.newContext({ acceptDownloads:true, ignoreHTTPSErrors:true, viewport:{width:1440,height:900} });
 const page = await ctx.newPage();
 
-// capture console errors/warnings
-page.on("console", msg => {
-  const type = msg.type();
-  if (type === "error") hadConsoleError = true;
+page.on("console", m => { if (m.type()==="error") hadConsoleError = true; });
+let exportPath = null;
+page.on("download", async dl => {
+  const out = path.join(ART, (dl.suggestedFilename()||"export.json").replace(/\?.*$/,""));
+  await dl.saveAs(out); exportPath = out;
 });
 
-let capturedJSONPath = null;
-page.on("download", async (dl) => {
-  const suggested = dl.suggestedFilename() || "export.json";
-  const out = path.join(ART, suggested.replace(/\?.*$/,""));
-  await dl.saveAs(out);
-  capturedJSONPath = out;
-});
+await page.goto(BASE, { waitUntil:"domcontentloaded", timeout:60000 });
 
-// 1) Navigate
-await page.goto(BASE, { waitUntil: "domcontentloaded", timeout: 60_000 });
-
-// 2) Ensure critical assets loaded (visible in network)
-const assetResults = await page.evaluate(async () => {
-  const check = async (p) => {
-    try {
-      const r = await fetch(p, { cache:"no-store" });
-      return { p, status:r.status, ok:r.ok, type:r.headers.get("content-type")||"" };
-    } catch (e) { return { p, status: "FAIL", ok:false, type:String(e) }; }
-  };
+// Ensure critical assets load
+const assets = await page.evaluate(async ()=>{
   const need = ["/css/style.css","/css/theme.css","/js/theme.js","/data/kinks.json"];
-  const res = [];
-  for (const p of need) res.push(await check(p));
-  return res;
+  const out = [];
+  for (const p of need) {
+    try { const r = await fetch(p,{cache:"no-store"}); out.push({p,status:r.status,ok:r.ok}); }
+    catch { out.push({p,status:"FAIL",ok:false}); }
+  }
+  return out;
 });
-const badAssets = assetResults.filter(r => r.status !== 200);
-if (badAssets.length) {
-  console.log("Asset check:", assetResults);
-  throw new Error("Missing assets: " + badAssets.map(r=>`${r.p}:${r.status}`).join(", "));
-}
+const bad = assets.filter(a => a.status !== 200);
+if (bad.length) { console.log("Asset check:", assets); throw new Error("Missing assets"); }
 
-// 3) If a Start button exists, enable & click it
-await page.evaluate(() => {
-  const b = document.querySelector("#start,#startSurvey");
-  if (b) b.removeAttribute("disabled");
-});
-const startBtn = await page.$("#start,#startSurvey");
-if (startBtn) {
-  await startBtn.click().catch(()=>{});
-  await page.waitForTimeout(400);
-}
+// click Start if present
+await page.evaluate(()=>document.querySelector("#start,#startSurvey")?.removeAttribute("disabled"));
+const start = await page.$("#start,#startSurvey");
+if (start) { await start.click().catch(()=>{}); await page.waitForTimeout(400); }
 
-// 4) Select ratings on the first N dropdowns
+// set ratings on first N dropdowns
 const changed = await page.evaluate(({N})=>{
-  const selects = Array.from(document.querySelectorAll("select"));
-  let c = 0;
-  for (const el of selects.slice(0, N)) {
-    const v = el.querySelector("option[value='3']") ? "3" :
-              (el.querySelector("option[value='4']") ? "4" : "2");
-    if (el.value !== v) {
-      el.value = v;
-      el.dispatchEvent(new Event("change", { bubbles: true }));
-      c++;
-    }
-  }
-  return c;
-},{N: 15});
-console.log(`Set ${changed} dropdown(s).`);
+  const sels = Array.from(document.querySelectorAll("select"));
+  let c=0; for (const el of sels.slice(0,N)) {
+    const v = el.querySelector("option[value='3']") ? "3" : (el.querySelector("option[value='4']")?"4":"2");
+    if (el.value !== v) { el.value = v; el.dispatchEvent(new Event("change",{bubbles:true})); c++; }
+  } return c;
+},{N:15});
+console.log(`Set ${changed} dropdown(s)`);
 
-// 5) Click an Export/Download/Save button if present
-const exportBtn = await page.locator('button:has-text("Export"), button:has-text("Download"), a:has-text("Export"), a:has-text("Download"), button:has-text("Save"), a:has-text("Save")').first();
+// click Export/Download/Save if present
+const exportBtn = await page.locator('button:has-text("Export"),a:has-text("Export"),button:has-text("Download"),a:has-text("Download"),button:has-text("Save"),a:has-text("Save")').first();
 if (await exportBtn.count()) {
-  const [dl] = await Promise.all([
-    page.waitForEvent("download").catch(()=>null),
-    exportBtn.click().catch(()=>null),
-  ]);
-  if (dl && !capturedJSONPath) {
-    const out = path.join(ART, dl.suggestedFilename() || "export.json");
-    await dl.saveAs(out);
-    capturedJSONPath = out;
-  }
+  const [dl] = await Promise.all([page.waitForEvent("download").catch(()=>null), exportBtn.click().catch(()=>null)]);
+  if (dl && !exportPath) { const out = path.join(ART, dl.suggestedFilename()||"export.json"); await dl.saveAs(out); exportPath = out; }
 } else {
-  console.log("No Export/Download/Save button found.");
+  console.log("No export button found.");
 }
 
-// 6) Screenshot
-const shot = path.join(ART, "kinks.png");
-await page.screenshot({ path: shot, fullPage: true });
-console.log("Saved screenshot:", shot);
+const shot = path.join(ART,"kinks.png"); await page.screenshot({path:shot, fullPage:true}); console.log("Screenshot:", shot);
 
-// 7) Validate exported JSON (if any)
-let okClamp = true;
-if (capturedJSONPath) {
-  const txt = await fs.readFile(capturedJSONPath, "utf8");
-  let obj = null;
-  try { obj = JSON.parse(txt); } catch { /* ignore */ }
+// validate clamp if we captured export
+let clampOK = true;
+if (exportPath) {
+  const txt = await fs.readFile(exportPath,"utf8"); let obj=null;
+  try { obj = JSON.parse(txt); } catch {}
   const arr = Array.isArray(obj) ? obj : (obj && Array.isArray(obj.kinks) ? obj.kinks : []);
-  const bad = [];
-  for (let i=0;i<arr.length;i++){
-    const r = arr[i]?.rating;
-    if (r == null) continue;
-    const n = +r;
-    if (!Number.isFinite(n) || n < 0 || n > 5) bad.push({i, rating:r});
-  }
-  if (bad.length) {
-    okClamp = false;
-    console.log("Out-of-range ratings:", bad.slice(0,10));
-  } else {
-    console.log("All ratings within 0–5 (or null) ✓");
-  }
-  console.log("Export captured:", capturedJSONPath, `(${txt.length} bytes)`);
-} else {
-  console.log("No export file captured.");
+  const badR = [];
+  for (let i=0;i<arr.length;i++){ const r = arr[i]?.rating; if (r==null) continue; const n=+r; if (!Number.isFinite(n) || n<0 || n>5) badR.push({i,rating:r}); }
+  if (badR.length) { clampOK = false; console.log("Out-of-range ratings (first 10):", badR.slice(0,10)); }
+  else console.log("All ratings within 0–5 (or null) ✓");
+  console.log("Export:", exportPath, `(${txt.length} bytes)`);
 }
 
-// 8) Summarize + exit code
-console.log("AssetResults:", assetResults);
-console.log("ConsoleErrors:", hadConsoleError);
 await browser.close();
-
-const okAssets = badAssets.length === 0;
-const overall = okAssets && !hadConsoleError && okClamp;
-if (!overall) {
-  console.log({ okAssets, hadConsoleError, okClamp });
-  process.exit(1);
-}
+if (!(clampOK) || hadConsoleError) { console.log({clampOK, hadConsoleError}); process.exit(1); }
 console.log("E2E OK ✓");


### PR DESCRIPTION
## Summary
- add a HEAD-based network probe for the kinks assets that also returns JSON for downstream tooling
- streamline the kinks Playwright E2E flow and keep the export clamping validation
- introduce a CI wrapper that falls back to serving the local static assets when the live site is unavailable and surface repository directories metadata

## Testing
- node scripts/kinks_netcheck.mjs
- node scripts/kinks_ci.mjs *(fails: playwright package unavailable because npm registry returns 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d1ad3e4624832cb561c532cfe3f544