### PR TITLE
Remove Mischief Manor join CTA from kink survey

### DIFF
--- a/docs/kinks/js/tk_kinksurvey_enhance.js
+++ b/docs/kinks/js/tk_kinksurvey_enhance.js
@@ -69,7 +69,6 @@
     pillRow.innerHTML = `
       <a class="tk-pill" href="/compatibility/">Compatibility Page</a>
       <a class="tk-pill" href="/ika/">Individual Kink Analysis</a>
-      <a class="tk-pill" href="/apply/">Request to Join Mischief Manor</a>
     `;
     hero.appendChild(pillRow);
 

--- a/js/tk_kinksurvey_enhance.js
+++ b/js/tk_kinksurvey_enhance.js
@@ -69,7 +69,6 @@
     pillRow.innerHTML = `
       <a class="tk-pill" href="/compatibility/">Compatibility Page</a>
       <a class="tk-pill" href="/ika/">Individual Kink Analysis</a>
-      <a class="tk-pill" href="/apply/">Request to Join Mischief Manor</a>
     `;
     hero.appendChild(pillRow);
 


### PR DESCRIPTION
## Summary
- remove the Mischief Manor join link from the kink survey hero actions
- mirror the change in the documentation copy of the enhancement script

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d88b2b623c832c9e2447bed062d117