### PR TITLE
Handle URI decoding errors in cookie parser

### DIFF
--- a/server.js
+++ b/server.js
@@ -87,7 +87,17 @@ function cookieParser(req, _res, next) {
   if (header) {
     header.split(';').forEach(part => {
       const [k, ...v] = part.trim().split('=');
-      if (k) cookies[k] = decodeURIComponent(v.join('=') || '');
+      if (!k) return;
+      const rawValue = v.join('=') || '';
+      try {
+        cookies[k] = decodeURIComponent(rawValue);
+      } catch (err) {
+        console.warn(
+          `[cookieParser] Failed to decode value for ${k}:`,
+          err instanceof Error ? err.message : err
+        );
+        cookies[k] = rawValue;
+      }
     });
   }
   req.cookies = cookies;

--- a/test/cookieParser.test.js
+++ b/test/cookieParser.test.js
@@ -2,12 +2,23 @@ import test from 'node:test';
 import assert from 'node:assert';
 import { cookieParser, server, cleanup } from '../server.js';
 
+function stopServer() {
+  if (server?.listening) {
+    server.close();
+  }
+  clearInterval(cleanup);
+}
+
 test('cookieParser handles equals in values', t => {
   const req = { headers: { cookie: 'a=1=2; b=3' } };
   cookieParser(req, null, null);
   assert.deepStrictEqual(req.cookies, { a: '1=2', b: '3' });
-  t.after(() => {
-    server.close();
-    clearInterval(cleanup);
-  });
+  t.after(stopServer);
+});
+
+test('cookieParser traps invalid encoding without throwing', t => {
+  const req = { headers: { cookie: 'bad=%E0%A4%A' } };
+  cookieParser(req, null, null);
+  assert.strictEqual(req.cookies.bad, '%E0%A4%A');
+  t.after(stopServer);
 });


### PR DESCRIPTION
## Summary
- log and fall back to raw values when cookie decoding fails instead of throwing
- add tests covering invalid cookie encoding and reuse a helper for shutting down the server

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d754072c8c832ca4422abb6c12d1a3