### PR TITLE
Remove Google Fonts dependencies and add system font fallbacks

### DIFF
--- a/auto-pdf.html
+++ b/auto-pdf.html
@@ -5,13 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Kink Compatibility PDF</title>
   <link rel="stylesheet" href="css/auto-pdf.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Fredoka+One&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="css/fonts-failopen.css" />
   <script src="js/template-survey.js"></script>
   <script type="module" src="js/auto-pdf.js"></script>
   <style>
     /* Base title look (web + PDF) */
     .site-title {
-      font-family: "Fredoka One", system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+      font-family: var(--tk-font-display, system-ui, -apple-system, 'Segoe UI', Roboto, Arial, sans-serif);
       color: #fff;
       text-align: center;
       /* Proportional sizing: scales with viewport but capped */

--- a/compatibility.html
+++ b/compatibility.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="/css/theme.css" />
   <link rel="stylesheet" href="/css/global.css" />
   <link rel="stylesheet" href="/css/compat-table.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Fredoka+One&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="/css/fonts-failopen.css" />
   <style>
   #pdf-container {
     width: 100%;

--- a/docs/kinks/css/fonts-failopen.css
+++ b/docs/kinks/css/fonts-failopen.css
@@ -1,0 +1,12 @@
+/* TK fonts fail-open: system stacks so text paints immediately */
+:root {
+  --tk-font-sans: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif;
+  --tk-font-serif: Georgia, "Times New Roman", Times, serif;
+  --tk-font-display: var(--tk-font-sans);
+}
+html, body { font-family: var(--tk-font-sans) !important; text-rendering: optimizeLegibility; -webkit-font-smoothing: antialiased; }
+h1, h2, h3, .title, .themed-title, .page-title { font-family: var(--tk-font-display) !important; }
+.serif, .prose, .copy { font-family: var(--tk-font-serif) !important; }
+html.tk-font-fallback *, html.tk-font-fallback input, html.tk-font-fallback button, html.tk-font-fallback select, html.tk-font-fallback textarea {
+  font-family: inherit !important;
+}

--- a/docs/kinks/css/style.css
+++ b/docs/kinks/css/style.css
@@ -1,5 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Fredoka+One&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=EB+Garamond&display=swap');
 
 /* Base Page Layout */
 body {

--- a/docs/kinks/index.html
+++ b/docs/kinks/index.html
@@ -17,7 +17,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Talk Kink</title>
-  <link href="https://fonts.googleapis.com/css2?family=Fredoka+One&family=EB+Garamond&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="./css/fonts-failopen.css" />
 </head>
 <body class="theme-dark has-category-panel">
 

--- a/greenlight/index.html
+++ b/greenlight/index.html
@@ -7,9 +7,8 @@
   <link rel="manifest" href="manifest.json">
   <link rel="icon" type="image/png" href="greenlightduck.png">
   <meta name="theme-color" content="#0F5132">
-  <link href="https://fonts.googleapis.com/css2?family=Lexend+Deca&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/style.css">
+  <link rel="stylesheet" href="/css/fonts-failopen.css">
 </head>
 <body>
   <div id="main-page">

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>Talk Kink</title>
   <link rel="stylesheet" href="css/style.css" />
   <link rel="stylesheet" href="css/theme.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Fredoka+One&family=EB+Garamond&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/fonts-failopen.css" />
 </head>
 <body class="theme-dark">
   <div class="landing-wrapper">

--- a/individualkinkanalysis.html
+++ b/individualkinkanalysis.html
@@ -5,7 +5,7 @@
   <title>Individual Kink Analysis</title>
   <link rel="stylesheet" href="css/style.css">
   <link rel="stylesheet" href="css/theme.css">
-  <link href="https://fonts.googleapis.com/css2?family=Fredoka+One&family=EB+Garamond&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/fonts-failopen.css">
 </head>
 <body class="theme-dark">
 
@@ -47,7 +47,7 @@
 }
 
 .ika-title{
-  font-family: 'Fredoka One', cursive, system-ui, -apple-system, sans-serif;
+  font-family: var(--tk-font-display, system-ui, -apple-system, 'Segoe UI', sans-serif);
   font-size: 2rem;           /* smaller title */
   line-height: 1.2;
   margin: 0 0 8px 0;
@@ -56,7 +56,7 @@
 
 .ika-instructions {
   margin-bottom: 20px;
-  font-family: 'Fredoka One', cursive;
+  font-family: var(--tk-font-display, system-ui, -apple-system, 'Segoe UI', sans-serif);
   color: #fff;
   font-size: 1.1em;
 }
@@ -66,7 +66,7 @@
   display: block;
   margin: 12px auto;
   padding: 12px 24px;
-  font-family: 'Fredoka One', cursive;
+  font-family: var(--tk-font-display, system-ui, -apple-system, 'Segoe UI', sans-serif);
   font-size: 1.1em;
   background: #000;
   border: 2px solid cyan;

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -99,7 +99,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Talk Kink</title>
-  <link href="https://fonts.googleapis.com/css2?family=Fredoka+One&family=EB+Garamond&display=swap" rel="stylesheet">
   <!-- TK: system-font fallback (loads after main CSS) -->
   <link rel="stylesheet" href="/css/fonts-failopen.css">
 </head>

--- a/snippet-individual-kink-analysis.html
+++ b/snippet-individual-kink-analysis.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <title>Individual Kink Analysis</title>
-  <link href="https://fonts.googleapis.com/css2?family=Fredoka+One&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="css/fonts-failopen.css">
   <style>
   body { margin: 0; }
   /* Full-page flex centering */
@@ -23,7 +23,7 @@
 
   /* Title */
   .ika-title {
-    font-family: 'Fredoka One', cursive;
+    font-family: var(--tk-font-display, system-ui, -apple-system, 'Segoe UI', sans-serif);
     font-size: 2rem;
     color: #00f0ff;
     margin-bottom: 0.5rem;
@@ -31,7 +31,7 @@
 
   /* Instructions */
   .ika-instructions {
-    font-family: 'Fredoka One', cursive;
+    font-family: var(--tk-font-display, system-ui, -apple-system, 'Segoe UI', sans-serif);
     font-size: 1rem;
     margin-bottom: 1.5rem;
   }
@@ -41,7 +41,7 @@
     display: block;
     margin: 0.75rem auto;
     padding: 0.75rem 1.5rem;
-    font-family: 'Fredoka One', cursive;
+    font-family: var(--tk-font-display, system-ui, -apple-system, 'Segoe UI', sans-serif);
     font-size: 1rem;
     background: transparent;
     border: 2px solid #00f0ff;

--- a/villain-quote.html
+++ b/villain-quote.html
@@ -6,7 +6,7 @@
   <title>Villain Quote</title>
   <link rel="stylesheet" href="css/style.css" />
   <link rel="stylesheet" href="css/theme.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Fredoka+One&family=EB+Garamond&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="css/fonts-failopen.css" />
 </head>
 <body class="theme-lipstick">
   <div class="themed-header no-print">Talk Kink</div>


### PR DESCRIPTION
## Summary
- remove Google Fonts link tags across the site to avoid external font requests
- add the system font fail-open stylesheet to each page, including the generated docs build
- update inline typography rules to rely on the fallback variables instead of Google-specific font names

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d738a85bb8832c9f4a5433cc8cbdb0