### PR TITLE
Add pop-out category drawer for kink survey

### DIFF
--- a/css/kinksurvey_overrides.css
+++ b/css/kinksurvey_overrides.css
@@ -8,6 +8,10 @@
   --tk-btn-bd:#00e6ff77;
   --tk-btn-bg:transparent;
   --tk-btn-fg:var(--tk-fg);
+  --tk-toolbar-bg:#06090c;
+  --tk-toolbar-panel:#0c1820;
+  --tk-toolbar-panel2:#0f212c;
+  --tk-toolbar-shadow:0 10px 30px rgba(0,0,0,.45);
 }
 
 .tk-hero{
@@ -46,6 +50,94 @@
   background:#071a1f; color:#eaffff; border:2px solid var(--tk-btn-bd);
   border-radius:10px; padding:8px 12px; outline:none;
 }
+
+/* Pop-out categories toolbar + drawer */
+.tk-toolbar{
+  position:sticky; top:0; z-index:40;
+  display:flex; gap:12px; align-items:center; justify-content:center;
+  background:linear-gradient(to bottom, rgba(6,9,12,.95), rgba(6,9,12,.6) 60%, rgba(6,9,12,0));
+  padding:12px 12px 16px;
+  backdrop-filter:blur(6px);
+}
+
+.tk-toolbar .tk-chip{margin-left:4px}
+
+.tk-btn.tk-toolbar-btn{
+  appearance:none;
+  border:2px solid var(--tk-accent);
+  color:var(--tk-fg);
+  background:transparent;
+  border-radius:12px;
+  padding:10px 16px;
+  font:600 16px/1.2 system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
+  cursor:pointer;
+  transition:transform .05s ease, box-shadow .2s ease, background .2s ease;
+  box-shadow:0 0 0 0 rgba(0,230,255,.35) inset;
+}
+
+.tk-btn.tk-toolbar-btn:hover{background:rgba(0,230,255,.08)}
+.tk-btn.tk-toolbar-btn:active{transform:translateY(1px)}
+.tk-btn.tk-toolbar-btn.primary{background:rgba(0,230,255,.12)}
+
+#tkDrawerBackdrop{
+  position:fixed; inset:0; background:rgba(0,0,0,.45);
+  backdrop-filter:blur(2px); z-index:60; display:none;
+}
+
+#tkCategoryDrawer{
+  position:fixed; left:0; top:0; height:100dvh; width:min(420px,92vw);
+  background:linear-gradient(180deg, var(--tk-toolbar-panel2), #0a151d);
+  color:var(--tk-fg);
+  border-right:2px solid rgba(0,230,255,.35);
+  box-shadow:var(--tk-toolbar-shadow);
+  transform:translateX(-100%);
+  transition:transform .22s ease;
+  z-index:61;
+  display:grid; grid-template-rows:auto 1fr;
+}
+
+.tk-drawer-header{
+  padding:14px 14px 10px; border-bottom:1px solid rgba(0,230,255,.18);
+  display:grid; grid-template-columns:1fr auto; gap:10px; align-items:center;
+}
+
+.tk-drawer-title{
+  font:700 18px/1.25 system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
+  letter-spacing:.2px;
+}
+
+.tk-drawer-actions{
+  display:flex; gap:10px; flex-wrap:wrap; justify-content:flex-end;
+}
+
+.tk-chip{
+  font:700 13px/1.1 system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
+  color:var(--tk-fg);
+  background:rgba(0,230,255,.12);
+  border:1px solid rgba(0,230,255,.3);
+  padding:6px 10px;
+  border-radius:999px;
+}
+
+.tk-drawer-body{overflow:auto; padding:12px 12px 16px;}
+
+body.tk-drawer-open #tkDrawerBackdrop{display:block}
+body.tk-drawer-open #tkCategoryDrawer{transform:translateX(0)}
+
+.tk-original-panel-hidden{display:none !important}
+
+#tkCategoryDrawer .category-list label,
+#tkCategoryDrawer .category-list .category-row{
+  display:grid; grid-template-columns:auto 1fr; align-items:center;
+  gap:10px; padding:10px 12px; margin:8px 0;
+  border:1px solid rgba(0,230,255,.18);
+  border-radius:12px;
+  background:rgba(255,255,255,.02);
+}
+
+#tkCategoryDrawer .category-list label:hover{background:rgba(255,255,255,.05)}
+
+#tkDrawerContent .category-list{margin:0}
 
 /* Wider, easier-to-see category panel */
 .tk-wide-panel{

--- a/docs/kinks/css/kinksurvey_overrides.css
+++ b/docs/kinks/css/kinksurvey_overrides.css
@@ -8,6 +8,10 @@
   --tk-btn-bd:#00e6ff77;
   --tk-btn-bg:transparent;
   --tk-btn-fg:var(--tk-fg);
+  --tk-toolbar-bg:#06090c;
+  --tk-toolbar-panel:#0c1820;
+  --tk-toolbar-panel2:#0f212c;
+  --tk-toolbar-shadow:0 10px 30px rgba(0,0,0,.45);
 }
 
 .tk-hero{
@@ -46,6 +50,94 @@
   background:#071a1f; color:#eaffff; border:2px solid var(--tk-btn-bd);
   border-radius:10px; padding:8px 12px; outline:none;
 }
+
+/* Pop-out categories toolbar + drawer */
+.tk-toolbar{
+  position:sticky; top:0; z-index:40;
+  display:flex; gap:12px; align-items:center; justify-content:center;
+  background:linear-gradient(to bottom, rgba(6,9,12,.95), rgba(6,9,12,.6) 60%, rgba(6,9,12,0));
+  padding:12px 12px 16px;
+  backdrop-filter:blur(6px);
+}
+
+.tk-toolbar .tk-chip{margin-left:4px}
+
+.tk-btn.tk-toolbar-btn{
+  appearance:none;
+  border:2px solid var(--tk-accent);
+  color:var(--tk-fg);
+  background:transparent;
+  border-radius:12px;
+  padding:10px 16px;
+  font:600 16px/1.2 system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
+  cursor:pointer;
+  transition:transform .05s ease, box-shadow .2s ease, background .2s ease;
+  box-shadow:0 0 0 0 rgba(0,230,255,.35) inset;
+}
+
+.tk-btn.tk-toolbar-btn:hover{background:rgba(0,230,255,.08)}
+.tk-btn.tk-toolbar-btn:active{transform:translateY(1px)}
+.tk-btn.tk-toolbar-btn.primary{background:rgba(0,230,255,.12)}
+
+#tkDrawerBackdrop{
+  position:fixed; inset:0; background:rgba(0,0,0,.45);
+  backdrop-filter:blur(2px); z-index:60; display:none;
+}
+
+#tkCategoryDrawer{
+  position:fixed; left:0; top:0; height:100dvh; width:min(420px,92vw);
+  background:linear-gradient(180deg, var(--tk-toolbar-panel2), #0a151d);
+  color:var(--tk-fg);
+  border-right:2px solid rgba(0,230,255,.35);
+  box-shadow:var(--tk-toolbar-shadow);
+  transform:translateX(-100%);
+  transition:transform .22s ease;
+  z-index:61;
+  display:grid; grid-template-rows:auto 1fr;
+}
+
+.tk-drawer-header{
+  padding:14px 14px 10px; border-bottom:1px solid rgba(0,230,255,.18);
+  display:grid; grid-template-columns:1fr auto; gap:10px; align-items:center;
+}
+
+.tk-drawer-title{
+  font:700 18px/1.25 system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
+  letter-spacing:.2px;
+}
+
+.tk-drawer-actions{
+  display:flex; gap:10px; flex-wrap:wrap; justify-content:flex-end;
+}
+
+.tk-chip{
+  font:700 13px/1.1 system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
+  color:var(--tk-fg);
+  background:rgba(0,230,255,.12);
+  border:1px solid rgba(0,230,255,.3);
+  padding:6px 10px;
+  border-radius:999px;
+}
+
+.tk-drawer-body{overflow:auto; padding:12px 12px 16px;}
+
+body.tk-drawer-open #tkDrawerBackdrop{display:block}
+body.tk-drawer-open #tkCategoryDrawer{transform:translateX(0)}
+
+.tk-original-panel-hidden{display:none !important}
+
+#tkCategoryDrawer .category-list label,
+#tkCategoryDrawer .category-list .category-row{
+  display:grid; grid-template-columns:auto 1fr; align-items:center;
+  gap:10px; padding:10px 12px; margin:8px 0;
+  border:1px solid rgba(0,230,255,.18);
+  border-radius:12px;
+  background:rgba(255,255,255,.02);
+}
+
+#tkCategoryDrawer .category-list label:hover{background:rgba(255,255,255,.05)}
+
+#tkDrawerContent .category-list{margin:0}
 
 /* Wider, easier-to-see category panel */
 .tk-wide-panel{

--- a/docs/kinks/index.html
+++ b/docs/kinks/index.html
@@ -52,8 +52,25 @@
     </select>
 <button id="startSurvey" data-legacy-id="startSurveyBtn" class="themed-button start-survey-btn" disabled>Start Survey</button>
 
-    <div id="warning" class="warning"></div>
+  <div id="warning" class="warning"></div>
   </div>
+  <div class="tk-toolbar" id="tkToolbar">
+    <button class="tk-btn tk-toolbar-btn primary" id="tkOpenDrawer" aria-haspopup="dialog" aria-controls="tkCategoryDrawer" aria-expanded="false">☰ Categories</button>
+    <span class="tk-chip" id="tkSelChip">0 selected</span>
+  </div>
+  <div id="tkDrawerBackdrop" tabindex="-1" aria-hidden="true"></div>
+  <aside id="tkCategoryDrawer" role="dialog" aria-modal="true" aria-label="Select categories" aria-hidden="true">
+    <div class="tk-drawer-header">
+      <div class="tk-drawer-title">Select categories</div>
+      <div class="tk-drawer-actions">
+        <span class="tk-chip" id="tkCount">0 selected / 0 total</span>
+        <button class="tk-btn tk-toolbar-btn" id="tkCloseDrawer" title="Close">✕</button>
+      </div>
+    </div>
+    <div class="tk-drawer-body">
+      <div id="tkDrawerContent"></div>
+    </div>
+  </aside>
   <button id="panelToggle" class="panel-toggle" aria-label="Toggle category panel" aria-controls="categorySurveyPanel" aria-expanded="true">☰</button>
 
   <!-- Category selection panel -->
@@ -139,6 +156,144 @@
   <!-- Panel Container (still hidden until needed) -->
   <div id="panelContainer" class="panel-container" style="display:none;"></div>
 
+  <script>
+  (function(){
+    const $ = (sel, root = document) => root.querySelector(sel);
+    const $$ = (sel, root = document) => Array.from(root.querySelectorAll(sel));
+
+    const body = document.body;
+    const openBtn = $('#tkOpenDrawer');
+    const closeBtn = $('#tkCloseDrawer');
+    const backdrop = $('#tkDrawerBackdrop');
+    const drawer = $('#tkCategoryDrawer');
+    const content = $('#tkDrawerContent');
+    const chip = $('#tkSelChip');
+    const countBadge = $('#tkCount');
+
+    const applyCounts = (selected, total) => {
+      if (chip) chip.textContent = `${selected} selected`;
+      if (countBadge) countBadge.textContent = `${selected} selected / ${total} total`;
+    };
+
+    const allCheckboxes = () => {
+      const nodes = $$('input[type="checkbox"]', content);
+      return nodes.filter(cb =>
+        cb.classList.contains('category-checkbox') ||
+        cb.name === 'category' ||
+        cb.closest('.category-list')
+      );
+    };
+
+    const refreshCounts = () => {
+      const boxes = allCheckboxes();
+      const total = boxes.length;
+      const selected = boxes.filter(cb => cb.checked).length;
+      applyCounts(selected, total);
+    };
+
+    window.tkUpdateCategoryChip = applyCounts;
+
+    const focusableSelector = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+    function openDrawer(){
+      body.classList.add('tk-drawer-open');
+      openBtn?.setAttribute('aria-expanded','true');
+      drawer?.setAttribute('aria-hidden','false');
+      backdrop?.setAttribute('aria-hidden','false');
+      setTimeout(() => {
+        const focusTarget = drawer?.querySelector(focusableSelector) || drawer;
+        focusTarget?.focus?.();
+      }, 10);
+      refreshCounts();
+    }
+
+    function closeDrawer(){
+      body.classList.remove('tk-drawer-open');
+      openBtn?.setAttribute('aria-expanded','false');
+      drawer?.setAttribute('aria-hidden','true');
+      backdrop?.setAttribute('aria-hidden','true');
+      openBtn?.focus?.();
+    }
+
+    const toggleDrawer = () => {
+      if (body.classList.contains('tk-drawer-open')){
+        closeDrawer();
+      } else {
+        openDrawer();
+      }
+    };
+
+    openBtn?.addEventListener('click', toggleDrawer);
+    closeBtn?.addEventListener('click', closeDrawer);
+    backdrop?.addEventListener('click', closeDrawer);
+    window.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && body.classList.contains('tk-drawer-open')){
+        closeDrawer();
+      }
+    });
+
+    const changeHandler = (e) => {
+      if (e.target && e.target.matches('input[type="checkbox"]')){
+        refreshCounts();
+      }
+    };
+    content?.addEventListener('change', changeHandler);
+
+    const observer = new MutationObserver(() => refreshCounts());
+    if (content){
+      observer.observe(content, {childList:true, subtree:true, attributes:true, attributeFilter:['checked']});
+    }
+
+    const findCategoryRoot = () =>
+      document.getElementById('categorySurveyPanel')
+      || $('.category-panel')
+      || $('.category-list')?.closest('div')
+      || null;
+
+    function moveCategoryListOnce(){
+      const root = findCategoryRoot();
+      if (!root) return false;
+      const list = root.querySelector('.category-list');
+      if (!list) return false;
+      const catbar = root.querySelector('.tk-catbar');
+      if (content && catbar && !content.contains(catbar)) {
+        content.appendChild(catbar);
+      }
+      if (content && !content.contains(list)) {
+        content.appendChild(list);
+      }
+      if (root !== list){
+        root.classList.add('tk-original-panel-hidden');
+      }
+      refreshCounts();
+      return true;
+    }
+
+    function ready(){
+      if (!moveCategoryListOnce()){
+        let tries = 0;
+        const t = setInterval(() => {
+          if (moveCategoryListOnce() || ++tries > 25){
+            clearInterval(t);
+          }
+        }, 150);
+      }
+    }
+
+    if (document.readyState === 'loading'){
+      document.addEventListener('DOMContentLoaded', ready, {once:true});
+    } else {
+      ready();
+    }
+
+    window.tkCategoriesDrawer = {
+      open: openDrawer,
+      close: closeDrawer,
+      refresh: refreshCounts
+    };
+  })();
+  </script>
+
   <!-- Theme & Survey Logic -->
   <script type="module">
     const getThemeModule = async () => {
@@ -159,8 +314,8 @@
       const startButton = document.getElementById('startSurvey') || document.getElementById('startSurveyBtn');
       const warningEl = document.getElementById('warning');
       const diagnosticsEl = document.getElementById('kinksDiagnostics');
-      const panelEl = document.getElementById('categorySurveyPanel');
       const panelToggleBtn = document.getElementById('panelToggle');
+      const getDrawerApi = () => window.tkCategoriesDrawer;
       const categoriesLeftEl = document.getElementById('categoriesLeft');
 
       const getCheckboxes = () => Array.from(document.querySelectorAll('.category-checkbox'))
@@ -187,18 +342,23 @@
       };
 
       const collapsePanel = () => {
-        if (!panelEl) return;
-        panelEl.classList.remove('open');
+        const drawer = getDrawerApi();
+        drawer?.close?.();
         if (panelToggleBtn) {
           panelToggleBtn.setAttribute('aria-expanded', 'false');
         }
       };
 
       const togglePanel = () => {
-        if (!panelEl) return;
-        const isOpen = panelEl.classList.toggle('open');
-        if (panelToggleBtn) {
-          panelToggleBtn.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        const drawer = getDrawerApi();
+        if (!drawer) return;
+        const isOpen = document.body.classList.contains('tk-drawer-open');
+        if (isOpen) {
+          drawer.close?.();
+          panelToggleBtn?.setAttribute('aria-expanded', 'false');
+        } else {
+          drawer.open?.();
+          panelToggleBtn?.setAttribute('aria-expanded', 'true');
         }
       };
 
@@ -216,6 +376,7 @@
             showWarning('');
             updateStartButtonState();
             updateCategoriesCounter();
+            getDrawerApi()?.refresh?.();
           });
         });
       };
@@ -258,6 +419,7 @@
           showWarning('');
           updateStartButtonState();
           updateCategoriesCounter();
+          getDrawerApi()?.refresh?.();
         });
       }
 
@@ -270,6 +432,7 @@
           showWarning('');
           updateStartButtonState();
           updateCategoriesCounter();
+          getDrawerApi()?.refresh?.();
         });
       }
 
@@ -280,6 +443,7 @@
         showWarning('');
         updateStartButtonState();
         updateCategoriesCounter();
+        getDrawerApi()?.refresh?.();
       };
 
       window.deselectAllCategories = () => {
@@ -289,11 +453,13 @@
         showWarning('');
         updateStartButtonState();
         updateCategoriesCounter();
+        getDrawerApi()?.refresh?.();
       };
 
       bindCheckboxes();
       updateStartButtonState();
       updateCategoriesCounter();
+      getDrawerApi()?.refresh?.();
     };
 
     if (document.readyState === 'loading') {

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -129,6 +129,23 @@
 
     <div id="warning" class="warning"></div>
   </div>
+  <div class="tk-toolbar" id="tkToolbar">
+    <button class="tk-btn tk-toolbar-btn primary" id="tkOpenDrawer" aria-haspopup="dialog" aria-controls="tkCategoryDrawer" aria-expanded="false">☰ Categories</button>
+    <span class="tk-chip" id="tkSelChip">0 selected</span>
+  </div>
+  <div id="tkDrawerBackdrop" tabindex="-1" aria-hidden="true"></div>
+  <aside id="tkCategoryDrawer" role="dialog" aria-modal="true" aria-label="Select categories" aria-hidden="true">
+    <div class="tk-drawer-header">
+      <div class="tk-drawer-title">Select categories</div>
+      <div class="tk-drawer-actions">
+        <span class="tk-chip" id="tkCount">0 selected / 0 total</span>
+        <button class="tk-btn tk-toolbar-btn" id="tkCloseDrawer" title="Close">✕</button>
+      </div>
+    </div>
+    <div class="tk-drawer-body">
+      <div id="tkDrawerContent"></div>
+    </div>
+  </aside>
   <button id="panelToggle" class="panel-toggle" aria-label="Toggle category panel" aria-controls="categorySurveyPanel" aria-expanded="true">☰</button>
 
   <!-- Category selection panel -->
@@ -214,6 +231,144 @@
   <!-- Panel Container (still hidden until needed) -->
   <div id="panelContainer" class="panel-container" style="display:none;"></div>
 
+  <script>
+  (function(){
+    const $ = (sel, root = document) => root.querySelector(sel);
+    const $$ = (sel, root = document) => Array.from(root.querySelectorAll(sel));
+
+    const body = document.body;
+    const openBtn = $('#tkOpenDrawer');
+    const closeBtn = $('#tkCloseDrawer');
+    const backdrop = $('#tkDrawerBackdrop');
+    const drawer = $('#tkCategoryDrawer');
+    const content = $('#tkDrawerContent');
+    const chip = $('#tkSelChip');
+    const countBadge = $('#tkCount');
+
+    const applyCounts = (selected, total) => {
+      if (chip) chip.textContent = `${selected} selected`;
+      if (countBadge) countBadge.textContent = `${selected} selected / ${total} total`;
+    };
+
+    const allCheckboxes = () => {
+      const nodes = $$('input[type="checkbox"]', content);
+      return nodes.filter(cb =>
+        cb.classList.contains('category-checkbox') ||
+        cb.name === 'category' ||
+        cb.closest('.category-list')
+      );
+    };
+
+    const refreshCounts = () => {
+      const boxes = allCheckboxes();
+      const total = boxes.length;
+      const selected = boxes.filter(cb => cb.checked).length;
+      applyCounts(selected, total);
+    };
+
+    window.tkUpdateCategoryChip = applyCounts;
+
+    const focusableSelector = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+    function openDrawer(){
+      body.classList.add('tk-drawer-open');
+      openBtn?.setAttribute('aria-expanded','true');
+      drawer?.setAttribute('aria-hidden','false');
+      backdrop?.setAttribute('aria-hidden','false');
+      setTimeout(() => {
+        const focusTarget = drawer?.querySelector(focusableSelector) || drawer;
+        focusTarget?.focus?.();
+      }, 10);
+      refreshCounts();
+    }
+
+    function closeDrawer(){
+      body.classList.remove('tk-drawer-open');
+      openBtn?.setAttribute('aria-expanded','false');
+      drawer?.setAttribute('aria-hidden','true');
+      backdrop?.setAttribute('aria-hidden','true');
+      openBtn?.focus?.();
+    }
+
+    const toggleDrawer = () => {
+      if (body.classList.contains('tk-drawer-open')){
+        closeDrawer();
+      } else {
+        openDrawer();
+      }
+    };
+
+    openBtn?.addEventListener('click', toggleDrawer);
+    closeBtn?.addEventListener('click', closeDrawer);
+    backdrop?.addEventListener('click', closeDrawer);
+    window.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape' && body.classList.contains('tk-drawer-open')){
+        closeDrawer();
+      }
+    });
+
+    const changeHandler = (e) => {
+      if (e.target && e.target.matches('input[type="checkbox"]')){
+        refreshCounts();
+      }
+    };
+    content?.addEventListener('change', changeHandler);
+
+    const observer = new MutationObserver(() => refreshCounts());
+    if (content){
+      observer.observe(content, {childList:true, subtree:true, attributes:true, attributeFilter:['checked']});
+    }
+
+    const findCategoryRoot = () =>
+      document.getElementById('categorySurveyPanel')
+      || $('.category-panel')
+      || $('.category-list')?.closest('div')
+      || null;
+
+    function moveCategoryListOnce(){
+      const root = findCategoryRoot();
+      if (!root) return false;
+      const list = root.querySelector('.category-list');
+      if (!list) return false;
+      const catbar = root.querySelector('.tk-catbar');
+      if (content && catbar && !content.contains(catbar)) {
+        content.appendChild(catbar);
+      }
+      if (content && !content.contains(list)) {
+        content.appendChild(list);
+      }
+      if (root !== list){
+        root.classList.add('tk-original-panel-hidden');
+      }
+      refreshCounts();
+      return true;
+    }
+
+    function ready(){
+      if (!moveCategoryListOnce()){
+        let tries = 0;
+        const t = setInterval(() => {
+          if (moveCategoryListOnce() || ++tries > 25){
+            clearInterval(t);
+          }
+        }, 150);
+      }
+    }
+
+    if (document.readyState === 'loading'){
+      document.addEventListener('DOMContentLoaded', ready, {once:true});
+    } else {
+      ready();
+    }
+
+    window.tkCategoriesDrawer = {
+      open: openDrawer,
+      close: closeDrawer,
+      refresh: refreshCounts
+    };
+  })();
+  </script>
+
   <!-- Theme & Survey Logic -->
   <script type="module">
     const getThemeModule = async () => {
@@ -234,8 +389,8 @@
       const startButton = document.getElementById('startSurvey') || document.getElementById('startSurveyBtn');
       const warningEl = document.getElementById('warning');
       const diagnosticsEl = document.getElementById('kinksDiagnostics');
-      const panelEl = document.getElementById('categorySurveyPanel');
       const panelToggleBtn = document.getElementById('panelToggle');
+      const getDrawerApi = () => window.tkCategoriesDrawer;
       const categoriesLeftEl = document.getElementById('categoriesLeft');
 
       const getCheckboxes = () => Array.from(document.querySelectorAll('.category-checkbox'))
@@ -262,18 +417,23 @@
       };
 
       const collapsePanel = () => {
-        if (!panelEl) return;
-        panelEl.classList.remove('open');
+        const drawer = getDrawerApi();
+        drawer?.close?.();
         if (panelToggleBtn) {
           panelToggleBtn.setAttribute('aria-expanded', 'false');
         }
       };
 
       const togglePanel = () => {
-        if (!panelEl) return;
-        const isOpen = panelEl.classList.toggle('open');
-        if (panelToggleBtn) {
-          panelToggleBtn.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        const drawer = getDrawerApi();
+        if (!drawer) return;
+        const isOpen = document.body.classList.contains('tk-drawer-open');
+        if (isOpen) {
+          drawer.close?.();
+          panelToggleBtn?.setAttribute('aria-expanded', 'false');
+        } else {
+          drawer.open?.();
+          panelToggleBtn?.setAttribute('aria-expanded', 'true');
         }
       };
 
@@ -291,6 +451,7 @@
             showWarning('');
             updateStartButtonState();
             updateCategoriesCounter();
+            getDrawerApi()?.refresh?.();
           });
         });
       };
@@ -333,6 +494,7 @@
           showWarning('');
           updateStartButtonState();
           updateCategoriesCounter();
+          getDrawerApi()?.refresh?.();
         });
       }
 
@@ -345,6 +507,7 @@
           showWarning('');
           updateStartButtonState();
           updateCategoriesCounter();
+          getDrawerApi()?.refresh?.();
         });
       }
 
@@ -355,6 +518,7 @@
         showWarning('');
         updateStartButtonState();
         updateCategoriesCounter();
+        getDrawerApi()?.refresh?.();
       };
 
       window.deselectAllCategories = () => {
@@ -364,11 +528,13 @@
         showWarning('');
         updateStartButtonState();
         updateCategoriesCounter();
+        getDrawerApi()?.refresh?.();
       };
 
       bindCheckboxes();
       updateStartButtonState();
       updateCategoriesCounter();
+      getDrawerApi()?.refresh?.();
     };
 
     if (document.readyState === 'loading') {


### PR DESCRIPTION
## Summary
- add a sticky toolbar and drawer shell to the kink survey page and its docs build to host category selection
- implement drawer scripting that hoists the category list, syncs counters, and exposes controls for existing survey logic
- update shared CSS and enhancement scripts so the new drawer layout keeps select/deselect actions and counter chips working

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8728f44e4832ca778067f20ea2b60