### PR TITLE
hotfix(kinks): add inline fail-open watchdog

### DIFF
--- a/kinks/index.html
+++ b/kinks/index.html
@@ -1,6 +1,21 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <script>
+    /*! TK watchdog: fail-open if boot stalls */
+    !function(){var t=setTimeout(function(){try{var d=document;
+    var s=d.createElement("style");s.textContent="body{background:#000;color:#e6f2ff}.spinner,[aria-busy=true],[data-loading]{display:none!important}";d.head.appendChild(s);
+    var start=d.querySelector("#start,#startSurvey,#startSurveyBtn");if(start)start.removeAttribute("disabled");
+    var box=d.createElement("div");box.id="tk-watch";box.style.cssText="position:fixed;top:10px;right:10px;z-index:2147483647;background:#111;color:#fff;border:1px solid #444;border-radius:8px;padding:8px;max-width:460px;font:12px system-ui";
+    box.innerHTML="<b>Still loading…</b><div id=tkw style=\"opacity:.8;margin-top:4px\">Checking data/kinks.json…</div>";d.body.appendChild(box);
+    fetch("/data/kinks.json?v="+Date.now(),{cache:"no-store"}).then(r=>r.text()).then(txt=>{
+     if(/^<!doctype html/i.test(txt)||/<html[\\s>]/i.test(txt)){d.getElementById("tkw").textContent="Server sent HTML instead of JSON. Publish data/kinks.json or stop rewriting /data/. Start enabled.";return}
+     try{var j=JSON.parse(txt);var arr=Array.isArray(j)?j:(j&&Array.isArray(j.kinks)?j.kinks:[]);d.getElementById("tkw").textContent="Data OK ("+arr.length+"). Start enabled; proceed."}catch(e){d.getElementById("tkw").textContent="data/kinks.json is invalid JSON"}
+    }).catch(e=>{d.getElementById("tkw").textContent="Fetch failed: "+e})
+    }catch(e){}} ,2500);
+    window.addEventListener("load",function(){clearTimeout(t)},{once:true});
+    }();
+  </script>
   <!-- TK-HOTFIX START -->
   <base href="/" />
   <!-- TK-HOTFIX END -->


### PR DESCRIPTION
## Summary
- inject an inline watchdog script into kinks/index.html to fail-open if loading stalls
- ensure the fallback styling hides spinners, re-enables the Start button, and reports data/kinks.json status

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5e145483c832c95d1c7a90dd0175b