### PR TITLE
Add kinks JSON availability diagnostics and nginx fix

### DIFF
--- a/ops/nginx-kinks-data-norewrite.conf
+++ b/ops/nginx-kinks-data-norewrite.conf
@@ -1,0 +1,12 @@
+# Include this BEFORE your SPA fallback location
+# Ensures /data/* serves JSON or 404 (NOT HTML fallback)
+location ^~ /data/ {
+    types { application/json json; }
+    default_type application/json;
+    try_files $uri =404;
+}
+
+# Example SPA fallback (keep AFTER the /data/ block)
+# location / {
+#     try_files $uri /compatibility.html;
+# }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "generate:tokens": "node generateTokens.js",
     "generate-pdf:landscape": "node --input-type=module -e \"globalThis.window={};await import('./js/vendor/jspdf.umd.min.js');await (await import('./js/compatibilityPdf.js')).generateCompatibilityPDFLandscape({categories: []})\"",
     "check:conflicts": "node scripts/check-conflicts.js",
-    "precommit": "npm run check:conflicts"
+    "precommit": "npm run check:conflicts",
+    "reason:kinks": "node scripts/reason-kinks-json.mjs"
   },
   "keywords": [],
   "author": "",

--- a/scripts/reason-kinks-json.mjs
+++ b/scripts/reason-kinks-json.mjs
@@ -1,0 +1,53 @@
+// Diagnose why /kinks/ won't render: missing JSON vs HTML rewrite (Node 18+)
+const BASE = process.env.KINKS_BASE || "https://talkkink.org";
+const paths = ["/data/kinks.json","/kinks.json","./data/kinks.json","./kinks.json"];
+
+const urlOf = p => new URL(p, BASE).toString();
+const looksHTML = (ct, body) =>
+  /text\/html/i.test(ct||"") || /^\s*<!doctype html/i.test(body||"") || /<html[\s>]/i.test(body||"");
+
+async function probe(u) {
+  try {
+    const r = await fetch(u, { cache: "no-store" });
+    const ct = r.headers.get("content-type") || "";
+    const body = await r.text();
+    return { url: u, ok: r.ok, status: r.status, ct, html: looksHTML(ct, body), len: body.length };
+  } catch (e) {
+    return { url: u, ok: false, status: "FAIL", ct: "", html: false, err: String(e) };
+  }
+}
+
+(async () => {
+  const results = [];
+  for (const p of paths) results.push(await probe(urlOf(p)));
+
+  // nothing reachable
+  const ok200 = results.filter(r => r.ok);
+  if (ok200.length === 0) {
+    console.error("❌ No JSON endpoint returned 200.", results.map(r => ({url:r.url, status:r.status})));
+    console.error("Likely: data/kinks.json not published or blocked by server.");
+    process.exit(1);
+  }
+
+  // first 200 that is actually HTML (rewrite)
+  const html200 = ok200.find(r => r.html);
+  if (html200) {
+    console.error(`❌ ${html200.url} returned HTML (${html200.ct||"text/html"}) with status ${html200.status}.`);
+    console.error("Reason: server rewrites missing JSON to an HTML fallback (e.g., compatibility page).");
+    console.error("Fix: publish data/kinks.json and/or exempt /data/ from rewrites so missing files 404.");
+    process.exit(1);
+  }
+
+  // good: try to parse JSON
+  const good = ok200[0];
+  try {
+    const r = await fetch(good.url, { cache: "no-store" });
+    const j = await r.json();
+    const arr = Array.isArray(j) ? j : (j && Array.isArray(j.kinks) ? j.kinks : []);
+    console.log(`✅ OK: ${good.url} (${good.ct||"application/json"}), items: ${Array.isArray(arr) ? arr.length : "unknown"}`);
+    process.exit(0);
+  } catch (e) {
+    console.error(`❌ ${good.url} claimed JSON but did not parse: ${String(e)}`);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- add a Node-based probe that diagnoses missing or rewritten kinks JSON endpoints
- register an npm script to run the probe locally or against alternate bases
- supply an nginx snippet to exempt /data/ from SPA fallback rewrites so JSON 404s instead of serving HTML

## Testing
- npm run reason:kinks *(fails: remote host did not return 200 for any JSON endpoint, demonstrating the detector's error path)*

------
https://chatgpt.com/codex/tasks/task_e_68d4b0ff378c832c9615bcd2e9b7bb94