### PR TITLE
perf(fonts): hard-block Google Fonts

### DIFF
--- a/auto-pdf.html
+++ b/auto-pdf.html
@@ -5,7 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Kink Compatibility PDF</title>
   <link rel="stylesheet" href="css/auto-pdf.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Fredoka+One&display=swap" rel="stylesheet" />
   <script src="js/template-survey.js"></script>
   <script type="module" src="js/auto-pdf.js"></script>
   <style>

--- a/compatibility.html
+++ b/compatibility.html
@@ -8,7 +8,6 @@
   <link rel="stylesheet" href="/css/theme.css" />
   <link rel="stylesheet" href="/css/global.css" />
   <link rel="stylesheet" href="/css/compat-table.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Fredoka+One&display=swap" rel="stylesheet" />
   <style>
   #pdf-container {
     width: 100%;

--- a/css/fonts-failopen.css
+++ b/css/fonts-failopen.css
@@ -1,15 +1,9 @@
-/* TK fonts fail-open: force system stacks; safe across OSes */
 :root{
-  --tk-font-sans: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Liberation Sans", sans-serif;
+  --tk-font-sans: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
   --tk-font-serif: Georgia, "Times New Roman", Times, serif;
   --tk-font-display: var(--tk-font-sans);
 }
-/* Make body and form controls safe immediately */
 html, body { font-family: var(--tk-font-sans) !important; text-rendering: optimizeLegibility; -webkit-font-smoothing: antialiased; }
-/* Typical title classes (override if present) */
 h1, h2, h3, .title, .themed-title, .page-title { font-family: var(--tk-font-display) !important; }
 .serif, .prose, .copy { font-family: var(--tk-font-serif) !important; }
-/* When JS flags fallback mode, harden overrides */
-html.tk-font-fallback *, html.tk-font-fallback input, html.tk-font-fallback button, html.tk-font-fallback select, html.tk-font-fallback textarea {
-  font-family: inherit !important;
-}
+html.tk-font-fallback *, html.tk-font-fallback input, html.tk-font-fallback button, html.tk-font-fallback select, html.tk-font-fallback textarea { font-family: inherit !important; }

--- a/docs/kinks/css/style.css
+++ b/docs/kinks/css/style.css
@@ -1,6 +1,3 @@
-@import url('https://fonts.googleapis.com/css2?family=Fredoka+One&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=EB+Garamond&display=swap');
-
 /* Base Page Layout */
 body {
   margin: 0;

--- a/docs/kinks/index.html
+++ b/docs/kinks/index.html
@@ -17,7 +17,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Talk Kink</title>
-  <link href="https://fonts.googleapis.com/css2?family=Fredoka+One&family=EB+Garamond&display=swap" rel="stylesheet">
 </head>
 <body class="theme-dark has-category-panel">
 

--- a/greenlight/index.html
+++ b/greenlight/index.html
@@ -7,8 +7,6 @@
   <link rel="manifest" href="manifest.json">
   <link rel="icon" type="image/png" href="greenlightduck.png">
   <meta name="theme-color" content="#0F5132">
-  <link href="https://fonts.googleapis.com/css2?family=Lexend+Deca&display=swap" rel="stylesheet">
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="css/style.css">
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,6 @@
   <title>Talk Kink</title>
   <link rel="stylesheet" href="css/style.css" />
   <link rel="stylesheet" href="css/theme.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Fredoka+One&family=EB+Garamond&display=swap" rel="stylesheet">
 </head>
 <body class="theme-dark">
   <div class="landing-wrapper">

--- a/individualkinkanalysis.html
+++ b/individualkinkanalysis.html
@@ -5,7 +5,6 @@
   <title>Individual Kink Analysis</title>
   <link rel="stylesheet" href="css/style.css">
   <link rel="stylesheet" href="css/theme.css">
-  <link href="https://fonts.googleapis.com/css2?family=Fredoka+One&family=EB+Garamond&display=swap" rel="stylesheet">
 </head>
 <body class="theme-dark">
 

--- a/js/tk_block_fonts.js
+++ b/js/tk_block_fonts.js
@@ -1,0 +1,49 @@
+/*! TK: hard block Google Fonts (static + dynamic) */
+(() => {
+  const BAD = href => typeof href === 'string' && /fonts\.googleapis\.com|fonts\.gstatic\.com/i.test(href);
+  const nuke = el => { try { el.disabled = true; el.remove(); } catch {} };
+
+  // Initial sweep
+  function sweep() {
+    document.querySelectorAll('link[rel][href]').forEach(l => { if (BAD(l.getAttribute('href'))) nuke(l); });
+    document.documentElement.classList.add('tk-font-fallback');
+  }
+
+  // Patch link attribute assignment
+  const origSet = Element.prototype.setAttribute;
+  Element.prototype.setAttribute = function(name, value) {
+    if (this.tagName === 'LINK' && name && name.toLowerCase() === 'href' && BAD(String(value))) { nuke(this); return; }
+    return origSet.apply(this, arguments);
+  };
+
+  // Patch DOM insertion APIs
+  for (const Proto of [Element.prototype, Node.prototype, Document.prototype, DocumentFragment.prototype]) {
+    for (const method of ['appendChild', 'insertBefore']) {
+      const orig = Proto[method];
+      if (typeof orig !== 'function') continue;
+      Object.defineProperty(Proto, method, {
+        configurable: true,
+        writable: true,
+        value: function(node, ref) {
+          try { if (node && node.tagName === 'LINK' && BAD(node.getAttribute('href'))) { nuke(node); return node; } } catch {}
+          return orig.call(this, node, ref);
+        }
+      });
+    }
+  }
+
+  // Observe SPA frameworks that mutate <head>
+  try {
+    const mo = new MutationObserver(muts => {
+      for (const m of muts) for (const n of m.addedNodes || []) {
+        if (n && n.tagName === 'LINK' && BAD(n.getAttribute('href'))) nuke(n);
+      }
+    });
+    mo.observe(document.documentElement, { childList: true, subtree: true });
+    setTimeout(() => mo.disconnect(), 10000); // stop after boot
+  } catch {}
+
+  // Run immediately & again on DOMContentLoaded
+  sweep();
+  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', sweep, { once: true });
+})();

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -1,7 +1,9 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<!-- TK-LOG-GATE inline -->
+  <!-- TK: hard-block Google Fonts early -->
+  <script src="/js/tk_block_fonts.js"></script>
+  <!-- TK-LOG-GATE inline -->
   <script>
   (function(){
     try {
@@ -99,7 +101,6 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Talk Kink</title>
-  <link href="https://fonts.googleapis.com/css2?family=Fredoka+One&family=EB+Garamond&display=swap" rel="stylesheet">
   <!-- TK: system-font fallback (loads after main CSS) -->
   <link rel="stylesheet" href="/css/fonts-failopen.css">
 </head>

--- a/snippet-individual-kink-analysis.html
+++ b/snippet-individual-kink-analysis.html
@@ -3,7 +3,6 @@
 <head>
   <meta charset="UTF-8">
   <title>Individual Kink Analysis</title>
-  <link href="https://fonts.googleapis.com/css2?family=Fredoka+One&display=swap" rel="stylesheet">
   <style>
   body { margin: 0; }
   /* Full-page flex centering */

--- a/villain-quote.html
+++ b/villain-quote.html
@@ -6,7 +6,6 @@
   <title>Villain Quote</title>
   <link rel="stylesheet" href="css/style.css" />
   <link rel="stylesheet" href="css/theme.css" />
-  <link href="https://fonts.googleapis.com/css2?family=Fredoka+One&family=EB+Garamond&display=swap" rel="stylesheet" />
 </head>
 <body class="theme-lipstick">
   <div class="themed-header no-print">Talk Kink</div>


### PR DESCRIPTION
## Summary
- add an early tk_block_fonts runtime guard that strips any Google Fonts links and blocks re-insertion
- enforce system font fallbacks and remove Google Fonts references from the HTML entry points and docs CSS

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d739a77390832c9eb3535bc87af030