### PR TITLE
fix: sync kink dataset across deployment targets

### DIFF
--- a/docs/data/kinks.json
+++ b/docs/data/kinks.json
@@ -1,0 +1,4357 @@
+[
+  {
+    "category": "Body Part Torture",
+    "items": [
+      {
+        "id": "body-part-torture-giving-nipple-clips",
+        "label": "Nipple clips",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-giving-nipple-weights",
+        "label": "Nipple weights",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-giving-nipple-suction-cups",
+        "label": "Nipple suction cups",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-giving-cock-ball-torture-cbt",
+        "label": "Cock, Ball Torture (CBT)",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-giving-clit-clips-weights-suction",
+        "label": "Clit clips/weights/suction",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-giving-hair-pulling",
+        "label": "Hair pulling",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-giving-face-slapping",
+        "label": "Face slapping",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-giving-butt-slapping",
+        "label": "Butt slapping",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-giving-breast-slapping",
+        "label": "Breast slapping",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-giving-genital-slapping",
+        "label": "Genital slapping",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-receiving-nipple-clips",
+        "label": "Nipple clips",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-receiving-nipple-weights",
+        "label": "Nipple weights",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-receiving-nipple-suction-cups",
+        "label": "Nipple suction cups",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-receiving-cock-ball-torture-cbt",
+        "label": "Cock, Ball Torture (CBT)",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-receiving-clit-clips-weights-suction",
+        "label": "Clit clips/weights/suction",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-receiving-hair-pulling",
+        "label": "Hair pulling",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-receiving-face-slapping",
+        "label": "Face slapping",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-receiving-butt-slapping",
+        "label": "Butt slapping",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-receiving-breast-slapping",
+        "label": "Breast slapping",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-receiving-genital-slapping",
+        "label": "Genital slapping",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Bondage and Suspension",
+    "items": [
+      {
+        "id": "bondage-and-suspension-giving-blindfolds",
+        "label": "Blindfolds",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-bondage-heavy",
+        "label": "Bondage (heavy)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-bondage-light",
+        "label": "Bondage (light)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-immobilisation",
+        "label": "Immobilisation",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-bondage-multi-day",
+        "label": "Bondage (multi-day)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-bondage-public-under-clothing",
+        "label": "Bondage (public, under clothing)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-leather-restraints",
+        "label": "Leather restraints",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-chains",
+        "label": "Chains",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-ropes",
+        "label": "Ropes",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-intricate-japanese-rope-bondage",
+        "label": "Intricate (Japanese) rope bondage",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-rope-body-harness",
+        "label": "Rope body harness",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-arm-leg-sleeves-armbinders",
+        "label": "Arm & leg sleeves (armbinders)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-harnesses-leather",
+        "label": "Harnesses (leather)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-harnesses-rope",
+        "label": "Harnesses (rope)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-cuffs-leather",
+        "label": "Cuffs (leather)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-cuffs-metal",
+        "label": "Cuffs (metal)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-manacles-irons",
+        "label": "Manacles & Irons",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-gags-cloth",
+        "label": "Gags (cloth)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-gags-rubber",
+        "label": "Gags (rubber)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-gags-tape",
+        "label": "Gags (tape)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-gags-phallic",
+        "label": "Gags (phallic)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-gags-ring",
+        "label": "Gags (ring)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-gags-ball",
+        "label": "Gags (ball)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-mouth-bits",
+        "label": "Mouth bits",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-full-head-hoods",
+        "label": "Full head hoods",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-mummification-saran-wrapping",
+        "label": "Mummification/saran wrapping",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-straight-jackets",
+        "label": "Straight jackets",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-suspension-upright",
+        "label": "Suspension (upright)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-suspension-horizontal",
+        "label": "Suspension (horizontal)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-suspension-inverted",
+        "label": "Suspension (inverted)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-breath-play",
+        "label": "Breath play",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-smothering",
+        "label": "Smothering",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-forced-self-breath-control",
+        "label": "Forced self-breath-control",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-gas-mask",
+        "label": "Gas mask",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-blindfolds",
+        "label": "Blindfolds",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-bondage-heavy",
+        "label": "Bondage (heavy)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-bondage-light",
+        "label": "Bondage (light)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-immobilisation",
+        "label": "Immobilisation",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-bondage-multi-day",
+        "label": "Bondage (multi-day)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-bondage-public-under-clothing",
+        "label": "Bondage (public, under clothing)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-leather-restraints",
+        "label": "Leather restraints",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-chains",
+        "label": "Chains",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-ropes",
+        "label": "Ropes",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-intricate-japanese-rope-bondage",
+        "label": "Intricate (Japanese) rope bondage",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-rope-body-harness",
+        "label": "Rope body harness",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-arm-leg-sleeves-armbinders",
+        "label": "Arm & leg sleeves (armbinders)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-harnesses-leather",
+        "label": "Harnesses (leather)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-harnesses-rope",
+        "label": "Harnesses (rope)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-cuffs-leather",
+        "label": "Cuffs (leather)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-cuffs-metal",
+        "label": "Cuffs (metal)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-manacles-irons",
+        "label": "Manacles & Irons",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-gags-cloth",
+        "label": "Gags (cloth)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-gags-rubber",
+        "label": "Gags (rubber)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-gags-tape",
+        "label": "Gags (tape)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-gags-phallic",
+        "label": "Gags (phallic)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-gags-ring",
+        "label": "Gags (ring)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-gags-ball",
+        "label": "Gags (ball)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-mouth-bits",
+        "label": "Mouth bits",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-full-head-hoods",
+        "label": "Full head hoods",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-mummification-saran-wrapping",
+        "label": "Mummification/saran wrapping",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-straight-jackets",
+        "label": "Straight jackets",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-suspension-upright",
+        "label": "Suspension (upright)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-suspension-horizontal",
+        "label": "Suspension (horizontal)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-suspension-inverted",
+        "label": "Suspension (inverted)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-breath-play",
+        "label": "Breath play",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-smothering",
+        "label": "Smothering",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-forced-self-breath-control",
+        "label": "Forced self-breath-control",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-gas-mask",
+        "label": "Gas mask",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Breath Play",
+    "items": [
+      {
+        "id": "breath-play-giving-asphyxiation",
+        "label": "Asphyxiation",
+        "type": "scale"
+      },
+      {
+        "id": "breath-play-giving-breath-control",
+        "label": "Breath control",
+        "type": "scale"
+      },
+      {
+        "id": "breath-play-giving-choking",
+        "label": "Choking",
+        "type": "scale"
+      },
+      {
+        "id": "breath-play-giving-drowning",
+        "label": "Drowning",
+        "type": "scale"
+      },
+      {
+        "id": "breath-play-giving-rebreathing-into-a-bag-or-object",
+        "label": "Rebreathing into a bag or object",
+        "type": "scale"
+      },
+      {
+        "id": "breath-play-giving-verbal-control-of-breath-e-g-hold-it-on-command",
+        "label": "Verbal control of breath (e.g., 'hold it' on command)",
+        "type": "scale"
+      },
+      {
+        "id": "breath-play-receiving-asphyxiation",
+        "label": "Asphyxiation",
+        "type": "scale"
+      },
+      {
+        "id": "breath-play-receiving-breath-control",
+        "label": "Breath control",
+        "type": "scale"
+      },
+      {
+        "id": "breath-play-receiving-choking",
+        "label": "Choking",
+        "type": "scale"
+      },
+      {
+        "id": "breath-play-receiving-drowning",
+        "label": "Drowning",
+        "type": "scale"
+      },
+      {
+        "id": "breath-play-receiving-rebreathing-into-a-bag-or-object",
+        "label": "Rebreathing into a bag or object",
+        "type": "scale"
+      },
+      {
+        "id": "breath-play-receiving-verbal-control-of-breath-e-g-hold-it-on-command",
+        "label": "Verbal control of breath (e.g., 'hold it' on command)",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Sexual Activity",
+    "items": [
+      {
+        "id": "sexual-activity-giving-licking",
+        "label": "Licking",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-fellatio-cunnilingus",
+        "label": "Fellatio/Cunnilingus",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-swallowing-semen",
+        "label": "Swallowing semen",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-cumming-on-partner",
+        "label": "Cumming on Partner",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-hand-jobs",
+        "label": "Hand jobs",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-anal-sex",
+        "label": "Anal sex",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-anal-plugs-small",
+        "label": "Anal plugs (small)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-anal-plugs-large",
+        "label": "Anal plugs (large)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-anal-beads",
+        "label": "Anal beads",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-vibrator-on-genitals",
+        "label": "Vibrator on genitals",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-fisting",
+        "label": "Fisting",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-oral-anal-play-rimming",
+        "label": "Oral/anal play (rimming)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-double-penetration-oral-and-vaginal",
+        "label": "Double penetration (oral and vaginal)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-double-penetration-oral-and-anal",
+        "label": "Double penetration (oral and anal)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-double-penetration-anal-and-vaginal",
+        "label": "Double penetration (anal and vaginal)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-triple-oral-vaginal-and-anal",
+        "label": "Triple (Oral, Vaginal and Anal)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-licking",
+        "label": "Licking",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-fellatio-cunnilingus",
+        "label": "Fellatio/Cunnilingus",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-swallowing-semen",
+        "label": "Swallowing semen",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-cumming-on-partner",
+        "label": "Cumming on Partner",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-hand-jobs",
+        "label": "Hand jobs",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-anal-sex",
+        "label": "Anal sex",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-anal-plugs-small",
+        "label": "Anal plugs (small)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-anal-plugs-large",
+        "label": "Anal plugs (large)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-anal-beads",
+        "label": "Anal beads",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-vibrator-on-genitals",
+        "label": "Vibrator on genitals",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-fisting",
+        "label": "Fisting",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-oral-anal-play-rimming",
+        "label": "Oral/anal play (rimming)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-double-penetration-oral-and-vaginal",
+        "label": "Double penetration (oral and vaginal)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-double-penetration-oral-and-anal",
+        "label": "Double penetration (oral and anal)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-double-penetration-anal-and-vaginal",
+        "label": "Double penetration (anal and vaginal)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-triple-oral-vaginal-and-anal",
+        "label": "Triple (Oral, Vaginal and Anal)",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Sensation Play",
+    "items": [
+      {
+        "id": "sensation-play-giving-abrasion",
+        "label": "Abrasion",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-scratching",
+        "label": "Scratching",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-biting",
+        "label": "Biting",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-tickling",
+        "label": "Tickling",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-kissing",
+        "label": "Kissing",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-zapping-e-g-electric-fly-swatter",
+        "label": "Zapping (e.g. electric fly swatter)",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-ice-cubes",
+        "label": "Ice cubes",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-wax-play",
+        "label": "Wax Play",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-fire",
+        "label": "Fire",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-clothespins",
+        "label": "Clothespins",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-needles",
+        "label": "Needles",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-sensory-deprivation",
+        "label": "Sensory deprivation",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-physical-overpowering-manhandling",
+        "label": "Physical overpowering / Manhandling",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-figging",
+        "label": "Figging",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-abrasion",
+        "label": "Abrasion",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-scratching",
+        "label": "Scratching",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-biting",
+        "label": "Biting",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-tickling",
+        "label": "Tickling",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-kissing",
+        "label": "Kissing",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-zapping-e-g-electric-fly-swatter",
+        "label": "Zapping (e.g. electric fly swatter)",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-ice-cubes",
+        "label": "Ice cubes",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-wax-play",
+        "label": "Wax Play",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-fire",
+        "label": "Fire",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-clothespins",
+        "label": "Clothespins",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-needles",
+        "label": "Needles",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-sensory-deprivation",
+        "label": "Sensory deprivation",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-physical-overpowering-manhandling",
+        "label": "Physical overpowering / Manhandling",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-figging",
+        "label": "Figging",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Other",
+    "items": [
+      {
+        "id": "other-general-feet",
+        "label": "Feet",
+        "type": "scale"
+      },
+      {
+        "id": "other-general-boots",
+        "label": "Boots",
+        "type": "scale"
+      },
+      {
+        "id": "other-general-underwear",
+        "label": "Underwear",
+        "type": "scale"
+      },
+      {
+        "id": "other-general-chastity-devices",
+        "label": "Chastity devices",
+        "type": "scale"
+      },
+      {
+        "id": "other-general-masks",
+        "label": "Masks",
+        "type": "scale"
+      },
+      {
+        "id": "other-general-breeding",
+        "label": "Breeding",
+        "type": "scale"
+      },
+      {
+        "id": "other-general-leather-clothing",
+        "label": "Leather clothing",
+        "type": "scale"
+      },
+      {
+        "id": "other-general-training-protocols-outside-scenes-e-g-etiquette-memory",
+        "label": "Training protocols outside scenes (e.g., etiquette, memory)",
+        "type": "scale"
+      },
+      {
+        "id": "other-general-long-distance-training-structure",
+        "label": "Long-distance training/structure",
+        "type": "scale"
+      },
+      {
+        "id": "other-general-scene-journaling-and-reflection",
+        "label": "Scene journaling and reflection",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Roleplaying",
+    "items": [
+      {
+        "id": "roleplaying-giving-fantasy-abandonment",
+        "label": "Fantasy abandonment",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-giving-kidnapping",
+        "label": "Kidnapping",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-giving-interrogation",
+        "label": "Interrogation",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-giving-sleep-deprivation",
+        "label": "Sleep deprivation",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-giving-cnc",
+        "label": "CNC",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-giving-gang-bang",
+        "label": "Gang bang",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-giving-initiation-rites",
+        "label": "Initiation rites",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-giving-religious-scenes",
+        "label": "Religious scenes",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-giving-medical-scenes",
+        "label": "Medical scenes",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-giving-prison-scenes",
+        "label": "Prison scenes",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-giving-primal-prey",
+        "label": "Primal/Prey",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-giving-schoolroom-scenes",
+        "label": "Schoolroom scenes",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-fantasy-abandonment",
+        "label": "Fantasy abandonment",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-kidnapping",
+        "label": "Kidnapping",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-interrogation",
+        "label": "Interrogation",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-sleep-deprivation",
+        "label": "Sleep deprivation",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-cnc",
+        "label": "CNC",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-gang-bang",
+        "label": "Gang bang",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-initiation-rites",
+        "label": "Initiation rites",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-religious-scenes",
+        "label": "Religious scenes",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-medical-scenes",
+        "label": "Medical scenes",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-prison-scenes",
+        "label": "Prison scenes",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-primal-prey",
+        "label": "Primal/Prey",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-schoolroom-scenes",
+        "label": "Schoolroom scenes",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Service and Restrictive Behaviour",
+    "items": [
+      {
+        "id": "service-and-restrictive-behaviour-giving-following-orders",
+        "label": "(Following) orders",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-forced-servitude",
+        "label": "Forced servitude",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-restrictive-rules-on-behaviour",
+        "label": "Restrictive rules on behaviour",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-eye-contact-restrictions",
+        "label": "Eye contact restrictions",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-speech-restrictions-when-what-to-whom",
+        "label": "Speech restrictions (when, what, to whom)",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-washroom-restrictions",
+        "label": "Washroom restrictions",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-punishments",
+        "label": "Punishments",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-tasks",
+        "label": "Tasks",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-massage",
+        "label": "Massage",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-domestic-tasks",
+        "label": "Domestic tasks",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-serving-food-and-drink",
+        "label": "Serving food and drink",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-personal-care-rituals",
+        "label": "Personal care rituals",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-being-on-call-at-specified-times",
+        "label": "Being on-call at specified times",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-daily-task-assignments",
+        "label": "Daily task assignments",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-corrections-for-imperfection",
+        "label": "Corrections for imperfection",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-uniforms-dress-codes",
+        "label": "Uniforms / Dress codes",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-kneeling-posture-presentation",
+        "label": "Kneeling / Posture presentation",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-silent-service",
+        "label": "Silent service",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-public-service-at-parties-or-events",
+        "label": "Public service (at parties or events)",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-erotic-service-pleasure-on-command-without-seeking-your-own",
+        "label": "Erotic service (pleasure on command, without seeking your own)",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-following-orders",
+        "label": "(Following) orders",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-forced-servitude",
+        "label": "Forced servitude",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-restrictive-rules-on-behaviour",
+        "label": "Restrictive rules on behaviour",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-eye-contact-restrictions",
+        "label": "Eye contact restrictions",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-speech-restrictions-when-what-to-whom",
+        "label": "Speech restrictions (when, what, to whom)",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-washroom-restrictions",
+        "label": "Washroom restrictions",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-punishments",
+        "label": "Punishments",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-tasks",
+        "label": "Tasks",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-massage",
+        "label": "Massage",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-domestic-tasks",
+        "label": "Domestic tasks",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-serving-food-and-drink",
+        "label": "Serving food and drink",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-personal-care-rituals",
+        "label": "Personal care rituals",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-being-on-call-at-specified-times",
+        "label": "Being on-call at specified times",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-daily-task-assignments",
+        "label": "Daily task assignments",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-corrections-for-imperfection",
+        "label": "Corrections for imperfection",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-uniforms-dress-codes",
+        "label": "Uniforms / Dress codes",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-kneeling-posture-presentation",
+        "label": "Kneeling / Posture presentation",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-silent-service",
+        "label": "Silent service",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-public-service-at-parties-or-events",
+        "label": "Public service (at parties or events)",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-erotic-service-pleasure-on-command-without-seeking-your-own",
+        "label": "Erotic service (pleasure on command, without seeking your own)",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Voyeurism/Exhibitionism",
+    "items": [
+      {
+        "id": "voyeurism-exhibitionism-giving-forced-nudity-private",
+        "label": "Forced nudity (private)",
+        "type": "scale"
+      },
+      {
+        "id": "voyeurism-exhibitionism-giving-forced-nudity-around-others",
+        "label": "Forced nudity (around others)",
+        "type": "scale"
+      },
+      {
+        "id": "voyeurism-exhibitionism-giving-exhibitionism-friends",
+        "label": "Exhibitionism (friends)",
+        "type": "scale"
+      },
+      {
+        "id": "voyeurism-exhibitionism-giving-exhibitionism-strangers",
+        "label": "Exhibitionism (strangers)",
+        "type": "scale"
+      },
+      {
+        "id": "voyeurism-exhibitionism-giving-modelling-for-erotic-photos",
+        "label": "Modelling for erotic photos",
+        "type": "scale"
+      },
+      {
+        "id": "voyeurism-exhibitionism-giving-toys-under-clothes-in-public",
+        "label": "Toys under clothes in public",
+        "type": "scale"
+      },
+      {
+        "id": "voyeurism-exhibitionism-receiving-forced-nudity-private",
+        "label": "Forced nudity (private)",
+        "type": "scale"
+      },
+      {
+        "id": "voyeurism-exhibitionism-receiving-forced-nudity-around-others",
+        "label": "Forced nudity (around others)",
+        "type": "scale"
+      },
+      {
+        "id": "voyeurism-exhibitionism-receiving-exhibitionism-friends",
+        "label": "Exhibitionism (friends)",
+        "type": "scale"
+      },
+      {
+        "id": "voyeurism-exhibitionism-receiving-exhibitionism-strangers",
+        "label": "Exhibitionism (strangers)",
+        "type": "scale"
+      },
+      {
+        "id": "voyeurism-exhibitionism-receiving-modelling-for-erotic-photos",
+        "label": "Modelling for erotic photos",
+        "type": "scale"
+      },
+      {
+        "id": "voyeurism-exhibitionism-receiving-toys-under-clothes-in-public",
+        "label": "Toys under clothes in public",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Virtual & Long-Distance Play",
+    "items": [
+      {
+        "id": "virtual-long-distance-play-giving-sending-tasks-or-orders-digitally",
+        "label": "Sending tasks or orders digitally",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-giving-recording-dominant-voice-clips-commands-edging-praise-degradation-etc",
+        "label": "Recording dominant voice clips (commands, edging, praise, degradation, etc.)",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-giving-remote-control-of-a-sex-toy",
+        "label": "Remote control of a sex toy",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-giving-monitoring-behavior-via-app-or-shared-doc",
+        "label": "Monitoring behavior via app or shared doc",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-giving-giving-punishment-assignments-remotely",
+        "label": "Giving punishment assignments remotely",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-giving-creating-countdowns-timers-or-denial-periods",
+        "label": "Creating countdowns, timers, or denial periods",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-giving-sending-written-instructions-with-delayed-permissions",
+        "label": "Sending written instructions with delayed permissions",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-giving-creating-custom-video-or-audio-tasks",
+        "label": "Creating custom video or audio tasks",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-giving-voice-message-control-during-scenes",
+        "label": "Voice message control during scenes",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-giving-being-on-call-at-specified-times",
+        "label": "Being on-call at specified times",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-receiving-receiving-tasks-or-orders-digitally",
+        "label": "Receiving tasks or orders digitally",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-receiving-listening-to-dominant-voice-clips",
+        "label": "Listening to dominant voice clips",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-receiving-using-a-remote-controlled-toy-controlled-by-another",
+        "label": "Using a remote-controlled toy controlled by another",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-receiving-completing-daily-protocol-assignments",
+        "label": "Completing daily protocol assignments",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-receiving-submitting-proof-photo-video-text",
+        "label": "Submitting proof (photo, video, text)",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-receiving-following-recorded-or-timed-commands",
+        "label": "Following recorded or timed commands",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-receiving-receiving-surprise-instructions",
+        "label": "Receiving surprise instructions",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-receiving-hearing-name-praise-spoken-in-a-custom-clip",
+        "label": "Hearing name/praise spoken in a custom clip",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-receiving-sending-submissive-voice-clips-obedience-begging-thank-you-messages-affirmations-etc",
+        "label": "Sending submissive voice clips (obedience, begging, thank-you messages, affirmations, etc.)",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-receiving-being-on-call-at-specified-times",
+        "label": "Being on-call at specified times",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-general-scheduling-digital-rituals-or-reminders",
+        "label": "Scheduling digital rituals or reminders",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-general-using-training-habit-or-behavior-tracking-apps",
+        "label": "Using training, habit, or behavior-tracking apps",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-general-online-rituals-digital-kneeling-posture-protocols",
+        "label": "Online rituals (digital kneeling, posture protocols)",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-general-role-based-texting-e-g-use-honorifics-in-chat",
+        "label": "Role-based texting (e.g., \"Use honorifics in chat\")",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-general-shared-playlists-affirmations-or-mantras",
+        "label": "Shared playlists, affirmations, or mantras",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-general-countdown-timers-to-next-task-release-or-interaction",
+        "label": "Countdown timers to next task, release, or interaction",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-general-scheduled-good-morning-night-rituals",
+        "label": "Scheduled good morning/night rituals",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-general-participating-in-video-call-scenes",
+        "label": "Participating in video call scenes",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-general-digital-aftercare-texts-voice-images",
+        "label": "Digital aftercare (texts, voice, images)",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-general-sexting-or-digital-roleplay-scenes",
+        "label": "Sexting or digital roleplay scenes",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-general-voice-notes-or-submissive-dominant-affirmations",
+        "label": "Voice notes or submissive/dominant affirmations",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Communication",
+    "items": [
+      {
+        "id": "communication-giving-playful-and-teasing",
+        "label": "Playful and teasing",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-quiet-and-intense",
+        "label": "Quiet and intense",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-observant-and-intentional",
+        "label": "Observant and intentional",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-praise-heavy",
+        "label": "Praise-heavy",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-blunt-and-efficient",
+        "label": "Blunt and efficient",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-affirming-and-soft",
+        "label": "Affirming and soft",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-psychological-interrogation",
+        "label": "Psychological interrogation",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-verbal-coercion-teasing-traps",
+        "label": "Verbal coercion / teasing traps",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-verbal-misdirection",
+        "label": "Verbal misdirection",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-mocking-shaming",
+        "label": "Mocking / shaming",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-predatory-pacing",
+        "label": "Predatory pacing",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-reluctant-obedience",
+        "label": "Reluctant obedience",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-stammering-submission",
+        "label": "Stammering submission",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-challenging-until-caught",
+        "label": "Challenging until caught",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-quiet-surrender",
+        "label": "Quiet surrender",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-sarcastic-teasing",
+        "label": "Sarcastic teasing",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-provoking-tone",
+        "label": "Provoking tone",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-challenge-based-dialogue",
+        "label": "Challenge-based dialogue",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-double-meaning-banter",
+        "label": "Double-meaning banter",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-soft-spoken-guidance",
+        "label": "Soft-spoken guidance",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-protective-but-firm-tone",
+        "label": "Protective but firm tone",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-emotional-redirection",
+        "label": "Emotional redirection",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-steady-reassurance",
+        "label": "Steady reassurance",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-direct-and-clear",
+        "label": "Direct and clear",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-playful-and-teasing",
+        "label": "Playful and teasing",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-gentle-and-nurturing",
+        "label": "Gentle and nurturing",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-commanding-and-firm",
+        "label": "Commanding and firm",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-quiet-and-observant",
+        "label": "Quiet and observant",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-instructive-teacher-like",
+        "label": "Instructive / teacher-like",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-emotionally-intense",
+        "label": "Emotionally intense",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-dismissive-withholding",
+        "label": "Dismissive / withholding",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-mocking-sarcastic",
+        "label": "Mocking / sarcastic",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-blunt-tactless",
+        "label": "Blunt / tactless",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-predatory-hunting-tone",
+        "label": "Predatory / hunting tone",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-stalking-or-circling-speech",
+        "label": "Stalking or circling speech",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-you-re-mine-control-language",
+        "label": "You’re mine / control language",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-threatening-consensual",
+        "label": "Threatening (consensual)",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-verbal-cornering-coaxing",
+        "label": "Verbal cornering / coaxing",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-watching-you-unravel",
+        "label": "Watching you unravel",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-cruel-and-cutting",
+        "label": "Cruel and cutting",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-psychological-baiting",
+        "label": "Psychological baiting",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-brat-breaking-language",
+        "label": "Brat-breaking language",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-mock-affection",
+        "label": "Mock affection",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-shaming-or-emotional-edge",
+        "label": "Shaming or emotional edge",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-disappointed-dom-voice",
+        "label": "Disappointed dom voice",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-mild-scolding-mocking-affection",
+        "label": "Mild scolding / mocking affection",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-verbal-power-struggle",
+        "label": "Verbal power struggle",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-challenge-response-dynamics",
+        "label": "Challenge-response dynamics",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-warm-tone-with-expectation",
+        "label": "Warm tone with expectation",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-nurturing-dominance",
+        "label": "Nurturing dominance",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-reassuring-commands",
+        "label": "Reassuring commands",
+        "type": "scale"
+      },
+      {
+        "id": "communication-general-phrases-that-work-on-you",
+        "label": "Phrases that work on you",
+        "type": "text"
+      },
+      {
+        "id": "communication-general-phrases-you-use-or-like-to-give",
+        "label": "Phrases you use or like to give",
+        "type": "text"
+      },
+      {
+        "id": "communication-general-what-helps-you-feel-emotionally-safe",
+        "label": "What helps you feel emotionally safe",
+        "type": "text"
+      },
+      {
+        "id": "communication-general-how-you-tend-to-show-affection",
+        "label": "How you tend to show affection",
+        "type": "text"
+      },
+      {
+        "id": "communication-general-emotional-check-in-style",
+        "label": "Emotional check-in style",
+        "type": "text"
+      },
+      {
+        "id": "communication-general-when-emotionally-activated-i-tend-to",
+        "label": "When emotionally activated, I tend to...",
+        "type": "text"
+      }
+    ]
+  },
+  {
+    "category": "Body Fluids and Functions",
+    "items": [
+      {
+        "id": "body-fluids-and-functions-giving-watersports-golden-showers",
+        "label": "Watersports/golden showers",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-giving-cum",
+        "label": "Cum",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-giving-blood",
+        "label": "Blood",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-giving-scat",
+        "label": "Scat",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-giving-sweat",
+        "label": "Sweat",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-giving-vomit",
+        "label": "Vomit",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-giving-tears-crying",
+        "label": "Tears/crying",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-receiving-watersports-golden-showers",
+        "label": "Watersports/golden showers",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-receiving-cum",
+        "label": "Cum",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-receiving-blood",
+        "label": "Blood",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-receiving-scat",
+        "label": "Scat",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-receiving-sweat",
+        "label": "Sweat",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-receiving-vomit",
+        "label": "Vomit",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-receiving-tears-crying",
+        "label": "Tears/crying",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Psychological Primal / Prey",
+    "items": [
+      {
+        "id": "psychological-primal-prey-giving-primal-prey",
+        "label": "Primal/Prey",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-conditioning",
+        "label": "Conditioning",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-coc",
+        "label": "COC",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-psycholagny-hands-free-mentally-stimulated-orgasm",
+        "label": "Psycholagny (hands free, mentally stimulated orgasm)",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-hypno-play",
+        "label": "Hypno Play",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-praise",
+        "label": "Praise",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-degradation",
+        "label": "Degradation",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-traditional-primal-prey",
+        "label": "Traditional primal/prey",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-fear-play",
+        "label": "Fear play",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-objectification",
+        "label": "Objectification",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-gaslighting",
+        "label": "Gaslighting",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-role-erosion-identity-play-loss-of-self",
+        "label": "Role erosion (identity play / loss of self)",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-jealousy-play",
+        "label": "Jealousy play",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-manipulation",
+        "label": "Manipulation",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-primal-prey",
+        "label": "Primal/Prey",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-conditioning",
+        "label": "Conditioning",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-coc",
+        "label": "COC",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-psycholagny-hands-free-mentally-stimulated-orgasm",
+        "label": "Psycholagny (hands free, mentally stimulated orgasm)",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-hypno-play",
+        "label": "Hypno Play",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-praise",
+        "label": "Praise",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-degradation",
+        "label": "Degradation",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-traditional-primal-prey",
+        "label": "Traditional primal/prey",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-fear-play",
+        "label": "Fear play",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-objectification",
+        "label": "Objectification",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-gaslighting",
+        "label": "Gaslighting",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-role-erosion-identity-play-loss-of-self",
+        "label": "Role erosion (identity play / loss of self)",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-jealousy-play",
+        "label": "Jealousy play",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-manipulation",
+        "label": "Manipulation",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Body Part / Fetish Play",
+    "items": [
+      {
+        "id": "body-part-fetish-play-giving-belly-fucking",
+        "label": "Belly fucking",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-giving-navel-play",
+        "label": "Navel play",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-giving-feet-foot-worship",
+        "label": "Feet / Foot worship",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-giving-hands",
+        "label": "Hands",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-giving-hair",
+        "label": "Hair",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-giving-thighs",
+        "label": "Thighs",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-giving-neck",
+        "label": "Neck",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-giving-ears",
+        "label": "Ears",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-giving-belly",
+        "label": "Belly",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-giving-voice-fetish",
+        "label": "Voice fetish",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-giving-nails-makeup-fetish",
+        "label": "Nails / Makeup fetish",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-receiving-belly-fucking",
+        "label": "Belly fucking",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-receiving-navel-play",
+        "label": "Navel play",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-receiving-feet-foot-worship",
+        "label": "Feet / Foot worship",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-receiving-hands",
+        "label": "Hands",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-receiving-hair",
+        "label": "Hair",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-receiving-thighs",
+        "label": "Thighs",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-receiving-neck",
+        "label": "Neck",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-receiving-ears",
+        "label": "Ears",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-receiving-belly",
+        "label": "Belly",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-receiving-voice-fetish",
+        "label": "Voice fetish",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-receiving-nails-makeup-fetish",
+        "label": "Nails / Makeup fetish",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-cuddles",
+        "label": "Cuddles",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-food-play",
+        "label": "Food Play",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-kisses",
+        "label": "Kisses",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-masturbation",
+        "label": "Masturbation",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-romance-affection",
+        "label": "Romance / affection",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-sex-toys",
+        "label": "Sex toys",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-sexting-chat-etc",
+        "label": "Sexting /Chat etc",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-sexting-via-phone-or-video-call",
+        "label": "Sexting via phone or video call",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-strip-tease",
+        "label": "Strip tease",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-vanilla-sex",
+        "label": "Vanilla Sex",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-voice-notes",
+        "label": "Voice Notes",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-shaving-body-hair",
+        "label": "Shaving (body hair)",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-sexy-clothing-private",
+        "label": "Sexy clothing (private)",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-sexy-clothing-public",
+        "label": "Sexy clothing (public)",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-outdoor-scenes",
+        "label": "Outdoor scenes",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-public-exposure",
+        "label": "Public exposure",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Orgasm Control & Sexual Manipulation",
+    "items": [
+      {
+        "id": "orgasm-control-sexual-manipulation-giving-edging",
+        "label": "Edging",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-giving-short-term-denial",
+        "label": "Short term denial",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-giving-long-term-denial",
+        "label": "Long term denial",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-giving-forced-orgasms-overstimulation",
+        "label": "Forced orgasms / Overstimulation",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-giving-ruined-orgasms",
+        "label": "Ruined orgasms",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-giving-no-touch-periods",
+        "label": "No touch periods",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-giving-milking",
+        "label": "Milking",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-giving-chastity-devices",
+        "label": "Chastity devices",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-giving-consensual-orgasm-control",
+        "label": "Consensual orgasm control",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-giving-forced-masturbation",
+        "label": "Forced masturbation",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-receiving-edging",
+        "label": "Edging",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-receiving-short-term-denial",
+        "label": "Short term denial",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-receiving-long-term-denial",
+        "label": "Long term denial",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-receiving-forced-orgasms-overstimulation",
+        "label": "Forced orgasms / Overstimulation",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-receiving-ruined-orgasms",
+        "label": "Ruined orgasms",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-receiving-no-touch-periods",
+        "label": "No touch periods",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-receiving-milking",
+        "label": "Milking",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-receiving-chastity-devices",
+        "label": "Chastity devices",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-receiving-consensual-orgasm-control",
+        "label": "Consensual orgasm control",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-receiving-forced-masturbation",
+        "label": "Forced masturbation",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Protocol and Ritual",
+    "items": [
+      {
+        "id": "protocol-and-ritual-giving-formal-language",
+        "label": "Formal language",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-greeting-and-departure-rituals-kneeling-verbal-scripts-gestures",
+        "label": "Greeting and departure rituals (kneeling, verbal scripts, gestures)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-requiring-permission-for-things-speech-movement-attire",
+        "label": "Requiring permission for things (speech, movement, attire)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-daily-rituals-morning-check-ins-status-reports-mantra-repetitions",
+        "label": "Daily rituals (morning check-ins, status reports, mantra repetitions)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-specific-postures-for-rest-attention-punishment-waiting",
+        "label": "Specific postures for rest, attention, punishment, waiting",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-restricted-behavior-no-eye-contact-silence-no-questions",
+        "label": "Restricted behavior (no eye contact, silence, no questions)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-ritual-object-use-collar-cuffs-leash-tokens",
+        "label": "Ritual object use (collar, cuffs, leash, tokens)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-tracking-obedience-journals-apps",
+        "label": "Tracking obedience (journals, apps)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-formalized-rules-for-misbehavior-and-correction",
+        "label": "Formalized rules for misbehavior and correction",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-ritualized-aftercare-or-scene-closure",
+        "label": "Ritualized aftercare or scene closure",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-object-retrieval-on-all-fours-with-item-in-mouth",
+        "label": "Object retrieval on all fours with item in mouth",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-fetching-hairbrush-or-punishment-tool-from-dresser-while-crawling",
+        "label": "Fetching hairbrush or punishment tool from dresser while crawling",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-presenting-chosen-discipline-tool-in-kneeling-posture",
+        "label": "Presenting chosen discipline tool in kneeling posture",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-assigned-posture-or-kneeling-positions-as-ritual",
+        "label": "Assigned posture or kneeling positions as ritual",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-requesting-permission-using-specific-protocol-phrases",
+        "label": "Requesting permission using specific protocol phrases",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-carrying-items-in-mouth-as-submissive-gesture",
+        "label": "Carrying items in mouth as submissive gesture",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-crawling-back-with-object-to-dominant-after-retrieval",
+        "label": "Crawling back with object to Dominant after retrieval",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-following-via-nipple-leash-as-protocol-or-punishment",
+        "label": "Following via nipple leash as protocol or punishment",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-crawling-assigned-paths-as-ritual-or-obedience-training",
+        "label": "Crawling assigned paths as ritual or obedience training",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-crawling-rituals-e-g-object-retrieval",
+        "label": "Crawling rituals (e.g., object retrieval)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-carrying-objects-in-mouth-as-obedience",
+        "label": "Carrying objects in mouth as obedience",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-presenting-tools-or-toys-in-posture",
+        "label": "Presenting tools or toys in posture",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-using-honorifics-or-preset-protocol-language",
+        "label": "Using honorifics or preset protocol language",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-greeting-rituals-e-g-kneeling-kissing-feet",
+        "label": "Greeting rituals (e.g., kneeling, kissing feet)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-daily-check-ins-or-structured-reports",
+        "label": "Daily check-ins or structured reports",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-clothing-restrictions-or-uniforms",
+        "label": "Clothing restrictions or uniforms",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-posture-training-sitting-kneeling-standing",
+        "label": "Posture training (sitting, kneeling, standing)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-punishments-for-incorrect-behavior-or-tone",
+        "label": "Punishments for incorrect behavior or tone",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-crawling-with-items-in-mouth-e-g-hairbrush-spoon",
+        "label": "Crawling with items in mouth (e.g., hairbrush, spoon)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-earning-permission-for-meals-bathroom-use-or-rest",
+        "label": "Earning permission for meals, bathroom use, or rest",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-formal-language",
+        "label": "Formal language",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-greeting-and-departure-rituals-kneeling-verbal-scripts-gestures",
+        "label": "Greeting and departure rituals (kneeling, verbal scripts, gestures)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-requiring-permission-for-things-speech-movement-attire",
+        "label": "Requiring permission for things (speech, movement, attire)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-daily-rituals-morning-check-ins-status-reports-mantra-repetitions",
+        "label": "Daily rituals (morning check-ins, status reports, mantra repetitions)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-specific-postures-for-rest-attention-punishment-waiting",
+        "label": "Specific postures for rest, attention, punishment, waiting",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-restricted-behavior-no-eye-contact-silence-no-questions",
+        "label": "Restricted behavior (no eye contact, silence, no questions)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-ritual-object-use-collar-cuffs-leash-tokens",
+        "label": "Ritual object use (collar, cuffs, leash, tokens)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-tracking-obedience-journals-apps",
+        "label": "Tracking obedience (journals, apps)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-formalized-rules-for-misbehavior-and-correction",
+        "label": "Formalized rules for misbehavior and correction",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-ritualized-aftercare-or-scene-closure",
+        "label": "Ritualized aftercare or scene closure",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-object-retrieval-on-all-fours-with-item-in-mouth",
+        "label": "Object retrieval on all fours with item in mouth",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-fetching-hairbrush-or-punishment-tool-from-dresser-while-crawling",
+        "label": "Fetching hairbrush or punishment tool from dresser while crawling",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-presenting-chosen-discipline-tool-in-kneeling-posture",
+        "label": "Presenting chosen discipline tool in kneeling posture",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-assigned-posture-or-kneeling-positions-as-ritual",
+        "label": "Assigned posture or kneeling positions as ritual",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-requesting-permission-using-specific-protocol-phrases",
+        "label": "Requesting permission using specific protocol phrases",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-carrying-items-in-mouth-as-submissive-gesture",
+        "label": "Carrying items in mouth as submissive gesture",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-crawling-back-with-object-to-dominant-after-retrieval",
+        "label": "Crawling back with object to Dominant after retrieval",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-following-via-nipple-leash-as-protocol-or-punishment",
+        "label": "Following via nipple leash as protocol or punishment",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-crawling-assigned-paths-as-ritual-or-obedience-training",
+        "label": "Crawling assigned paths as ritual or obedience training",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-crawling-rituals-e-g-object-retrieval",
+        "label": "Crawling rituals (e.g., object retrieval)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-carrying-objects-in-mouth-as-obedience",
+        "label": "Carrying objects in mouth as obedience",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-presenting-tools-or-toys-in-posture",
+        "label": "Presenting tools or toys in posture",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-using-honorifics-or-preset-protocol-language",
+        "label": "Using honorifics or preset protocol language",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-greeting-rituals-e-g-kneeling-kissing-feet",
+        "label": "Greeting rituals (e.g., kneeling, kissing feet)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-daily-check-ins-or-structured-reports",
+        "label": "Daily check-ins or structured reports",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-clothing-restrictions-or-uniforms",
+        "label": "Clothing restrictions or uniforms",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-posture-training-sitting-kneeling-standing",
+        "label": "Posture training (sitting, kneeling, standing)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-punishments-for-incorrect-behavior-or-tone",
+        "label": "Punishments for incorrect behavior or tone",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-crawling-with-items-in-mouth-e-g-hairbrush-spoon",
+        "label": "Crawling with items in mouth (e.g., hairbrush, spoon)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-earning-permission-for-meals-bathroom-use-or-rest",
+        "label": "Earning permission for meals, bathroom use, or rest",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-general-following-daily-rituals-or-protocol",
+        "label": "Following daily rituals or protocol",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-general-structured-speech-rules-e-g-titles-third-person",
+        "label": "Structured speech rules (e.g., titles, third person)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-general-receiving-correction-when-out-of-line",
+        "label": "Receiving correction when out of line",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-general-inspection-rituals-or-readiness-checks",
+        "label": "Inspection rituals or readiness checks",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Primal & Bratting",
+    "items": [
+      {
+        "id": "primal-bratting-giving-chase-and-capture-play",
+        "label": "Chase and capture play",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-giving-bratting-for-punishment",
+        "label": "Bratting for punishment",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-giving-playful-growling-and-biting",
+        "label": "Playful growling and biting",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-giving-provoking-with-teasing-or-taunts",
+        "label": "Provoking with teasing or taunts",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-giving-escaping-or-hiding-to-encourage-pursuit",
+        "label": "Escaping or hiding to encourage pursuit",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-giving-refusing-commands-just-for-fun",
+        "label": "Refusing commands just for fun",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-giving-provoking-your-partner-to-chase-or-discipline-you",
+        "label": "Provoking your partner to chase or discipline you",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-giving-taunting-or-teasing-as-a-form-of-play",
+        "label": "Taunting or teasing as a form of play",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-giving-intentional-resistance-during-power-exchange",
+        "label": "Intentional resistance during power exchange",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-giving-being-caught-and-overpowered",
+        "label": "Being caught and overpowered",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-receiving-chase-and-capture-play",
+        "label": "Chase and capture play",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-receiving-bratting-for-punishment",
+        "label": "Bratting for punishment",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-receiving-playful-growling-and-biting",
+        "label": "Playful growling and biting",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-receiving-provoking-with-teasing-or-taunts",
+        "label": "Provoking with teasing or taunts",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-receiving-escaping-or-hiding-to-encourage-pursuit",
+        "label": "Escaping or hiding to encourage pursuit",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-receiving-refusing-commands-just-for-fun",
+        "label": "Refusing commands just for fun",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-receiving-provoking-your-partner-to-chase-or-discipline-you",
+        "label": "Provoking your partner to chase or discipline you",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-receiving-taunting-or-teasing-as-a-form-of-play",
+        "label": "Taunting or teasing as a form of play",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-receiving-intentional-resistance-during-power-exchange",
+        "label": "Intentional resistance during power exchange",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-receiving-being-caught-and-overpowered",
+        "label": "Being caught and overpowered",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Headspace & Regression",
+    "items": [
+      {
+        "id": "headspace-regression-giving-caregiver-little-regression-play",
+        "label": "Caregiver/little regression play",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-giving-using-pacifiers-or-sippy-cups",
+        "label": "Using pacifiers or sippy cups",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-giving-coloring-or-childlike-crafts",
+        "label": "Coloring or childlike crafts",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-giving-stuffed-animal-comfort",
+        "label": "Stuffed animal comfort",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-giving-speaking-in-a-childlike-voice",
+        "label": "Speaking in a childlike voice",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-giving-bedtime-stories-or-lullabies",
+        "label": "Bedtime stories or lullabies",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-giving-entering-altered-headspaces-e-g-prey-pet-little",
+        "label": "Entering altered headspaces (e.g., prey, pet, little)",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-giving-regressive-behaviors-as-comfort-coloring-babytalk",
+        "label": "Regressive behaviors as comfort (coloring, babytalk)",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-giving-being-cared-for-during-emotional-vulnerability",
+        "label": "Being cared for during emotional vulnerability",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-giving-guided-emotional-headspace-entry",
+        "label": "Guided emotional headspace entry",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-receiving-caregiver-little-regression-play",
+        "label": "Caregiver/little regression play",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-receiving-using-pacifiers-or-sippy-cups",
+        "label": "Using pacifiers or sippy cups",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-receiving-coloring-or-childlike-crafts",
+        "label": "Coloring or childlike crafts",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-receiving-stuffed-animal-comfort",
+        "label": "Stuffed animal comfort",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-receiving-speaking-in-a-childlike-voice",
+        "label": "Speaking in a childlike voice",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-receiving-bedtime-stories-or-lullabies",
+        "label": "Bedtime stories or lullabies",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-receiving-entering-altered-headspaces-e-g-prey-pet-little",
+        "label": "Entering altered headspaces (e.g., prey, pet, little)",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-receiving-regressive-behaviors-as-comfort-coloring-babytalk",
+        "label": "Regressive behaviors as comfort (coloring, babytalk)",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-receiving-being-cared-for-during-emotional-vulnerability",
+        "label": "Being cared for during emotional vulnerability",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-receiving-guided-emotional-headspace-entry",
+        "label": "Guided emotional headspace entry",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Performance & Internal Struggle",
+    "items": [
+      {
+        "id": "performance-internal-struggle-general-obedience-under-observation",
+        "label": "Obedience under observation",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-speech-restriction-and-self-denial",
+        "label": "Speech restriction and self-denial",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-maintaining-composure-during-humiliation",
+        "label": "Maintaining composure during humiliation",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-obedience-drills-for-an-audience",
+        "label": "Obedience drills for an audience",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-struggling-against-personal-urges",
+        "label": "Struggling against personal urges",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-displaying-submission-despite-conflict",
+        "label": "Displaying submission despite conflict",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-being-told-to-act-normal-while-struggling-internally",
+        "label": "Being told to act normal while struggling internally",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-pleasing-through-high-functioning-obedience",
+        "label": "Pleasing through high-functioning obedience",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-performing-submission-while-masking-resistance",
+        "label": "Performing submission while masking resistance",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-the-pressure-of-appearing-good-while-feeling-conflicted",
+        "label": "The pressure of appearing 'good' while feeling conflicted",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-being-made-to-perform-emotions-on-command-cry-beg-moan",
+        "label": "Being made to perform emotions on command (cry, beg, moan)",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-struggling-openly-while-still-obeying",
+        "label": "Struggling openly while still obeying",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-performing-exaggerated-resistance-or-denial",
+        "label": "Performing exaggerated resistance or denial",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-being-punished-for-breaking-character",
+        "label": "Being punished for 'breaking character'",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-putting-on-a-show-for-someone-else-s-pleasure",
+        "label": "Putting on a show for someone else’s pleasure",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-rehearsed-degradation-or-humiliation-scripts",
+        "label": "Rehearsed degradation or humiliation scripts",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Mindfuck & Manipulation",
+    "items": [
+      {
+        "id": "mindfuck-manipulation-giving-confusing-commands-and-reality-shifts",
+        "label": "Confusing commands and reality shifts",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-gaslighting-or-contradictory-cues",
+        "label": "Gaslighting or contradictory cues",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-presenting-false-choices",
+        "label": "Presenting false choices",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-hidden-motives-or-secret-tasks",
+        "label": "Hidden motives or secret tasks",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-illogical-rules-meant-to-confuse",
+        "label": "Illogical rules meant to confuse",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-gaslight-style-scenes-with-consent-and-clarity",
+        "label": "Gaslight-style scenes (with consent and clarity)",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-false-threats-or-staged-surprises",
+        "label": "False threats or staged surprises",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-confusing-commands-to-prompt-hesitation",
+        "label": "Confusing commands to prompt hesitation",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-emotional-trickery-as-arousal",
+        "label": "Emotional trickery as arousal",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-being-misled-or-deceived-on-purpose-during-play",
+        "label": "Being misled or deceived on purpose during play",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-surprise-rule-changes-or-twists-mid-scene",
+        "label": "Surprise rule changes or twists mid-scene",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-false-safeword-games-with-negotiated-limits",
+        "label": "False safeword games (with negotiated limits)",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-withholding-or-delaying-aftercare-for-effect",
+        "label": "Withholding or delaying aftercare for effect",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-being-gaslit-or-doubted-in-a-controlled-roleplay",
+        "label": "Being gaslit or doubted in a controlled roleplay",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-told-you-asked-for-this-or-you-love-this-when-resisting",
+        "label": "Told 'you asked for this' or 'you love this' when resisting",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-confusing-commands-and-reality-shifts",
+        "label": "Confusing commands and reality shifts",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-gaslighting-or-contradictory-cues",
+        "label": "Gaslighting or contradictory cues",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-presenting-false-choices",
+        "label": "Presenting false choices",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-hidden-motives-or-secret-tasks",
+        "label": "Hidden motives or secret tasks",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-illogical-rules-meant-to-confuse",
+        "label": "Illogical rules meant to confuse",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-gaslight-style-scenes-with-consent-and-clarity",
+        "label": "Gaslight-style scenes (with consent and clarity)",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-false-threats-or-staged-surprises",
+        "label": "False threats or staged surprises",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-confusing-commands-to-prompt-hesitation",
+        "label": "Confusing commands to prompt hesitation",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-emotional-trickery-as-arousal",
+        "label": "Emotional trickery as arousal",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-being-misled-or-deceived-on-purpose-during-play",
+        "label": "Being misled or deceived on purpose during play",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-surprise-rule-changes-or-twists-mid-scene",
+        "label": "Surprise rule changes or twists mid-scene",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-false-safeword-games-with-negotiated-limits",
+        "label": "False safeword games (with negotiated limits)",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-withholding-or-delaying-aftercare-for-effect",
+        "label": "Withholding or delaying aftercare for effect",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-being-gaslit-or-doubted-in-a-controlled-roleplay",
+        "label": "Being gaslit or doubted in a controlled roleplay",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-told-you-asked-for-this-or-you-love-this-when-resisting",
+        "label": "Told 'you asked for this' or 'you love this' when resisting",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Mouth Play",
+    "items": [
+      {
+        "id": "mouth-play-giving-holding-tools-or-restraints-in-teeth-while-crawling",
+        "label": "Holding tools or restraints in teeth while crawling",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-placing-objects-from-mouth-into-dominant-s-palm",
+        "label": "Placing objects from mouth into Dominant’s palm",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-using-mouth-instead-of-hands-for-service-rituals",
+        "label": "Using mouth instead of hands for service rituals",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-gag-presentation-and-silent-waiting-protocol",
+        "label": "Gag presentation and silent waiting protocol",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-holding-objects-in-teeth-while-crawling",
+        "label": "Holding objects in teeth while crawling",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-returning-items-using-mouth-only",
+        "label": "Returning items using mouth only",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-gag-rituals-or-waiting-silently",
+        "label": "Gag rituals or waiting silently",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-leash-held-in-mouth",
+        "label": "Leash held in mouth",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-being-gagged-or-forced-silent",
+        "label": "Being gagged or forced silent",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-having-to-hold-objects-in-your-mouth-spoon-hairbrush-leash",
+        "label": "Having to hold objects in your mouth (spoon, hairbrush, leash)",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-being-used-for-oral-service-without-reciprocal-pleasure",
+        "label": "Being used for oral service without reciprocal pleasure",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-being-fed-by-hand-mouth-to-mouth-or-with-utensils",
+        "label": "Being fed by hand, mouth-to-mouth, or with utensils",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-verbal-control-e-g-only-speak-when-spoken-to",
+        "label": "Verbal control (e.g., only speak when spoken to)",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-mouth-as-a-symbol-of-ownership-or-control",
+        "label": "Mouth as a symbol of ownership or control",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-holding-tools-or-restraints-in-teeth-while-crawling",
+        "label": "Holding tools or restraints in teeth while crawling",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-placing-objects-from-mouth-into-dominant-s-palm",
+        "label": "Placing objects from mouth into Dominant’s palm",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-using-mouth-instead-of-hands-for-service-rituals",
+        "label": "Using mouth instead of hands for service rituals",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-gag-presentation-and-silent-waiting-protocol",
+        "label": "Gag presentation and silent waiting protocol",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-holding-objects-in-teeth-while-crawling",
+        "label": "Holding objects in teeth while crawling",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-returning-items-using-mouth-only",
+        "label": "Returning items using mouth only",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-gag-rituals-or-waiting-silently",
+        "label": "Gag rituals or waiting silently",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-leash-held-in-mouth",
+        "label": "Leash held in mouth",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-being-gagged-or-forced-silent",
+        "label": "Being gagged or forced silent",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-having-to-hold-objects-in-your-mouth-spoon-hairbrush-leash",
+        "label": "Having to hold objects in your mouth (spoon, hairbrush, leash)",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-being-used-for-oral-service-without-reciprocal-pleasure",
+        "label": "Being used for oral service without reciprocal pleasure",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-being-fed-by-hand-mouth-to-mouth-or-with-utensils",
+        "label": "Being fed by hand, mouth-to-mouth, or with utensils",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-verbal-control-e-g-only-speak-when-spoken-to",
+        "label": "Verbal control (e.g., only speak when spoken to)",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-mouth-as-a-symbol-of-ownership-or-control",
+        "label": "Mouth as a symbol of ownership or control",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Impact Play",
+    "items": [
+      {
+        "id": "impact-play-giving-hand-spanking",
+        "label": "Hand spanking",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-giving-paddle-strikes",
+        "label": "Paddle strikes",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-giving-crop-snaps",
+        "label": "Crop snaps",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-giving-flogger-swings",
+        "label": "Flogger swings",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-giving-cane-strokes",
+        "label": "Cane strokes",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-giving-belt-or-strap-hits",
+        "label": "Belt or strap hits",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-giving-whip-cracks",
+        "label": "Whip cracks",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-receiving-hand-spanking",
+        "label": "Hand spanking",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-receiving-paddle-strikes",
+        "label": "Paddle strikes",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-receiving-crop-snaps",
+        "label": "Crop snaps",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-receiving-flogger-swings",
+        "label": "Flogger swings",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-receiving-cane-strokes",
+        "label": "Cane strokes",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-receiving-belt-or-strap-hits",
+        "label": "Belt or strap hits",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-receiving-whip-cracks",
+        "label": "Whip cracks",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-general-preferred-intensity-levels",
+        "label": "Preferred intensity levels",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-general-aftercare-for-bruises",
+        "label": "Aftercare for bruises",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-general-target-body-areas",
+        "label": "Target body areas",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-general-implement-selection",
+        "label": "Implement selection",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Medical Play",
+    "items": [
+      {
+        "id": "medical-play-giving-needle-play",
+        "label": "Needle play",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-giving-catheter-insertion",
+        "label": "Catheter insertion",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-giving-speculum-exams",
+        "label": "Speculum exams",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-giving-enema-administration",
+        "label": "Enema administration",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-giving-temperature-taking",
+        "label": "Temperature taking",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-giving-medical-restraints",
+        "label": "Medical restraints",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-giving-doctor-nurse-roleplay",
+        "label": "Doctor/nurse roleplay",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-receiving-needle-play",
+        "label": "Needle play",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-receiving-catheter-insertion",
+        "label": "Catheter insertion",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-receiving-speculum-exams",
+        "label": "Speculum exams",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-receiving-enema-administration",
+        "label": "Enema administration",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-receiving-temperature-taking",
+        "label": "Temperature taking",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-receiving-medical-restraints",
+        "label": "Medical restraints",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-receiving-doctor-nurse-roleplay",
+        "label": "Doctor/nurse roleplay",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-general-sterilization-procedures",
+        "label": "Sterilization procedures",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-general-professional-vs-roleplay-scenes",
+        "label": "Professional vs roleplay scenes",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-general-consent-for-invasive-acts",
+        "label": "Consent for invasive acts",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-general-access-to-medical-equipment",
+        "label": "Access to medical equipment",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Pet Play",
+    "items": [
+      {
+        "id": "pet-play-giving-puppy-or-kitten-play",
+        "label": "Puppy or kitten play",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-giving-pony-play",
+        "label": "Pony play",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-giving-wearing-collar-and-leash",
+        "label": "Wearing collar and leash",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-giving-eating-from-a-bowl",
+        "label": "Eating from a bowl",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-giving-kenneling-or-caging",
+        "label": "Kenneling or caging",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-giving-pet-training-commands",
+        "label": "Pet training commands",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-giving-animal-costumes-or-gear",
+        "label": "Animal costumes or gear",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-receiving-puppy-or-kitten-play",
+        "label": "Puppy or kitten play",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-receiving-pony-play",
+        "label": "Pony play",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-receiving-wearing-collar-and-leash",
+        "label": "Wearing collar and leash",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-receiving-eating-from-a-bowl",
+        "label": "Eating from a bowl",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-receiving-kenneling-or-caging",
+        "label": "Kenneling or caging",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-receiving-pet-training-commands",
+        "label": "Pet training commands",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-receiving-animal-costumes-or-gear",
+        "label": "Animal costumes or gear",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-general-preferred-animal-identities",
+        "label": "Preferred animal identities",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-general-public-vs-private-play",
+        "label": "Public vs private play",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-general-training-style-and-discipline",
+        "label": "Training style and discipline",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-general-use-of-pet-names-and-commands",
+        "label": "Use of pet names and commands",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Body Modification",
+    "items": [
+      {
+        "id": "body-modification-giving-piercings",
+        "label": "Piercings",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-giving-tattoos",
+        "label": "Tattoos",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-giving-branding",
+        "label": "Branding",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-giving-scarification",
+        "label": "Scarification",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-giving-permanent-chastity-devices",
+        "label": "Permanent chastity devices",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-giving-cosmetic-implants",
+        "label": "Cosmetic implants",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-giving-stretching-or-gauges",
+        "label": "Stretching or gauges",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-receiving-piercings",
+        "label": "Piercings",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-receiving-tattoos",
+        "label": "Tattoos",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-receiving-branding",
+        "label": "Branding",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-receiving-scarification",
+        "label": "Scarification",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-receiving-permanent-chastity-devices",
+        "label": "Permanent chastity devices",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-receiving-cosmetic-implants",
+        "label": "Cosmetic implants",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-receiving-stretching-or-gauges",
+        "label": "Stretching or gauges",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-general-temporary-vs-permanent-changes",
+        "label": "Temporary vs permanent changes",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-general-professional-vs-diy-methods",
+        "label": "Professional vs DIY methods",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-general-body-placement-considerations",
+        "label": "Body placement considerations",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-general-healing-and-aftercare",
+        "label": "Healing and aftercare",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Relationship Preferences",
+    "items": [
+      {
+        "id": "relationship-preferences-general-preferred-relationship-style",
+        "label": "Preferred relationship style",
+        "type": "text"
+      },
+      {
+        "id": "relationship-preferences-general-relationship-goals",
+        "label": "Relationship goals",
+        "type": "text"
+      },
+      {
+        "id": "relationship-preferences-general-monogamous",
+        "label": "Monogamous",
+        "type": "scale"
+      },
+      {
+        "id": "relationship-preferences-general-polyamorous",
+        "label": "Polyamorous",
+        "type": "scale"
+      },
+      {
+        "id": "relationship-preferences-general-hierarchical-dynamics",
+        "label": "Hierarchical dynamics",
+        "type": "scale"
+      },
+      {
+        "id": "relationship-preferences-general-non-hierarchical-poly",
+        "label": "Non-hierarchical poly",
+        "type": "scale"
+      },
+      {
+        "id": "relationship-preferences-general-solo-poly",
+        "label": "Solo-poly",
+        "type": "scale"
+      },
+      {
+        "id": "relationship-preferences-general-open-with-boundaries",
+        "label": "Open with boundaries",
+        "type": "scale"
+      },
+      {
+        "id": "relationship-preferences-general-closed-but-kinky-with-others",
+        "label": "Closed but kinky with others",
+        "type": "scale"
+      },
+      {
+        "id": "relationship-preferences-general-switch-friendly-dynamics",
+        "label": "Switch-friendly dynamics",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Gender Play & Transformation",
+    "items": [
+      {
+        "id": "gender-play-transformation-giving-crossdressing",
+        "label": "Crossdressing",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-giving-forced-feminization",
+        "label": "Forced feminization",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-giving-forced-masculinization",
+        "label": "Forced masculinization",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-giving-gender-role-reversal",
+        "label": "Gender role reversal",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-giving-pronoun-changes",
+        "label": "Pronoun changes",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-giving-voice-or-mannerism-training",
+        "label": "Voice or mannerism training",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-giving-sissy-or-tomboy-persona",
+        "label": "Sissy or tomboy persona",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-receiving-crossdressing",
+        "label": "Crossdressing",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-receiving-forced-feminization",
+        "label": "Forced feminization",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-receiving-forced-masculinization",
+        "label": "Forced masculinization",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-receiving-gender-role-reversal",
+        "label": "Gender role reversal",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-receiving-pronoun-changes",
+        "label": "Pronoun changes",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-receiving-voice-or-mannerism-training",
+        "label": "Voice or mannerism training",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-receiving-sissy-or-tomboy-persona",
+        "label": "Sissy or tomboy persona",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-general-preferred-pronouns-and-names",
+        "label": "Preferred pronouns and names",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-general-public-presentation-comfort",
+        "label": "Public presentation comfort",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-general-clothing-and-appearance",
+        "label": "Clothing and appearance",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-general-exploration-of-identity",
+        "label": "Exploration of identity",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Chastity Devices",
+    "items": [
+      {
+        "id": "chastity-devices-giving-wearing-a-chastity-cage-short-term",
+        "label": "Wearing a chastity cage (short term)",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-giving-long-term-chastity-training",
+        "label": "Long-term chastity training",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-giving-chastity-device-control-with-permission-to-unlock",
+        "label": "Chastity device control with permission to unlock",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-giving-locked-remotely-by-another-person",
+        "label": "Locked remotely by another person",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-giving-orgasm-denial-enforced-by-chastity",
+        "label": "Orgasm denial enforced by chastity",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-giving-wearing-a-belt-style-chastity-device",
+        "label": "Wearing a belt-style chastity device",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-giving-humiliation-while-locked-in-chastity",
+        "label": "Humiliation while locked in chastity",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-giving-sleep-in-chastity-overnight",
+        "label": "Sleep in chastity (overnight)",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-giving-being-teased-while-unable-to-touch-yourself",
+        "label": "Being teased while unable to touch yourself",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-giving-begging-for-release-from-chastity",
+        "label": "Begging for release from chastity",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-receiving-wearing-a-chastity-cage-short-term",
+        "label": "Wearing a chastity cage (short term)",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-receiving-long-term-chastity-training",
+        "label": "Long-term chastity training",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-receiving-chastity-device-control-with-permission-to-unlock",
+        "label": "Chastity device control with permission to unlock",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-receiving-locked-remotely-by-another-person",
+        "label": "Locked remotely by another person",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-receiving-orgasm-denial-enforced-by-chastity",
+        "label": "Orgasm denial enforced by chastity",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-receiving-wearing-a-belt-style-chastity-device",
+        "label": "Wearing a belt-style chastity device",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-receiving-humiliation-while-locked-in-chastity",
+        "label": "Humiliation while locked in chastity",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-receiving-sleep-in-chastity-overnight",
+        "label": "Sleep in chastity (overnight)",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-receiving-being-teased-while-unable-to-touch-yourself",
+        "label": "Being teased while unable to touch yourself",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-receiving-begging-for-release-from-chastity",
+        "label": "Begging for release from chastity",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Shibari & Rope Bondage",
+    "items": [
+      {
+        "id": "shibari-rope-bondage-giving-being-tied-in-aesthetic-rope-patterns-shibari",
+        "label": "Being tied in aesthetic rope patterns (Shibari)",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-giving-rope-bondage-for-restraint-and-control",
+        "label": "Rope bondage for restraint and control",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-giving-rope-suspension-partial-or-full",
+        "label": "Rope suspension (partial or full)",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-giving-learning-to-tie-rope-as-a-form-of-dominance",
+        "label": "Learning to tie rope as a form of dominance",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-giving-being-tied-in-vulnerable-or-exposing-poses",
+        "label": "Being tied in vulnerable or exposing poses",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-giving-practicing-rope-with-emotional-connection",
+        "label": "Practicing rope with emotional connection",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-giving-enduring-discomfort-for-the-beauty-of-the-rope",
+        "label": "Enduring discomfort for the beauty of the rope",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-giving-being-tied-in-a-mirror-and-told-to-look",
+        "label": "Being tied in a mirror and told to look",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-giving-punishment-ties-e-g-uncomfortable-or-humiliating-positions",
+        "label": "Punishment ties (e.g., uncomfortable or humiliating positions)",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-giving-solo-rope-practice-for-mindfulness-or-masochism",
+        "label": "Solo rope practice for mindfulness or masochism",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-receiving-being-tied-in-aesthetic-rope-patterns-shibari",
+        "label": "Being tied in aesthetic rope patterns (Shibari)",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-receiving-rope-bondage-for-restraint-and-control",
+        "label": "Rope bondage for restraint and control",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-receiving-rope-suspension-partial-or-full",
+        "label": "Rope suspension (partial or full)",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-receiving-learning-to-tie-rope-as-a-form-of-dominance",
+        "label": "Learning to tie rope as a form of dominance",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-receiving-being-tied-in-vulnerable-or-exposing-poses",
+        "label": "Being tied in vulnerable or exposing poses",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-receiving-practicing-rope-with-emotional-connection",
+        "label": "Practicing rope with emotional connection",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-receiving-enduring-discomfort-for-the-beauty-of-the-rope",
+        "label": "Enduring discomfort for the beauty of the rope",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-receiving-being-tied-in-a-mirror-and-told-to-look",
+        "label": "Being tied in a mirror and told to look",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-receiving-punishment-ties-e-g-uncomfortable-or-humiliating-positions",
+        "label": "Punishment ties (e.g., uncomfortable or humiliating positions)",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-receiving-solo-rope-practice-for-mindfulness-or-masochism",
+        "label": "Solo rope practice for mindfulness or masochism",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Cosplay & Identity Play",
+    "items": [
+      {
+        "id": "cosplay-identity-play-giving-dressing-up-in-costumes-for-scenes",
+        "label": "Dressing up in costumes for scenes",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-giving-playing-as-fictional-characters",
+        "label": "Playing as fictional characters",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-giving-petplay-with-collars-ears-or-tails",
+        "label": "Petplay with collars, ears, or tails",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-giving-pretending-to-be-a-doll-robot-or-object",
+        "label": "Pretending to be a doll, robot, or object",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-giving-master-slave-cosplay-dynamic-non-24-7",
+        "label": "Master/slave cosplay dynamic (non-24/7)",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-giving-roleplaying-as-a-fantasy-species-or-non-human",
+        "label": "Roleplaying as a fantasy species or non-human",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-giving-using-cosplay-to-deepen-power-exchange",
+        "label": "Using cosplay to deepen power exchange",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-giving-scene-built-around-a-character-s-story-or-world",
+        "label": "Scene built around a character’s story or world",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-giving-fantasy-uniforms-nurse-teacher-etc",
+        "label": "Fantasy uniforms (nurse, teacher, etc.)",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-receiving-dressing-up-in-costumes-for-scenes",
+        "label": "Dressing up in costumes for scenes",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-receiving-playing-as-fictional-characters",
+        "label": "Playing as fictional characters",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-receiving-petplay-with-collars-ears-or-tails",
+        "label": "Petplay with collars, ears, or tails",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-receiving-pretending-to-be-a-doll-robot-or-object",
+        "label": "Pretending to be a doll, robot, or object",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-receiving-master-slave-cosplay-dynamic-non-24-7",
+        "label": "Master/slave cosplay dynamic (non-24/7)",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-receiving-roleplaying-as-a-fantasy-species-or-non-human",
+        "label": "Roleplaying as a fantasy species or non-human",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-receiving-using-cosplay-to-deepen-power-exchange",
+        "label": "Using cosplay to deepen power exchange",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-receiving-scene-built-around-a-character-s-story-or-world",
+        "label": "Scene built around a character’s story or world",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-receiving-fantasy-uniforms-nurse-teacher-etc",
+        "label": "Fantasy uniforms (nurse, teacher, etc.)",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "High-Intensity Kinks (SSC-Aware)",
+    "items": [
+      {
+        "id": "high-intensity-kinks-ssc-aware-giving-intense-breath-play-e-g-smothering-or-pressure",
+        "label": "Intense breath play (e.g., smothering or pressure)",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-giving-knife-play-or-blade-play-without-injury",
+        "label": "Knife play or blade play (without injury)",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-giving-fear-play-using-known-or-negotiated-triggers",
+        "label": "Fear play using known or negotiated triggers",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-giving-abduction-or-home-invasion-style-roleplay-negotiated",
+        "label": "Abduction or home-invasion style roleplay (negotiated)",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-giving-medical-themed-scenes-with-sharp-objects-not-bloodletting",
+        "label": "Medical-themed scenes with sharp objects (not bloodletting)",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-giving-sensory-deprivation-with-added-disorientation-or-helplessness",
+        "label": "Sensory deprivation with added disorientation or helplessness",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-giving-scenes-involving-heavy-objectification-or-emotional-manipulation-with-care",
+        "label": "Scenes involving heavy objectification or emotional manipulation (with care)",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-giving-mock-interrogation-or-intense-role-pressure",
+        "label": "Mock interrogation or intense role pressure",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-giving-consensual-threats-without-follow-through-e-g-if-you-don-t",
+        "label": "Consensual threats without follow-through (e.g. 'If you don’t...')",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-giving-high-intensity-primal-scenes-involving-struggle-or-fear",
+        "label": "High-intensity primal scenes involving struggle or fear",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-receiving-intense-breath-play-e-g-smothering-or-pressure",
+        "label": "Intense breath play (e.g., smothering or pressure)",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-receiving-knife-play-or-blade-play-without-injury",
+        "label": "Knife play or blade play (without injury)",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-receiving-fear-play-using-known-or-negotiated-triggers",
+        "label": "Fear play using known or negotiated triggers",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-receiving-abduction-or-home-invasion-style-roleplay-negotiated",
+        "label": "Abduction or home-invasion style roleplay (negotiated)",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-receiving-medical-themed-scenes-with-sharp-objects-not-bloodletting",
+        "label": "Medical-themed scenes with sharp objects (not bloodletting)",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-receiving-sensory-deprivation-with-added-disorientation-or-helplessness",
+        "label": "Sensory deprivation with added disorientation or helplessness",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-receiving-scenes-involving-heavy-objectification-or-emotional-manipulation-with-care",
+        "label": "Scenes involving heavy objectification or emotional manipulation (with care)",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-receiving-mock-interrogation-or-intense-role-pressure",
+        "label": "Mock interrogation or intense role pressure",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-receiving-consensual-threats-without-follow-through-e-g-if-you-don-t",
+        "label": "Consensual threats without follow-through (e.g. 'If you don’t...')",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-receiving-high-intensity-primal-scenes-involving-struggle-or-fear",
+        "label": "High-intensity primal scenes involving struggle or fear",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Behavioral Play",
+    "items": [
+      {
+        "id": "behavioral-play-giving-assigning-corner-time-or-time-outs",
+        "label": "Assigning corner time or time-outs",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-giving-writing-lines-or-apology-letters-as-correction",
+        "label": "Writing lines or apology letters as correction",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-giving-removing-privileges-phone-tv-sweets",
+        "label": "Removing privileges (phone, TV, sweets)",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-giving-playful-punishments-that-still-reinforce-rules",
+        "label": "Playful punishments that still reinforce rules",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-giving-lecturing-or-scolding-to-modify-behavior",
+        "label": "Lecturing or scolding to modify behavior",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-receiving-being-placed-in-the-corner-or-given-a-time-out",
+        "label": "Being placed in the corner or given a time-out",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-receiving-writing-lines-or-apology-letters-when-misbehaving",
+        "label": "Writing lines or apology letters when misbehaving",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-receiving-having-privileges-revoked-phone-tv",
+        "label": "Having privileges revoked (phone, TV)",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-receiving-receiving-playful-funishments-for-minor-rule-breaking",
+        "label": "Receiving playful 'funishments' for minor rule-breaking",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-receiving-getting-scolded-or-lectured-for-correction",
+        "label": "Getting scolded or lectured for correction",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-general-preferred-style-of-discipline-strict-vs-lenient",
+        "label": "Preferred style of discipline (strict vs lenient)",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-general-attitude-toward-funishment-vs-serious-correction",
+        "label": "Attitude toward funishment vs serious correction",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-general-use-of-behavior-contracts-or-rule-agreements",
+        "label": "Use of behavior contracts or rule agreements",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Appearance Play",
+    "items": [
+      {
+        "id": "appearance-play-giving-choosing-my-partner-s-outfit-for-the-day-or-a-scene",
+        "label": "Choosing my partner’s outfit for the day or a scene",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-giving-selecting-their-underwear-lingerie-or-base-layers",
+        "label": "Selecting their underwear, lingerie, or base layers",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-giving-styling-their-hair-braiding-brushing-tying-etc",
+        "label": "Styling their hair (braiding, brushing, tying, etc.)",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-giving-picking-head-coverings-bonnets-veils-hoods-hats-for-mood-or-protocol",
+        "label": "Picking head coverings (bonnets, veils, hoods, hats) for mood or protocol",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-giving-offering-makeup-polish-or-accessories-as-part-of-ritual-or-play",
+        "label": "Offering makeup, polish, or accessories as part of ritual or play",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-giving-creating-themed-looks-slutty-innocent-doll-like-sharp-etc",
+        "label": "Creating themed looks (slutty, innocent, doll-like, sharp, etc.)",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-giving-dressing-them-in-role-specific-costumes-maid-bunny-doll-etc",
+        "label": "Dressing them in role-specific costumes (maid, bunny, doll, etc.)",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-giving-curating-time-period-or-historical-outfits-e-g-victorian-50s",
+        "label": "Curating time-period or historical outfits (e.g., Victorian, 50s)",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-giving-helping-them-present-more-femme-masc-or-androgynous-by-request",
+        "label": "Helping them present more femme, masc, or androgynous by request",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-giving-coordinating-their-look-with-mine-for-public-or-private-scenes",
+        "label": "Coordinating their look with mine for public or private scenes",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-giving-implementing-a-dress-ritual-or-aesthetic-preparation",
+        "label": "Implementing a “dress ritual” or aesthetic preparation",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-giving-enforcing-a-visual-protocol-e-g-no-bra-heels-required-tied-hair",
+        "label": "Enforcing a visual protocol (e.g., no bra, heels required, tied hair)",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-having-my-outfit-selected-for-me-by-a-partner",
+        "label": "Having my outfit selected for me by a partner",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-wearing-the-underwear-or-lingerie-they-choose",
+        "label": "Wearing the underwear or lingerie they choose",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-having-my-hair-brushed-braided-tied-or-styled-for-them",
+        "label": "Having my hair brushed, braided, tied, or styled for them",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-putting-on-a-head-covering-e-g-bonnet-veil-hood-they-chose",
+        "label": "Putting on a head covering (e.g., bonnet, veil, hood) they chose",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-following-visual-appearance-rules-as-part-of-submission",
+        "label": "Following visual appearance rules as part of submission",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-wearing-makeup-polish-or-accessories-they-request",
+        "label": "Wearing makeup, polish, or accessories they request",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-dressing-to-please-their-vision-cute-filthy-classy-etc",
+        "label": "Dressing to please their vision (cute, filthy, classy, etc.)",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-wearing-roleplay-costumes-or-character-looks",
+        "label": "Wearing roleplay costumes or character looks",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-presenting-in-a-way-that-matches-their-chosen-aesthetic",
+        "label": "Presenting in a way that matches their chosen aesthetic",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-participating-in-dressing-rituals-or-undressing-ceremonies",
+        "label": "Participating in dressing rituals or undressing ceremonies",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-being-admired-for-the-way-i-look-under-their-direction",
+        "label": "Being admired for the way I look under their direction",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-receiving-praise-or-gentle-teasing-about-my-appearance",
+        "label": "Receiving praise or gentle teasing about my appearance",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-general-cosplay-or-fantasy-looks-anime-game-fairytale-etc",
+        "label": "Cosplay or fantasy looks (anime, game, fairytale, etc.)",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-general-time-period-dress-up-regency-gothic-1920s-etc",
+        "label": "Time-period dress-up (regency, gothic, 1920s, etc.)",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-general-dollification-or-polished-presented-object-aesthetics",
+        "label": "Dollification or polished/presented object aesthetics",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-general-uniforms-schoolgirl-military-clerical-nurse-etc",
+        "label": "Uniforms (schoolgirl, military, clerical, nurse, etc.)",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-general-hair-based-play-forced-brushing-ribbons-or-tied-styles",
+        "label": "Hair-based play (forced brushing, ribbons, or tied styles)",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-general-head-coverings-or-symbolic-hoods-in-ritualized-dynamics",
+        "label": "Head coverings or symbolic hoods in ritualized dynamics",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-general-matching-looks-or-coordinated-dress-codes",
+        "label": "Matching looks or coordinated dress codes",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-general-ritualized-grooming-before-scenes",
+        "label": "Ritualized grooming before scenes",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-general-praise-or-positive-attention-for-pleasing-visual-display",
+        "label": "Praise or positive attention for pleasing visual display",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-general-formal-appearance-protocols-for-scenes-or-dynamics",
+        "label": "Formal appearance protocols for scenes or dynamics",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-general-using-clothing-or-style-to-embody-emotional-or-power-roles",
+        "label": "Using clothing or style to embody emotional or power roles",
+        "type": "scale"
+      }
+    ]
+  }
+]

--- a/docs/kinks.json
+++ b/docs/kinks.json
@@ -1,0 +1,4357 @@
+[
+  {
+    "category": "Body Part Torture",
+    "items": [
+      {
+        "id": "body-part-torture-giving-nipple-clips",
+        "label": "Nipple clips",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-giving-nipple-weights",
+        "label": "Nipple weights",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-giving-nipple-suction-cups",
+        "label": "Nipple suction cups",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-giving-cock-ball-torture-cbt",
+        "label": "Cock, Ball Torture (CBT)",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-giving-clit-clips-weights-suction",
+        "label": "Clit clips/weights/suction",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-giving-hair-pulling",
+        "label": "Hair pulling",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-giving-face-slapping",
+        "label": "Face slapping",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-giving-butt-slapping",
+        "label": "Butt slapping",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-giving-breast-slapping",
+        "label": "Breast slapping",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-giving-genital-slapping",
+        "label": "Genital slapping",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-receiving-nipple-clips",
+        "label": "Nipple clips",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-receiving-nipple-weights",
+        "label": "Nipple weights",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-receiving-nipple-suction-cups",
+        "label": "Nipple suction cups",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-receiving-cock-ball-torture-cbt",
+        "label": "Cock, Ball Torture (CBT)",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-receiving-clit-clips-weights-suction",
+        "label": "Clit clips/weights/suction",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-receiving-hair-pulling",
+        "label": "Hair pulling",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-receiving-face-slapping",
+        "label": "Face slapping",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-receiving-butt-slapping",
+        "label": "Butt slapping",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-receiving-breast-slapping",
+        "label": "Breast slapping",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-receiving-genital-slapping",
+        "label": "Genital slapping",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Bondage and Suspension",
+    "items": [
+      {
+        "id": "bondage-and-suspension-giving-blindfolds",
+        "label": "Blindfolds",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-bondage-heavy",
+        "label": "Bondage (heavy)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-bondage-light",
+        "label": "Bondage (light)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-immobilisation",
+        "label": "Immobilisation",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-bondage-multi-day",
+        "label": "Bondage (multi-day)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-bondage-public-under-clothing",
+        "label": "Bondage (public, under clothing)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-leather-restraints",
+        "label": "Leather restraints",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-chains",
+        "label": "Chains",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-ropes",
+        "label": "Ropes",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-intricate-japanese-rope-bondage",
+        "label": "Intricate (Japanese) rope bondage",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-rope-body-harness",
+        "label": "Rope body harness",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-arm-leg-sleeves-armbinders",
+        "label": "Arm & leg sleeves (armbinders)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-harnesses-leather",
+        "label": "Harnesses (leather)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-harnesses-rope",
+        "label": "Harnesses (rope)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-cuffs-leather",
+        "label": "Cuffs (leather)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-cuffs-metal",
+        "label": "Cuffs (metal)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-manacles-irons",
+        "label": "Manacles & Irons",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-gags-cloth",
+        "label": "Gags (cloth)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-gags-rubber",
+        "label": "Gags (rubber)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-gags-tape",
+        "label": "Gags (tape)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-gags-phallic",
+        "label": "Gags (phallic)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-gags-ring",
+        "label": "Gags (ring)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-gags-ball",
+        "label": "Gags (ball)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-mouth-bits",
+        "label": "Mouth bits",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-full-head-hoods",
+        "label": "Full head hoods",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-mummification-saran-wrapping",
+        "label": "Mummification/saran wrapping",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-straight-jackets",
+        "label": "Straight jackets",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-suspension-upright",
+        "label": "Suspension (upright)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-suspension-horizontal",
+        "label": "Suspension (horizontal)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-suspension-inverted",
+        "label": "Suspension (inverted)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-breath-play",
+        "label": "Breath play",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-smothering",
+        "label": "Smothering",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-forced-self-breath-control",
+        "label": "Forced self-breath-control",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-gas-mask",
+        "label": "Gas mask",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-blindfolds",
+        "label": "Blindfolds",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-bondage-heavy",
+        "label": "Bondage (heavy)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-bondage-light",
+        "label": "Bondage (light)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-immobilisation",
+        "label": "Immobilisation",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-bondage-multi-day",
+        "label": "Bondage (multi-day)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-bondage-public-under-clothing",
+        "label": "Bondage (public, under clothing)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-leather-restraints",
+        "label": "Leather restraints",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-chains",
+        "label": "Chains",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-ropes",
+        "label": "Ropes",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-intricate-japanese-rope-bondage",
+        "label": "Intricate (Japanese) rope bondage",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-rope-body-harness",
+        "label": "Rope body harness",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-arm-leg-sleeves-armbinders",
+        "label": "Arm & leg sleeves (armbinders)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-harnesses-leather",
+        "label": "Harnesses (leather)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-harnesses-rope",
+        "label": "Harnesses (rope)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-cuffs-leather",
+        "label": "Cuffs (leather)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-cuffs-metal",
+        "label": "Cuffs (metal)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-manacles-irons",
+        "label": "Manacles & Irons",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-gags-cloth",
+        "label": "Gags (cloth)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-gags-rubber",
+        "label": "Gags (rubber)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-gags-tape",
+        "label": "Gags (tape)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-gags-phallic",
+        "label": "Gags (phallic)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-gags-ring",
+        "label": "Gags (ring)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-gags-ball",
+        "label": "Gags (ball)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-mouth-bits",
+        "label": "Mouth bits",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-full-head-hoods",
+        "label": "Full head hoods",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-mummification-saran-wrapping",
+        "label": "Mummification/saran wrapping",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-straight-jackets",
+        "label": "Straight jackets",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-suspension-upright",
+        "label": "Suspension (upright)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-suspension-horizontal",
+        "label": "Suspension (horizontal)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-suspension-inverted",
+        "label": "Suspension (inverted)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-breath-play",
+        "label": "Breath play",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-smothering",
+        "label": "Smothering",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-forced-self-breath-control",
+        "label": "Forced self-breath-control",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-gas-mask",
+        "label": "Gas mask",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Breath Play",
+    "items": [
+      {
+        "id": "breath-play-giving-asphyxiation",
+        "label": "Asphyxiation",
+        "type": "scale"
+      },
+      {
+        "id": "breath-play-giving-breath-control",
+        "label": "Breath control",
+        "type": "scale"
+      },
+      {
+        "id": "breath-play-giving-choking",
+        "label": "Choking",
+        "type": "scale"
+      },
+      {
+        "id": "breath-play-giving-drowning",
+        "label": "Drowning",
+        "type": "scale"
+      },
+      {
+        "id": "breath-play-giving-rebreathing-into-a-bag-or-object",
+        "label": "Rebreathing into a bag or object",
+        "type": "scale"
+      },
+      {
+        "id": "breath-play-giving-verbal-control-of-breath-e-g-hold-it-on-command",
+        "label": "Verbal control of breath (e.g., 'hold it' on command)",
+        "type": "scale"
+      },
+      {
+        "id": "breath-play-receiving-asphyxiation",
+        "label": "Asphyxiation",
+        "type": "scale"
+      },
+      {
+        "id": "breath-play-receiving-breath-control",
+        "label": "Breath control",
+        "type": "scale"
+      },
+      {
+        "id": "breath-play-receiving-choking",
+        "label": "Choking",
+        "type": "scale"
+      },
+      {
+        "id": "breath-play-receiving-drowning",
+        "label": "Drowning",
+        "type": "scale"
+      },
+      {
+        "id": "breath-play-receiving-rebreathing-into-a-bag-or-object",
+        "label": "Rebreathing into a bag or object",
+        "type": "scale"
+      },
+      {
+        "id": "breath-play-receiving-verbal-control-of-breath-e-g-hold-it-on-command",
+        "label": "Verbal control of breath (e.g., 'hold it' on command)",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Sexual Activity",
+    "items": [
+      {
+        "id": "sexual-activity-giving-licking",
+        "label": "Licking",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-fellatio-cunnilingus",
+        "label": "Fellatio/Cunnilingus",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-swallowing-semen",
+        "label": "Swallowing semen",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-cumming-on-partner",
+        "label": "Cumming on Partner",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-hand-jobs",
+        "label": "Hand jobs",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-anal-sex",
+        "label": "Anal sex",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-anal-plugs-small",
+        "label": "Anal plugs (small)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-anal-plugs-large",
+        "label": "Anal plugs (large)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-anal-beads",
+        "label": "Anal beads",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-vibrator-on-genitals",
+        "label": "Vibrator on genitals",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-fisting",
+        "label": "Fisting",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-oral-anal-play-rimming",
+        "label": "Oral/anal play (rimming)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-double-penetration-oral-and-vaginal",
+        "label": "Double penetration (oral and vaginal)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-double-penetration-oral-and-anal",
+        "label": "Double penetration (oral and anal)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-double-penetration-anal-and-vaginal",
+        "label": "Double penetration (anal and vaginal)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-triple-oral-vaginal-and-anal",
+        "label": "Triple (Oral, Vaginal and Anal)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-licking",
+        "label": "Licking",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-fellatio-cunnilingus",
+        "label": "Fellatio/Cunnilingus",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-swallowing-semen",
+        "label": "Swallowing semen",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-cumming-on-partner",
+        "label": "Cumming on Partner",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-hand-jobs",
+        "label": "Hand jobs",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-anal-sex",
+        "label": "Anal sex",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-anal-plugs-small",
+        "label": "Anal plugs (small)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-anal-plugs-large",
+        "label": "Anal plugs (large)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-anal-beads",
+        "label": "Anal beads",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-vibrator-on-genitals",
+        "label": "Vibrator on genitals",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-fisting",
+        "label": "Fisting",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-oral-anal-play-rimming",
+        "label": "Oral/anal play (rimming)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-double-penetration-oral-and-vaginal",
+        "label": "Double penetration (oral and vaginal)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-double-penetration-oral-and-anal",
+        "label": "Double penetration (oral and anal)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-double-penetration-anal-and-vaginal",
+        "label": "Double penetration (anal and vaginal)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-triple-oral-vaginal-and-anal",
+        "label": "Triple (Oral, Vaginal and Anal)",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Sensation Play",
+    "items": [
+      {
+        "id": "sensation-play-giving-abrasion",
+        "label": "Abrasion",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-scratching",
+        "label": "Scratching",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-biting",
+        "label": "Biting",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-tickling",
+        "label": "Tickling",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-kissing",
+        "label": "Kissing",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-zapping-e-g-electric-fly-swatter",
+        "label": "Zapping (e.g. electric fly swatter)",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-ice-cubes",
+        "label": "Ice cubes",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-wax-play",
+        "label": "Wax Play",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-fire",
+        "label": "Fire",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-clothespins",
+        "label": "Clothespins",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-needles",
+        "label": "Needles",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-sensory-deprivation",
+        "label": "Sensory deprivation",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-physical-overpowering-manhandling",
+        "label": "Physical overpowering / Manhandling",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-figging",
+        "label": "Figging",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-abrasion",
+        "label": "Abrasion",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-scratching",
+        "label": "Scratching",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-biting",
+        "label": "Biting",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-tickling",
+        "label": "Tickling",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-kissing",
+        "label": "Kissing",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-zapping-e-g-electric-fly-swatter",
+        "label": "Zapping (e.g. electric fly swatter)",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-ice-cubes",
+        "label": "Ice cubes",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-wax-play",
+        "label": "Wax Play",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-fire",
+        "label": "Fire",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-clothespins",
+        "label": "Clothespins",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-needles",
+        "label": "Needles",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-sensory-deprivation",
+        "label": "Sensory deprivation",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-physical-overpowering-manhandling",
+        "label": "Physical overpowering / Manhandling",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-figging",
+        "label": "Figging",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Other",
+    "items": [
+      {
+        "id": "other-general-feet",
+        "label": "Feet",
+        "type": "scale"
+      },
+      {
+        "id": "other-general-boots",
+        "label": "Boots",
+        "type": "scale"
+      },
+      {
+        "id": "other-general-underwear",
+        "label": "Underwear",
+        "type": "scale"
+      },
+      {
+        "id": "other-general-chastity-devices",
+        "label": "Chastity devices",
+        "type": "scale"
+      },
+      {
+        "id": "other-general-masks",
+        "label": "Masks",
+        "type": "scale"
+      },
+      {
+        "id": "other-general-breeding",
+        "label": "Breeding",
+        "type": "scale"
+      },
+      {
+        "id": "other-general-leather-clothing",
+        "label": "Leather clothing",
+        "type": "scale"
+      },
+      {
+        "id": "other-general-training-protocols-outside-scenes-e-g-etiquette-memory",
+        "label": "Training protocols outside scenes (e.g., etiquette, memory)",
+        "type": "scale"
+      },
+      {
+        "id": "other-general-long-distance-training-structure",
+        "label": "Long-distance training/structure",
+        "type": "scale"
+      },
+      {
+        "id": "other-general-scene-journaling-and-reflection",
+        "label": "Scene journaling and reflection",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Roleplaying",
+    "items": [
+      {
+        "id": "roleplaying-giving-fantasy-abandonment",
+        "label": "Fantasy abandonment",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-giving-kidnapping",
+        "label": "Kidnapping",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-giving-interrogation",
+        "label": "Interrogation",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-giving-sleep-deprivation",
+        "label": "Sleep deprivation",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-giving-cnc",
+        "label": "CNC",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-giving-gang-bang",
+        "label": "Gang bang",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-giving-initiation-rites",
+        "label": "Initiation rites",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-giving-religious-scenes",
+        "label": "Religious scenes",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-giving-medical-scenes",
+        "label": "Medical scenes",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-giving-prison-scenes",
+        "label": "Prison scenes",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-giving-primal-prey",
+        "label": "Primal/Prey",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-giving-schoolroom-scenes",
+        "label": "Schoolroom scenes",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-fantasy-abandonment",
+        "label": "Fantasy abandonment",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-kidnapping",
+        "label": "Kidnapping",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-interrogation",
+        "label": "Interrogation",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-sleep-deprivation",
+        "label": "Sleep deprivation",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-cnc",
+        "label": "CNC",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-gang-bang",
+        "label": "Gang bang",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-initiation-rites",
+        "label": "Initiation rites",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-religious-scenes",
+        "label": "Religious scenes",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-medical-scenes",
+        "label": "Medical scenes",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-prison-scenes",
+        "label": "Prison scenes",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-primal-prey",
+        "label": "Primal/Prey",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-schoolroom-scenes",
+        "label": "Schoolroom scenes",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Service and Restrictive Behaviour",
+    "items": [
+      {
+        "id": "service-and-restrictive-behaviour-giving-following-orders",
+        "label": "(Following) orders",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-forced-servitude",
+        "label": "Forced servitude",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-restrictive-rules-on-behaviour",
+        "label": "Restrictive rules on behaviour",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-eye-contact-restrictions",
+        "label": "Eye contact restrictions",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-speech-restrictions-when-what-to-whom",
+        "label": "Speech restrictions (when, what, to whom)",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-washroom-restrictions",
+        "label": "Washroom restrictions",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-punishments",
+        "label": "Punishments",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-tasks",
+        "label": "Tasks",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-massage",
+        "label": "Massage",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-domestic-tasks",
+        "label": "Domestic tasks",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-serving-food-and-drink",
+        "label": "Serving food and drink",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-personal-care-rituals",
+        "label": "Personal care rituals",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-being-on-call-at-specified-times",
+        "label": "Being on-call at specified times",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-daily-task-assignments",
+        "label": "Daily task assignments",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-corrections-for-imperfection",
+        "label": "Corrections for imperfection",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-uniforms-dress-codes",
+        "label": "Uniforms / Dress codes",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-kneeling-posture-presentation",
+        "label": "Kneeling / Posture presentation",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-silent-service",
+        "label": "Silent service",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-public-service-at-parties-or-events",
+        "label": "Public service (at parties or events)",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-erotic-service-pleasure-on-command-without-seeking-your-own",
+        "label": "Erotic service (pleasure on command, without seeking your own)",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-following-orders",
+        "label": "(Following) orders",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-forced-servitude",
+        "label": "Forced servitude",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-restrictive-rules-on-behaviour",
+        "label": "Restrictive rules on behaviour",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-eye-contact-restrictions",
+        "label": "Eye contact restrictions",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-speech-restrictions-when-what-to-whom",
+        "label": "Speech restrictions (when, what, to whom)",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-washroom-restrictions",
+        "label": "Washroom restrictions",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-punishments",
+        "label": "Punishments",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-tasks",
+        "label": "Tasks",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-massage",
+        "label": "Massage",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-domestic-tasks",
+        "label": "Domestic tasks",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-serving-food-and-drink",
+        "label": "Serving food and drink",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-personal-care-rituals",
+        "label": "Personal care rituals",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-being-on-call-at-specified-times",
+        "label": "Being on-call at specified times",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-daily-task-assignments",
+        "label": "Daily task assignments",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-corrections-for-imperfection",
+        "label": "Corrections for imperfection",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-uniforms-dress-codes",
+        "label": "Uniforms / Dress codes",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-kneeling-posture-presentation",
+        "label": "Kneeling / Posture presentation",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-silent-service",
+        "label": "Silent service",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-public-service-at-parties-or-events",
+        "label": "Public service (at parties or events)",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-erotic-service-pleasure-on-command-without-seeking-your-own",
+        "label": "Erotic service (pleasure on command, without seeking your own)",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Voyeurism/Exhibitionism",
+    "items": [
+      {
+        "id": "voyeurism-exhibitionism-giving-forced-nudity-private",
+        "label": "Forced nudity (private)",
+        "type": "scale"
+      },
+      {
+        "id": "voyeurism-exhibitionism-giving-forced-nudity-around-others",
+        "label": "Forced nudity (around others)",
+        "type": "scale"
+      },
+      {
+        "id": "voyeurism-exhibitionism-giving-exhibitionism-friends",
+        "label": "Exhibitionism (friends)",
+        "type": "scale"
+      },
+      {
+        "id": "voyeurism-exhibitionism-giving-exhibitionism-strangers",
+        "label": "Exhibitionism (strangers)",
+        "type": "scale"
+      },
+      {
+        "id": "voyeurism-exhibitionism-giving-modelling-for-erotic-photos",
+        "label": "Modelling for erotic photos",
+        "type": "scale"
+      },
+      {
+        "id": "voyeurism-exhibitionism-giving-toys-under-clothes-in-public",
+        "label": "Toys under clothes in public",
+        "type": "scale"
+      },
+      {
+        "id": "voyeurism-exhibitionism-receiving-forced-nudity-private",
+        "label": "Forced nudity (private)",
+        "type": "scale"
+      },
+      {
+        "id": "voyeurism-exhibitionism-receiving-forced-nudity-around-others",
+        "label": "Forced nudity (around others)",
+        "type": "scale"
+      },
+      {
+        "id": "voyeurism-exhibitionism-receiving-exhibitionism-friends",
+        "label": "Exhibitionism (friends)",
+        "type": "scale"
+      },
+      {
+        "id": "voyeurism-exhibitionism-receiving-exhibitionism-strangers",
+        "label": "Exhibitionism (strangers)",
+        "type": "scale"
+      },
+      {
+        "id": "voyeurism-exhibitionism-receiving-modelling-for-erotic-photos",
+        "label": "Modelling for erotic photos",
+        "type": "scale"
+      },
+      {
+        "id": "voyeurism-exhibitionism-receiving-toys-under-clothes-in-public",
+        "label": "Toys under clothes in public",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Virtual & Long-Distance Play",
+    "items": [
+      {
+        "id": "virtual-long-distance-play-giving-sending-tasks-or-orders-digitally",
+        "label": "Sending tasks or orders digitally",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-giving-recording-dominant-voice-clips-commands-edging-praise-degradation-etc",
+        "label": "Recording dominant voice clips (commands, edging, praise, degradation, etc.)",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-giving-remote-control-of-a-sex-toy",
+        "label": "Remote control of a sex toy",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-giving-monitoring-behavior-via-app-or-shared-doc",
+        "label": "Monitoring behavior via app or shared doc",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-giving-giving-punishment-assignments-remotely",
+        "label": "Giving punishment assignments remotely",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-giving-creating-countdowns-timers-or-denial-periods",
+        "label": "Creating countdowns, timers, or denial periods",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-giving-sending-written-instructions-with-delayed-permissions",
+        "label": "Sending written instructions with delayed permissions",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-giving-creating-custom-video-or-audio-tasks",
+        "label": "Creating custom video or audio tasks",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-giving-voice-message-control-during-scenes",
+        "label": "Voice message control during scenes",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-giving-being-on-call-at-specified-times",
+        "label": "Being on-call at specified times",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-receiving-receiving-tasks-or-orders-digitally",
+        "label": "Receiving tasks or orders digitally",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-receiving-listening-to-dominant-voice-clips",
+        "label": "Listening to dominant voice clips",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-receiving-using-a-remote-controlled-toy-controlled-by-another",
+        "label": "Using a remote-controlled toy controlled by another",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-receiving-completing-daily-protocol-assignments",
+        "label": "Completing daily protocol assignments",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-receiving-submitting-proof-photo-video-text",
+        "label": "Submitting proof (photo, video, text)",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-receiving-following-recorded-or-timed-commands",
+        "label": "Following recorded or timed commands",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-receiving-receiving-surprise-instructions",
+        "label": "Receiving surprise instructions",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-receiving-hearing-name-praise-spoken-in-a-custom-clip",
+        "label": "Hearing name/praise spoken in a custom clip",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-receiving-sending-submissive-voice-clips-obedience-begging-thank-you-messages-affirmations-etc",
+        "label": "Sending submissive voice clips (obedience, begging, thank-you messages, affirmations, etc.)",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-receiving-being-on-call-at-specified-times",
+        "label": "Being on-call at specified times",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-general-scheduling-digital-rituals-or-reminders",
+        "label": "Scheduling digital rituals or reminders",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-general-using-training-habit-or-behavior-tracking-apps",
+        "label": "Using training, habit, or behavior-tracking apps",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-general-online-rituals-digital-kneeling-posture-protocols",
+        "label": "Online rituals (digital kneeling, posture protocols)",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-general-role-based-texting-e-g-use-honorifics-in-chat",
+        "label": "Role-based texting (e.g., \"Use honorifics in chat\")",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-general-shared-playlists-affirmations-or-mantras",
+        "label": "Shared playlists, affirmations, or mantras",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-general-countdown-timers-to-next-task-release-or-interaction",
+        "label": "Countdown timers to next task, release, or interaction",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-general-scheduled-good-morning-night-rituals",
+        "label": "Scheduled good morning/night rituals",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-general-participating-in-video-call-scenes",
+        "label": "Participating in video call scenes",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-general-digital-aftercare-texts-voice-images",
+        "label": "Digital aftercare (texts, voice, images)",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-general-sexting-or-digital-roleplay-scenes",
+        "label": "Sexting or digital roleplay scenes",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-general-voice-notes-or-submissive-dominant-affirmations",
+        "label": "Voice notes or submissive/dominant affirmations",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Communication",
+    "items": [
+      {
+        "id": "communication-giving-playful-and-teasing",
+        "label": "Playful and teasing",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-quiet-and-intense",
+        "label": "Quiet and intense",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-observant-and-intentional",
+        "label": "Observant and intentional",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-praise-heavy",
+        "label": "Praise-heavy",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-blunt-and-efficient",
+        "label": "Blunt and efficient",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-affirming-and-soft",
+        "label": "Affirming and soft",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-psychological-interrogation",
+        "label": "Psychological interrogation",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-verbal-coercion-teasing-traps",
+        "label": "Verbal coercion / teasing traps",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-verbal-misdirection",
+        "label": "Verbal misdirection",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-mocking-shaming",
+        "label": "Mocking / shaming",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-predatory-pacing",
+        "label": "Predatory pacing",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-reluctant-obedience",
+        "label": "Reluctant obedience",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-stammering-submission",
+        "label": "Stammering submission",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-challenging-until-caught",
+        "label": "Challenging until caught",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-quiet-surrender",
+        "label": "Quiet surrender",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-sarcastic-teasing",
+        "label": "Sarcastic teasing",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-provoking-tone",
+        "label": "Provoking tone",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-challenge-based-dialogue",
+        "label": "Challenge-based dialogue",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-double-meaning-banter",
+        "label": "Double-meaning banter",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-soft-spoken-guidance",
+        "label": "Soft-spoken guidance",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-protective-but-firm-tone",
+        "label": "Protective but firm tone",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-emotional-redirection",
+        "label": "Emotional redirection",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-steady-reassurance",
+        "label": "Steady reassurance",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-direct-and-clear",
+        "label": "Direct and clear",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-playful-and-teasing",
+        "label": "Playful and teasing",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-gentle-and-nurturing",
+        "label": "Gentle and nurturing",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-commanding-and-firm",
+        "label": "Commanding and firm",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-quiet-and-observant",
+        "label": "Quiet and observant",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-instructive-teacher-like",
+        "label": "Instructive / teacher-like",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-emotionally-intense",
+        "label": "Emotionally intense",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-dismissive-withholding",
+        "label": "Dismissive / withholding",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-mocking-sarcastic",
+        "label": "Mocking / sarcastic",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-blunt-tactless",
+        "label": "Blunt / tactless",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-predatory-hunting-tone",
+        "label": "Predatory / hunting tone",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-stalking-or-circling-speech",
+        "label": "Stalking or circling speech",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-you-re-mine-control-language",
+        "label": "You’re mine / control language",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-threatening-consensual",
+        "label": "Threatening (consensual)",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-verbal-cornering-coaxing",
+        "label": "Verbal cornering / coaxing",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-watching-you-unravel",
+        "label": "Watching you unravel",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-cruel-and-cutting",
+        "label": "Cruel and cutting",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-psychological-baiting",
+        "label": "Psychological baiting",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-brat-breaking-language",
+        "label": "Brat-breaking language",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-mock-affection",
+        "label": "Mock affection",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-shaming-or-emotional-edge",
+        "label": "Shaming or emotional edge",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-disappointed-dom-voice",
+        "label": "Disappointed dom voice",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-mild-scolding-mocking-affection",
+        "label": "Mild scolding / mocking affection",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-verbal-power-struggle",
+        "label": "Verbal power struggle",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-challenge-response-dynamics",
+        "label": "Challenge-response dynamics",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-warm-tone-with-expectation",
+        "label": "Warm tone with expectation",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-nurturing-dominance",
+        "label": "Nurturing dominance",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-reassuring-commands",
+        "label": "Reassuring commands",
+        "type": "scale"
+      },
+      {
+        "id": "communication-general-phrases-that-work-on-you",
+        "label": "Phrases that work on you",
+        "type": "text"
+      },
+      {
+        "id": "communication-general-phrases-you-use-or-like-to-give",
+        "label": "Phrases you use or like to give",
+        "type": "text"
+      },
+      {
+        "id": "communication-general-what-helps-you-feel-emotionally-safe",
+        "label": "What helps you feel emotionally safe",
+        "type": "text"
+      },
+      {
+        "id": "communication-general-how-you-tend-to-show-affection",
+        "label": "How you tend to show affection",
+        "type": "text"
+      },
+      {
+        "id": "communication-general-emotional-check-in-style",
+        "label": "Emotional check-in style",
+        "type": "text"
+      },
+      {
+        "id": "communication-general-when-emotionally-activated-i-tend-to",
+        "label": "When emotionally activated, I tend to...",
+        "type": "text"
+      }
+    ]
+  },
+  {
+    "category": "Body Fluids and Functions",
+    "items": [
+      {
+        "id": "body-fluids-and-functions-giving-watersports-golden-showers",
+        "label": "Watersports/golden showers",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-giving-cum",
+        "label": "Cum",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-giving-blood",
+        "label": "Blood",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-giving-scat",
+        "label": "Scat",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-giving-sweat",
+        "label": "Sweat",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-giving-vomit",
+        "label": "Vomit",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-giving-tears-crying",
+        "label": "Tears/crying",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-receiving-watersports-golden-showers",
+        "label": "Watersports/golden showers",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-receiving-cum",
+        "label": "Cum",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-receiving-blood",
+        "label": "Blood",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-receiving-scat",
+        "label": "Scat",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-receiving-sweat",
+        "label": "Sweat",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-receiving-vomit",
+        "label": "Vomit",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-receiving-tears-crying",
+        "label": "Tears/crying",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Psychological Primal / Prey",
+    "items": [
+      {
+        "id": "psychological-primal-prey-giving-primal-prey",
+        "label": "Primal/Prey",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-conditioning",
+        "label": "Conditioning",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-coc",
+        "label": "COC",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-psycholagny-hands-free-mentally-stimulated-orgasm",
+        "label": "Psycholagny (hands free, mentally stimulated orgasm)",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-hypno-play",
+        "label": "Hypno Play",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-praise",
+        "label": "Praise",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-degradation",
+        "label": "Degradation",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-traditional-primal-prey",
+        "label": "Traditional primal/prey",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-fear-play",
+        "label": "Fear play",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-objectification",
+        "label": "Objectification",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-gaslighting",
+        "label": "Gaslighting",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-role-erosion-identity-play-loss-of-self",
+        "label": "Role erosion (identity play / loss of self)",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-jealousy-play",
+        "label": "Jealousy play",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-manipulation",
+        "label": "Manipulation",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-primal-prey",
+        "label": "Primal/Prey",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-conditioning",
+        "label": "Conditioning",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-coc",
+        "label": "COC",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-psycholagny-hands-free-mentally-stimulated-orgasm",
+        "label": "Psycholagny (hands free, mentally stimulated orgasm)",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-hypno-play",
+        "label": "Hypno Play",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-praise",
+        "label": "Praise",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-degradation",
+        "label": "Degradation",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-traditional-primal-prey",
+        "label": "Traditional primal/prey",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-fear-play",
+        "label": "Fear play",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-objectification",
+        "label": "Objectification",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-gaslighting",
+        "label": "Gaslighting",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-role-erosion-identity-play-loss-of-self",
+        "label": "Role erosion (identity play / loss of self)",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-jealousy-play",
+        "label": "Jealousy play",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-manipulation",
+        "label": "Manipulation",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Body Part / Fetish Play",
+    "items": [
+      {
+        "id": "body-part-fetish-play-giving-belly-fucking",
+        "label": "Belly fucking",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-giving-navel-play",
+        "label": "Navel play",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-giving-feet-foot-worship",
+        "label": "Feet / Foot worship",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-giving-hands",
+        "label": "Hands",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-giving-hair",
+        "label": "Hair",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-giving-thighs",
+        "label": "Thighs",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-giving-neck",
+        "label": "Neck",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-giving-ears",
+        "label": "Ears",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-giving-belly",
+        "label": "Belly",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-giving-voice-fetish",
+        "label": "Voice fetish",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-giving-nails-makeup-fetish",
+        "label": "Nails / Makeup fetish",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-receiving-belly-fucking",
+        "label": "Belly fucking",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-receiving-navel-play",
+        "label": "Navel play",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-receiving-feet-foot-worship",
+        "label": "Feet / Foot worship",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-receiving-hands",
+        "label": "Hands",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-receiving-hair",
+        "label": "Hair",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-receiving-thighs",
+        "label": "Thighs",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-receiving-neck",
+        "label": "Neck",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-receiving-ears",
+        "label": "Ears",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-receiving-belly",
+        "label": "Belly",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-receiving-voice-fetish",
+        "label": "Voice fetish",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-receiving-nails-makeup-fetish",
+        "label": "Nails / Makeup fetish",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-cuddles",
+        "label": "Cuddles",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-food-play",
+        "label": "Food Play",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-kisses",
+        "label": "Kisses",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-masturbation",
+        "label": "Masturbation",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-romance-affection",
+        "label": "Romance / affection",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-sex-toys",
+        "label": "Sex toys",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-sexting-chat-etc",
+        "label": "Sexting /Chat etc",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-sexting-via-phone-or-video-call",
+        "label": "Sexting via phone or video call",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-strip-tease",
+        "label": "Strip tease",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-vanilla-sex",
+        "label": "Vanilla Sex",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-voice-notes",
+        "label": "Voice Notes",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-shaving-body-hair",
+        "label": "Shaving (body hair)",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-sexy-clothing-private",
+        "label": "Sexy clothing (private)",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-sexy-clothing-public",
+        "label": "Sexy clothing (public)",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-outdoor-scenes",
+        "label": "Outdoor scenes",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-public-exposure",
+        "label": "Public exposure",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Orgasm Control & Sexual Manipulation",
+    "items": [
+      {
+        "id": "orgasm-control-sexual-manipulation-giving-edging",
+        "label": "Edging",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-giving-short-term-denial",
+        "label": "Short term denial",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-giving-long-term-denial",
+        "label": "Long term denial",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-giving-forced-orgasms-overstimulation",
+        "label": "Forced orgasms / Overstimulation",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-giving-ruined-orgasms",
+        "label": "Ruined orgasms",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-giving-no-touch-periods",
+        "label": "No touch periods",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-giving-milking",
+        "label": "Milking",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-giving-chastity-devices",
+        "label": "Chastity devices",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-giving-consensual-orgasm-control",
+        "label": "Consensual orgasm control",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-giving-forced-masturbation",
+        "label": "Forced masturbation",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-receiving-edging",
+        "label": "Edging",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-receiving-short-term-denial",
+        "label": "Short term denial",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-receiving-long-term-denial",
+        "label": "Long term denial",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-receiving-forced-orgasms-overstimulation",
+        "label": "Forced orgasms / Overstimulation",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-receiving-ruined-orgasms",
+        "label": "Ruined orgasms",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-receiving-no-touch-periods",
+        "label": "No touch periods",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-receiving-milking",
+        "label": "Milking",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-receiving-chastity-devices",
+        "label": "Chastity devices",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-receiving-consensual-orgasm-control",
+        "label": "Consensual orgasm control",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-receiving-forced-masturbation",
+        "label": "Forced masturbation",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Protocol and Ritual",
+    "items": [
+      {
+        "id": "protocol-and-ritual-giving-formal-language",
+        "label": "Formal language",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-greeting-and-departure-rituals-kneeling-verbal-scripts-gestures",
+        "label": "Greeting and departure rituals (kneeling, verbal scripts, gestures)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-requiring-permission-for-things-speech-movement-attire",
+        "label": "Requiring permission for things (speech, movement, attire)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-daily-rituals-morning-check-ins-status-reports-mantra-repetitions",
+        "label": "Daily rituals (morning check-ins, status reports, mantra repetitions)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-specific-postures-for-rest-attention-punishment-waiting",
+        "label": "Specific postures for rest, attention, punishment, waiting",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-restricted-behavior-no-eye-contact-silence-no-questions",
+        "label": "Restricted behavior (no eye contact, silence, no questions)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-ritual-object-use-collar-cuffs-leash-tokens",
+        "label": "Ritual object use (collar, cuffs, leash, tokens)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-tracking-obedience-journals-apps",
+        "label": "Tracking obedience (journals, apps)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-formalized-rules-for-misbehavior-and-correction",
+        "label": "Formalized rules for misbehavior and correction",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-ritualized-aftercare-or-scene-closure",
+        "label": "Ritualized aftercare or scene closure",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-object-retrieval-on-all-fours-with-item-in-mouth",
+        "label": "Object retrieval on all fours with item in mouth",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-fetching-hairbrush-or-punishment-tool-from-dresser-while-crawling",
+        "label": "Fetching hairbrush or punishment tool from dresser while crawling",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-presenting-chosen-discipline-tool-in-kneeling-posture",
+        "label": "Presenting chosen discipline tool in kneeling posture",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-assigned-posture-or-kneeling-positions-as-ritual",
+        "label": "Assigned posture or kneeling positions as ritual",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-requesting-permission-using-specific-protocol-phrases",
+        "label": "Requesting permission using specific protocol phrases",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-carrying-items-in-mouth-as-submissive-gesture",
+        "label": "Carrying items in mouth as submissive gesture",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-crawling-back-with-object-to-dominant-after-retrieval",
+        "label": "Crawling back with object to Dominant after retrieval",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-following-via-nipple-leash-as-protocol-or-punishment",
+        "label": "Following via nipple leash as protocol or punishment",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-crawling-assigned-paths-as-ritual-or-obedience-training",
+        "label": "Crawling assigned paths as ritual or obedience training",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-crawling-rituals-e-g-object-retrieval",
+        "label": "Crawling rituals (e.g., object retrieval)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-carrying-objects-in-mouth-as-obedience",
+        "label": "Carrying objects in mouth as obedience",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-presenting-tools-or-toys-in-posture",
+        "label": "Presenting tools or toys in posture",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-using-honorifics-or-preset-protocol-language",
+        "label": "Using honorifics or preset protocol language",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-greeting-rituals-e-g-kneeling-kissing-feet",
+        "label": "Greeting rituals (e.g., kneeling, kissing feet)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-daily-check-ins-or-structured-reports",
+        "label": "Daily check-ins or structured reports",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-clothing-restrictions-or-uniforms",
+        "label": "Clothing restrictions or uniforms",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-posture-training-sitting-kneeling-standing",
+        "label": "Posture training (sitting, kneeling, standing)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-punishments-for-incorrect-behavior-or-tone",
+        "label": "Punishments for incorrect behavior or tone",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-crawling-with-items-in-mouth-e-g-hairbrush-spoon",
+        "label": "Crawling with items in mouth (e.g., hairbrush, spoon)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-earning-permission-for-meals-bathroom-use-or-rest",
+        "label": "Earning permission for meals, bathroom use, or rest",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-formal-language",
+        "label": "Formal language",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-greeting-and-departure-rituals-kneeling-verbal-scripts-gestures",
+        "label": "Greeting and departure rituals (kneeling, verbal scripts, gestures)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-requiring-permission-for-things-speech-movement-attire",
+        "label": "Requiring permission for things (speech, movement, attire)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-daily-rituals-morning-check-ins-status-reports-mantra-repetitions",
+        "label": "Daily rituals (morning check-ins, status reports, mantra repetitions)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-specific-postures-for-rest-attention-punishment-waiting",
+        "label": "Specific postures for rest, attention, punishment, waiting",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-restricted-behavior-no-eye-contact-silence-no-questions",
+        "label": "Restricted behavior (no eye contact, silence, no questions)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-ritual-object-use-collar-cuffs-leash-tokens",
+        "label": "Ritual object use (collar, cuffs, leash, tokens)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-tracking-obedience-journals-apps",
+        "label": "Tracking obedience (journals, apps)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-formalized-rules-for-misbehavior-and-correction",
+        "label": "Formalized rules for misbehavior and correction",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-ritualized-aftercare-or-scene-closure",
+        "label": "Ritualized aftercare or scene closure",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-object-retrieval-on-all-fours-with-item-in-mouth",
+        "label": "Object retrieval on all fours with item in mouth",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-fetching-hairbrush-or-punishment-tool-from-dresser-while-crawling",
+        "label": "Fetching hairbrush or punishment tool from dresser while crawling",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-presenting-chosen-discipline-tool-in-kneeling-posture",
+        "label": "Presenting chosen discipline tool in kneeling posture",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-assigned-posture-or-kneeling-positions-as-ritual",
+        "label": "Assigned posture or kneeling positions as ritual",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-requesting-permission-using-specific-protocol-phrases",
+        "label": "Requesting permission using specific protocol phrases",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-carrying-items-in-mouth-as-submissive-gesture",
+        "label": "Carrying items in mouth as submissive gesture",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-crawling-back-with-object-to-dominant-after-retrieval",
+        "label": "Crawling back with object to Dominant after retrieval",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-following-via-nipple-leash-as-protocol-or-punishment",
+        "label": "Following via nipple leash as protocol or punishment",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-crawling-assigned-paths-as-ritual-or-obedience-training",
+        "label": "Crawling assigned paths as ritual or obedience training",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-crawling-rituals-e-g-object-retrieval",
+        "label": "Crawling rituals (e.g., object retrieval)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-carrying-objects-in-mouth-as-obedience",
+        "label": "Carrying objects in mouth as obedience",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-presenting-tools-or-toys-in-posture",
+        "label": "Presenting tools or toys in posture",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-using-honorifics-or-preset-protocol-language",
+        "label": "Using honorifics or preset protocol language",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-greeting-rituals-e-g-kneeling-kissing-feet",
+        "label": "Greeting rituals (e.g., kneeling, kissing feet)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-daily-check-ins-or-structured-reports",
+        "label": "Daily check-ins or structured reports",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-clothing-restrictions-or-uniforms",
+        "label": "Clothing restrictions or uniforms",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-posture-training-sitting-kneeling-standing",
+        "label": "Posture training (sitting, kneeling, standing)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-punishments-for-incorrect-behavior-or-tone",
+        "label": "Punishments for incorrect behavior or tone",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-crawling-with-items-in-mouth-e-g-hairbrush-spoon",
+        "label": "Crawling with items in mouth (e.g., hairbrush, spoon)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-earning-permission-for-meals-bathroom-use-or-rest",
+        "label": "Earning permission for meals, bathroom use, or rest",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-general-following-daily-rituals-or-protocol",
+        "label": "Following daily rituals or protocol",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-general-structured-speech-rules-e-g-titles-third-person",
+        "label": "Structured speech rules (e.g., titles, third person)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-general-receiving-correction-when-out-of-line",
+        "label": "Receiving correction when out of line",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-general-inspection-rituals-or-readiness-checks",
+        "label": "Inspection rituals or readiness checks",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Primal & Bratting",
+    "items": [
+      {
+        "id": "primal-bratting-giving-chase-and-capture-play",
+        "label": "Chase and capture play",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-giving-bratting-for-punishment",
+        "label": "Bratting for punishment",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-giving-playful-growling-and-biting",
+        "label": "Playful growling and biting",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-giving-provoking-with-teasing-or-taunts",
+        "label": "Provoking with teasing or taunts",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-giving-escaping-or-hiding-to-encourage-pursuit",
+        "label": "Escaping or hiding to encourage pursuit",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-giving-refusing-commands-just-for-fun",
+        "label": "Refusing commands just for fun",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-giving-provoking-your-partner-to-chase-or-discipline-you",
+        "label": "Provoking your partner to chase or discipline you",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-giving-taunting-or-teasing-as-a-form-of-play",
+        "label": "Taunting or teasing as a form of play",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-giving-intentional-resistance-during-power-exchange",
+        "label": "Intentional resistance during power exchange",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-giving-being-caught-and-overpowered",
+        "label": "Being caught and overpowered",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-receiving-chase-and-capture-play",
+        "label": "Chase and capture play",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-receiving-bratting-for-punishment",
+        "label": "Bratting for punishment",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-receiving-playful-growling-and-biting",
+        "label": "Playful growling and biting",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-receiving-provoking-with-teasing-or-taunts",
+        "label": "Provoking with teasing or taunts",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-receiving-escaping-or-hiding-to-encourage-pursuit",
+        "label": "Escaping or hiding to encourage pursuit",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-receiving-refusing-commands-just-for-fun",
+        "label": "Refusing commands just for fun",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-receiving-provoking-your-partner-to-chase-or-discipline-you",
+        "label": "Provoking your partner to chase or discipline you",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-receiving-taunting-or-teasing-as-a-form-of-play",
+        "label": "Taunting or teasing as a form of play",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-receiving-intentional-resistance-during-power-exchange",
+        "label": "Intentional resistance during power exchange",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-receiving-being-caught-and-overpowered",
+        "label": "Being caught and overpowered",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Headspace & Regression",
+    "items": [
+      {
+        "id": "headspace-regression-giving-caregiver-little-regression-play",
+        "label": "Caregiver/little regression play",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-giving-using-pacifiers-or-sippy-cups",
+        "label": "Using pacifiers or sippy cups",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-giving-coloring-or-childlike-crafts",
+        "label": "Coloring or childlike crafts",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-giving-stuffed-animal-comfort",
+        "label": "Stuffed animal comfort",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-giving-speaking-in-a-childlike-voice",
+        "label": "Speaking in a childlike voice",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-giving-bedtime-stories-or-lullabies",
+        "label": "Bedtime stories or lullabies",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-giving-entering-altered-headspaces-e-g-prey-pet-little",
+        "label": "Entering altered headspaces (e.g., prey, pet, little)",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-giving-regressive-behaviors-as-comfort-coloring-babytalk",
+        "label": "Regressive behaviors as comfort (coloring, babytalk)",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-giving-being-cared-for-during-emotional-vulnerability",
+        "label": "Being cared for during emotional vulnerability",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-giving-guided-emotional-headspace-entry",
+        "label": "Guided emotional headspace entry",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-receiving-caregiver-little-regression-play",
+        "label": "Caregiver/little regression play",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-receiving-using-pacifiers-or-sippy-cups",
+        "label": "Using pacifiers or sippy cups",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-receiving-coloring-or-childlike-crafts",
+        "label": "Coloring or childlike crafts",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-receiving-stuffed-animal-comfort",
+        "label": "Stuffed animal comfort",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-receiving-speaking-in-a-childlike-voice",
+        "label": "Speaking in a childlike voice",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-receiving-bedtime-stories-or-lullabies",
+        "label": "Bedtime stories or lullabies",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-receiving-entering-altered-headspaces-e-g-prey-pet-little",
+        "label": "Entering altered headspaces (e.g., prey, pet, little)",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-receiving-regressive-behaviors-as-comfort-coloring-babytalk",
+        "label": "Regressive behaviors as comfort (coloring, babytalk)",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-receiving-being-cared-for-during-emotional-vulnerability",
+        "label": "Being cared for during emotional vulnerability",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-receiving-guided-emotional-headspace-entry",
+        "label": "Guided emotional headspace entry",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Performance & Internal Struggle",
+    "items": [
+      {
+        "id": "performance-internal-struggle-general-obedience-under-observation",
+        "label": "Obedience under observation",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-speech-restriction-and-self-denial",
+        "label": "Speech restriction and self-denial",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-maintaining-composure-during-humiliation",
+        "label": "Maintaining composure during humiliation",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-obedience-drills-for-an-audience",
+        "label": "Obedience drills for an audience",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-struggling-against-personal-urges",
+        "label": "Struggling against personal urges",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-displaying-submission-despite-conflict",
+        "label": "Displaying submission despite conflict",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-being-told-to-act-normal-while-struggling-internally",
+        "label": "Being told to act normal while struggling internally",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-pleasing-through-high-functioning-obedience",
+        "label": "Pleasing through high-functioning obedience",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-performing-submission-while-masking-resistance",
+        "label": "Performing submission while masking resistance",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-the-pressure-of-appearing-good-while-feeling-conflicted",
+        "label": "The pressure of appearing 'good' while feeling conflicted",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-being-made-to-perform-emotions-on-command-cry-beg-moan",
+        "label": "Being made to perform emotions on command (cry, beg, moan)",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-struggling-openly-while-still-obeying",
+        "label": "Struggling openly while still obeying",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-performing-exaggerated-resistance-or-denial",
+        "label": "Performing exaggerated resistance or denial",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-being-punished-for-breaking-character",
+        "label": "Being punished for 'breaking character'",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-putting-on-a-show-for-someone-else-s-pleasure",
+        "label": "Putting on a show for someone else’s pleasure",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-rehearsed-degradation-or-humiliation-scripts",
+        "label": "Rehearsed degradation or humiliation scripts",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Mindfuck & Manipulation",
+    "items": [
+      {
+        "id": "mindfuck-manipulation-giving-confusing-commands-and-reality-shifts",
+        "label": "Confusing commands and reality shifts",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-gaslighting-or-contradictory-cues",
+        "label": "Gaslighting or contradictory cues",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-presenting-false-choices",
+        "label": "Presenting false choices",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-hidden-motives-or-secret-tasks",
+        "label": "Hidden motives or secret tasks",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-illogical-rules-meant-to-confuse",
+        "label": "Illogical rules meant to confuse",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-gaslight-style-scenes-with-consent-and-clarity",
+        "label": "Gaslight-style scenes (with consent and clarity)",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-false-threats-or-staged-surprises",
+        "label": "False threats or staged surprises",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-confusing-commands-to-prompt-hesitation",
+        "label": "Confusing commands to prompt hesitation",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-emotional-trickery-as-arousal",
+        "label": "Emotional trickery as arousal",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-being-misled-or-deceived-on-purpose-during-play",
+        "label": "Being misled or deceived on purpose during play",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-surprise-rule-changes-or-twists-mid-scene",
+        "label": "Surprise rule changes or twists mid-scene",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-false-safeword-games-with-negotiated-limits",
+        "label": "False safeword games (with negotiated limits)",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-withholding-or-delaying-aftercare-for-effect",
+        "label": "Withholding or delaying aftercare for effect",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-being-gaslit-or-doubted-in-a-controlled-roleplay",
+        "label": "Being gaslit or doubted in a controlled roleplay",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-told-you-asked-for-this-or-you-love-this-when-resisting",
+        "label": "Told 'you asked for this' or 'you love this' when resisting",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-confusing-commands-and-reality-shifts",
+        "label": "Confusing commands and reality shifts",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-gaslighting-or-contradictory-cues",
+        "label": "Gaslighting or contradictory cues",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-presenting-false-choices",
+        "label": "Presenting false choices",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-hidden-motives-or-secret-tasks",
+        "label": "Hidden motives or secret tasks",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-illogical-rules-meant-to-confuse",
+        "label": "Illogical rules meant to confuse",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-gaslight-style-scenes-with-consent-and-clarity",
+        "label": "Gaslight-style scenes (with consent and clarity)",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-false-threats-or-staged-surprises",
+        "label": "False threats or staged surprises",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-confusing-commands-to-prompt-hesitation",
+        "label": "Confusing commands to prompt hesitation",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-emotional-trickery-as-arousal",
+        "label": "Emotional trickery as arousal",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-being-misled-or-deceived-on-purpose-during-play",
+        "label": "Being misled or deceived on purpose during play",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-surprise-rule-changes-or-twists-mid-scene",
+        "label": "Surprise rule changes or twists mid-scene",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-false-safeword-games-with-negotiated-limits",
+        "label": "False safeword games (with negotiated limits)",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-withholding-or-delaying-aftercare-for-effect",
+        "label": "Withholding or delaying aftercare for effect",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-being-gaslit-or-doubted-in-a-controlled-roleplay",
+        "label": "Being gaslit or doubted in a controlled roleplay",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-told-you-asked-for-this-or-you-love-this-when-resisting",
+        "label": "Told 'you asked for this' or 'you love this' when resisting",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Mouth Play",
+    "items": [
+      {
+        "id": "mouth-play-giving-holding-tools-or-restraints-in-teeth-while-crawling",
+        "label": "Holding tools or restraints in teeth while crawling",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-placing-objects-from-mouth-into-dominant-s-palm",
+        "label": "Placing objects from mouth into Dominant’s palm",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-using-mouth-instead-of-hands-for-service-rituals",
+        "label": "Using mouth instead of hands for service rituals",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-gag-presentation-and-silent-waiting-protocol",
+        "label": "Gag presentation and silent waiting protocol",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-holding-objects-in-teeth-while-crawling",
+        "label": "Holding objects in teeth while crawling",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-returning-items-using-mouth-only",
+        "label": "Returning items using mouth only",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-gag-rituals-or-waiting-silently",
+        "label": "Gag rituals or waiting silently",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-leash-held-in-mouth",
+        "label": "Leash held in mouth",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-being-gagged-or-forced-silent",
+        "label": "Being gagged or forced silent",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-having-to-hold-objects-in-your-mouth-spoon-hairbrush-leash",
+        "label": "Having to hold objects in your mouth (spoon, hairbrush, leash)",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-being-used-for-oral-service-without-reciprocal-pleasure",
+        "label": "Being used for oral service without reciprocal pleasure",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-being-fed-by-hand-mouth-to-mouth-or-with-utensils",
+        "label": "Being fed by hand, mouth-to-mouth, or with utensils",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-verbal-control-e-g-only-speak-when-spoken-to",
+        "label": "Verbal control (e.g., only speak when spoken to)",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-mouth-as-a-symbol-of-ownership-or-control",
+        "label": "Mouth as a symbol of ownership or control",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-holding-tools-or-restraints-in-teeth-while-crawling",
+        "label": "Holding tools or restraints in teeth while crawling",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-placing-objects-from-mouth-into-dominant-s-palm",
+        "label": "Placing objects from mouth into Dominant’s palm",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-using-mouth-instead-of-hands-for-service-rituals",
+        "label": "Using mouth instead of hands for service rituals",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-gag-presentation-and-silent-waiting-protocol",
+        "label": "Gag presentation and silent waiting protocol",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-holding-objects-in-teeth-while-crawling",
+        "label": "Holding objects in teeth while crawling",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-returning-items-using-mouth-only",
+        "label": "Returning items using mouth only",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-gag-rituals-or-waiting-silently",
+        "label": "Gag rituals or waiting silently",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-leash-held-in-mouth",
+        "label": "Leash held in mouth",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-being-gagged-or-forced-silent",
+        "label": "Being gagged or forced silent",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-having-to-hold-objects-in-your-mouth-spoon-hairbrush-leash",
+        "label": "Having to hold objects in your mouth (spoon, hairbrush, leash)",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-being-used-for-oral-service-without-reciprocal-pleasure",
+        "label": "Being used for oral service without reciprocal pleasure",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-being-fed-by-hand-mouth-to-mouth-or-with-utensils",
+        "label": "Being fed by hand, mouth-to-mouth, or with utensils",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-verbal-control-e-g-only-speak-when-spoken-to",
+        "label": "Verbal control (e.g., only speak when spoken to)",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-mouth-as-a-symbol-of-ownership-or-control",
+        "label": "Mouth as a symbol of ownership or control",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Impact Play",
+    "items": [
+      {
+        "id": "impact-play-giving-hand-spanking",
+        "label": "Hand spanking",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-giving-paddle-strikes",
+        "label": "Paddle strikes",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-giving-crop-snaps",
+        "label": "Crop snaps",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-giving-flogger-swings",
+        "label": "Flogger swings",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-giving-cane-strokes",
+        "label": "Cane strokes",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-giving-belt-or-strap-hits",
+        "label": "Belt or strap hits",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-giving-whip-cracks",
+        "label": "Whip cracks",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-receiving-hand-spanking",
+        "label": "Hand spanking",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-receiving-paddle-strikes",
+        "label": "Paddle strikes",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-receiving-crop-snaps",
+        "label": "Crop snaps",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-receiving-flogger-swings",
+        "label": "Flogger swings",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-receiving-cane-strokes",
+        "label": "Cane strokes",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-receiving-belt-or-strap-hits",
+        "label": "Belt or strap hits",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-receiving-whip-cracks",
+        "label": "Whip cracks",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-general-preferred-intensity-levels",
+        "label": "Preferred intensity levels",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-general-aftercare-for-bruises",
+        "label": "Aftercare for bruises",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-general-target-body-areas",
+        "label": "Target body areas",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-general-implement-selection",
+        "label": "Implement selection",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Medical Play",
+    "items": [
+      {
+        "id": "medical-play-giving-needle-play",
+        "label": "Needle play",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-giving-catheter-insertion",
+        "label": "Catheter insertion",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-giving-speculum-exams",
+        "label": "Speculum exams",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-giving-enema-administration",
+        "label": "Enema administration",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-giving-temperature-taking",
+        "label": "Temperature taking",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-giving-medical-restraints",
+        "label": "Medical restraints",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-giving-doctor-nurse-roleplay",
+        "label": "Doctor/nurse roleplay",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-receiving-needle-play",
+        "label": "Needle play",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-receiving-catheter-insertion",
+        "label": "Catheter insertion",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-receiving-speculum-exams",
+        "label": "Speculum exams",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-receiving-enema-administration",
+        "label": "Enema administration",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-receiving-temperature-taking",
+        "label": "Temperature taking",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-receiving-medical-restraints",
+        "label": "Medical restraints",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-receiving-doctor-nurse-roleplay",
+        "label": "Doctor/nurse roleplay",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-general-sterilization-procedures",
+        "label": "Sterilization procedures",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-general-professional-vs-roleplay-scenes",
+        "label": "Professional vs roleplay scenes",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-general-consent-for-invasive-acts",
+        "label": "Consent for invasive acts",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-general-access-to-medical-equipment",
+        "label": "Access to medical equipment",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Pet Play",
+    "items": [
+      {
+        "id": "pet-play-giving-puppy-or-kitten-play",
+        "label": "Puppy or kitten play",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-giving-pony-play",
+        "label": "Pony play",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-giving-wearing-collar-and-leash",
+        "label": "Wearing collar and leash",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-giving-eating-from-a-bowl",
+        "label": "Eating from a bowl",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-giving-kenneling-or-caging",
+        "label": "Kenneling or caging",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-giving-pet-training-commands",
+        "label": "Pet training commands",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-giving-animal-costumes-or-gear",
+        "label": "Animal costumes or gear",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-receiving-puppy-or-kitten-play",
+        "label": "Puppy or kitten play",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-receiving-pony-play",
+        "label": "Pony play",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-receiving-wearing-collar-and-leash",
+        "label": "Wearing collar and leash",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-receiving-eating-from-a-bowl",
+        "label": "Eating from a bowl",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-receiving-kenneling-or-caging",
+        "label": "Kenneling or caging",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-receiving-pet-training-commands",
+        "label": "Pet training commands",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-receiving-animal-costumes-or-gear",
+        "label": "Animal costumes or gear",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-general-preferred-animal-identities",
+        "label": "Preferred animal identities",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-general-public-vs-private-play",
+        "label": "Public vs private play",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-general-training-style-and-discipline",
+        "label": "Training style and discipline",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-general-use-of-pet-names-and-commands",
+        "label": "Use of pet names and commands",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Body Modification",
+    "items": [
+      {
+        "id": "body-modification-giving-piercings",
+        "label": "Piercings",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-giving-tattoos",
+        "label": "Tattoos",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-giving-branding",
+        "label": "Branding",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-giving-scarification",
+        "label": "Scarification",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-giving-permanent-chastity-devices",
+        "label": "Permanent chastity devices",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-giving-cosmetic-implants",
+        "label": "Cosmetic implants",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-giving-stretching-or-gauges",
+        "label": "Stretching or gauges",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-receiving-piercings",
+        "label": "Piercings",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-receiving-tattoos",
+        "label": "Tattoos",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-receiving-branding",
+        "label": "Branding",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-receiving-scarification",
+        "label": "Scarification",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-receiving-permanent-chastity-devices",
+        "label": "Permanent chastity devices",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-receiving-cosmetic-implants",
+        "label": "Cosmetic implants",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-receiving-stretching-or-gauges",
+        "label": "Stretching or gauges",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-general-temporary-vs-permanent-changes",
+        "label": "Temporary vs permanent changes",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-general-professional-vs-diy-methods",
+        "label": "Professional vs DIY methods",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-general-body-placement-considerations",
+        "label": "Body placement considerations",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-general-healing-and-aftercare",
+        "label": "Healing and aftercare",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Relationship Preferences",
+    "items": [
+      {
+        "id": "relationship-preferences-general-preferred-relationship-style",
+        "label": "Preferred relationship style",
+        "type": "text"
+      },
+      {
+        "id": "relationship-preferences-general-relationship-goals",
+        "label": "Relationship goals",
+        "type": "text"
+      },
+      {
+        "id": "relationship-preferences-general-monogamous",
+        "label": "Monogamous",
+        "type": "scale"
+      },
+      {
+        "id": "relationship-preferences-general-polyamorous",
+        "label": "Polyamorous",
+        "type": "scale"
+      },
+      {
+        "id": "relationship-preferences-general-hierarchical-dynamics",
+        "label": "Hierarchical dynamics",
+        "type": "scale"
+      },
+      {
+        "id": "relationship-preferences-general-non-hierarchical-poly",
+        "label": "Non-hierarchical poly",
+        "type": "scale"
+      },
+      {
+        "id": "relationship-preferences-general-solo-poly",
+        "label": "Solo-poly",
+        "type": "scale"
+      },
+      {
+        "id": "relationship-preferences-general-open-with-boundaries",
+        "label": "Open with boundaries",
+        "type": "scale"
+      },
+      {
+        "id": "relationship-preferences-general-closed-but-kinky-with-others",
+        "label": "Closed but kinky with others",
+        "type": "scale"
+      },
+      {
+        "id": "relationship-preferences-general-switch-friendly-dynamics",
+        "label": "Switch-friendly dynamics",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Gender Play & Transformation",
+    "items": [
+      {
+        "id": "gender-play-transformation-giving-crossdressing",
+        "label": "Crossdressing",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-giving-forced-feminization",
+        "label": "Forced feminization",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-giving-forced-masculinization",
+        "label": "Forced masculinization",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-giving-gender-role-reversal",
+        "label": "Gender role reversal",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-giving-pronoun-changes",
+        "label": "Pronoun changes",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-giving-voice-or-mannerism-training",
+        "label": "Voice or mannerism training",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-giving-sissy-or-tomboy-persona",
+        "label": "Sissy or tomboy persona",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-receiving-crossdressing",
+        "label": "Crossdressing",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-receiving-forced-feminization",
+        "label": "Forced feminization",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-receiving-forced-masculinization",
+        "label": "Forced masculinization",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-receiving-gender-role-reversal",
+        "label": "Gender role reversal",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-receiving-pronoun-changes",
+        "label": "Pronoun changes",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-receiving-voice-or-mannerism-training",
+        "label": "Voice or mannerism training",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-receiving-sissy-or-tomboy-persona",
+        "label": "Sissy or tomboy persona",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-general-preferred-pronouns-and-names",
+        "label": "Preferred pronouns and names",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-general-public-presentation-comfort",
+        "label": "Public presentation comfort",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-general-clothing-and-appearance",
+        "label": "Clothing and appearance",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-general-exploration-of-identity",
+        "label": "Exploration of identity",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Chastity Devices",
+    "items": [
+      {
+        "id": "chastity-devices-giving-wearing-a-chastity-cage-short-term",
+        "label": "Wearing a chastity cage (short term)",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-giving-long-term-chastity-training",
+        "label": "Long-term chastity training",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-giving-chastity-device-control-with-permission-to-unlock",
+        "label": "Chastity device control with permission to unlock",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-giving-locked-remotely-by-another-person",
+        "label": "Locked remotely by another person",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-giving-orgasm-denial-enforced-by-chastity",
+        "label": "Orgasm denial enforced by chastity",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-giving-wearing-a-belt-style-chastity-device",
+        "label": "Wearing a belt-style chastity device",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-giving-humiliation-while-locked-in-chastity",
+        "label": "Humiliation while locked in chastity",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-giving-sleep-in-chastity-overnight",
+        "label": "Sleep in chastity (overnight)",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-giving-being-teased-while-unable-to-touch-yourself",
+        "label": "Being teased while unable to touch yourself",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-giving-begging-for-release-from-chastity",
+        "label": "Begging for release from chastity",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-receiving-wearing-a-chastity-cage-short-term",
+        "label": "Wearing a chastity cage (short term)",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-receiving-long-term-chastity-training",
+        "label": "Long-term chastity training",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-receiving-chastity-device-control-with-permission-to-unlock",
+        "label": "Chastity device control with permission to unlock",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-receiving-locked-remotely-by-another-person",
+        "label": "Locked remotely by another person",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-receiving-orgasm-denial-enforced-by-chastity",
+        "label": "Orgasm denial enforced by chastity",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-receiving-wearing-a-belt-style-chastity-device",
+        "label": "Wearing a belt-style chastity device",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-receiving-humiliation-while-locked-in-chastity",
+        "label": "Humiliation while locked in chastity",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-receiving-sleep-in-chastity-overnight",
+        "label": "Sleep in chastity (overnight)",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-receiving-being-teased-while-unable-to-touch-yourself",
+        "label": "Being teased while unable to touch yourself",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-receiving-begging-for-release-from-chastity",
+        "label": "Begging for release from chastity",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Shibari & Rope Bondage",
+    "items": [
+      {
+        "id": "shibari-rope-bondage-giving-being-tied-in-aesthetic-rope-patterns-shibari",
+        "label": "Being tied in aesthetic rope patterns (Shibari)",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-giving-rope-bondage-for-restraint-and-control",
+        "label": "Rope bondage for restraint and control",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-giving-rope-suspension-partial-or-full",
+        "label": "Rope suspension (partial or full)",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-giving-learning-to-tie-rope-as-a-form-of-dominance",
+        "label": "Learning to tie rope as a form of dominance",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-giving-being-tied-in-vulnerable-or-exposing-poses",
+        "label": "Being tied in vulnerable or exposing poses",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-giving-practicing-rope-with-emotional-connection",
+        "label": "Practicing rope with emotional connection",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-giving-enduring-discomfort-for-the-beauty-of-the-rope",
+        "label": "Enduring discomfort for the beauty of the rope",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-giving-being-tied-in-a-mirror-and-told-to-look",
+        "label": "Being tied in a mirror and told to look",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-giving-punishment-ties-e-g-uncomfortable-or-humiliating-positions",
+        "label": "Punishment ties (e.g., uncomfortable or humiliating positions)",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-giving-solo-rope-practice-for-mindfulness-or-masochism",
+        "label": "Solo rope practice for mindfulness or masochism",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-receiving-being-tied-in-aesthetic-rope-patterns-shibari",
+        "label": "Being tied in aesthetic rope patterns (Shibari)",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-receiving-rope-bondage-for-restraint-and-control",
+        "label": "Rope bondage for restraint and control",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-receiving-rope-suspension-partial-or-full",
+        "label": "Rope suspension (partial or full)",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-receiving-learning-to-tie-rope-as-a-form-of-dominance",
+        "label": "Learning to tie rope as a form of dominance",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-receiving-being-tied-in-vulnerable-or-exposing-poses",
+        "label": "Being tied in vulnerable or exposing poses",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-receiving-practicing-rope-with-emotional-connection",
+        "label": "Practicing rope with emotional connection",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-receiving-enduring-discomfort-for-the-beauty-of-the-rope",
+        "label": "Enduring discomfort for the beauty of the rope",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-receiving-being-tied-in-a-mirror-and-told-to-look",
+        "label": "Being tied in a mirror and told to look",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-receiving-punishment-ties-e-g-uncomfortable-or-humiliating-positions",
+        "label": "Punishment ties (e.g., uncomfortable or humiliating positions)",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-receiving-solo-rope-practice-for-mindfulness-or-masochism",
+        "label": "Solo rope practice for mindfulness or masochism",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Cosplay & Identity Play",
+    "items": [
+      {
+        "id": "cosplay-identity-play-giving-dressing-up-in-costumes-for-scenes",
+        "label": "Dressing up in costumes for scenes",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-giving-playing-as-fictional-characters",
+        "label": "Playing as fictional characters",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-giving-petplay-with-collars-ears-or-tails",
+        "label": "Petplay with collars, ears, or tails",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-giving-pretending-to-be-a-doll-robot-or-object",
+        "label": "Pretending to be a doll, robot, or object",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-giving-master-slave-cosplay-dynamic-non-24-7",
+        "label": "Master/slave cosplay dynamic (non-24/7)",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-giving-roleplaying-as-a-fantasy-species-or-non-human",
+        "label": "Roleplaying as a fantasy species or non-human",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-giving-using-cosplay-to-deepen-power-exchange",
+        "label": "Using cosplay to deepen power exchange",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-giving-scene-built-around-a-character-s-story-or-world",
+        "label": "Scene built around a character’s story or world",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-giving-fantasy-uniforms-nurse-teacher-etc",
+        "label": "Fantasy uniforms (nurse, teacher, etc.)",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-receiving-dressing-up-in-costumes-for-scenes",
+        "label": "Dressing up in costumes for scenes",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-receiving-playing-as-fictional-characters",
+        "label": "Playing as fictional characters",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-receiving-petplay-with-collars-ears-or-tails",
+        "label": "Petplay with collars, ears, or tails",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-receiving-pretending-to-be-a-doll-robot-or-object",
+        "label": "Pretending to be a doll, robot, or object",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-receiving-master-slave-cosplay-dynamic-non-24-7",
+        "label": "Master/slave cosplay dynamic (non-24/7)",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-receiving-roleplaying-as-a-fantasy-species-or-non-human",
+        "label": "Roleplaying as a fantasy species or non-human",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-receiving-using-cosplay-to-deepen-power-exchange",
+        "label": "Using cosplay to deepen power exchange",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-receiving-scene-built-around-a-character-s-story-or-world",
+        "label": "Scene built around a character’s story or world",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-receiving-fantasy-uniforms-nurse-teacher-etc",
+        "label": "Fantasy uniforms (nurse, teacher, etc.)",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "High-Intensity Kinks (SSC-Aware)",
+    "items": [
+      {
+        "id": "high-intensity-kinks-ssc-aware-giving-intense-breath-play-e-g-smothering-or-pressure",
+        "label": "Intense breath play (e.g., smothering or pressure)",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-giving-knife-play-or-blade-play-without-injury",
+        "label": "Knife play or blade play (without injury)",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-giving-fear-play-using-known-or-negotiated-triggers",
+        "label": "Fear play using known or negotiated triggers",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-giving-abduction-or-home-invasion-style-roleplay-negotiated",
+        "label": "Abduction or home-invasion style roleplay (negotiated)",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-giving-medical-themed-scenes-with-sharp-objects-not-bloodletting",
+        "label": "Medical-themed scenes with sharp objects (not bloodletting)",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-giving-sensory-deprivation-with-added-disorientation-or-helplessness",
+        "label": "Sensory deprivation with added disorientation or helplessness",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-giving-scenes-involving-heavy-objectification-or-emotional-manipulation-with-care",
+        "label": "Scenes involving heavy objectification or emotional manipulation (with care)",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-giving-mock-interrogation-or-intense-role-pressure",
+        "label": "Mock interrogation or intense role pressure",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-giving-consensual-threats-without-follow-through-e-g-if-you-don-t",
+        "label": "Consensual threats without follow-through (e.g. 'If you don’t...')",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-giving-high-intensity-primal-scenes-involving-struggle-or-fear",
+        "label": "High-intensity primal scenes involving struggle or fear",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-receiving-intense-breath-play-e-g-smothering-or-pressure",
+        "label": "Intense breath play (e.g., smothering or pressure)",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-receiving-knife-play-or-blade-play-without-injury",
+        "label": "Knife play or blade play (without injury)",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-receiving-fear-play-using-known-or-negotiated-triggers",
+        "label": "Fear play using known or negotiated triggers",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-receiving-abduction-or-home-invasion-style-roleplay-negotiated",
+        "label": "Abduction or home-invasion style roleplay (negotiated)",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-receiving-medical-themed-scenes-with-sharp-objects-not-bloodletting",
+        "label": "Medical-themed scenes with sharp objects (not bloodletting)",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-receiving-sensory-deprivation-with-added-disorientation-or-helplessness",
+        "label": "Sensory deprivation with added disorientation or helplessness",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-receiving-scenes-involving-heavy-objectification-or-emotional-manipulation-with-care",
+        "label": "Scenes involving heavy objectification or emotional manipulation (with care)",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-receiving-mock-interrogation-or-intense-role-pressure",
+        "label": "Mock interrogation or intense role pressure",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-receiving-consensual-threats-without-follow-through-e-g-if-you-don-t",
+        "label": "Consensual threats without follow-through (e.g. 'If you don’t...')",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-receiving-high-intensity-primal-scenes-involving-struggle-or-fear",
+        "label": "High-intensity primal scenes involving struggle or fear",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Behavioral Play",
+    "items": [
+      {
+        "id": "behavioral-play-giving-assigning-corner-time-or-time-outs",
+        "label": "Assigning corner time or time-outs",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-giving-writing-lines-or-apology-letters-as-correction",
+        "label": "Writing lines or apology letters as correction",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-giving-removing-privileges-phone-tv-sweets",
+        "label": "Removing privileges (phone, TV, sweets)",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-giving-playful-punishments-that-still-reinforce-rules",
+        "label": "Playful punishments that still reinforce rules",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-giving-lecturing-or-scolding-to-modify-behavior",
+        "label": "Lecturing or scolding to modify behavior",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-receiving-being-placed-in-the-corner-or-given-a-time-out",
+        "label": "Being placed in the corner or given a time-out",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-receiving-writing-lines-or-apology-letters-when-misbehaving",
+        "label": "Writing lines or apology letters when misbehaving",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-receiving-having-privileges-revoked-phone-tv",
+        "label": "Having privileges revoked (phone, TV)",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-receiving-receiving-playful-funishments-for-minor-rule-breaking",
+        "label": "Receiving playful 'funishments' for minor rule-breaking",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-receiving-getting-scolded-or-lectured-for-correction",
+        "label": "Getting scolded or lectured for correction",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-general-preferred-style-of-discipline-strict-vs-lenient",
+        "label": "Preferred style of discipline (strict vs lenient)",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-general-attitude-toward-funishment-vs-serious-correction",
+        "label": "Attitude toward funishment vs serious correction",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-general-use-of-behavior-contracts-or-rule-agreements",
+        "label": "Use of behavior contracts or rule agreements",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Appearance Play",
+    "items": [
+      {
+        "id": "appearance-play-giving-choosing-my-partner-s-outfit-for-the-day-or-a-scene",
+        "label": "Choosing my partner’s outfit for the day or a scene",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-giving-selecting-their-underwear-lingerie-or-base-layers",
+        "label": "Selecting their underwear, lingerie, or base layers",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-giving-styling-their-hair-braiding-brushing-tying-etc",
+        "label": "Styling their hair (braiding, brushing, tying, etc.)",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-giving-picking-head-coverings-bonnets-veils-hoods-hats-for-mood-or-protocol",
+        "label": "Picking head coverings (bonnets, veils, hoods, hats) for mood or protocol",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-giving-offering-makeup-polish-or-accessories-as-part-of-ritual-or-play",
+        "label": "Offering makeup, polish, or accessories as part of ritual or play",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-giving-creating-themed-looks-slutty-innocent-doll-like-sharp-etc",
+        "label": "Creating themed looks (slutty, innocent, doll-like, sharp, etc.)",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-giving-dressing-them-in-role-specific-costumes-maid-bunny-doll-etc",
+        "label": "Dressing them in role-specific costumes (maid, bunny, doll, etc.)",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-giving-curating-time-period-or-historical-outfits-e-g-victorian-50s",
+        "label": "Curating time-period or historical outfits (e.g., Victorian, 50s)",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-giving-helping-them-present-more-femme-masc-or-androgynous-by-request",
+        "label": "Helping them present more femme, masc, or androgynous by request",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-giving-coordinating-their-look-with-mine-for-public-or-private-scenes",
+        "label": "Coordinating their look with mine for public or private scenes",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-giving-implementing-a-dress-ritual-or-aesthetic-preparation",
+        "label": "Implementing a “dress ritual” or aesthetic preparation",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-giving-enforcing-a-visual-protocol-e-g-no-bra-heels-required-tied-hair",
+        "label": "Enforcing a visual protocol (e.g., no bra, heels required, tied hair)",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-having-my-outfit-selected-for-me-by-a-partner",
+        "label": "Having my outfit selected for me by a partner",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-wearing-the-underwear-or-lingerie-they-choose",
+        "label": "Wearing the underwear or lingerie they choose",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-having-my-hair-brushed-braided-tied-or-styled-for-them",
+        "label": "Having my hair brushed, braided, tied, or styled for them",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-putting-on-a-head-covering-e-g-bonnet-veil-hood-they-chose",
+        "label": "Putting on a head covering (e.g., bonnet, veil, hood) they chose",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-following-visual-appearance-rules-as-part-of-submission",
+        "label": "Following visual appearance rules as part of submission",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-wearing-makeup-polish-or-accessories-they-request",
+        "label": "Wearing makeup, polish, or accessories they request",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-dressing-to-please-their-vision-cute-filthy-classy-etc",
+        "label": "Dressing to please their vision (cute, filthy, classy, etc.)",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-wearing-roleplay-costumes-or-character-looks",
+        "label": "Wearing roleplay costumes or character looks",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-presenting-in-a-way-that-matches-their-chosen-aesthetic",
+        "label": "Presenting in a way that matches their chosen aesthetic",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-participating-in-dressing-rituals-or-undressing-ceremonies",
+        "label": "Participating in dressing rituals or undressing ceremonies",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-being-admired-for-the-way-i-look-under-their-direction",
+        "label": "Being admired for the way I look under their direction",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-receiving-praise-or-gentle-teasing-about-my-appearance",
+        "label": "Receiving praise or gentle teasing about my appearance",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-general-cosplay-or-fantasy-looks-anime-game-fairytale-etc",
+        "label": "Cosplay or fantasy looks (anime, game, fairytale, etc.)",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-general-time-period-dress-up-regency-gothic-1920s-etc",
+        "label": "Time-period dress-up (regency, gothic, 1920s, etc.)",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-general-dollification-or-polished-presented-object-aesthetics",
+        "label": "Dollification or polished/presented object aesthetics",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-general-uniforms-schoolgirl-military-clerical-nurse-etc",
+        "label": "Uniforms (schoolgirl, military, clerical, nurse, etc.)",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-general-hair-based-play-forced-brushing-ribbons-or-tied-styles",
+        "label": "Hair-based play (forced brushing, ribbons, or tied styles)",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-general-head-coverings-or-symbolic-hoods-in-ritualized-dynamics",
+        "label": "Head coverings or symbolic hoods in ritualized dynamics",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-general-matching-looks-or-coordinated-dress-codes",
+        "label": "Matching looks or coordinated dress codes",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-general-ritualized-grooming-before-scenes",
+        "label": "Ritualized grooming before scenes",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-general-praise-or-positive-attention-for-pleasing-visual-display",
+        "label": "Praise or positive attention for pleasing visual display",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-general-formal-appearance-protocols-for-scenes-or-dynamics",
+        "label": "Formal appearance protocols for scenes or dynamics",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-general-using-clothing-or-style-to-embody-emotional-or-power-roles",
+        "label": "Using clothing or style to embody emotional or power roles",
+        "type": "scale"
+      }
+    ]
+  }
+]

--- a/kinks.json
+++ b/kinks.json
@@ -1,0 +1,4357 @@
+[
+  {
+    "category": "Body Part Torture",
+    "items": [
+      {
+        "id": "body-part-torture-giving-nipple-clips",
+        "label": "Nipple clips",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-giving-nipple-weights",
+        "label": "Nipple weights",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-giving-nipple-suction-cups",
+        "label": "Nipple suction cups",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-giving-cock-ball-torture-cbt",
+        "label": "Cock, Ball Torture (CBT)",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-giving-clit-clips-weights-suction",
+        "label": "Clit clips/weights/suction",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-giving-hair-pulling",
+        "label": "Hair pulling",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-giving-face-slapping",
+        "label": "Face slapping",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-giving-butt-slapping",
+        "label": "Butt slapping",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-giving-breast-slapping",
+        "label": "Breast slapping",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-giving-genital-slapping",
+        "label": "Genital slapping",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-receiving-nipple-clips",
+        "label": "Nipple clips",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-receiving-nipple-weights",
+        "label": "Nipple weights",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-receiving-nipple-suction-cups",
+        "label": "Nipple suction cups",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-receiving-cock-ball-torture-cbt",
+        "label": "Cock, Ball Torture (CBT)",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-receiving-clit-clips-weights-suction",
+        "label": "Clit clips/weights/suction",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-receiving-hair-pulling",
+        "label": "Hair pulling",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-receiving-face-slapping",
+        "label": "Face slapping",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-receiving-butt-slapping",
+        "label": "Butt slapping",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-receiving-breast-slapping",
+        "label": "Breast slapping",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-torture-receiving-genital-slapping",
+        "label": "Genital slapping",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Bondage and Suspension",
+    "items": [
+      {
+        "id": "bondage-and-suspension-giving-blindfolds",
+        "label": "Blindfolds",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-bondage-heavy",
+        "label": "Bondage (heavy)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-bondage-light",
+        "label": "Bondage (light)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-immobilisation",
+        "label": "Immobilisation",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-bondage-multi-day",
+        "label": "Bondage (multi-day)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-bondage-public-under-clothing",
+        "label": "Bondage (public, under clothing)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-leather-restraints",
+        "label": "Leather restraints",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-chains",
+        "label": "Chains",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-ropes",
+        "label": "Ropes",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-intricate-japanese-rope-bondage",
+        "label": "Intricate (Japanese) rope bondage",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-rope-body-harness",
+        "label": "Rope body harness",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-arm-leg-sleeves-armbinders",
+        "label": "Arm & leg sleeves (armbinders)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-harnesses-leather",
+        "label": "Harnesses (leather)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-harnesses-rope",
+        "label": "Harnesses (rope)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-cuffs-leather",
+        "label": "Cuffs (leather)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-cuffs-metal",
+        "label": "Cuffs (metal)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-manacles-irons",
+        "label": "Manacles & Irons",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-gags-cloth",
+        "label": "Gags (cloth)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-gags-rubber",
+        "label": "Gags (rubber)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-gags-tape",
+        "label": "Gags (tape)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-gags-phallic",
+        "label": "Gags (phallic)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-gags-ring",
+        "label": "Gags (ring)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-gags-ball",
+        "label": "Gags (ball)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-mouth-bits",
+        "label": "Mouth bits",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-full-head-hoods",
+        "label": "Full head hoods",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-mummification-saran-wrapping",
+        "label": "Mummification/saran wrapping",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-straight-jackets",
+        "label": "Straight jackets",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-suspension-upright",
+        "label": "Suspension (upright)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-suspension-horizontal",
+        "label": "Suspension (horizontal)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-suspension-inverted",
+        "label": "Suspension (inverted)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-breath-play",
+        "label": "Breath play",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-smothering",
+        "label": "Smothering",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-forced-self-breath-control",
+        "label": "Forced self-breath-control",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-giving-gas-mask",
+        "label": "Gas mask",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-blindfolds",
+        "label": "Blindfolds",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-bondage-heavy",
+        "label": "Bondage (heavy)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-bondage-light",
+        "label": "Bondage (light)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-immobilisation",
+        "label": "Immobilisation",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-bondage-multi-day",
+        "label": "Bondage (multi-day)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-bondage-public-under-clothing",
+        "label": "Bondage (public, under clothing)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-leather-restraints",
+        "label": "Leather restraints",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-chains",
+        "label": "Chains",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-ropes",
+        "label": "Ropes",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-intricate-japanese-rope-bondage",
+        "label": "Intricate (Japanese) rope bondage",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-rope-body-harness",
+        "label": "Rope body harness",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-arm-leg-sleeves-armbinders",
+        "label": "Arm & leg sleeves (armbinders)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-harnesses-leather",
+        "label": "Harnesses (leather)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-harnesses-rope",
+        "label": "Harnesses (rope)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-cuffs-leather",
+        "label": "Cuffs (leather)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-cuffs-metal",
+        "label": "Cuffs (metal)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-manacles-irons",
+        "label": "Manacles & Irons",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-gags-cloth",
+        "label": "Gags (cloth)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-gags-rubber",
+        "label": "Gags (rubber)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-gags-tape",
+        "label": "Gags (tape)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-gags-phallic",
+        "label": "Gags (phallic)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-gags-ring",
+        "label": "Gags (ring)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-gags-ball",
+        "label": "Gags (ball)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-mouth-bits",
+        "label": "Mouth bits",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-full-head-hoods",
+        "label": "Full head hoods",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-mummification-saran-wrapping",
+        "label": "Mummification/saran wrapping",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-straight-jackets",
+        "label": "Straight jackets",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-suspension-upright",
+        "label": "Suspension (upright)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-suspension-horizontal",
+        "label": "Suspension (horizontal)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-suspension-inverted",
+        "label": "Suspension (inverted)",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-breath-play",
+        "label": "Breath play",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-smothering",
+        "label": "Smothering",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-forced-self-breath-control",
+        "label": "Forced self-breath-control",
+        "type": "scale"
+      },
+      {
+        "id": "bondage-and-suspension-receiving-gas-mask",
+        "label": "Gas mask",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Breath Play",
+    "items": [
+      {
+        "id": "breath-play-giving-asphyxiation",
+        "label": "Asphyxiation",
+        "type": "scale"
+      },
+      {
+        "id": "breath-play-giving-breath-control",
+        "label": "Breath control",
+        "type": "scale"
+      },
+      {
+        "id": "breath-play-giving-choking",
+        "label": "Choking",
+        "type": "scale"
+      },
+      {
+        "id": "breath-play-giving-drowning",
+        "label": "Drowning",
+        "type": "scale"
+      },
+      {
+        "id": "breath-play-giving-rebreathing-into-a-bag-or-object",
+        "label": "Rebreathing into a bag or object",
+        "type": "scale"
+      },
+      {
+        "id": "breath-play-giving-verbal-control-of-breath-e-g-hold-it-on-command",
+        "label": "Verbal control of breath (e.g., 'hold it' on command)",
+        "type": "scale"
+      },
+      {
+        "id": "breath-play-receiving-asphyxiation",
+        "label": "Asphyxiation",
+        "type": "scale"
+      },
+      {
+        "id": "breath-play-receiving-breath-control",
+        "label": "Breath control",
+        "type": "scale"
+      },
+      {
+        "id": "breath-play-receiving-choking",
+        "label": "Choking",
+        "type": "scale"
+      },
+      {
+        "id": "breath-play-receiving-drowning",
+        "label": "Drowning",
+        "type": "scale"
+      },
+      {
+        "id": "breath-play-receiving-rebreathing-into-a-bag-or-object",
+        "label": "Rebreathing into a bag or object",
+        "type": "scale"
+      },
+      {
+        "id": "breath-play-receiving-verbal-control-of-breath-e-g-hold-it-on-command",
+        "label": "Verbal control of breath (e.g., 'hold it' on command)",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Sexual Activity",
+    "items": [
+      {
+        "id": "sexual-activity-giving-licking",
+        "label": "Licking",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-fellatio-cunnilingus",
+        "label": "Fellatio/Cunnilingus",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-swallowing-semen",
+        "label": "Swallowing semen",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-cumming-on-partner",
+        "label": "Cumming on Partner",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-hand-jobs",
+        "label": "Hand jobs",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-anal-sex",
+        "label": "Anal sex",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-anal-plugs-small",
+        "label": "Anal plugs (small)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-anal-plugs-large",
+        "label": "Anal plugs (large)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-anal-beads",
+        "label": "Anal beads",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-vibrator-on-genitals",
+        "label": "Vibrator on genitals",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-fisting",
+        "label": "Fisting",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-oral-anal-play-rimming",
+        "label": "Oral/anal play (rimming)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-double-penetration-oral-and-vaginal",
+        "label": "Double penetration (oral and vaginal)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-double-penetration-oral-and-anal",
+        "label": "Double penetration (oral and anal)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-double-penetration-anal-and-vaginal",
+        "label": "Double penetration (anal and vaginal)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-giving-triple-oral-vaginal-and-anal",
+        "label": "Triple (Oral, Vaginal and Anal)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-licking",
+        "label": "Licking",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-fellatio-cunnilingus",
+        "label": "Fellatio/Cunnilingus",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-swallowing-semen",
+        "label": "Swallowing semen",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-cumming-on-partner",
+        "label": "Cumming on Partner",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-hand-jobs",
+        "label": "Hand jobs",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-anal-sex",
+        "label": "Anal sex",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-anal-plugs-small",
+        "label": "Anal plugs (small)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-anal-plugs-large",
+        "label": "Anal plugs (large)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-anal-beads",
+        "label": "Anal beads",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-vibrator-on-genitals",
+        "label": "Vibrator on genitals",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-fisting",
+        "label": "Fisting",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-oral-anal-play-rimming",
+        "label": "Oral/anal play (rimming)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-double-penetration-oral-and-vaginal",
+        "label": "Double penetration (oral and vaginal)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-double-penetration-oral-and-anal",
+        "label": "Double penetration (oral and anal)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-double-penetration-anal-and-vaginal",
+        "label": "Double penetration (anal and vaginal)",
+        "type": "scale"
+      },
+      {
+        "id": "sexual-activity-receiving-triple-oral-vaginal-and-anal",
+        "label": "Triple (Oral, Vaginal and Anal)",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Sensation Play",
+    "items": [
+      {
+        "id": "sensation-play-giving-abrasion",
+        "label": "Abrasion",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-scratching",
+        "label": "Scratching",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-biting",
+        "label": "Biting",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-tickling",
+        "label": "Tickling",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-kissing",
+        "label": "Kissing",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-zapping-e-g-electric-fly-swatter",
+        "label": "Zapping (e.g. electric fly swatter)",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-ice-cubes",
+        "label": "Ice cubes",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-wax-play",
+        "label": "Wax Play",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-fire",
+        "label": "Fire",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-clothespins",
+        "label": "Clothespins",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-needles",
+        "label": "Needles",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-sensory-deprivation",
+        "label": "Sensory deprivation",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-physical-overpowering-manhandling",
+        "label": "Physical overpowering / Manhandling",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-giving-figging",
+        "label": "Figging",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-abrasion",
+        "label": "Abrasion",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-scratching",
+        "label": "Scratching",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-biting",
+        "label": "Biting",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-tickling",
+        "label": "Tickling",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-kissing",
+        "label": "Kissing",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-zapping-e-g-electric-fly-swatter",
+        "label": "Zapping (e.g. electric fly swatter)",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-ice-cubes",
+        "label": "Ice cubes",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-wax-play",
+        "label": "Wax Play",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-fire",
+        "label": "Fire",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-clothespins",
+        "label": "Clothespins",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-needles",
+        "label": "Needles",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-sensory-deprivation",
+        "label": "Sensory deprivation",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-physical-overpowering-manhandling",
+        "label": "Physical overpowering / Manhandling",
+        "type": "scale"
+      },
+      {
+        "id": "sensation-play-receiving-figging",
+        "label": "Figging",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Other",
+    "items": [
+      {
+        "id": "other-general-feet",
+        "label": "Feet",
+        "type": "scale"
+      },
+      {
+        "id": "other-general-boots",
+        "label": "Boots",
+        "type": "scale"
+      },
+      {
+        "id": "other-general-underwear",
+        "label": "Underwear",
+        "type": "scale"
+      },
+      {
+        "id": "other-general-chastity-devices",
+        "label": "Chastity devices",
+        "type": "scale"
+      },
+      {
+        "id": "other-general-masks",
+        "label": "Masks",
+        "type": "scale"
+      },
+      {
+        "id": "other-general-breeding",
+        "label": "Breeding",
+        "type": "scale"
+      },
+      {
+        "id": "other-general-leather-clothing",
+        "label": "Leather clothing",
+        "type": "scale"
+      },
+      {
+        "id": "other-general-training-protocols-outside-scenes-e-g-etiquette-memory",
+        "label": "Training protocols outside scenes (e.g., etiquette, memory)",
+        "type": "scale"
+      },
+      {
+        "id": "other-general-long-distance-training-structure",
+        "label": "Long-distance training/structure",
+        "type": "scale"
+      },
+      {
+        "id": "other-general-scene-journaling-and-reflection",
+        "label": "Scene journaling and reflection",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Roleplaying",
+    "items": [
+      {
+        "id": "roleplaying-giving-fantasy-abandonment",
+        "label": "Fantasy abandonment",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-giving-kidnapping",
+        "label": "Kidnapping",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-giving-interrogation",
+        "label": "Interrogation",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-giving-sleep-deprivation",
+        "label": "Sleep deprivation",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-giving-cnc",
+        "label": "CNC",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-giving-gang-bang",
+        "label": "Gang bang",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-giving-initiation-rites",
+        "label": "Initiation rites",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-giving-religious-scenes",
+        "label": "Religious scenes",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-giving-medical-scenes",
+        "label": "Medical scenes",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-giving-prison-scenes",
+        "label": "Prison scenes",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-giving-primal-prey",
+        "label": "Primal/Prey",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-giving-schoolroom-scenes",
+        "label": "Schoolroom scenes",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-fantasy-abandonment",
+        "label": "Fantasy abandonment",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-kidnapping",
+        "label": "Kidnapping",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-interrogation",
+        "label": "Interrogation",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-sleep-deprivation",
+        "label": "Sleep deprivation",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-cnc",
+        "label": "CNC",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-gang-bang",
+        "label": "Gang bang",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-initiation-rites",
+        "label": "Initiation rites",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-religious-scenes",
+        "label": "Religious scenes",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-medical-scenes",
+        "label": "Medical scenes",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-prison-scenes",
+        "label": "Prison scenes",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-primal-prey",
+        "label": "Primal/Prey",
+        "type": "scale"
+      },
+      {
+        "id": "roleplaying-receiving-schoolroom-scenes",
+        "label": "Schoolroom scenes",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Service and Restrictive Behaviour",
+    "items": [
+      {
+        "id": "service-and-restrictive-behaviour-giving-following-orders",
+        "label": "(Following) orders",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-forced-servitude",
+        "label": "Forced servitude",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-restrictive-rules-on-behaviour",
+        "label": "Restrictive rules on behaviour",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-eye-contact-restrictions",
+        "label": "Eye contact restrictions",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-speech-restrictions-when-what-to-whom",
+        "label": "Speech restrictions (when, what, to whom)",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-washroom-restrictions",
+        "label": "Washroom restrictions",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-punishments",
+        "label": "Punishments",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-tasks",
+        "label": "Tasks",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-massage",
+        "label": "Massage",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-domestic-tasks",
+        "label": "Domestic tasks",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-serving-food-and-drink",
+        "label": "Serving food and drink",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-personal-care-rituals",
+        "label": "Personal care rituals",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-being-on-call-at-specified-times",
+        "label": "Being on-call at specified times",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-daily-task-assignments",
+        "label": "Daily task assignments",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-corrections-for-imperfection",
+        "label": "Corrections for imperfection",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-uniforms-dress-codes",
+        "label": "Uniforms / Dress codes",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-kneeling-posture-presentation",
+        "label": "Kneeling / Posture presentation",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-silent-service",
+        "label": "Silent service",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-public-service-at-parties-or-events",
+        "label": "Public service (at parties or events)",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-giving-erotic-service-pleasure-on-command-without-seeking-your-own",
+        "label": "Erotic service (pleasure on command, without seeking your own)",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-following-orders",
+        "label": "(Following) orders",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-forced-servitude",
+        "label": "Forced servitude",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-restrictive-rules-on-behaviour",
+        "label": "Restrictive rules on behaviour",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-eye-contact-restrictions",
+        "label": "Eye contact restrictions",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-speech-restrictions-when-what-to-whom",
+        "label": "Speech restrictions (when, what, to whom)",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-washroom-restrictions",
+        "label": "Washroom restrictions",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-punishments",
+        "label": "Punishments",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-tasks",
+        "label": "Tasks",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-massage",
+        "label": "Massage",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-domestic-tasks",
+        "label": "Domestic tasks",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-serving-food-and-drink",
+        "label": "Serving food and drink",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-personal-care-rituals",
+        "label": "Personal care rituals",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-being-on-call-at-specified-times",
+        "label": "Being on-call at specified times",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-daily-task-assignments",
+        "label": "Daily task assignments",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-corrections-for-imperfection",
+        "label": "Corrections for imperfection",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-uniforms-dress-codes",
+        "label": "Uniforms / Dress codes",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-kneeling-posture-presentation",
+        "label": "Kneeling / Posture presentation",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-silent-service",
+        "label": "Silent service",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-public-service-at-parties-or-events",
+        "label": "Public service (at parties or events)",
+        "type": "scale"
+      },
+      {
+        "id": "service-and-restrictive-behaviour-receiving-erotic-service-pleasure-on-command-without-seeking-your-own",
+        "label": "Erotic service (pleasure on command, without seeking your own)",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Voyeurism/Exhibitionism",
+    "items": [
+      {
+        "id": "voyeurism-exhibitionism-giving-forced-nudity-private",
+        "label": "Forced nudity (private)",
+        "type": "scale"
+      },
+      {
+        "id": "voyeurism-exhibitionism-giving-forced-nudity-around-others",
+        "label": "Forced nudity (around others)",
+        "type": "scale"
+      },
+      {
+        "id": "voyeurism-exhibitionism-giving-exhibitionism-friends",
+        "label": "Exhibitionism (friends)",
+        "type": "scale"
+      },
+      {
+        "id": "voyeurism-exhibitionism-giving-exhibitionism-strangers",
+        "label": "Exhibitionism (strangers)",
+        "type": "scale"
+      },
+      {
+        "id": "voyeurism-exhibitionism-giving-modelling-for-erotic-photos",
+        "label": "Modelling for erotic photos",
+        "type": "scale"
+      },
+      {
+        "id": "voyeurism-exhibitionism-giving-toys-under-clothes-in-public",
+        "label": "Toys under clothes in public",
+        "type": "scale"
+      },
+      {
+        "id": "voyeurism-exhibitionism-receiving-forced-nudity-private",
+        "label": "Forced nudity (private)",
+        "type": "scale"
+      },
+      {
+        "id": "voyeurism-exhibitionism-receiving-forced-nudity-around-others",
+        "label": "Forced nudity (around others)",
+        "type": "scale"
+      },
+      {
+        "id": "voyeurism-exhibitionism-receiving-exhibitionism-friends",
+        "label": "Exhibitionism (friends)",
+        "type": "scale"
+      },
+      {
+        "id": "voyeurism-exhibitionism-receiving-exhibitionism-strangers",
+        "label": "Exhibitionism (strangers)",
+        "type": "scale"
+      },
+      {
+        "id": "voyeurism-exhibitionism-receiving-modelling-for-erotic-photos",
+        "label": "Modelling for erotic photos",
+        "type": "scale"
+      },
+      {
+        "id": "voyeurism-exhibitionism-receiving-toys-under-clothes-in-public",
+        "label": "Toys under clothes in public",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Virtual & Long-Distance Play",
+    "items": [
+      {
+        "id": "virtual-long-distance-play-giving-sending-tasks-or-orders-digitally",
+        "label": "Sending tasks or orders digitally",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-giving-recording-dominant-voice-clips-commands-edging-praise-degradation-etc",
+        "label": "Recording dominant voice clips (commands, edging, praise, degradation, etc.)",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-giving-remote-control-of-a-sex-toy",
+        "label": "Remote control of a sex toy",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-giving-monitoring-behavior-via-app-or-shared-doc",
+        "label": "Monitoring behavior via app or shared doc",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-giving-giving-punishment-assignments-remotely",
+        "label": "Giving punishment assignments remotely",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-giving-creating-countdowns-timers-or-denial-periods",
+        "label": "Creating countdowns, timers, or denial periods",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-giving-sending-written-instructions-with-delayed-permissions",
+        "label": "Sending written instructions with delayed permissions",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-giving-creating-custom-video-or-audio-tasks",
+        "label": "Creating custom video or audio tasks",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-giving-voice-message-control-during-scenes",
+        "label": "Voice message control during scenes",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-giving-being-on-call-at-specified-times",
+        "label": "Being on-call at specified times",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-receiving-receiving-tasks-or-orders-digitally",
+        "label": "Receiving tasks or orders digitally",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-receiving-listening-to-dominant-voice-clips",
+        "label": "Listening to dominant voice clips",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-receiving-using-a-remote-controlled-toy-controlled-by-another",
+        "label": "Using a remote-controlled toy controlled by another",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-receiving-completing-daily-protocol-assignments",
+        "label": "Completing daily protocol assignments",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-receiving-submitting-proof-photo-video-text",
+        "label": "Submitting proof (photo, video, text)",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-receiving-following-recorded-or-timed-commands",
+        "label": "Following recorded or timed commands",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-receiving-receiving-surprise-instructions",
+        "label": "Receiving surprise instructions",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-receiving-hearing-name-praise-spoken-in-a-custom-clip",
+        "label": "Hearing name/praise spoken in a custom clip",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-receiving-sending-submissive-voice-clips-obedience-begging-thank-you-messages-affirmations-etc",
+        "label": "Sending submissive voice clips (obedience, begging, thank-you messages, affirmations, etc.)",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-receiving-being-on-call-at-specified-times",
+        "label": "Being on-call at specified times",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-general-scheduling-digital-rituals-or-reminders",
+        "label": "Scheduling digital rituals or reminders",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-general-using-training-habit-or-behavior-tracking-apps",
+        "label": "Using training, habit, or behavior-tracking apps",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-general-online-rituals-digital-kneeling-posture-protocols",
+        "label": "Online rituals (digital kneeling, posture protocols)",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-general-role-based-texting-e-g-use-honorifics-in-chat",
+        "label": "Role-based texting (e.g., \"Use honorifics in chat\")",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-general-shared-playlists-affirmations-or-mantras",
+        "label": "Shared playlists, affirmations, or mantras",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-general-countdown-timers-to-next-task-release-or-interaction",
+        "label": "Countdown timers to next task, release, or interaction",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-general-scheduled-good-morning-night-rituals",
+        "label": "Scheduled good morning/night rituals",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-general-participating-in-video-call-scenes",
+        "label": "Participating in video call scenes",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-general-digital-aftercare-texts-voice-images",
+        "label": "Digital aftercare (texts, voice, images)",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-general-sexting-or-digital-roleplay-scenes",
+        "label": "Sexting or digital roleplay scenes",
+        "type": "scale"
+      },
+      {
+        "id": "virtual-long-distance-play-general-voice-notes-or-submissive-dominant-affirmations",
+        "label": "Voice notes or submissive/dominant affirmations",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Communication",
+    "items": [
+      {
+        "id": "communication-giving-playful-and-teasing",
+        "label": "Playful and teasing",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-quiet-and-intense",
+        "label": "Quiet and intense",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-observant-and-intentional",
+        "label": "Observant and intentional",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-praise-heavy",
+        "label": "Praise-heavy",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-blunt-and-efficient",
+        "label": "Blunt and efficient",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-affirming-and-soft",
+        "label": "Affirming and soft",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-psychological-interrogation",
+        "label": "Psychological interrogation",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-verbal-coercion-teasing-traps",
+        "label": "Verbal coercion / teasing traps",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-verbal-misdirection",
+        "label": "Verbal misdirection",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-mocking-shaming",
+        "label": "Mocking / shaming",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-predatory-pacing",
+        "label": "Predatory pacing",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-reluctant-obedience",
+        "label": "Reluctant obedience",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-stammering-submission",
+        "label": "Stammering submission",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-challenging-until-caught",
+        "label": "Challenging until caught",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-quiet-surrender",
+        "label": "Quiet surrender",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-sarcastic-teasing",
+        "label": "Sarcastic teasing",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-provoking-tone",
+        "label": "Provoking tone",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-challenge-based-dialogue",
+        "label": "Challenge-based dialogue",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-double-meaning-banter",
+        "label": "Double-meaning banter",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-soft-spoken-guidance",
+        "label": "Soft-spoken guidance",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-protective-but-firm-tone",
+        "label": "Protective but firm tone",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-emotional-redirection",
+        "label": "Emotional redirection",
+        "type": "scale"
+      },
+      {
+        "id": "communication-giving-steady-reassurance",
+        "label": "Steady reassurance",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-direct-and-clear",
+        "label": "Direct and clear",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-playful-and-teasing",
+        "label": "Playful and teasing",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-gentle-and-nurturing",
+        "label": "Gentle and nurturing",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-commanding-and-firm",
+        "label": "Commanding and firm",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-quiet-and-observant",
+        "label": "Quiet and observant",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-instructive-teacher-like",
+        "label": "Instructive / teacher-like",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-emotionally-intense",
+        "label": "Emotionally intense",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-dismissive-withholding",
+        "label": "Dismissive / withholding",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-mocking-sarcastic",
+        "label": "Mocking / sarcastic",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-blunt-tactless",
+        "label": "Blunt / tactless",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-predatory-hunting-tone",
+        "label": "Predatory / hunting tone",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-stalking-or-circling-speech",
+        "label": "Stalking or circling speech",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-you-re-mine-control-language",
+        "label": "You’re mine / control language",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-threatening-consensual",
+        "label": "Threatening (consensual)",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-verbal-cornering-coaxing",
+        "label": "Verbal cornering / coaxing",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-watching-you-unravel",
+        "label": "Watching you unravel",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-cruel-and-cutting",
+        "label": "Cruel and cutting",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-psychological-baiting",
+        "label": "Psychological baiting",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-brat-breaking-language",
+        "label": "Brat-breaking language",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-mock-affection",
+        "label": "Mock affection",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-shaming-or-emotional-edge",
+        "label": "Shaming or emotional edge",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-disappointed-dom-voice",
+        "label": "Disappointed dom voice",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-mild-scolding-mocking-affection",
+        "label": "Mild scolding / mocking affection",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-verbal-power-struggle",
+        "label": "Verbal power struggle",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-challenge-response-dynamics",
+        "label": "Challenge-response dynamics",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-warm-tone-with-expectation",
+        "label": "Warm tone with expectation",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-nurturing-dominance",
+        "label": "Nurturing dominance",
+        "type": "scale"
+      },
+      {
+        "id": "communication-receiving-reassuring-commands",
+        "label": "Reassuring commands",
+        "type": "scale"
+      },
+      {
+        "id": "communication-general-phrases-that-work-on-you",
+        "label": "Phrases that work on you",
+        "type": "text"
+      },
+      {
+        "id": "communication-general-phrases-you-use-or-like-to-give",
+        "label": "Phrases you use or like to give",
+        "type": "text"
+      },
+      {
+        "id": "communication-general-what-helps-you-feel-emotionally-safe",
+        "label": "What helps you feel emotionally safe",
+        "type": "text"
+      },
+      {
+        "id": "communication-general-how-you-tend-to-show-affection",
+        "label": "How you tend to show affection",
+        "type": "text"
+      },
+      {
+        "id": "communication-general-emotional-check-in-style",
+        "label": "Emotional check-in style",
+        "type": "text"
+      },
+      {
+        "id": "communication-general-when-emotionally-activated-i-tend-to",
+        "label": "When emotionally activated, I tend to...",
+        "type": "text"
+      }
+    ]
+  },
+  {
+    "category": "Body Fluids and Functions",
+    "items": [
+      {
+        "id": "body-fluids-and-functions-giving-watersports-golden-showers",
+        "label": "Watersports/golden showers",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-giving-cum",
+        "label": "Cum",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-giving-blood",
+        "label": "Blood",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-giving-scat",
+        "label": "Scat",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-giving-sweat",
+        "label": "Sweat",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-giving-vomit",
+        "label": "Vomit",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-giving-tears-crying",
+        "label": "Tears/crying",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-receiving-watersports-golden-showers",
+        "label": "Watersports/golden showers",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-receiving-cum",
+        "label": "Cum",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-receiving-blood",
+        "label": "Blood",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-receiving-scat",
+        "label": "Scat",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-receiving-sweat",
+        "label": "Sweat",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-receiving-vomit",
+        "label": "Vomit",
+        "type": "scale"
+      },
+      {
+        "id": "body-fluids-and-functions-receiving-tears-crying",
+        "label": "Tears/crying",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Psychological Primal / Prey",
+    "items": [
+      {
+        "id": "psychological-primal-prey-giving-primal-prey",
+        "label": "Primal/Prey",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-conditioning",
+        "label": "Conditioning",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-coc",
+        "label": "COC",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-psycholagny-hands-free-mentally-stimulated-orgasm",
+        "label": "Psycholagny (hands free, mentally stimulated orgasm)",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-hypno-play",
+        "label": "Hypno Play",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-praise",
+        "label": "Praise",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-degradation",
+        "label": "Degradation",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-traditional-primal-prey",
+        "label": "Traditional primal/prey",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-fear-play",
+        "label": "Fear play",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-objectification",
+        "label": "Objectification",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-gaslighting",
+        "label": "Gaslighting",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-role-erosion-identity-play-loss-of-self",
+        "label": "Role erosion (identity play / loss of self)",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-jealousy-play",
+        "label": "Jealousy play",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-giving-manipulation",
+        "label": "Manipulation",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-primal-prey",
+        "label": "Primal/Prey",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-conditioning",
+        "label": "Conditioning",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-coc",
+        "label": "COC",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-psycholagny-hands-free-mentally-stimulated-orgasm",
+        "label": "Psycholagny (hands free, mentally stimulated orgasm)",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-hypno-play",
+        "label": "Hypno Play",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-praise",
+        "label": "Praise",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-degradation",
+        "label": "Degradation",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-traditional-primal-prey",
+        "label": "Traditional primal/prey",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-fear-play",
+        "label": "Fear play",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-objectification",
+        "label": "Objectification",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-gaslighting",
+        "label": "Gaslighting",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-role-erosion-identity-play-loss-of-self",
+        "label": "Role erosion (identity play / loss of self)",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-jealousy-play",
+        "label": "Jealousy play",
+        "type": "scale"
+      },
+      {
+        "id": "psychological-primal-prey-receiving-manipulation",
+        "label": "Manipulation",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Body Part / Fetish Play",
+    "items": [
+      {
+        "id": "body-part-fetish-play-giving-belly-fucking",
+        "label": "Belly fucking",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-giving-navel-play",
+        "label": "Navel play",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-giving-feet-foot-worship",
+        "label": "Feet / Foot worship",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-giving-hands",
+        "label": "Hands",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-giving-hair",
+        "label": "Hair",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-giving-thighs",
+        "label": "Thighs",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-giving-neck",
+        "label": "Neck",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-giving-ears",
+        "label": "Ears",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-giving-belly",
+        "label": "Belly",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-giving-voice-fetish",
+        "label": "Voice fetish",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-giving-nails-makeup-fetish",
+        "label": "Nails / Makeup fetish",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-receiving-belly-fucking",
+        "label": "Belly fucking",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-receiving-navel-play",
+        "label": "Navel play",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-receiving-feet-foot-worship",
+        "label": "Feet / Foot worship",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-receiving-hands",
+        "label": "Hands",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-receiving-hair",
+        "label": "Hair",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-receiving-thighs",
+        "label": "Thighs",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-receiving-neck",
+        "label": "Neck",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-receiving-ears",
+        "label": "Ears",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-receiving-belly",
+        "label": "Belly",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-receiving-voice-fetish",
+        "label": "Voice fetish",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-receiving-nails-makeup-fetish",
+        "label": "Nails / Makeup fetish",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-cuddles",
+        "label": "Cuddles",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-food-play",
+        "label": "Food Play",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-kisses",
+        "label": "Kisses",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-masturbation",
+        "label": "Masturbation",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-romance-affection",
+        "label": "Romance / affection",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-sex-toys",
+        "label": "Sex toys",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-sexting-chat-etc",
+        "label": "Sexting /Chat etc",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-sexting-via-phone-or-video-call",
+        "label": "Sexting via phone or video call",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-strip-tease",
+        "label": "Strip tease",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-vanilla-sex",
+        "label": "Vanilla Sex",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-voice-notes",
+        "label": "Voice Notes",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-shaving-body-hair",
+        "label": "Shaving (body hair)",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-sexy-clothing-private",
+        "label": "Sexy clothing (private)",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-sexy-clothing-public",
+        "label": "Sexy clothing (public)",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-outdoor-scenes",
+        "label": "Outdoor scenes",
+        "type": "scale"
+      },
+      {
+        "id": "body-part-fetish-play-general-public-exposure",
+        "label": "Public exposure",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Orgasm Control & Sexual Manipulation",
+    "items": [
+      {
+        "id": "orgasm-control-sexual-manipulation-giving-edging",
+        "label": "Edging",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-giving-short-term-denial",
+        "label": "Short term denial",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-giving-long-term-denial",
+        "label": "Long term denial",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-giving-forced-orgasms-overstimulation",
+        "label": "Forced orgasms / Overstimulation",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-giving-ruined-orgasms",
+        "label": "Ruined orgasms",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-giving-no-touch-periods",
+        "label": "No touch periods",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-giving-milking",
+        "label": "Milking",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-giving-chastity-devices",
+        "label": "Chastity devices",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-giving-consensual-orgasm-control",
+        "label": "Consensual orgasm control",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-giving-forced-masturbation",
+        "label": "Forced masturbation",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-receiving-edging",
+        "label": "Edging",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-receiving-short-term-denial",
+        "label": "Short term denial",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-receiving-long-term-denial",
+        "label": "Long term denial",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-receiving-forced-orgasms-overstimulation",
+        "label": "Forced orgasms / Overstimulation",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-receiving-ruined-orgasms",
+        "label": "Ruined orgasms",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-receiving-no-touch-periods",
+        "label": "No touch periods",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-receiving-milking",
+        "label": "Milking",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-receiving-chastity-devices",
+        "label": "Chastity devices",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-receiving-consensual-orgasm-control",
+        "label": "Consensual orgasm control",
+        "type": "scale"
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-receiving-forced-masturbation",
+        "label": "Forced masturbation",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Protocol and Ritual",
+    "items": [
+      {
+        "id": "protocol-and-ritual-giving-formal-language",
+        "label": "Formal language",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-greeting-and-departure-rituals-kneeling-verbal-scripts-gestures",
+        "label": "Greeting and departure rituals (kneeling, verbal scripts, gestures)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-requiring-permission-for-things-speech-movement-attire",
+        "label": "Requiring permission for things (speech, movement, attire)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-daily-rituals-morning-check-ins-status-reports-mantra-repetitions",
+        "label": "Daily rituals (morning check-ins, status reports, mantra repetitions)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-specific-postures-for-rest-attention-punishment-waiting",
+        "label": "Specific postures for rest, attention, punishment, waiting",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-restricted-behavior-no-eye-contact-silence-no-questions",
+        "label": "Restricted behavior (no eye contact, silence, no questions)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-ritual-object-use-collar-cuffs-leash-tokens",
+        "label": "Ritual object use (collar, cuffs, leash, tokens)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-tracking-obedience-journals-apps",
+        "label": "Tracking obedience (journals, apps)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-formalized-rules-for-misbehavior-and-correction",
+        "label": "Formalized rules for misbehavior and correction",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-ritualized-aftercare-or-scene-closure",
+        "label": "Ritualized aftercare or scene closure",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-object-retrieval-on-all-fours-with-item-in-mouth",
+        "label": "Object retrieval on all fours with item in mouth",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-fetching-hairbrush-or-punishment-tool-from-dresser-while-crawling",
+        "label": "Fetching hairbrush or punishment tool from dresser while crawling",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-presenting-chosen-discipline-tool-in-kneeling-posture",
+        "label": "Presenting chosen discipline tool in kneeling posture",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-assigned-posture-or-kneeling-positions-as-ritual",
+        "label": "Assigned posture or kneeling positions as ritual",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-requesting-permission-using-specific-protocol-phrases",
+        "label": "Requesting permission using specific protocol phrases",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-carrying-items-in-mouth-as-submissive-gesture",
+        "label": "Carrying items in mouth as submissive gesture",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-crawling-back-with-object-to-dominant-after-retrieval",
+        "label": "Crawling back with object to Dominant after retrieval",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-following-via-nipple-leash-as-protocol-or-punishment",
+        "label": "Following via nipple leash as protocol or punishment",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-crawling-assigned-paths-as-ritual-or-obedience-training",
+        "label": "Crawling assigned paths as ritual or obedience training",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-crawling-rituals-e-g-object-retrieval",
+        "label": "Crawling rituals (e.g., object retrieval)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-carrying-objects-in-mouth-as-obedience",
+        "label": "Carrying objects in mouth as obedience",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-presenting-tools-or-toys-in-posture",
+        "label": "Presenting tools or toys in posture",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-using-honorifics-or-preset-protocol-language",
+        "label": "Using honorifics or preset protocol language",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-greeting-rituals-e-g-kneeling-kissing-feet",
+        "label": "Greeting rituals (e.g., kneeling, kissing feet)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-daily-check-ins-or-structured-reports",
+        "label": "Daily check-ins or structured reports",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-clothing-restrictions-or-uniforms",
+        "label": "Clothing restrictions or uniforms",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-posture-training-sitting-kneeling-standing",
+        "label": "Posture training (sitting, kneeling, standing)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-punishments-for-incorrect-behavior-or-tone",
+        "label": "Punishments for incorrect behavior or tone",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-crawling-with-items-in-mouth-e-g-hairbrush-spoon",
+        "label": "Crawling with items in mouth (e.g., hairbrush, spoon)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-giving-earning-permission-for-meals-bathroom-use-or-rest",
+        "label": "Earning permission for meals, bathroom use, or rest",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-formal-language",
+        "label": "Formal language",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-greeting-and-departure-rituals-kneeling-verbal-scripts-gestures",
+        "label": "Greeting and departure rituals (kneeling, verbal scripts, gestures)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-requiring-permission-for-things-speech-movement-attire",
+        "label": "Requiring permission for things (speech, movement, attire)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-daily-rituals-morning-check-ins-status-reports-mantra-repetitions",
+        "label": "Daily rituals (morning check-ins, status reports, mantra repetitions)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-specific-postures-for-rest-attention-punishment-waiting",
+        "label": "Specific postures for rest, attention, punishment, waiting",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-restricted-behavior-no-eye-contact-silence-no-questions",
+        "label": "Restricted behavior (no eye contact, silence, no questions)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-ritual-object-use-collar-cuffs-leash-tokens",
+        "label": "Ritual object use (collar, cuffs, leash, tokens)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-tracking-obedience-journals-apps",
+        "label": "Tracking obedience (journals, apps)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-formalized-rules-for-misbehavior-and-correction",
+        "label": "Formalized rules for misbehavior and correction",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-ritualized-aftercare-or-scene-closure",
+        "label": "Ritualized aftercare or scene closure",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-object-retrieval-on-all-fours-with-item-in-mouth",
+        "label": "Object retrieval on all fours with item in mouth",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-fetching-hairbrush-or-punishment-tool-from-dresser-while-crawling",
+        "label": "Fetching hairbrush or punishment tool from dresser while crawling",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-presenting-chosen-discipline-tool-in-kneeling-posture",
+        "label": "Presenting chosen discipline tool in kneeling posture",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-assigned-posture-or-kneeling-positions-as-ritual",
+        "label": "Assigned posture or kneeling positions as ritual",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-requesting-permission-using-specific-protocol-phrases",
+        "label": "Requesting permission using specific protocol phrases",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-carrying-items-in-mouth-as-submissive-gesture",
+        "label": "Carrying items in mouth as submissive gesture",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-crawling-back-with-object-to-dominant-after-retrieval",
+        "label": "Crawling back with object to Dominant after retrieval",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-following-via-nipple-leash-as-protocol-or-punishment",
+        "label": "Following via nipple leash as protocol or punishment",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-crawling-assigned-paths-as-ritual-or-obedience-training",
+        "label": "Crawling assigned paths as ritual or obedience training",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-crawling-rituals-e-g-object-retrieval",
+        "label": "Crawling rituals (e.g., object retrieval)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-carrying-objects-in-mouth-as-obedience",
+        "label": "Carrying objects in mouth as obedience",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-presenting-tools-or-toys-in-posture",
+        "label": "Presenting tools or toys in posture",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-using-honorifics-or-preset-protocol-language",
+        "label": "Using honorifics or preset protocol language",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-greeting-rituals-e-g-kneeling-kissing-feet",
+        "label": "Greeting rituals (e.g., kneeling, kissing feet)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-daily-check-ins-or-structured-reports",
+        "label": "Daily check-ins or structured reports",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-clothing-restrictions-or-uniforms",
+        "label": "Clothing restrictions or uniforms",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-posture-training-sitting-kneeling-standing",
+        "label": "Posture training (sitting, kneeling, standing)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-punishments-for-incorrect-behavior-or-tone",
+        "label": "Punishments for incorrect behavior or tone",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-crawling-with-items-in-mouth-e-g-hairbrush-spoon",
+        "label": "Crawling with items in mouth (e.g., hairbrush, spoon)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-receiving-earning-permission-for-meals-bathroom-use-or-rest",
+        "label": "Earning permission for meals, bathroom use, or rest",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-general-following-daily-rituals-or-protocol",
+        "label": "Following daily rituals or protocol",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-general-structured-speech-rules-e-g-titles-third-person",
+        "label": "Structured speech rules (e.g., titles, third person)",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-general-receiving-correction-when-out-of-line",
+        "label": "Receiving correction when out of line",
+        "type": "scale"
+      },
+      {
+        "id": "protocol-and-ritual-general-inspection-rituals-or-readiness-checks",
+        "label": "Inspection rituals or readiness checks",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Primal & Bratting",
+    "items": [
+      {
+        "id": "primal-bratting-giving-chase-and-capture-play",
+        "label": "Chase and capture play",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-giving-bratting-for-punishment",
+        "label": "Bratting for punishment",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-giving-playful-growling-and-biting",
+        "label": "Playful growling and biting",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-giving-provoking-with-teasing-or-taunts",
+        "label": "Provoking with teasing or taunts",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-giving-escaping-or-hiding-to-encourage-pursuit",
+        "label": "Escaping or hiding to encourage pursuit",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-giving-refusing-commands-just-for-fun",
+        "label": "Refusing commands just for fun",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-giving-provoking-your-partner-to-chase-or-discipline-you",
+        "label": "Provoking your partner to chase or discipline you",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-giving-taunting-or-teasing-as-a-form-of-play",
+        "label": "Taunting or teasing as a form of play",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-giving-intentional-resistance-during-power-exchange",
+        "label": "Intentional resistance during power exchange",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-giving-being-caught-and-overpowered",
+        "label": "Being caught and overpowered",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-receiving-chase-and-capture-play",
+        "label": "Chase and capture play",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-receiving-bratting-for-punishment",
+        "label": "Bratting for punishment",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-receiving-playful-growling-and-biting",
+        "label": "Playful growling and biting",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-receiving-provoking-with-teasing-or-taunts",
+        "label": "Provoking with teasing or taunts",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-receiving-escaping-or-hiding-to-encourage-pursuit",
+        "label": "Escaping or hiding to encourage pursuit",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-receiving-refusing-commands-just-for-fun",
+        "label": "Refusing commands just for fun",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-receiving-provoking-your-partner-to-chase-or-discipline-you",
+        "label": "Provoking your partner to chase or discipline you",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-receiving-taunting-or-teasing-as-a-form-of-play",
+        "label": "Taunting or teasing as a form of play",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-receiving-intentional-resistance-during-power-exchange",
+        "label": "Intentional resistance during power exchange",
+        "type": "scale"
+      },
+      {
+        "id": "primal-bratting-receiving-being-caught-and-overpowered",
+        "label": "Being caught and overpowered",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Headspace & Regression",
+    "items": [
+      {
+        "id": "headspace-regression-giving-caregiver-little-regression-play",
+        "label": "Caregiver/little regression play",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-giving-using-pacifiers-or-sippy-cups",
+        "label": "Using pacifiers or sippy cups",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-giving-coloring-or-childlike-crafts",
+        "label": "Coloring or childlike crafts",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-giving-stuffed-animal-comfort",
+        "label": "Stuffed animal comfort",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-giving-speaking-in-a-childlike-voice",
+        "label": "Speaking in a childlike voice",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-giving-bedtime-stories-or-lullabies",
+        "label": "Bedtime stories or lullabies",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-giving-entering-altered-headspaces-e-g-prey-pet-little",
+        "label": "Entering altered headspaces (e.g., prey, pet, little)",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-giving-regressive-behaviors-as-comfort-coloring-babytalk",
+        "label": "Regressive behaviors as comfort (coloring, babytalk)",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-giving-being-cared-for-during-emotional-vulnerability",
+        "label": "Being cared for during emotional vulnerability",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-giving-guided-emotional-headspace-entry",
+        "label": "Guided emotional headspace entry",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-receiving-caregiver-little-regression-play",
+        "label": "Caregiver/little regression play",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-receiving-using-pacifiers-or-sippy-cups",
+        "label": "Using pacifiers or sippy cups",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-receiving-coloring-or-childlike-crafts",
+        "label": "Coloring or childlike crafts",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-receiving-stuffed-animal-comfort",
+        "label": "Stuffed animal comfort",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-receiving-speaking-in-a-childlike-voice",
+        "label": "Speaking in a childlike voice",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-receiving-bedtime-stories-or-lullabies",
+        "label": "Bedtime stories or lullabies",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-receiving-entering-altered-headspaces-e-g-prey-pet-little",
+        "label": "Entering altered headspaces (e.g., prey, pet, little)",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-receiving-regressive-behaviors-as-comfort-coloring-babytalk",
+        "label": "Regressive behaviors as comfort (coloring, babytalk)",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-receiving-being-cared-for-during-emotional-vulnerability",
+        "label": "Being cared for during emotional vulnerability",
+        "type": "scale"
+      },
+      {
+        "id": "headspace-regression-receiving-guided-emotional-headspace-entry",
+        "label": "Guided emotional headspace entry",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Performance & Internal Struggle",
+    "items": [
+      {
+        "id": "performance-internal-struggle-general-obedience-under-observation",
+        "label": "Obedience under observation",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-speech-restriction-and-self-denial",
+        "label": "Speech restriction and self-denial",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-maintaining-composure-during-humiliation",
+        "label": "Maintaining composure during humiliation",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-obedience-drills-for-an-audience",
+        "label": "Obedience drills for an audience",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-struggling-against-personal-urges",
+        "label": "Struggling against personal urges",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-displaying-submission-despite-conflict",
+        "label": "Displaying submission despite conflict",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-being-told-to-act-normal-while-struggling-internally",
+        "label": "Being told to act normal while struggling internally",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-pleasing-through-high-functioning-obedience",
+        "label": "Pleasing through high-functioning obedience",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-performing-submission-while-masking-resistance",
+        "label": "Performing submission while masking resistance",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-the-pressure-of-appearing-good-while-feeling-conflicted",
+        "label": "The pressure of appearing 'good' while feeling conflicted",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-being-made-to-perform-emotions-on-command-cry-beg-moan",
+        "label": "Being made to perform emotions on command (cry, beg, moan)",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-struggling-openly-while-still-obeying",
+        "label": "Struggling openly while still obeying",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-performing-exaggerated-resistance-or-denial",
+        "label": "Performing exaggerated resistance or denial",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-being-punished-for-breaking-character",
+        "label": "Being punished for 'breaking character'",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-putting-on-a-show-for-someone-else-s-pleasure",
+        "label": "Putting on a show for someone else’s pleasure",
+        "type": "scale"
+      },
+      {
+        "id": "performance-internal-struggle-general-rehearsed-degradation-or-humiliation-scripts",
+        "label": "Rehearsed degradation or humiliation scripts",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Mindfuck & Manipulation",
+    "items": [
+      {
+        "id": "mindfuck-manipulation-giving-confusing-commands-and-reality-shifts",
+        "label": "Confusing commands and reality shifts",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-gaslighting-or-contradictory-cues",
+        "label": "Gaslighting or contradictory cues",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-presenting-false-choices",
+        "label": "Presenting false choices",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-hidden-motives-or-secret-tasks",
+        "label": "Hidden motives or secret tasks",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-illogical-rules-meant-to-confuse",
+        "label": "Illogical rules meant to confuse",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-gaslight-style-scenes-with-consent-and-clarity",
+        "label": "Gaslight-style scenes (with consent and clarity)",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-false-threats-or-staged-surprises",
+        "label": "False threats or staged surprises",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-confusing-commands-to-prompt-hesitation",
+        "label": "Confusing commands to prompt hesitation",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-emotional-trickery-as-arousal",
+        "label": "Emotional trickery as arousal",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-being-misled-or-deceived-on-purpose-during-play",
+        "label": "Being misled or deceived on purpose during play",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-surprise-rule-changes-or-twists-mid-scene",
+        "label": "Surprise rule changes or twists mid-scene",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-false-safeword-games-with-negotiated-limits",
+        "label": "False safeword games (with negotiated limits)",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-withholding-or-delaying-aftercare-for-effect",
+        "label": "Withholding or delaying aftercare for effect",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-being-gaslit-or-doubted-in-a-controlled-roleplay",
+        "label": "Being gaslit or doubted in a controlled roleplay",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-giving-told-you-asked-for-this-or-you-love-this-when-resisting",
+        "label": "Told 'you asked for this' or 'you love this' when resisting",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-confusing-commands-and-reality-shifts",
+        "label": "Confusing commands and reality shifts",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-gaslighting-or-contradictory-cues",
+        "label": "Gaslighting or contradictory cues",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-presenting-false-choices",
+        "label": "Presenting false choices",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-hidden-motives-or-secret-tasks",
+        "label": "Hidden motives or secret tasks",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-illogical-rules-meant-to-confuse",
+        "label": "Illogical rules meant to confuse",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-gaslight-style-scenes-with-consent-and-clarity",
+        "label": "Gaslight-style scenes (with consent and clarity)",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-false-threats-or-staged-surprises",
+        "label": "False threats or staged surprises",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-confusing-commands-to-prompt-hesitation",
+        "label": "Confusing commands to prompt hesitation",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-emotional-trickery-as-arousal",
+        "label": "Emotional trickery as arousal",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-being-misled-or-deceived-on-purpose-during-play",
+        "label": "Being misled or deceived on purpose during play",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-surprise-rule-changes-or-twists-mid-scene",
+        "label": "Surprise rule changes or twists mid-scene",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-false-safeword-games-with-negotiated-limits",
+        "label": "False safeword games (with negotiated limits)",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-withholding-or-delaying-aftercare-for-effect",
+        "label": "Withholding or delaying aftercare for effect",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-being-gaslit-or-doubted-in-a-controlled-roleplay",
+        "label": "Being gaslit or doubted in a controlled roleplay",
+        "type": "scale"
+      },
+      {
+        "id": "mindfuck-manipulation-receiving-told-you-asked-for-this-or-you-love-this-when-resisting",
+        "label": "Told 'you asked for this' or 'you love this' when resisting",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Mouth Play",
+    "items": [
+      {
+        "id": "mouth-play-giving-holding-tools-or-restraints-in-teeth-while-crawling",
+        "label": "Holding tools or restraints in teeth while crawling",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-placing-objects-from-mouth-into-dominant-s-palm",
+        "label": "Placing objects from mouth into Dominant’s palm",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-using-mouth-instead-of-hands-for-service-rituals",
+        "label": "Using mouth instead of hands for service rituals",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-gag-presentation-and-silent-waiting-protocol",
+        "label": "Gag presentation and silent waiting protocol",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-holding-objects-in-teeth-while-crawling",
+        "label": "Holding objects in teeth while crawling",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-returning-items-using-mouth-only",
+        "label": "Returning items using mouth only",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-gag-rituals-or-waiting-silently",
+        "label": "Gag rituals or waiting silently",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-leash-held-in-mouth",
+        "label": "Leash held in mouth",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-being-gagged-or-forced-silent",
+        "label": "Being gagged or forced silent",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-having-to-hold-objects-in-your-mouth-spoon-hairbrush-leash",
+        "label": "Having to hold objects in your mouth (spoon, hairbrush, leash)",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-being-used-for-oral-service-without-reciprocal-pleasure",
+        "label": "Being used for oral service without reciprocal pleasure",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-being-fed-by-hand-mouth-to-mouth-or-with-utensils",
+        "label": "Being fed by hand, mouth-to-mouth, or with utensils",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-verbal-control-e-g-only-speak-when-spoken-to",
+        "label": "Verbal control (e.g., only speak when spoken to)",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-giving-mouth-as-a-symbol-of-ownership-or-control",
+        "label": "Mouth as a symbol of ownership or control",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-holding-tools-or-restraints-in-teeth-while-crawling",
+        "label": "Holding tools or restraints in teeth while crawling",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-placing-objects-from-mouth-into-dominant-s-palm",
+        "label": "Placing objects from mouth into Dominant’s palm",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-using-mouth-instead-of-hands-for-service-rituals",
+        "label": "Using mouth instead of hands for service rituals",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-gag-presentation-and-silent-waiting-protocol",
+        "label": "Gag presentation and silent waiting protocol",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-holding-objects-in-teeth-while-crawling",
+        "label": "Holding objects in teeth while crawling",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-returning-items-using-mouth-only",
+        "label": "Returning items using mouth only",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-gag-rituals-or-waiting-silently",
+        "label": "Gag rituals or waiting silently",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-leash-held-in-mouth",
+        "label": "Leash held in mouth",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-being-gagged-or-forced-silent",
+        "label": "Being gagged or forced silent",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-having-to-hold-objects-in-your-mouth-spoon-hairbrush-leash",
+        "label": "Having to hold objects in your mouth (spoon, hairbrush, leash)",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-being-used-for-oral-service-without-reciprocal-pleasure",
+        "label": "Being used for oral service without reciprocal pleasure",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-being-fed-by-hand-mouth-to-mouth-or-with-utensils",
+        "label": "Being fed by hand, mouth-to-mouth, or with utensils",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-verbal-control-e-g-only-speak-when-spoken-to",
+        "label": "Verbal control (e.g., only speak when spoken to)",
+        "type": "scale"
+      },
+      {
+        "id": "mouth-play-receiving-mouth-as-a-symbol-of-ownership-or-control",
+        "label": "Mouth as a symbol of ownership or control",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Impact Play",
+    "items": [
+      {
+        "id": "impact-play-giving-hand-spanking",
+        "label": "Hand spanking",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-giving-paddle-strikes",
+        "label": "Paddle strikes",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-giving-crop-snaps",
+        "label": "Crop snaps",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-giving-flogger-swings",
+        "label": "Flogger swings",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-giving-cane-strokes",
+        "label": "Cane strokes",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-giving-belt-or-strap-hits",
+        "label": "Belt or strap hits",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-giving-whip-cracks",
+        "label": "Whip cracks",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-receiving-hand-spanking",
+        "label": "Hand spanking",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-receiving-paddle-strikes",
+        "label": "Paddle strikes",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-receiving-crop-snaps",
+        "label": "Crop snaps",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-receiving-flogger-swings",
+        "label": "Flogger swings",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-receiving-cane-strokes",
+        "label": "Cane strokes",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-receiving-belt-or-strap-hits",
+        "label": "Belt or strap hits",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-receiving-whip-cracks",
+        "label": "Whip cracks",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-general-preferred-intensity-levels",
+        "label": "Preferred intensity levels",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-general-aftercare-for-bruises",
+        "label": "Aftercare for bruises",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-general-target-body-areas",
+        "label": "Target body areas",
+        "type": "scale"
+      },
+      {
+        "id": "impact-play-general-implement-selection",
+        "label": "Implement selection",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Medical Play",
+    "items": [
+      {
+        "id": "medical-play-giving-needle-play",
+        "label": "Needle play",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-giving-catheter-insertion",
+        "label": "Catheter insertion",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-giving-speculum-exams",
+        "label": "Speculum exams",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-giving-enema-administration",
+        "label": "Enema administration",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-giving-temperature-taking",
+        "label": "Temperature taking",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-giving-medical-restraints",
+        "label": "Medical restraints",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-giving-doctor-nurse-roleplay",
+        "label": "Doctor/nurse roleplay",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-receiving-needle-play",
+        "label": "Needle play",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-receiving-catheter-insertion",
+        "label": "Catheter insertion",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-receiving-speculum-exams",
+        "label": "Speculum exams",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-receiving-enema-administration",
+        "label": "Enema administration",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-receiving-temperature-taking",
+        "label": "Temperature taking",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-receiving-medical-restraints",
+        "label": "Medical restraints",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-receiving-doctor-nurse-roleplay",
+        "label": "Doctor/nurse roleplay",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-general-sterilization-procedures",
+        "label": "Sterilization procedures",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-general-professional-vs-roleplay-scenes",
+        "label": "Professional vs roleplay scenes",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-general-consent-for-invasive-acts",
+        "label": "Consent for invasive acts",
+        "type": "scale"
+      },
+      {
+        "id": "medical-play-general-access-to-medical-equipment",
+        "label": "Access to medical equipment",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Pet Play",
+    "items": [
+      {
+        "id": "pet-play-giving-puppy-or-kitten-play",
+        "label": "Puppy or kitten play",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-giving-pony-play",
+        "label": "Pony play",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-giving-wearing-collar-and-leash",
+        "label": "Wearing collar and leash",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-giving-eating-from-a-bowl",
+        "label": "Eating from a bowl",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-giving-kenneling-or-caging",
+        "label": "Kenneling or caging",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-giving-pet-training-commands",
+        "label": "Pet training commands",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-giving-animal-costumes-or-gear",
+        "label": "Animal costumes or gear",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-receiving-puppy-or-kitten-play",
+        "label": "Puppy or kitten play",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-receiving-pony-play",
+        "label": "Pony play",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-receiving-wearing-collar-and-leash",
+        "label": "Wearing collar and leash",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-receiving-eating-from-a-bowl",
+        "label": "Eating from a bowl",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-receiving-kenneling-or-caging",
+        "label": "Kenneling or caging",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-receiving-pet-training-commands",
+        "label": "Pet training commands",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-receiving-animal-costumes-or-gear",
+        "label": "Animal costumes or gear",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-general-preferred-animal-identities",
+        "label": "Preferred animal identities",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-general-public-vs-private-play",
+        "label": "Public vs private play",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-general-training-style-and-discipline",
+        "label": "Training style and discipline",
+        "type": "scale"
+      },
+      {
+        "id": "pet-play-general-use-of-pet-names-and-commands",
+        "label": "Use of pet names and commands",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Body Modification",
+    "items": [
+      {
+        "id": "body-modification-giving-piercings",
+        "label": "Piercings",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-giving-tattoos",
+        "label": "Tattoos",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-giving-branding",
+        "label": "Branding",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-giving-scarification",
+        "label": "Scarification",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-giving-permanent-chastity-devices",
+        "label": "Permanent chastity devices",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-giving-cosmetic-implants",
+        "label": "Cosmetic implants",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-giving-stretching-or-gauges",
+        "label": "Stretching or gauges",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-receiving-piercings",
+        "label": "Piercings",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-receiving-tattoos",
+        "label": "Tattoos",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-receiving-branding",
+        "label": "Branding",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-receiving-scarification",
+        "label": "Scarification",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-receiving-permanent-chastity-devices",
+        "label": "Permanent chastity devices",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-receiving-cosmetic-implants",
+        "label": "Cosmetic implants",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-receiving-stretching-or-gauges",
+        "label": "Stretching or gauges",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-general-temporary-vs-permanent-changes",
+        "label": "Temporary vs permanent changes",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-general-professional-vs-diy-methods",
+        "label": "Professional vs DIY methods",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-general-body-placement-considerations",
+        "label": "Body placement considerations",
+        "type": "scale"
+      },
+      {
+        "id": "body-modification-general-healing-and-aftercare",
+        "label": "Healing and aftercare",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Relationship Preferences",
+    "items": [
+      {
+        "id": "relationship-preferences-general-preferred-relationship-style",
+        "label": "Preferred relationship style",
+        "type": "text"
+      },
+      {
+        "id": "relationship-preferences-general-relationship-goals",
+        "label": "Relationship goals",
+        "type": "text"
+      },
+      {
+        "id": "relationship-preferences-general-monogamous",
+        "label": "Monogamous",
+        "type": "scale"
+      },
+      {
+        "id": "relationship-preferences-general-polyamorous",
+        "label": "Polyamorous",
+        "type": "scale"
+      },
+      {
+        "id": "relationship-preferences-general-hierarchical-dynamics",
+        "label": "Hierarchical dynamics",
+        "type": "scale"
+      },
+      {
+        "id": "relationship-preferences-general-non-hierarchical-poly",
+        "label": "Non-hierarchical poly",
+        "type": "scale"
+      },
+      {
+        "id": "relationship-preferences-general-solo-poly",
+        "label": "Solo-poly",
+        "type": "scale"
+      },
+      {
+        "id": "relationship-preferences-general-open-with-boundaries",
+        "label": "Open with boundaries",
+        "type": "scale"
+      },
+      {
+        "id": "relationship-preferences-general-closed-but-kinky-with-others",
+        "label": "Closed but kinky with others",
+        "type": "scale"
+      },
+      {
+        "id": "relationship-preferences-general-switch-friendly-dynamics",
+        "label": "Switch-friendly dynamics",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Gender Play & Transformation",
+    "items": [
+      {
+        "id": "gender-play-transformation-giving-crossdressing",
+        "label": "Crossdressing",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-giving-forced-feminization",
+        "label": "Forced feminization",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-giving-forced-masculinization",
+        "label": "Forced masculinization",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-giving-gender-role-reversal",
+        "label": "Gender role reversal",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-giving-pronoun-changes",
+        "label": "Pronoun changes",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-giving-voice-or-mannerism-training",
+        "label": "Voice or mannerism training",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-giving-sissy-or-tomboy-persona",
+        "label": "Sissy or tomboy persona",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-receiving-crossdressing",
+        "label": "Crossdressing",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-receiving-forced-feminization",
+        "label": "Forced feminization",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-receiving-forced-masculinization",
+        "label": "Forced masculinization",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-receiving-gender-role-reversal",
+        "label": "Gender role reversal",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-receiving-pronoun-changes",
+        "label": "Pronoun changes",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-receiving-voice-or-mannerism-training",
+        "label": "Voice or mannerism training",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-receiving-sissy-or-tomboy-persona",
+        "label": "Sissy or tomboy persona",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-general-preferred-pronouns-and-names",
+        "label": "Preferred pronouns and names",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-general-public-presentation-comfort",
+        "label": "Public presentation comfort",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-general-clothing-and-appearance",
+        "label": "Clothing and appearance",
+        "type": "scale"
+      },
+      {
+        "id": "gender-play-transformation-general-exploration-of-identity",
+        "label": "Exploration of identity",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Chastity Devices",
+    "items": [
+      {
+        "id": "chastity-devices-giving-wearing-a-chastity-cage-short-term",
+        "label": "Wearing a chastity cage (short term)",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-giving-long-term-chastity-training",
+        "label": "Long-term chastity training",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-giving-chastity-device-control-with-permission-to-unlock",
+        "label": "Chastity device control with permission to unlock",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-giving-locked-remotely-by-another-person",
+        "label": "Locked remotely by another person",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-giving-orgasm-denial-enforced-by-chastity",
+        "label": "Orgasm denial enforced by chastity",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-giving-wearing-a-belt-style-chastity-device",
+        "label": "Wearing a belt-style chastity device",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-giving-humiliation-while-locked-in-chastity",
+        "label": "Humiliation while locked in chastity",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-giving-sleep-in-chastity-overnight",
+        "label": "Sleep in chastity (overnight)",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-giving-being-teased-while-unable-to-touch-yourself",
+        "label": "Being teased while unable to touch yourself",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-giving-begging-for-release-from-chastity",
+        "label": "Begging for release from chastity",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-receiving-wearing-a-chastity-cage-short-term",
+        "label": "Wearing a chastity cage (short term)",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-receiving-long-term-chastity-training",
+        "label": "Long-term chastity training",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-receiving-chastity-device-control-with-permission-to-unlock",
+        "label": "Chastity device control with permission to unlock",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-receiving-locked-remotely-by-another-person",
+        "label": "Locked remotely by another person",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-receiving-orgasm-denial-enforced-by-chastity",
+        "label": "Orgasm denial enforced by chastity",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-receiving-wearing-a-belt-style-chastity-device",
+        "label": "Wearing a belt-style chastity device",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-receiving-humiliation-while-locked-in-chastity",
+        "label": "Humiliation while locked in chastity",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-receiving-sleep-in-chastity-overnight",
+        "label": "Sleep in chastity (overnight)",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-receiving-being-teased-while-unable-to-touch-yourself",
+        "label": "Being teased while unable to touch yourself",
+        "type": "scale"
+      },
+      {
+        "id": "chastity-devices-receiving-begging-for-release-from-chastity",
+        "label": "Begging for release from chastity",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Shibari & Rope Bondage",
+    "items": [
+      {
+        "id": "shibari-rope-bondage-giving-being-tied-in-aesthetic-rope-patterns-shibari",
+        "label": "Being tied in aesthetic rope patterns (Shibari)",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-giving-rope-bondage-for-restraint-and-control",
+        "label": "Rope bondage for restraint and control",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-giving-rope-suspension-partial-or-full",
+        "label": "Rope suspension (partial or full)",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-giving-learning-to-tie-rope-as-a-form-of-dominance",
+        "label": "Learning to tie rope as a form of dominance",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-giving-being-tied-in-vulnerable-or-exposing-poses",
+        "label": "Being tied in vulnerable or exposing poses",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-giving-practicing-rope-with-emotional-connection",
+        "label": "Practicing rope with emotional connection",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-giving-enduring-discomfort-for-the-beauty-of-the-rope",
+        "label": "Enduring discomfort for the beauty of the rope",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-giving-being-tied-in-a-mirror-and-told-to-look",
+        "label": "Being tied in a mirror and told to look",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-giving-punishment-ties-e-g-uncomfortable-or-humiliating-positions",
+        "label": "Punishment ties (e.g., uncomfortable or humiliating positions)",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-giving-solo-rope-practice-for-mindfulness-or-masochism",
+        "label": "Solo rope practice for mindfulness or masochism",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-receiving-being-tied-in-aesthetic-rope-patterns-shibari",
+        "label": "Being tied in aesthetic rope patterns (Shibari)",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-receiving-rope-bondage-for-restraint-and-control",
+        "label": "Rope bondage for restraint and control",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-receiving-rope-suspension-partial-or-full",
+        "label": "Rope suspension (partial or full)",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-receiving-learning-to-tie-rope-as-a-form-of-dominance",
+        "label": "Learning to tie rope as a form of dominance",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-receiving-being-tied-in-vulnerable-or-exposing-poses",
+        "label": "Being tied in vulnerable or exposing poses",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-receiving-practicing-rope-with-emotional-connection",
+        "label": "Practicing rope with emotional connection",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-receiving-enduring-discomfort-for-the-beauty-of-the-rope",
+        "label": "Enduring discomfort for the beauty of the rope",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-receiving-being-tied-in-a-mirror-and-told-to-look",
+        "label": "Being tied in a mirror and told to look",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-receiving-punishment-ties-e-g-uncomfortable-or-humiliating-positions",
+        "label": "Punishment ties (e.g., uncomfortable or humiliating positions)",
+        "type": "scale"
+      },
+      {
+        "id": "shibari-rope-bondage-receiving-solo-rope-practice-for-mindfulness-or-masochism",
+        "label": "Solo rope practice for mindfulness or masochism",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Cosplay & Identity Play",
+    "items": [
+      {
+        "id": "cosplay-identity-play-giving-dressing-up-in-costumes-for-scenes",
+        "label": "Dressing up in costumes for scenes",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-giving-playing-as-fictional-characters",
+        "label": "Playing as fictional characters",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-giving-petplay-with-collars-ears-or-tails",
+        "label": "Petplay with collars, ears, or tails",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-giving-pretending-to-be-a-doll-robot-or-object",
+        "label": "Pretending to be a doll, robot, or object",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-giving-master-slave-cosplay-dynamic-non-24-7",
+        "label": "Master/slave cosplay dynamic (non-24/7)",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-giving-roleplaying-as-a-fantasy-species-or-non-human",
+        "label": "Roleplaying as a fantasy species or non-human",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-giving-using-cosplay-to-deepen-power-exchange",
+        "label": "Using cosplay to deepen power exchange",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-giving-scene-built-around-a-character-s-story-or-world",
+        "label": "Scene built around a character’s story or world",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-giving-fantasy-uniforms-nurse-teacher-etc",
+        "label": "Fantasy uniforms (nurse, teacher, etc.)",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-receiving-dressing-up-in-costumes-for-scenes",
+        "label": "Dressing up in costumes for scenes",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-receiving-playing-as-fictional-characters",
+        "label": "Playing as fictional characters",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-receiving-petplay-with-collars-ears-or-tails",
+        "label": "Petplay with collars, ears, or tails",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-receiving-pretending-to-be-a-doll-robot-or-object",
+        "label": "Pretending to be a doll, robot, or object",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-receiving-master-slave-cosplay-dynamic-non-24-7",
+        "label": "Master/slave cosplay dynamic (non-24/7)",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-receiving-roleplaying-as-a-fantasy-species-or-non-human",
+        "label": "Roleplaying as a fantasy species or non-human",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-receiving-using-cosplay-to-deepen-power-exchange",
+        "label": "Using cosplay to deepen power exchange",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-receiving-scene-built-around-a-character-s-story-or-world",
+        "label": "Scene built around a character’s story or world",
+        "type": "scale"
+      },
+      {
+        "id": "cosplay-identity-play-receiving-fantasy-uniforms-nurse-teacher-etc",
+        "label": "Fantasy uniforms (nurse, teacher, etc.)",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "High-Intensity Kinks (SSC-Aware)",
+    "items": [
+      {
+        "id": "high-intensity-kinks-ssc-aware-giving-intense-breath-play-e-g-smothering-or-pressure",
+        "label": "Intense breath play (e.g., smothering or pressure)",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-giving-knife-play-or-blade-play-without-injury",
+        "label": "Knife play or blade play (without injury)",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-giving-fear-play-using-known-or-negotiated-triggers",
+        "label": "Fear play using known or negotiated triggers",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-giving-abduction-or-home-invasion-style-roleplay-negotiated",
+        "label": "Abduction or home-invasion style roleplay (negotiated)",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-giving-medical-themed-scenes-with-sharp-objects-not-bloodletting",
+        "label": "Medical-themed scenes with sharp objects (not bloodletting)",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-giving-sensory-deprivation-with-added-disorientation-or-helplessness",
+        "label": "Sensory deprivation with added disorientation or helplessness",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-giving-scenes-involving-heavy-objectification-or-emotional-manipulation-with-care",
+        "label": "Scenes involving heavy objectification or emotional manipulation (with care)",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-giving-mock-interrogation-or-intense-role-pressure",
+        "label": "Mock interrogation or intense role pressure",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-giving-consensual-threats-without-follow-through-e-g-if-you-don-t",
+        "label": "Consensual threats without follow-through (e.g. 'If you don’t...')",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-giving-high-intensity-primal-scenes-involving-struggle-or-fear",
+        "label": "High-intensity primal scenes involving struggle or fear",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-receiving-intense-breath-play-e-g-smothering-or-pressure",
+        "label": "Intense breath play (e.g., smothering or pressure)",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-receiving-knife-play-or-blade-play-without-injury",
+        "label": "Knife play or blade play (without injury)",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-receiving-fear-play-using-known-or-negotiated-triggers",
+        "label": "Fear play using known or negotiated triggers",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-receiving-abduction-or-home-invasion-style-roleplay-negotiated",
+        "label": "Abduction or home-invasion style roleplay (negotiated)",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-receiving-medical-themed-scenes-with-sharp-objects-not-bloodletting",
+        "label": "Medical-themed scenes with sharp objects (not bloodletting)",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-receiving-sensory-deprivation-with-added-disorientation-or-helplessness",
+        "label": "Sensory deprivation with added disorientation or helplessness",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-receiving-scenes-involving-heavy-objectification-or-emotional-manipulation-with-care",
+        "label": "Scenes involving heavy objectification or emotional manipulation (with care)",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-receiving-mock-interrogation-or-intense-role-pressure",
+        "label": "Mock interrogation or intense role pressure",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-receiving-consensual-threats-without-follow-through-e-g-if-you-don-t",
+        "label": "Consensual threats without follow-through (e.g. 'If you don’t...')",
+        "type": "scale"
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-receiving-high-intensity-primal-scenes-involving-struggle-or-fear",
+        "label": "High-intensity primal scenes involving struggle or fear",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Behavioral Play",
+    "items": [
+      {
+        "id": "behavioral-play-giving-assigning-corner-time-or-time-outs",
+        "label": "Assigning corner time or time-outs",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-giving-writing-lines-or-apology-letters-as-correction",
+        "label": "Writing lines or apology letters as correction",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-giving-removing-privileges-phone-tv-sweets",
+        "label": "Removing privileges (phone, TV, sweets)",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-giving-playful-punishments-that-still-reinforce-rules",
+        "label": "Playful punishments that still reinforce rules",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-giving-lecturing-or-scolding-to-modify-behavior",
+        "label": "Lecturing or scolding to modify behavior",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-receiving-being-placed-in-the-corner-or-given-a-time-out",
+        "label": "Being placed in the corner or given a time-out",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-receiving-writing-lines-or-apology-letters-when-misbehaving",
+        "label": "Writing lines or apology letters when misbehaving",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-receiving-having-privileges-revoked-phone-tv",
+        "label": "Having privileges revoked (phone, TV)",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-receiving-receiving-playful-funishments-for-minor-rule-breaking",
+        "label": "Receiving playful 'funishments' for minor rule-breaking",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-receiving-getting-scolded-or-lectured-for-correction",
+        "label": "Getting scolded or lectured for correction",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-general-preferred-style-of-discipline-strict-vs-lenient",
+        "label": "Preferred style of discipline (strict vs lenient)",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-general-attitude-toward-funishment-vs-serious-correction",
+        "label": "Attitude toward funishment vs serious correction",
+        "type": "scale"
+      },
+      {
+        "id": "behavioral-play-general-use-of-behavior-contracts-or-rule-agreements",
+        "label": "Use of behavior contracts or rule agreements",
+        "type": "scale"
+      }
+    ]
+  },
+  {
+    "category": "Appearance Play",
+    "items": [
+      {
+        "id": "appearance-play-giving-choosing-my-partner-s-outfit-for-the-day-or-a-scene",
+        "label": "Choosing my partner’s outfit for the day or a scene",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-giving-selecting-their-underwear-lingerie-or-base-layers",
+        "label": "Selecting their underwear, lingerie, or base layers",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-giving-styling-their-hair-braiding-brushing-tying-etc",
+        "label": "Styling their hair (braiding, brushing, tying, etc.)",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-giving-picking-head-coverings-bonnets-veils-hoods-hats-for-mood-or-protocol",
+        "label": "Picking head coverings (bonnets, veils, hoods, hats) for mood or protocol",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-giving-offering-makeup-polish-or-accessories-as-part-of-ritual-or-play",
+        "label": "Offering makeup, polish, or accessories as part of ritual or play",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-giving-creating-themed-looks-slutty-innocent-doll-like-sharp-etc",
+        "label": "Creating themed looks (slutty, innocent, doll-like, sharp, etc.)",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-giving-dressing-them-in-role-specific-costumes-maid-bunny-doll-etc",
+        "label": "Dressing them in role-specific costumes (maid, bunny, doll, etc.)",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-giving-curating-time-period-or-historical-outfits-e-g-victorian-50s",
+        "label": "Curating time-period or historical outfits (e.g., Victorian, 50s)",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-giving-helping-them-present-more-femme-masc-or-androgynous-by-request",
+        "label": "Helping them present more femme, masc, or androgynous by request",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-giving-coordinating-their-look-with-mine-for-public-or-private-scenes",
+        "label": "Coordinating their look with mine for public or private scenes",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-giving-implementing-a-dress-ritual-or-aesthetic-preparation",
+        "label": "Implementing a “dress ritual” or aesthetic preparation",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-giving-enforcing-a-visual-protocol-e-g-no-bra-heels-required-tied-hair",
+        "label": "Enforcing a visual protocol (e.g., no bra, heels required, tied hair)",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-having-my-outfit-selected-for-me-by-a-partner",
+        "label": "Having my outfit selected for me by a partner",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-wearing-the-underwear-or-lingerie-they-choose",
+        "label": "Wearing the underwear or lingerie they choose",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-having-my-hair-brushed-braided-tied-or-styled-for-them",
+        "label": "Having my hair brushed, braided, tied, or styled for them",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-putting-on-a-head-covering-e-g-bonnet-veil-hood-they-chose",
+        "label": "Putting on a head covering (e.g., bonnet, veil, hood) they chose",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-following-visual-appearance-rules-as-part-of-submission",
+        "label": "Following visual appearance rules as part of submission",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-wearing-makeup-polish-or-accessories-they-request",
+        "label": "Wearing makeup, polish, or accessories they request",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-dressing-to-please-their-vision-cute-filthy-classy-etc",
+        "label": "Dressing to please their vision (cute, filthy, classy, etc.)",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-wearing-roleplay-costumes-or-character-looks",
+        "label": "Wearing roleplay costumes or character looks",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-presenting-in-a-way-that-matches-their-chosen-aesthetic",
+        "label": "Presenting in a way that matches their chosen aesthetic",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-participating-in-dressing-rituals-or-undressing-ceremonies",
+        "label": "Participating in dressing rituals or undressing ceremonies",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-being-admired-for-the-way-i-look-under-their-direction",
+        "label": "Being admired for the way I look under their direction",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-receiving-receiving-praise-or-gentle-teasing-about-my-appearance",
+        "label": "Receiving praise or gentle teasing about my appearance",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-general-cosplay-or-fantasy-looks-anime-game-fairytale-etc",
+        "label": "Cosplay or fantasy looks (anime, game, fairytale, etc.)",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-general-time-period-dress-up-regency-gothic-1920s-etc",
+        "label": "Time-period dress-up (regency, gothic, 1920s, etc.)",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-general-dollification-or-polished-presented-object-aesthetics",
+        "label": "Dollification or polished/presented object aesthetics",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-general-uniforms-schoolgirl-military-clerical-nurse-etc",
+        "label": "Uniforms (schoolgirl, military, clerical, nurse, etc.)",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-general-hair-based-play-forced-brushing-ribbons-or-tied-styles",
+        "label": "Hair-based play (forced brushing, ribbons, or tied styles)",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-general-head-coverings-or-symbolic-hoods-in-ritualized-dynamics",
+        "label": "Head coverings or symbolic hoods in ritualized dynamics",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-general-matching-looks-or-coordinated-dress-codes",
+        "label": "Matching looks or coordinated dress codes",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-general-ritualized-grooming-before-scenes",
+        "label": "Ritualized grooming before scenes",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-general-praise-or-positive-attention-for-pleasing-visual-display",
+        "label": "Praise or positive attention for pleasing visual display",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-general-formal-appearance-protocols-for-scenes-or-dynamics",
+        "label": "Formal appearance protocols for scenes or dynamics",
+        "type": "scale"
+      },
+      {
+        "id": "appearance-play-general-using-clothing-or-style-to-embody-emotional-or-power-roles",
+        "label": "Using clothing or style to embody emotional or power roles",
+        "type": "scale"
+      }
+    ]
+  }
+]

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "check:conflicts": "node scripts/check-conflicts.js",
     "precommit": "npm run check:conflicts",
     "reason:kinks": "node scripts/reason-kinks-json.mjs",
-    "kinks:flatten": "node scripts/flatten_kinks.mjs"
+    "kinks:flatten": "node scripts/flatten_kinks.mjs",
+    "kinks:data": "node scripts/generate-kinks-data.mjs && node scripts/sync-kinks-json.mjs",
+    "kinks:sync": "node scripts/sync-kinks-json.mjs"
   },
   "keywords": [],
   "author": "",

--- a/scripts/sync-kinks-json.mjs
+++ b/scripts/sync-kinks-json.mjs
@@ -1,0 +1,42 @@
+// Ensure the kink dataset is present at all URLs the /kinks page will try.
+// Usage: node scripts/sync-kinks-json.mjs
+import { promises as fs } from "fs";
+import path from "path";
+
+const repoRoot = process.cwd();
+const src = path.join(repoRoot, "data", "kinks.json");
+
+const targets = [
+  // site root fallbacks used by the client
+  path.join(repoRoot, "kinks.json"),
+  path.join(repoRoot, "data", "kinks.json"),
+
+  // GitHub Pages when publishing from /docs (both forms)
+  path.join(repoRoot, "docs", "kinks.json"),
+  path.join(repoRoot, "docs", "data", "kinks.json"),
+  path.join(repoRoot, "docs", "kinks", "data", "kinks.json"),
+];
+
+async function ensureDir(p) { await fs.mkdir(path.dirname(p), { recursive: true }); }
+
+async function main() {
+  try {
+    const buf = await fs.readFile(src);
+    const pretty = JSON.stringify(JSON.parse(buf.toString()), null, 2); // validate & normalize
+    let wrote = 0;
+    for (const t of targets) {
+      await ensureDir(t);
+      await fs.writeFile(t, pretty + "\n");
+      wrote++;
+    }
+    console.log(`✅ Synced kinks dataset to ${wrote} locations.`);
+    console.log("   Source:", src);
+    targets.forEach(t => console.log("   →", path.relative(repoRoot, t)));
+  } catch (e) {
+    console.error("❌ Could not sync dataset:", e?.message || e);
+    console.error("Hint: generate it first with:  node scripts/generate-kinks-data.mjs");
+    process.exit(1);
+  }
+}
+main();
+


### PR DESCRIPTION
## Summary
- add a sync helper that copies data/kinks.json to all endpoints the site may request
- wire the sync helper into npm scripts and generate fresh artifacts for the docs deployment

## Testing
- npm run -s kinks:data

------
https://chatgpt.com/codex/tasks/task_e_68d838e12650832c885747d3bf137d8f