### PR TITLE
Add fullscreen start flow for kink survey drawer

### DIFF
--- a/css/kinksurvey_overrides.css
+++ b/css/kinksurvey_overrides.css
@@ -124,6 +124,22 @@
 body.tk-drawer-open #tkDrawerBackdrop{display:block}
 body.tk-drawer-open #tkCategoryDrawer{transform:translateX(0)}
 
+.tk-fullscreen #tkCategoryDrawer{
+  left:0;
+  top:0;
+  width:100vw;
+  max-width:100vw;
+  height:100dvh;
+  transform:translateX(0) !important;
+  border-right:none;
+  border-radius:0;
+  z-index:9999;
+}
+
+.tk-fullscreen #tkDrawerBackdrop{display:none !important}
+.tk-fullscreen #tkToolbar{display:none !important}
+.tk-body-lock{overflow:hidden}
+
 .tk-original-panel-hidden{display:none !important}
 
 #tkCategoryDrawer .category-list label,

--- a/docs/kinks/css/kinksurvey_overrides.css
+++ b/docs/kinks/css/kinksurvey_overrides.css
@@ -124,6 +124,22 @@
 body.tk-drawer-open #tkDrawerBackdrop{display:block}
 body.tk-drawer-open #tkCategoryDrawer{transform:translateX(0)}
 
+.tk-fullscreen #tkCategoryDrawer{
+  left:0;
+  top:0;
+  width:100vw;
+  max-width:100vw;
+  height:100dvh;
+  transform:translateX(0) !important;
+  border-right:none;
+  border-radius:0;
+  z-index:9999;
+}
+
+.tk-fullscreen #tkDrawerBackdrop{display:none !important}
+.tk-fullscreen #tkToolbar{display:none !important}
+.tk-body-lock{overflow:hidden}
+
 .tk-original-panel-hidden{display:none !important}
 
 #tkCategoryDrawer .category-list label,


### PR DESCRIPTION
## Summary
- add fullscreen styling for the category drawer when launched from the start survey action
- wire the start button to open the drawer fullscreen and run the survey boot logic after validation
- mirror the updates in the docs bundle to keep parity

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68d8839d1cb4832ca76f31bcf1c6bd81