### PR TITLE
Add kinksurvey cache busting and boot retry helpers

### DIFF
--- a/js/tk_kinksurvey_enhance.js
+++ b/js/tk_kinksurvey_enhance.js
@@ -222,4 +222,10 @@
   } else {
     boot();
   }
+
+  try {
+    window.tkKinkSurveyBoot = boot;
+  } catch (err) {
+    /* noop */
+  }
 })();

--- a/kinksurvey/index.html
+++ b/kinksurvey/index.html
@@ -4,11 +4,15 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>Talk Kink — Survey</title>
+<base href="/" />
+<meta http-equiv="Cache-Control" content="no-store, max-age=0" />
+<meta http-equiv="Pragma" content="no-cache" />
+<meta http-equiv="Expires" content="0" />
 
 <!-- Reuse site styles for familiar look; local CSS below makes panel behave like /kinks/ -->
 <link rel="stylesheet" href="/css/style.css">
 <link rel="stylesheet" href="/css/theme.css">
-<link rel="stylesheet" href="/css/kinksurvey_overrides.css">
+<link rel="stylesheet" href="/css/kinksurvey_overrides.css?v=ks-20240927b">
 
 <style>
   :root { --panel-w: 320px; --bg:#000; --fg:#e6ffff; --accent:#00e6ff; --line:#00e5ff33; }
@@ -245,7 +249,38 @@
   }
 })();
 </script>
-<!-- load enhancer last so it can find the existing DOM -->
-<script type="module" src="/js/tk_kinksurvey_enhance.js"></script>
+<!-- One-time SW/cache buster (also triggers when ?tkreset=1) -->
+<script>
+(function(){
+  const VER = 'ks-20240927b';
+  try {
+    const k = 'tk_ks_ver';
+    const sp = new URL(location.href).searchParams;
+    const mustReset = sp.has('tkreset') || localStorage.getItem(k) !== VER;
+    if (mustReset) {
+      if ('caches' in window) {
+        caches.keys().then(ks => Promise.all(ks.map(n => caches.delete(n))));
+      }
+      if (navigator.serviceWorker && navigator.serviceWorker.getRegistration) {
+        navigator.serviceWorker.getRegistration().then(r => r && r.unregister());
+      }
+      localStorage.setItem(k, VER);
+    }
+  } catch (_) {}
+})();
+</script>
+<!-- load enhancer last so it can find the existing DOM (versioned URL to beat stale caches) -->
+<script type="module" src="/js/tk_kinksurvey_enhance.js?v=ks-20240927b"></script>
+<!-- Self-heal: if hero didn't appear quickly (stale inline/partial), retry loading once -->
+<script>
+setTimeout(() => {
+  if (!document.querySelector('.tk-hero')) {
+    const s = document.createElement('script');
+    s.type = 'module';
+    s.src = '/js/tk_kinksurvey_enhance.js?v=ks-20240927b&retry=1';
+    document.head.appendChild(s);
+  }
+}, 800);
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- version kinksurvey styles and enhancer script with cache-busting query strings and add cache reset meta tags
- add one-time cache clearing script and retry loader to recover from stale service worker or partial loads
- expose the kinksurvey boot helper on window for manual retries/debugging

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68d8708be040832c8a0c51cdc7ca1ab8