### PR TITLE
Ensure kink dataset static asset availability

### DIFF
--- a/scripts/verify_assets.mjs
+++ b/scripts/verify_assets.mjs
@@ -1,17 +1,30 @@
 const base = process.argv[2] || "https://talkkink.org";
 const page = base.endsWith("/") ? base + "kinks/" : base + "/kinks/";
-const targets = ["/css/style.css","/css/theme.css","/js/theme.js","/data/kinks.json"];
+const targets = [
+  "/css/style.css",
+  "/css/theme.css",
+  "/js/theme.js",
+  "/data/kinks.json",
+  "/kinks.json"
+];
 async function head(u){
-  try{
-    const r = await fetch(u, { cache:"no-store" });
-    return { url:u, ok:r.ok, status:r.status, type:r.headers.get("content-type") || "" };
-  }catch(e){ return { url:u, ok:false, status:"FETCH_FAIL", type:String(e) }; }
+    try{
+      const r = await fetch(u, { cache:"no-store" });
+      const type = r.headers.get("content-type") || "";
+      return {
+        url:u,
+        ok:r.ok,
+        status:r.status,
+        type,
+        json:type.toLowerCase().startsWith("application/json")
+      };
+    }catch(e){ return { url:u, ok:false, status:"FETCH_FAIL", type:String(e), json:false }; }
 }
 (async()=>{
   console.log("Checking:", page);
   const res = await Promise.all(targets.map(t => head(new URL(t, base).toString())));
   const pad = (s,n)=>String(s).padEnd(n);
-  console.log(pad("STATUS",8), pad("OK",4), "URL", "TYPE");
-  res.forEach(r => console.log(pad(r.status,8), pad(r.ok,4), r.url, r.type));
+  console.log(pad("STATUS",8), pad("OK",4), pad("JSON",5), "URL", "TYPE");
+  res.forEach(r => console.log(pad(r.status,8), pad(r.ok,4), pad(r.json,5), r.url, r.type));
 })();
 

--- a/server.js
+++ b/server.js
@@ -341,17 +341,31 @@ app.use((req, res, next) => {
 // Serve kink survey and data without auth
 app.use((req, res, next) => {
   if (
-    req.method === 'GET' &&
+    (req.method === 'GET' || req.method === 'HEAD') &&
     (req.url === '/kinks/' || req.url === '/kinks' || req.url === '/kinks/index.html')
   ) {
+    if (req.method === 'HEAD') {
+      res.statusCode = 200;
+      res.end();
+      return;
+    }
     sendFile(res, path.join(__dirname, 'kinks', 'index.html'));
     return;
   }
-  if (req.method === 'GET' && (req.url === '/data/kinks.json' || req.url === '/kinks.json')) {
+  if (
+    (req.method === 'GET' || req.method === 'HEAD') &&
+    (req.url === '/data/kinks.json' || req.url === '/kinks.json')
+  ) {
     readFile(path.join(__dirname, 'data', 'kinks.json'))
       .then(data => {
+        const size = data.length;
         res.statusCode = 200;
         res.setHeader('Content-Type', 'application/json; charset=utf-8');
+        res.setHeader('Content-Length', size);
+        if (req.method === 'HEAD') {
+          res.end();
+          return;
+        }
         res.end(data);
       })
       .catch(() => {

--- a/test/kinksAccess.test.js
+++ b/test/kinksAccess.test.js
@@ -17,6 +17,13 @@ test('kink survey available without authentication', async t => {
 
   const jsonRes = await fetch(`${base}/data/kinks.json`);
   assert.strictEqual(jsonRes.status, 200);
+  assert.match(jsonRes.headers.get('content-type') || '', /^application\/json/i);
   const data = await jsonRes.json();
   assert.ok(Array.isArray(data.categories) || data.length);
+
+  const fallbackRes = await fetch(`${base}/kinks.json`);
+  assert.strictEqual(fallbackRes.status, 200);
+  assert.match(fallbackRes.headers.get('content-type') || '', /^application\/json/i);
+  const fallbackData = await fallbackRes.json();
+  assert.deepStrictEqual(fallbackData, data);
 });

--- a/test/kinksDatasetPublication.test.js
+++ b/test/kinksDatasetPublication.test.js
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, '..');
+
+const DATA_PATH = path.join(ROOT, 'data', 'kinks.json');
+const DOCS_DATA_PATH = path.join(ROOT, 'docs', 'kinks', 'data', 'kinks.json');
+
+async function load(filePath) {
+  const contents = await readFile(filePath, 'utf8');
+  assert.ok(contents.length > 0, `${filePath} should not be empty`);
+  return contents;
+}
+
+test('kinks dataset published with static assets', async () => {
+  const [rootData, docsData] = await Promise.all([
+    load(DATA_PATH),
+    load(DOCS_DATA_PATH)
+  ]);
+
+  assert.strictEqual(rootData, docsData, 'data/kinks.json and docs/kinks/data/kinks.json should match');
+});


### PR DESCRIPTION
## Summary
- serve the kink survey endpoints over GET/HEAD with explicit JSON metadata
- harden the static server so /kinks.json resolves to the published dataset
- extend verification tooling and add tests to ensure the dataset ships with the static bundle

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d8347e9d2c832cab8e50636a91d978