### PR TITLE
Add early diagnostics overlay for kinks page

### DIFF
--- a/css/tk_diag_fallback.css
+++ b/css/tk_diag_fallback.css
@@ -1,0 +1,5 @@
+/* loads early, very small; only kicks in if colors are black/transparent */
+html.tk-diag-fallback, html.tk-diag-fallback body {
+  background:#000!important; color:#e6f2ff!important;
+  -webkit-font-smoothing:antialiased; text-rendering:optimizeLegibility;
+}

--- a/js/tk_diag.js
+++ b/js/tk_diag.js
@@ -1,0 +1,55 @@
+/*! TK Diag: early error trap + on-screen status for /kinks/ */
+(function(){
+  // Build overlay
+  const box = document.createElement('div');
+  box.id = 'tk-diag';
+  box.style.cssText = 'position:fixed;top:8px;left:8px;z-index:2147483647;padding:8px 10px;border:1px solid #00e6ff66;border-radius:8px;background:#0a0a0a;color:#e6f2ff;font:12px system-ui;max-width:46ch;box-shadow:0 2px 14px #000a';
+  box.innerHTML = '<b>TK diag</b><span id="tkx" style="float:right;cursor:pointer">×</span><div id="tkl" style="margin-top:6px;white-space:pre-wrap"></div>';
+  document.addEventListener('DOMContentLoaded',()=>document.body.appendChild(box),{once:true});
+  document.head.appendChild(Object.assign(document.createElement('link'),{rel:'stylesheet',href:'/css/tk_diag_fallback.css'}));
+  document.addEventListener('click',e=>{ if(e.target && e.target.id==='tkx'){ box.remove(); } });
+
+  const log = (...a)=> { const el = document.getElementById('tkl'); el && (el.textContent += a.join(' ')+'\n'); console.log('[TK]',...a); };
+
+  // Early error trapping
+  const errs=[];
+  window.addEventListener('error', e=>{ errs.push({type:'error', msg:e.message, src:(e.filename||'')+':'+(e.lineno||'')}); log('ERR', e.message); }, true);
+  window.addEventListener('unhandledrejection', e=>{ const m=String(e.reason && (e.reason.message||e.reason) || e); errs.push({type:'promise', msg:m}); log('REJECT', m); }, true);
+
+  // Quick environment checks after paint
+  function checks(){
+    try {
+      // 1) If computed body color is black, enable fallback class
+      const bc = getComputedStyle(document.body||document.documentElement).color;
+      if (/rgb\(0,\s*0,\s*0\)/.test(bc) || bc==='') {
+        document.documentElement.classList.add('tk-diag-fallback');
+        log('Color looked black → applied fallback text color.');
+      }
+      // 2) CSS presence
+      const cssList = [...document.styleSheets].map(s=>s.href||'(inline)').filter(Boolean);
+      log('CSS loaded:', cssList.join(', '));
+
+      // 3) Data check
+      fetch('/data/kinks.json', {cache:'no-store'}).then(r=>{
+        log('kinks.json', r.status, r.headers.get('content-type')||'');
+        if(!r.ok) return;
+        return r.json().then(j=>{
+          const items = Array.isArray(j) ? j.length
+                     : Array.isArray(j?.kinks) ? j.kinks.length
+                     : Array.isArray(j?.[0]?.items) ? j[0].items.length : 0;
+          log('kinks items (approx):', String(items));
+        }).catch(e=>log('kinks.json parse failed:', String(e)));
+      }).catch(e=>log('kinks.json fetch failed:', String(e)));
+
+      // 4) Start button + categories status
+      const start = document.querySelector('#start,#startSurvey');
+      const cats  = document.querySelectorAll('.category-panel input[type="checkbox"]').length;
+      if (start) { log('Start disabled?', String(start.disabled)); if (cats>0) { start.disabled=false; log('Enabled Start (categories present).'); } }
+      log('Category checkboxes seen:', String(cats));
+
+      // 5) Print any trapped errors last (for quick copy)
+      if (errs.length) log('errors:', JSON.stringify(errs));
+    } catch(e){ log('diag exception:', String(e)); }
+  }
+  (document.readyState==='loading') ? document.addEventListener('DOMContentLoaded', checks, {once:true}) : checks();
+})();

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <!-- TK: early diagnostics -->
+  <script src="/js/tk_diag.js"></script>
   <!-- TK: passive event shim -->
   <script src="/js/tk_passive_events.js"></script>
   <!-- TK: hard-block Google Fonts early -->
@@ -108,6 +110,7 @@
   <link rel="stylesheet" href="/css/touch-passive.css">
   <!-- TK: force-visible fallback -->
   <link rel="stylesheet" href="/css/tk_force_visible.css">
+  <link rel="stylesheet" href="/css/tk_diag_fallback.css">
 </head>
 <body class="theme-dark has-category-panel">
   <script id="kinks-embedded-data" type="application/json">[]</script>


### PR DESCRIPTION
## Summary
- add a tk diagnostic overlay script for the /kinks/ experience to surface early errors and environment checks
- include a lightweight fallback stylesheet to keep text readable if theme colors fail
- wire the diagnostics assets into kinks/index.html so they load at the top of the head

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7525bf780832cbeb391d61028307f