### PR TITLE
Center kinksurvey hero CTAs and drop request join

### DIFF
--- a/css/kinksurvey_overrides.css
+++ b/css/kinksurvey_overrides.css
@@ -14,6 +14,13 @@
   --tk-toolbar-shadow:0 10px 30px rgba(0,0,0,.45);
 }
 
+body[data-kinksurvey="1"] .tk-hero{
+  display:flex; flex-direction:column; align-items:center; gap:28px;
+  margin:18px auto 26px; text-align:center;
+}
+body[data-kinksurvey="1"] .tk-hero .row{display:flex; flex-wrap:wrap; justify-content:center; gap:28px;}
+body[data-kinksurvey="1"] .tk-hero .row .cta{display:inline-flex; align-items:center; justify-content:center; text-align:center;}
+body[data-kinksurvey="1"] #startSurvey{display:inline-flex; margin-inline:auto;}
 .tk-hero{
   display:flex; flex-direction:column; align-items:center; gap:18px;
   margin:6px auto 26px; text-align:center;

--- a/docs/kinks/css/kinksurvey_overrides.css
+++ b/docs/kinks/css/kinksurvey_overrides.css
@@ -14,6 +14,13 @@
   --tk-toolbar-shadow:0 10px 30px rgba(0,0,0,.45);
 }
 
+body[data-kinksurvey="1"] .tk-hero{
+  display:flex; flex-direction:column; align-items:center; gap:28px;
+  margin:18px auto 26px; text-align:center;
+}
+body[data-kinksurvey="1"] .tk-hero .row{display:flex; flex-wrap:wrap; justify-content:center; gap:28px;}
+body[data-kinksurvey="1"] .tk-hero .row .cta{display:inline-flex; align-items:center; justify-content:center; text-align:center;}
+body[data-kinksurvey="1"] #startSurvey{display:inline-flex; margin-inline:auto;}
 .tk-hero{
   display:flex; flex-direction:column; align-items:center; gap:18px;
   margin:6px auto 26px; text-align:center;


### PR DESCRIPTION
## Summary
- add a kinksurvey-specific body flag to scope centered hero CTA layout rules
- restructure the hero builder to create centered CTA rows and tag buttons as CTAs
- strip the “Request to Join Mischief Manor” entry when present so only survey CTAs remain

## Testing
- Manually loaded http://localhost:3000/kinksurvey/

------
https://chatgpt.com/codex/tasks/task_e_68d88cb57094832c8df9c12535ba1e3d