### PR TITLE
Handle theme module load failures on kinks page

### DIFF
--- a/docs/kinks/index.html
+++ b/docs/kinks/index.html
@@ -137,7 +137,16 @@
 
   <!-- Theme & Survey Logic -->
   <script type="module">
-    import { initTheme, applyThemeColors } from './js/theme.js?v=1758253846';
+    const getThemeModule = async () => {
+      try {
+        return await import('./js/theme.js?v=1758253846');
+      } catch (err) {
+        console.warn('[survey] Failed to load theme module', err);
+        return {};
+      }
+    };
+
+    const { initTheme = () => {}, applyThemeColors = () => {} } = await getThemeModule();
 
     initTheme();
     window.applyThemeColors = applyThemeColors;

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -120,7 +120,16 @@
 
   <!-- Theme & Survey Logic -->
   <script type="module">
-    import { initTheme, applyThemeColors } from '/js/theme.js?v=1730846400000';
+    const getThemeModule = async () => {
+      try {
+        return await import('/js/theme.js?v=1730846400000');
+      } catch (err) {
+        console.warn('[survey] Failed to load theme module', err);
+        return {};
+      }
+    };
+
+    const { initTheme = () => {}, applyThemeColors = () => {} } = await getThemeModule();
 
     initTheme();
     window.applyThemeColors = applyThemeColors;


### PR DESCRIPTION
## Summary
- wrap the kinks page theme import in a guarded dynamic loader so survey logic still runs when the module is unavailable
- expose no-op theme helpers when the theme script fails to keep selection buttons and checkboxes functional

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d44709c878832cb1ef9d476590d527