### PR TITLE
Add passive default handling for touch interactions

### DIFF
--- a/css/touch-passive.css
+++ b/css/touch-passive.css
@@ -1,0 +1,4 @@
+/* TK: keep scrolling smooth and non-blocking */
+html, body { touch-action: pan-x pan-y; overscroll-behavior: contain; }
+.scroll-y { touch-action: pan-y; }
+.scroll-x { touch-action: pan-x; }

--- a/js/tk_passive_events.js
+++ b/js/tk_passive_events.js
@@ -1,0 +1,34 @@
+/*! TK passive events: default passive:true for scroll-blocking inputs.
+    Opt-out: add {passive:false} or visit ?tkpassive=0 */
+(() => {
+  try {
+    if (new URL(location.href).searchParams.get('tkpassive') === '0') return;
+  } catch {}
+  // Detect passive support
+  let supportsPassive = false;
+  try {
+    const opts = Object.defineProperty({}, 'passive', { get() { supportsPassive = true; } });
+    window.addEventListener('tk-passive-test', null, opts);
+    window.removeEventListener('tk-passive-test', null, opts);
+  } catch {}
+  if (!supportsPassive) return;
+
+  const PASSIVE_EVENTS = new Set(['touchstart','touchmove','touchend','touchcancel','wheel','mousewheel']);
+  const ET = (window.EventTarget || window.Node || function(){}).prototype;
+  const origAdd = ET.addEventListener;
+
+  ET.addEventListener = function(type, listener, options){
+    try {
+      if (PASSIVE_EVENTS.has(type)) {
+        if (options == null) {
+          options = { passive: true };
+        } else if (typeof options === 'boolean') {
+          options = { capture: options, passive: true };
+        } else if (typeof options === 'object' && !('passive' in options)) {
+          options = Object.assign({}, options, { passive: true });
+        }
+      }
+    } catch {}
+    return origAdd.call(this, type, listener, options);
+  };
+})();

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <!-- TK: passive event shim -->
+  <script src="/js/tk_passive_events.js"></script>
   <!-- TK: hard-block Google Fonts early -->
   <script src="/js/tk_block_fonts.js"></script>
   <!-- TK-LOG-GATE inline -->
@@ -103,6 +105,7 @@
   <title>Talk Kink</title>
   <!-- TK: system-font fallback (loads after main CSS) -->
   <link rel="stylesheet" href="/css/font-failopen.css">
+  <link rel="stylesheet" href="/css/touch-passive.css">
 </head>
 <body class="theme-dark has-category-panel">
   <script id="kinks-embedded-data" type="application/json">[]</script>


### PR DESCRIPTION
## Summary
- add a passive-event shim so touch and wheel listeners default to passive mode
- add touch-action CSS for fail-open scrolling and wire both assets into the kinks page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d74426a830832cb8cda688b23cb569