### PR TITLE
chore(logging): gate [KINKS-UNSQUISH] logs behind tkdebug flag

### DIFF
--- a/docs/kinks/index.html
+++ b/docs/kinks/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <!-- TK: log gate (filters/throttles [KINKS-UNSQUISH]) -->
+  <script src="./js/tk_log_gate.js"></script>
 <!-- TK-DOCS START -->
 <style id="tk-fallback">
   :root{ --tk-fg:#e6f2ff; --tk-accent:#00e6ff; }
@@ -761,7 +763,7 @@ How to use
 
 <script>
 (() => {
-  const LOG = (...a) => console.log("[KINKS-UNSQUISH]", ...a);
+  const LOG = (...a) => { try { if (typeof window !== 'undefined' && !window.__tk_shouldLog) return; } catch {} console.log('[KINKS-UNSQUISH]', ...a); };
 
   // 6) Unclamp anything that forces short/squished tracker panes
   function unclampOnce(root = document) {
@@ -845,8 +847,12 @@ How to use
 
   // 0) quiet the spammy logger
   const _log = console.log.bind(console);
+  const allowUnsquish = () => {
+    try { return typeof window !== 'undefined' && window.__tk_shouldLog; }
+    catch (_) { return false; }
+  };
   console.log = (...a) => {
-    if (String(a?.[0] ?? "").includes("[KINKS-UNSQUISH]")) return;
+    if (String(a?.[0] ?? "").includes("[KINKS-UNSQUISH]") && !allowUnsquish()) return;
     _log(...a);
   };
 

--- a/js/tk_failopen.js
+++ b/js/tk_failopen.js
@@ -100,7 +100,14 @@
 
   // Silence the noisy logger so DevTools stays responsive
   const origLog = console.log.bind(console);
-  console.log = (...a)=> { if (String(a?.[0]??'').includes('[KINKS-UNSQUISH]')) return; origLog(...a); };
+  const allowUnsquish = () => {
+    try { return typeof window !== 'undefined' && window.__tk_shouldLog; }
+    catch (_) { return false; }
+  };
+  console.log = (...a)=> {
+    if (String(a?.[0]??'').includes('[KINKS-UNSQUISH]') && !allowUnsquish()) return;
+    origLog(...a);
+  };
 
   if (document.readyState === 'complete' || document.readyState === 'interactive') run();
   else d.addEventListener('DOMContentLoaded', run, { once:true });

--- a/js/tk_log_gate.js
+++ b/js/tk_log_gate.js
@@ -1,0 +1,48 @@
+/*! TK LOG GATE: drop/throttle "[KINKS-UNSQUISH]" unless tkdebug enabled */
+(() => {
+  // Opt-in flag: ?tkdebug=1 or localStorage.tkdebug="1"
+  const url = new URL(location.href);
+  const TK_DEBUG = url.searchParams.get('tkdebug') === '1' || localStorage.getItem('tkdebug') === '1';
+  // Expose for codemodded LOG
+  window.__tk_shouldLog = !!TK_DEBUG;
+
+  // Throttle map (per prefix)
+  const last = new Map();
+  const THROTTLE_MS = 2000;
+  const shouldEmit = (key) => {
+    const now = performance.now();
+    const prev = last.get(key) || 0;
+    if (now - prev < THROTTLE_MS) return false;
+    last.set(key, now);
+    return true;
+  };
+
+  const wrap = (orig) => function(...args){
+    try {
+      // If first arg is the UNSQUISH prefix, gate it
+      const first = args[0];
+      const isUnsquish = typeof first === 'string' && first.includes('[KINKS-UNSQUISH]');
+      if (isUnsquish) {
+        if (!TK_DEBUG) return;                 // drop entirely in prod
+        if (!shouldEmit('[KINKS-UNSQUISH]')) { // throttle in debug
+          return;
+        }
+      }
+    } catch {}
+    return orig.apply(this, args);
+  };
+
+  // Patch common consoles
+  for (const k of ['log','info','debug']) {
+    if (typeof console[k] === 'function') console[k] = wrap(console[k]);
+  }
+
+  // Small badge if debug enabled (so you know logs are flowing)
+  if (TK_DEBUG) {
+    const b = document.createElement('div');
+    b.textContent = 'tkdebug=1 (UNSQUISH logs throttled)';
+    b.style.cssText = 'position:fixed;bottom:10px;left:10px;z-index:2147483647;background:#0b0;color:#000;padding:4px 8px;border-radius:6px;font:12px system-ui';
+    setTimeout(()=>b.remove(), 1500);
+    (document.readyState === 'loading') ? document.addEventListener('DOMContentLoaded', ()=>document.body.appendChild(b), {once:true}) : document.body.appendChild(b);
+  }
+})();

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <!-- TK: log gate (filters/throttles [KINKS-UNSQUISH]) -->
+  <script src="/js/tk_log_gate.js"></script>
   <!-- TK: grouped→flat JSON shim -->
   <script src="/js/kinks_fetch_compat.js"></script>
   <script>
@@ -776,7 +778,7 @@ How to use
 
 <script>
 (() => {
-  const LOG = (...a) => console.log("[KINKS-UNSQUISH]", ...a);
+  const LOG = (...a) => { try { if (typeof window !== 'undefined' && !window.__tk_shouldLog) return; } catch {} console.log('[KINKS-UNSQUISH]', ...a); };
 
   // 6) Unclamp anything that forces short/squished tracker panes
   function unclampOnce(root = document) {
@@ -860,8 +862,12 @@ How to use
 
   // 0) quiet the spammy logger
   const _log = console.log.bind(console);
+  const allowUnsquish = () => {
+    try { return typeof window !== 'undefined' && window.__tk_shouldLog; }
+    catch (_) { return false; }
+  };
   console.log = (...a) => {
-    if (String(a?.[0] ?? "").includes("[KINKS-UNSQUISH]")) return;
+    if (String(a?.[0] ?? "").includes("[KINKS-UNSQUISH]") && !allowUnsquish()) return;
     _log(...a);
   };
 


### PR DESCRIPTION
## Summary
- add a tk_log_gate bootstrap script that drops or throttles `[KINKS-UNSQUISH]` logs unless tkdebug is enabled
- load the gate in the kinks runtime (and docs copy) and only emit `[KINKS-UNSQUISH]` logs when the opt-in flag is set
- update the fail-open helper to respect the shared tkdebug opt-in when silencing console output

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68d72dc3a9b4832ca90f990081fa93ba