### PR TITLE
Fix TalkKink /kinks overlays to restore controls

### DIFF
--- a/css/tk_unblock_clicks.css
+++ b/css/tk_unblock_clicks.css
@@ -1,0 +1,9 @@
+/* TK: keep primary controls interactive even if an overlay is present */
+button,.themed-button,[role="button"],#start,#startSurvey{
+  position: relative;
+  z-index: 2147483640 !important;
+  pointer-events: auto !important;
+}
+.category-panel input[type="checkbox"]{
+  pointer-events: auto !important;
+}

--- a/docs/diagnostics/talkkink-kinks.md
+++ b/docs/diagnostics/talkkink-kinks.md
@@ -1,0 +1,23 @@
+# Talk Kink /kinks Diagnostics
+
+## Summary
+- The public dataset `https://talkkink.org/data/kinks.json` is not accessible; all standard fallback locations return either `403` errors or no response.
+- Because the survey bootstrap requires that JSON payload, the Start Survey button remains disabled and the page never loads categories for unauthenticated visitors.
+- Publishing `data/kinks.json` (or allowing it to return a 200 JSON payload) will restore the category loader; alternatively, adjust the CDN to avoid rewriting the path to an authenticated-only resource.
+
+## Steps Performed
+1. Ran the repository's diagnostic helper: `node scripts/reason-kinks-json.mjs`.
+2. Observed the script probe `data/kinks.json` and its fallbacks at the production origin.
+
+## Detailed Output
+```
+❌ No JSON endpoint returned 200. [
+  { url: 'https://talkkink.org/data/kinks.json', status: 'FAIL' },
+  { url: 'https://talkkink.org/kinks.json', status: 'FAIL' },
+  { url: 'https://talkkink.org/data/kinks.json', status: 'FAIL' },
+  { url: 'https://talkkink.org/kinks.json', status: 'FAIL' }
+]
+Likely: data/kinks.json not published or blocked by server.
+```
+
+The failures confirm that every candidate endpoint is blocked, so the front-end bootstrap script never receives the kink catalog that it needs to render the survey UI.

--- a/js/tk_passive_events.js
+++ b/js/tk_passive_events.js
@@ -13,7 +13,7 @@
   } catch {}
   if (!supportsPassive) return;
 
-  const PASSIVE_EVENTS = new Set(['touchstart','touchmove','touchend','touchcancel','wheel','mousewheel']);
+  const PASSIVE_EVENTS = new Set(['touchstart','touchmove','wheel','mousewheel']);
   const ET = (window.EventTarget || window.Node || function(){}).prototype;
   const origAdd = ET.addEventListener;
 

--- a/js/tk_unblock_clicks.js
+++ b/js/tk_unblock_clicks.js
@@ -1,0 +1,80 @@
+/*! TK unblock: neutralize full-viewport overlays & keep taps working */
+(function(){
+  // Make touchend/touchcancel non-passive so tap handlers can preventDefault when needed
+  try{
+    const ET=(window.EventTarget||window.Node||function(){}).prototype;
+    const orig=ET.addEventListener;
+    ET.addEventListener=function(type,listener,opts){
+      if(type==='touchend'||type==='touchcancel'){
+        if (opts==null) opts={}; else if (typeof opts==='boolean') opts={capture:opts};
+        opts.passive=false;
+        return orig.call(this,type,listener,opts);
+      }
+      return orig.call(this,type,listener,opts);
+    };
+  }catch{}
+
+  // Turn full-screen overlays inert (pointer-events: none)
+  function neutralize(){
+    try{
+      Array.from(document.querySelectorAll('body *')).forEach(el=>{
+        const cs=getComputedStyle(el);
+        const r=el.getBoundingClientRect();
+        const big=r.width>innerWidth*0.85 && r.height>innerHeight*0.85;
+        if ((['fixed','absolute','sticky'].includes(cs.position) || big) &&
+            cs.pointerEvents!=='none' && +cs.zIndex>=1) {
+          el.style.pointerEvents='none';
+        }
+      });
+    }catch{}
+  }
+
+  // Enable/disable Start depending on category selections
+  function enableStart(){
+    try{
+      const start=document.querySelector('#start,#startSurvey');
+      if (!start) return;
+      const any=!!document.querySelector('.category-panel input[type="checkbox"]:checked');
+      start.disabled=!any; start.removeAttribute('aria-disabled');
+    }catch{}
+  }
+
+  // Fallback Select All / Deselect All handlers by button text (idempotent)
+  function bindFallbackButtons(){
+    const btns=[...document.querySelectorAll('button,[role="button"]')];
+    const boxes=()=>[...document.querySelectorAll('.category-panel input[type="checkbox"]')];
+
+    const selectAll   = btns.find(b => /select\s*all/i.test(b.textContent||'')) || null;
+    const deselectAll = btns.find(b => /deselect\s*all/i.test(b.textContent||'')) || null;
+
+    if (selectAll && !selectAll.dataset.tkBound) {
+      selectAll.addEventListener('click', e=>{
+        e.preventDefault();
+        boxes().forEach(b=>{ if (!b.checked) { b.checked=true; b.dispatchEvent(new Event('change',{bubbles:true})); } });
+        enableStart();
+      }, true);
+      selectAll.dataset.tkBound='1';
+    }
+    if (deselectAll && !deselectAll.dataset.tkBound) {
+      deselectAll.addEventListener('click', e=>{
+        e.preventDefault();
+        boxes().forEach(b=>{ if (b.checked) { b.checked=false; b.dispatchEvent(new Event('change',{bubbles:true})); } });
+        enableStart();
+      }, true);
+      deselectAll.dataset.tkBound='1';
+    }
+  }
+
+  // Keep Start in sync when user checks/unchecks a category
+  document.addEventListener('change', e=>{
+    if (e.target && e.target.matches('.category-panel input[type="checkbox"]')) enableStart();
+  }, true);
+
+  // Run now & after load (covers SPA/layout shifts)
+  if (document.readyState==='loading') {
+    document.addEventListener('DOMContentLoaded', ()=>{ neutralize(); bindFallbackButtons(); enableStart(); }, {once:true});
+  } else {
+    neutralize(); bindFallbackButtons(); enableStart();
+  }
+  window.addEventListener('load', ()=>setTimeout(()=>{ neutralize(); bindFallbackButtons(); enableStart(); }, 120), {once:true});
+})();

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -111,6 +111,7 @@
   <!-- TK: force-visible fallback -->
   <link rel="stylesheet" href="/css/tk_force_visible.css">
   <link rel="stylesheet" href="/css/tk_diag_fallback.css">
+  <link rel="stylesheet" href="/css/tk_unblock_clicks.css">
 </head>
 <body class="theme-dark has-category-panel">
   <script id="kinks-embedded-data" type="application/json">[]</script>
@@ -1162,5 +1163,6 @@ How to use
 <script type="module" src="/js/tk_failopen.js"></script>
   <!-- TK: reveal fallback -->
   <script src="/js/tk_reveal.js"></script>
+  <script src="/js/tk_unblock_clicks.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add dedicated CSS to keep primary controls interactive even when overlays try to capture clicks
- neutralize high-z overlays, keep touchend/touchcancel active, and add fallback handlers for Select/Deselect/Start
- update the passive-events shim so touchend/touchcancel listeners can call preventDefault when needed

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d75c0a5ba8832c825094836a6be68d