### PR TITLE
Restore Mischief Manor CTA on home page only

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
       <a id="startSurvey" href="/kinksurvey/" class="themed-button highlighted-box">Start Survey</a>
       <a href="compatibility.html" class="themed-button highlighted-box">Compatibility Page</a>
       <a href="individualkinkanalysis.html" class="themed-button highlighted-box">Individual Kink Analysis</a>
-      <a href="https://discord.gg/Ub8ebnQP9a" class="themed-button highlighted-box" target="_blank">Request to Join Mischief Manor</a>
+      <a href="/apply/" class="themed-button highlighted-box">Request to Join Mischief Manor</a>
     </div>
     <select id="themeSelector" class="theme-selector highlighted-box" onchange="changeTheme(this.value)">
       <option value="dark">Dark Theme</option>

--- a/talk-kink-new-survey.html
+++ b/talk-kink-new-survey.html
@@ -110,7 +110,6 @@
       <div class="heroRow">
         <a class="btn" href="/compatibility/">Compatibility Page</a>
         <a class="btn" href="/ika/">Individual Kink Analysis</a>
-        <a class="btn" href="/apply/">Request to Join Mischief Manor</a>
       </div>
       <div class="heroRow" aria-label="Theme">
         <label style="display:flex;gap:10px;align-items:center">


### PR DESCRIPTION
## Summary
- point the home page "Request to Join Mischief Manor" button to the /apply/ route
- remove the Mischief Manor CTA from the new survey page so it only appears on the landing page

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d88e45f108832c898ec771fedd5561