### PR TITLE
Implement kink survey drawer layout refresh

### DIFF
--- a/js/tk_kinksurvey_enhance.js
+++ b/js/tk_kinksurvey_enhance.js
@@ -87,7 +87,7 @@
       startRow.appendChild(startNode);
     }
 
-    const navRow = el('div',{class:'row row-nav'});
+    const navRow = el('div',{class:'row row-nav action-row'});
     navRow.appendChild(el('a',{class:'tk-pill cta', href:'/compatibility/'},'Compatibility Page'));
     navRow.appendChild(el('a',{class:'tk-pill cta', href:'/ika/'},'Individual Kink Analysis'));
     hero.appendChild(navRow);
@@ -115,6 +115,11 @@
       startNode?.addEventListener('click', () => {
         const panel = $('#categorySurveyPanel') || $('.category-panel') || $('#categoryPanel');
         const toggle = $('#panelToggle') || $('.panel-toggle');
+        const drawer = $('#tkDrawer');
+        if (drawer){
+          drawer.classList.add('open');
+          document.body?.classList?.add('drawer-open');
+        }
         if (panel){
           panel.classList.add('open');
           document.body?.classList?.add('panel-open');

--- a/kinksurvey/index.html
+++ b/kinksurvey/index.html
@@ -14,59 +14,136 @@
 <link rel="stylesheet" href="/css/theme.css">
 <link rel="stylesheet" href="/css/kinksurvey_overrides.css?v=ks-20240927b">
 
-<!-- TK /kinksurvey — hard-center the link row under Start -->
-<style id="tk-kinksurvey-center-fix">
+<!-- TK /kinksurvey: keep hero centered & make category panel a fixed full-page drawer -->
+<style id="tk-kinksurvey-layout-fix">
   /* scope to this page only */
-  body[data-kinksurvey="1"] .tk-hero{
-    display:grid;
-    grid-template-rows:auto auto auto;
-    justify-items:center;      /* center contents horizontally */
-    align-items:center;        /* center each row's items vertically */
-    row-gap:28px;
-    width:100%;
-    margin:0 auto;
-  }
+  body[data-kinksurvey] { contain: paint; }
 
-  /* Start button stays centered */
-  body[data-kinksurvey="1"] #startSurvey{
-    margin:0 !important;
-  }
-
-  /* >>> This is the important part: the two links as one centered row */
-  body[data-kinksurvey="1"] .tk-hero .links{
+  /* Start + the two link buttons stay centered */
+  body[data-kinksurvey] .action-row{
     display:flex !important;
-    justify-content:center !important;   /* center the pair */
+    justify-content:center !important;
     align-items:center;
-    gap:40px;                             /* space between the two buttons */
+    gap:40px;
+    flex-wrap:wrap;
     width:100%;
-    max-width:900px;                      /* keeps the pair visually centered */
-    margin:0 auto !important;             /* center the row itself */
+    max-width:900px;
+    margin:0 auto !important;
     text-align:center;
   }
+  body[data-kinksurvey] .action-row a,
+  body[data-kinksurvey] .action-row button{ margin:0 !important; }
 
-  /* kill any inherited margins/pushes on the buttons themselves */
-  body[data-kinksurvey="1"] .tk-hero .links a,
-  body[data-kinksurvey="1"] .tk-hero .links button{
-    margin:0 !important;
+  /* Full-page drawer for the category panel (doesn't change page layout) */
+  #tkDrawer{
+    position:fixed;
+    inset:0;
+    transform:translateX(-100%);
+    transition:transform .28s ease;
+    pointer-events:none;
+    z-index:2147483647;
+    background:#0000;
   }
+  #tkDrawer.open{ transform:translateX(0); pointer-events:auto; }
+  #tkDrawer .sheet{
+    position:absolute; inset:0;
+    background:#071317;
+    overflow:auto;
+    border-left:1px solid #00e6ff55;
+    box-shadow:0 0 0 1px #00e6ff22 inset;
+  }
+  body.drawer-open{ overflow:hidden; }
 
-  /* mobile: stack them neatly */
+  /* mobile nicety */
   @media (max-width: 720px){
-    body[data-kinksurvey="1"] .tk-hero{ row-gap:22px; }
-    body[data-kinksurvey="1"] .tk-hero .links{
-      flex-direction:column;
-      gap:16px;
-      max-width:420px;
-    }
-    body[data-kinksurvey="1"] .tk-hero .links a{ width:100%; }
+    body[data-kinksurvey] .action-row{ gap:16px; max-width:420px; }
+    body[data-kinksurvey] .action-row a{ width:100%; }
   }
 </style>
 
-<script>
-  // Ensure the page is tagged so the styles only apply here
-  if (/^\/kinksurvey\/?$/.test(location.pathname)) {
-    document.body.setAttribute('data-kinksurvey','1');
+<script id="tk-kinksurvey-layout-fix-js">
+(function(){
+  if (!/^\/kinksurvey\/?$/.test(location.pathname)) return;
+  document.body.setAttribute('data-kinksurvey','1');
+
+  // 1) Build the drawer shell (so it never participates in layout)
+  var drawer = document.getElementById('tkDrawer');
+  if (!drawer){
+    drawer = document.createElement('div');
+    drawer.id = 'tkDrawer';
+    drawer.innerHTML = '<div class="sheet" id="tkDrawerSheet"></div>';
+    document.body.appendChild(drawer);
   }
+
+  // 2) Move the existing category panel into the drawer (out of flow)
+  var panel = document.getElementById('categorySurveyPanel') || document.querySelector('.category-panel');
+  if (panel && panel.parentNode !== drawer.querySelector('#tkDrawerSheet')){
+    drawer.querySelector('#tkDrawerSheet').appendChild(panel);
+  }
+
+  // 3) Start Survey opens the drawer (no layout shift)
+  function bindStart(node){
+    if (node && !node.dataset.tkBind){
+      if (node.closest && node.closest('#tkDrawer')) return;
+      node.dataset.tkBind = '1';
+      node.addEventListener('click', function(e){
+        if (node.tagName !== 'BUTTON') e.preventDefault();
+        drawer.classList.add('open');
+        panel && panel.classList.add('open');
+        document.body.classList.add('drawer-open');
+        document.body.classList.add('panel-open');
+        var toggle = document.getElementById('panelToggle');
+        toggle && toggle.setAttribute('aria-expanded','true');
+      });
+    }
+  }
+  bindStart(document.getElementById('startSurvey'));
+  bindStart(document.getElementById('start'));
+  bindStart(document.getElementById('startSurveyBtn'));
+  bindStart(document.getElementById('tkHeroStart'));
+
+  var heroObserver = null;
+  if (!document.getElementById('tkHeroStart')){
+    heroObserver = new MutationObserver(function(){
+      var heroStart = document.getElementById('tkHeroStart');
+      if (heroStart){
+        bindStart(heroStart);
+        if (heroObserver){
+          heroObserver.disconnect();
+          heroObserver = null;
+        }
+      }
+    });
+    heroObserver.observe(document.body,{childList:true, subtree:true});
+  }
+
+  // 4) Click outside panel to close (optional)
+  drawer.addEventListener('click', function(e){
+    if (e.target === drawer){
+      drawer.classList.remove('open');
+      panel && panel.classList.remove('open');
+      document.body.classList.remove('drawer-open');
+      document.body.classList.remove('panel-open');
+      var toggle = document.getElementById('panelToggle');
+      toggle && toggle.setAttribute('aria-expanded','false');
+    }
+  });
+
+  // 5) Ensure the two lower buttons are in a centering row; if not, auto-wrap them
+  var row = document.querySelector('.action-row');
+  if (!row){
+    var compat = Array.from(document.querySelectorAll('a,button')).find(function(el){ return /compatibility\s*page/i.test(el.textContent||''); });
+    var ika    = Array.from(document.querySelectorAll('a,button')).find(function(el){ return /individual\s*kink\s*analysis/i.test(el.textContent||''); });
+    if (compat && ika && compat.parentNode === ika.parentNode){
+      row = document.createElement('div');
+      row.className = 'action-row';
+      var parent = compat.parentNode;
+      parent.insertBefore(row, compat);
+      row.appendChild(compat);
+      row.appendChild(ika);
+    }
+  }
+})();
 </script>
 
 <style>
@@ -85,21 +162,22 @@
 
   /* LEFT SIDE PANEL (classic /kinks/ feel) */
   #panelToggle{
-    position:fixed; left:12px; top:12px; z-index:10010;
+    position:fixed; left:12px; top:12px; z-index:2147483648;
     background:#06161a; border:1px solid var(--line); color:var(--fg);
     border-radius:10px; padding:8px 12px; cursor:pointer;
   }
   .category-panel{
-    position:fixed; inset:0;
-    width:100vw; max-width:100vw;
-    background:#000; border-right:1px solid var(--line);
-    padding:14px 14px 18px; overflow:auto; z-index:10000;
-    transform:translateX(-100%); transition:transform .3s ease;
+    position:relative;
+    width:100%;
+    max-width:none;
+    min-height:100%;
+    background:#071317;
+    padding:14px 14px 18px;
+    overflow:auto;
     text-align:center;
   }
-  .category-panel.open{ transform:translateX(0); }
 
-  body.panel-open{ overflow:hidden; }
+  body.panel-open, body.drawer-open{ overflow:hidden; }
 
   /* Shift content when panel open */
   .content{
@@ -191,6 +269,7 @@
   const $ = (id)=>document.getElementById(id);
   const panel = $('categorySurveyPanel');
   const toggle = $('panelToggle');
+  const drawer = document.getElementById('tkDrawer');
   const list = $('categoryList');
   const status = $('statusMsg');
   const startBtn = $('start');
@@ -200,11 +279,23 @@
   const items = $('items');
   const done = $('done');
 
+  function setDrawerState(open){
+    const want = Boolean(open);
+    if (drawer){
+      drawer.classList.toggle('open', want);
+    }
+    if (panel){
+      panel.classList.toggle('open', want);
+    }
+    document.body.classList.toggle('drawer-open', want);
+    document.body.classList.toggle('panel-open', want);
+    toggle?.setAttribute('aria-expanded', want ? 'true' : 'false');
+  }
+
   // Toggle panel open/closed (like /kinks/)
   toggle.addEventListener('click', ()=>{
-    const isOpen = panel.classList.toggle('open');
-    toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
-    document.body.classList.toggle('panel-open', isOpen);
+    const isOpen = drawer ? !drawer.classList.contains('open') : !panel.classList.contains('open');
+    setDrawerState(isOpen);
   });
 
   const S = { cats:[], sel:[], i:0 };
@@ -307,9 +398,7 @@
     S.i = 0;
     if (!S.sel.length){ showDiag('No matching categories in dataset.'); return; }
     // Collapse the panel like the classic page
-    panel.classList.remove('open');
-    document.body.classList.remove('panel-open');
-    toggle.setAttribute('aria-expanded','false');
+    setDrawerState(false);
     renderCat(S.i);
   });
   document.getElementById('skip').addEventListener('click', ()=>{ S.i++; renderCat(S.i); });


### PR DESCRIPTION
## Summary
- center the kink survey hero call-to-action row with a responsive flex layout
- move the category selection panel into a full-screen drawer and wire start actions to open it
- update the survey script to manage the drawer state when toggling or beginning the survey

## Testing
- No automated tests were run (not requested)
- Manually verified the drawer layout in a local browser


------
https://chatgpt.com/codex/tasks/task_e_68d8a02787ac832c9c1631cab285a4b4