### PR TITLE
Rebuild hero layout for Talk Kink survey entry points

### DIFF
--- a/css/kinksurvey_overrides.css
+++ b/css/kinksurvey_overrides.css
@@ -1,0 +1,40 @@
+.tk-hero{
+  display:flex; flex-direction:column; align-items:center; gap:18px;
+  margin:6px auto 26px; text-align:center;
+}
+.tk-heroTop{display:flex; justify-content:center}
+.tk-heroRow{display:flex; gap:14px; flex-wrap:wrap; justify-content:center}
+
+/* Title like the screenshot */
+.tk-title{
+  font-weight:900; letter-spacing:.3px;
+  font-size: clamp(28px, 4.6vw, 54px);
+  margin: 8px 0 6px;
+  color: #d6fbff;
+  text-shadow: 0 2px 0 #001317;
+}
+
+.tk-btn{
+  display:inline-block; padding:14px 22px; border:2px solid var(--tk-btn-bd);
+  border-radius:12px; background:var(--tk-btn-bg); color:var(--tk-btn-fg);
+  cursor:pointer; font-weight:800; letter-spacing:.2px; transition:.15s;
+}
+.tk-btn:hover{transform:translateY(-1px)}
+.tk-btn.xl{padding:16px 26px; font-size:1.05rem}
+
+/* Pill links row (Compatibility / IKA / Request…) */
+.tk-pill{
+  display:inline-block; padding:12px 18px;
+  border:2px solid var(--tk-btn-bd); border-radius:12px;
+  background: transparent; color: var(--tk-fg); text-decoration:none;
+  font-weight:800; letter-spacing:.15px;
+  box-shadow: 0 0 0 1px #00141a inset;
+}
+.tk-pill:hover{background:#032029; transform:translateY(-1px)}
+
+/* Theme row */
+.tk-theme{display:flex; align-items:center; gap:10px; color:#c6f6ff; font-weight:700}
+.tk-theme select{
+  background:#071a1f; color:#eaffff; border:2px solid var(--tk-btn-bd);
+  border-radius:10px; padding:8px 12px; outline:none;
+}

--- a/docs/kinks/css/kinksurvey_overrides.css
+++ b/docs/kinks/css/kinksurvey_overrides.css
@@ -1,0 +1,40 @@
+.tk-hero{
+  display:flex; flex-direction:column; align-items:center; gap:18px;
+  margin:6px auto 26px; text-align:center;
+}
+.tk-heroTop{display:flex; justify-content:center}
+.tk-heroRow{display:flex; gap:14px; flex-wrap:wrap; justify-content:center}
+
+/* Title like the screenshot */
+.tk-title{
+  font-weight:900; letter-spacing:.3px;
+  font-size: clamp(28px, 4.6vw, 54px);
+  margin: 8px 0 6px;
+  color: #d6fbff;
+  text-shadow: 0 2px 0 #001317;
+}
+
+.tk-btn{
+  display:inline-block; padding:14px 22px; border:2px solid var(--tk-btn-bd);
+  border-radius:12px; background:var(--tk-btn-bg); color:var(--tk-btn-fg);
+  cursor:pointer; font-weight:800; letter-spacing:.2px; transition:.15s;
+}
+.tk-btn:hover{transform:translateY(-1px)}
+.tk-btn.xl{padding:16px 26px; font-size:1.05rem}
+
+/* Pill links row (Compatibility / IKA / Request…) */
+.tk-pill{
+  display:inline-block; padding:12px 18px;
+  border:2px solid var(--tk-btn-bd); border-radius:12px;
+  background: transparent; color: var(--tk-fg); text-decoration:none;
+  font-weight:800; letter-spacing:.15px;
+  box-shadow: 0 0 0 1px #00141a inset;
+}
+.tk-pill:hover{background:#032029; transform:translateY(-1px)}
+
+/* Theme row */
+.tk-theme{display:flex; align-items:center; gap:10px; color:#c6f6ff; font-weight:700}
+.tk-theme select{
+  background:#071a1f; color:#eaffff; border:2px solid var(--tk-btn-bd);
+  border-radius:10px; padding:8px 12px; outline:none;
+}

--- a/docs/kinks/index.html
+++ b/docs/kinks/index.html
@@ -13,6 +13,7 @@
 <!-- TK-DOCS END -->
   <link rel="stylesheet" href="./css/style.css?v=1758253846" id="tk-style-root" />
   <link rel="stylesheet" href="./css/theme.css?v=1758253846" id="tk-theme-root" />
+  <link rel="stylesheet" href="./css/kinksurvey_overrides.css">
   <script type="module" id="tk-theme-module" src="./js/theme.js?v=1758253846"></script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -884,6 +885,7 @@ How to use
   _log("[TK] clickfix applied. Try clicking the category checkboxes now.");
 })();
 </script>
+<script src="./js/tk_kinksurvey_enhance.js"></script>
 <!-- ✅ 1) Add this *once* near the end of every page that was freezing (before </body>) -->
 <script>
 /* ---------- TalkKink Safe Bootstrap (drop-in) ---------- */

--- a/docs/kinks/js/tk_kinksurvey_enhance.js
+++ b/docs/kinks/js/tk_kinksurvey_enhance.js
@@ -1,0 +1,107 @@
+/*! Talk Kink kinksurvey enhancements */
+(function(){
+  const $ = (sel, root = document) => root.querySelector(sel);
+  const $all = (sel, root = document) => Array.from(root.querySelectorAll(sel));
+  const el = (tag, attrs = {}, html = "") => {
+    const node = document.createElement(tag);
+    Object.entries(attrs).forEach(([key, value]) => {
+      if (value == null) return;
+      if (key === "class") node.className = value;
+      else node.setAttribute(key, value);
+    });
+    if (html) node.innerHTML = html;
+    return node;
+  };
+
+  function ensureHero(){
+    // If an old hero exists, replace it to avoid duplicates/styles from prior patches
+    $all('.tk-hero').forEach(n=>n.remove());
+
+    const legacyWrap = $('.landing-wrapper');
+    const wrap = legacyWrap?.parentElement || $('.wrap, main, .page, .kinks-root, body');
+    const anchor = legacyWrap || $('#categoryPanel') || $('.category-panel') || wrap?.firstChild;
+    if (!wrap || !anchor) return;
+
+    const hero = el('section',{class:'tk-hero','aria-label':'Main actions'});
+    hero.appendChild(el('h1',{class:'tk-title'},'Talk Kink — Survey'));
+
+    const heroTop = el('div',{class:'tk-heroTop'});
+    const startSelectors = ['#startSurvey','#startBtn','#start','#startSurveyBtn','[data-start]'];
+    let startNode = null;
+    for (const sel of startSelectors) {
+      const candidate = $(sel);
+      if (candidate) { startNode = candidate; break; }
+    }
+
+    let usingExistingStart = false;
+    if (legacyWrap && startNode && legacyWrap.contains(startNode)) {
+      startNode.classList.add('tk-btn','xl');
+      heroTop.appendChild(startNode);
+      usingExistingStart = true;
+    } else {
+      startNode = el('button',{class:'tk-btn xl', id:'tkHeroStart', type:'button'},'Start Survey');
+      heroTop.appendChild(startNode);
+    }
+    hero.appendChild(heroTop);
+
+    const pillRow = el('div',{class:'tk-heroRow'});
+    pillRow.innerHTML = `
+      <a class="tk-pill" href="/compatibility/">Compatibility Page</a>
+      <a class="tk-pill" href="/ika/">Individual Kink Analysis</a>
+      <a class="tk-pill" href="/apply/">Request to Join Mischief Manor</a>
+    `;
+    hero.appendChild(pillRow);
+
+    const themeRow = el('div',{class:'tk-heroRow', id:'tkThemeRow'});
+    hero.appendChild(themeRow);
+
+    if (anchor && anchor.parentNode === wrap) {
+      wrap.insertBefore(hero, anchor);
+    } else {
+      wrap.insertBefore(hero, wrap.firstChild);
+    }
+
+    // Move any existing theme selector into the theme row
+    const themeContainer = $('#tkThemeRow', hero);
+    const existingTheme =
+      (legacyWrap && $('#themeSelector', legacyWrap)) ||
+      $('#themeSelector') ||
+      $('.theme-select') ||
+      $('select[name="theme"]');
+    if (existingTheme) {
+      const label = el('label',{class:'tk-theme'},`Theme`);
+      label.appendChild(existingTheme);
+      themeContainer.appendChild(label);
+    } else {
+      // No theme selector present—hide the row
+      themeContainer.style.display='none';
+    }
+
+    // Preserve warnings/info blocks that previously lived inside the landing wrapper
+    if (legacyWrap) {
+      const warning = $('#warning', legacyWrap) || $('#warning');
+      if (warning && hero !== warning.parentNode) {
+        hero.appendChild(warning);
+      }
+    }
+
+    legacyWrap?.remove();
+
+    // Scroll/focus to panel Start on big Start click if we had to create a synthetic button
+    if (!usingExistingStart) {
+      const go = ()=> {
+        const panel = $('#categoryPanel') || $('.category-panel');
+        const start = $('#startBtn') || $('#startSurvey') || $('#startSurveyBtn') || $('[data-start]');
+        if (panel) panel.scrollIntoView({behavior:'smooth', block:'start'});
+        setTimeout(()=> start && start.focus && start.focus(), 300);
+      };
+      startNode?.addEventListener('click', go);
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', ensureHero);
+  } else {
+    ensureHero();
+  }
+})();

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <title>Talk Kink</title>
   <link rel="stylesheet" href="css/style.css" />
   <link rel="stylesheet" href="css/theme.css" />
+  <link rel="stylesheet" href="css/kinksurvey_overrides.css" />
 <link rel="stylesheet" href="/css/font-failopen.css">
 
 <!-- TK: home-start-router CSS -->
@@ -48,6 +49,7 @@
 
   });
   </script>
+  <script src="js/tk_kinksurvey_enhance.js"></script>
 <!-- ✅ 1) Add this *once* near the end of every page that was freezing (before </body>) -->
 <script>
 /* ---------- TalkKink Safe Bootstrap (drop-in) ---------- */

--- a/js/tk_kinksurvey_enhance.js
+++ b/js/tk_kinksurvey_enhance.js
@@ -1,0 +1,107 @@
+/*! Talk Kink kinksurvey enhancements */
+(function(){
+  const $ = (sel, root = document) => root.querySelector(sel);
+  const $all = (sel, root = document) => Array.from(root.querySelectorAll(sel));
+  const el = (tag, attrs = {}, html = "") => {
+    const node = document.createElement(tag);
+    Object.entries(attrs).forEach(([key, value]) => {
+      if (value == null) return;
+      if (key === "class") node.className = value;
+      else node.setAttribute(key, value);
+    });
+    if (html) node.innerHTML = html;
+    return node;
+  };
+
+  function ensureHero(){
+    // If an old hero exists, replace it to avoid duplicates/styles from prior patches
+    $all('.tk-hero').forEach(n=>n.remove());
+
+    const legacyWrap = $('.landing-wrapper');
+    const wrap = legacyWrap?.parentElement || $('.wrap, main, .page, .kinks-root, body');
+    const anchor = legacyWrap || $('#categoryPanel') || $('.category-panel') || wrap?.firstChild;
+    if (!wrap || !anchor) return;
+
+    const hero = el('section',{class:'tk-hero','aria-label':'Main actions'});
+    hero.appendChild(el('h1',{class:'tk-title'},'Talk Kink — Survey'));
+
+    const heroTop = el('div',{class:'tk-heroTop'});
+    const startSelectors = ['#startSurvey','#startBtn','#start','#startSurveyBtn','[data-start]'];
+    let startNode = null;
+    for (const sel of startSelectors) {
+      const candidate = $(sel);
+      if (candidate) { startNode = candidate; break; }
+    }
+
+    let usingExistingStart = false;
+    if (legacyWrap && startNode && legacyWrap.contains(startNode)) {
+      startNode.classList.add('tk-btn','xl');
+      heroTop.appendChild(startNode);
+      usingExistingStart = true;
+    } else {
+      startNode = el('button',{class:'tk-btn xl', id:'tkHeroStart', type:'button'},'Start Survey');
+      heroTop.appendChild(startNode);
+    }
+    hero.appendChild(heroTop);
+
+    const pillRow = el('div',{class:'tk-heroRow'});
+    pillRow.innerHTML = `
+      <a class="tk-pill" href="/compatibility/">Compatibility Page</a>
+      <a class="tk-pill" href="/ika/">Individual Kink Analysis</a>
+      <a class="tk-pill" href="/apply/">Request to Join Mischief Manor</a>
+    `;
+    hero.appendChild(pillRow);
+
+    const themeRow = el('div',{class:'tk-heroRow', id:'tkThemeRow'});
+    hero.appendChild(themeRow);
+
+    if (anchor && anchor.parentNode === wrap) {
+      wrap.insertBefore(hero, anchor);
+    } else {
+      wrap.insertBefore(hero, wrap.firstChild);
+    }
+
+    // Move any existing theme selector into the theme row
+    const themeContainer = $('#tkThemeRow', hero);
+    const existingTheme =
+      (legacyWrap && $('#themeSelector', legacyWrap)) ||
+      $('#themeSelector') ||
+      $('.theme-select') ||
+      $('select[name="theme"]');
+    if (existingTheme) {
+      const label = el('label',{class:'tk-theme'},`Theme`);
+      label.appendChild(existingTheme);
+      themeContainer.appendChild(label);
+    } else {
+      // No theme selector present—hide the row
+      themeContainer.style.display='none';
+    }
+
+    // Preserve warnings/info blocks that previously lived inside the landing wrapper
+    if (legacyWrap) {
+      const warning = $('#warning', legacyWrap) || $('#warning');
+      if (warning && hero !== warning.parentNode) {
+        hero.appendChild(warning);
+      }
+    }
+
+    legacyWrap?.remove();
+
+    // Scroll/focus to panel Start on big Start click if we had to create a synthetic button
+    if (!usingExistingStart) {
+      const go = ()=> {
+        const panel = $('#categoryPanel') || $('.category-panel');
+        const start = $('#startBtn') || $('#startSurvey') || $('#startSurveyBtn') || $('[data-start]');
+        if (panel) panel.scrollIntoView({behavior:'smooth', block:'start'});
+        setTimeout(()=> start && start.focus && start.focus(), 300);
+      };
+      startNode?.addEventListener('click', go);
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', ensureHero);
+  } else {
+    ensureHero();
+  }
+})();

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -93,6 +93,7 @@
   <!-- TK-HOTFIX START -->
   <link rel="stylesheet" href="/css/style.css?v=1730846400000" id="tk-style-root"/>
   <link rel="stylesheet" href="/css/theme.css?v=1730846400000" id="tk-theme-root"/>
+  <link rel="stylesheet" href="/css/kinksurvey_overrides.css">
   <!-- readable fallback so black text can't disappear on black bg -->
   <style id="tk-fallback">
     :root{ --tk-fg:#e6f2ff; --tk-accent:#00e6ff; }
@@ -1150,6 +1151,7 @@ How to use
 </script>
 <!-- ---------- End Safe Bootstrap ---------- -->
 
+<script src="/js/tk_kinksurvey_enhance.js"></script>
 <!-- TK-HOTFIX START -->
 <script id="tk-diag">
 (function(){


### PR DESCRIPTION
## Summary
- add a shared Talk Kink survey hero stylesheet with updated spacing, title, pills, and theme control styling
- create a hero enhancement script that rehomes the existing start button and theme selector into the new layout and removes the legacy wrapper
- load the new assets on the public survey landing pages and their docs copies so both versions share the refreshed hero

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d867debaa0832ca77f9e07ad4b6fd9