### PR TITLE
Add fetch shim and flatten CLI for kinks data

### DIFF
--- a/js/kinks_fetch_compat.js
+++ b/js/kinks_fetch_compat.js
@@ -1,0 +1,58 @@
+/*! TK: fetch compatibility for /data/kinks.json (grouped → flat) */
+(() => {
+  const orig = window.fetch.bind(window);
+
+  function toFlat(data) {
+    // already flat?
+    if (Array.isArray(data) && data.length && !('items' in (data[0]||{}))) return data;
+    // { kinks: [] } ?
+    if (data && Array.isArray(data.kinks)) return data.kinks;
+
+    // grouped: [{ category, items: [...] }, ...]
+    if (Array.isArray(data) && data.length && data[0] && Array.isArray(data[0].items)) {
+      const flat = [];
+      for (const group of data) {
+        const cat = String(group.category ?? group.cat ?? '').trim();
+        for (const it of (group.items || [])) {
+          flat.push({
+            id: it.id ?? `${cat}:${(it.label||'').toLowerCase().replace(/\s+/g,'-')}`,
+            label: it.label ?? it.name ?? '',
+            name: it.name ?? it.label ?? '',
+            type: it.type ?? 'scale',
+            category: cat,
+            rating: it.rating ?? null
+          });
+        }
+      }
+      return flat;
+    }
+    // unknown shape → return as-is
+    return data;
+  }
+
+  window.fetch = async function(input, init) {
+    const url = (typeof input === 'string' ? input : input?.url) || '';
+    if (url.includes('/data/kinks.json')) {
+      const res = await orig(input, init);
+      try {
+        // bail if not 200
+        if (!res.ok) return res;
+        // bail if HTML (rewrite); let your watchdog/diagnostics handle it
+        const ct = res.headers.get('content-type') || '';
+        const txt = await res.clone().text();
+        if (/^<!doctype html/i.test(txt) || /<html[\s>]/i.test(txt) || /text\/html/i.test(ct)) return res;
+
+        // parse and flatten
+        const json = JSON.parse(txt);
+        const flat = toFlat(json);
+
+        // hand back a *new* JSON response the app expects
+        const blob = new Blob([JSON.stringify(flat)], { type: 'application/json' });
+        return new Response(blob, { status: 200, statusText: 'OK', headers: { 'Content-Type': 'application/json' } });
+      } catch {
+        return res; // on any error, fall back to original response
+      }
+    }
+    return orig(input, init);
+  };
+})();

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <!-- TK: grouped→flat JSON shim -->
+  <script src="/js/kinks_fetch_compat.js"></script>
   <script>
     /*! TK watchdog: fail-open + SW reset flag */
     (function(){

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "generate-pdf:landscape": "node --input-type=module -e \"globalThis.window={};await import('./js/vendor/jspdf.umd.min.js');await (await import('./js/compatibilityPdf.js')).generateCompatibilityPDFLandscape({categories: []})\"",
     "check:conflicts": "node scripts/check-conflicts.js",
     "precommit": "npm run check:conflicts",
-    "reason:kinks": "node scripts/reason-kinks-json.mjs"
+    "reason:kinks": "node scripts/reason-kinks-json.mjs",
+    "kinks:flatten": "node scripts/flatten_kinks.mjs"
   },
   "keywords": [],
   "author": "",

--- a/scripts/flatten_kinks.mjs
+++ b/scripts/flatten_kinks.mjs
@@ -1,0 +1,33 @@
+import fs from 'node:fs/promises';
+
+function toFlat(data){
+  if (Array.isArray(data) && data.length && !('items' in (data[0]||{}))) return data;
+  if (data && Array.isArray(data.kinks)) return data.kinks;
+  if (Array.isArray(data) && data.length && data[0] && Array.isArray(data[0].items)) {
+    const flat = [];
+    for (const group of data) {
+      const cat = String(group.category ?? group.cat ?? '').trim();
+      for (const it of (group.items || [])) {
+        flat.push({
+          id: it.id ?? `${cat}:${(it.label||'').toLowerCase().replace(/\s+/g,'-')}`,
+          label: it.label ?? it.name ?? '',
+          name: it.name ?? it.label ?? '',
+          type: it.type ?? 'scale',
+          category: cat,
+          rating: it.rating ?? null
+        });
+      }
+    }
+    return flat;
+  }
+  return data;
+}
+
+const inFile  = process.env.IN  || 'data/kinks.json';
+const outFile = process.env.OUT || 'data/kinks.flat.json';
+
+const raw = await fs.readFile(inFile, 'utf8');
+const json = JSON.parse(raw);
+const flat = toFlat(json);
+await fs.writeFile(outFile, JSON.stringify(flat, null, 2), 'utf8');
+console.log(`Flattened ${inFile} → ${outFile} (rows: ${flat.length})`);


### PR DESCRIPTION
## Summary
- inject a fetch shim so grouped /data/kinks.json responses are flattened for the UI
- add a CLI helper that can flatten the grouped data into data/kinks.flat.json
- expose the helper via an npm script for convenient local usage

## Testing
- node scripts/flatten_kinks.mjs


------
https://chatgpt.com/codex/tasks/task_e_68d5f7ff76a4832c9d70f686b77c877c