### PR TITLE
Adjust kinksurvey hero sizing

### DIFF
--- a/kinksurvey/index.html
+++ b/kinksurvey/index.html
@@ -30,8 +30,9 @@
     transition: transform 280ms ease;
   }
   #ksvHeroStack h1{
-    margin:0 0 clamp(10px, 2vh, 16px) 0;
-    font-size: clamp(42px, 6.5vw, 96px);
+    margin:0 0 clamp(16px, 2.4vw, 28px) 0;
+    font-size: clamp(36px, 5.2vw, 72px);
+    line-height: 1.06;
     font-weight: 800;
     letter-spacing:.02em;
     color:#fff;
@@ -47,18 +48,17 @@
   .ksvBtn{
     display:flex; align-items:center; justify-content:center;
     box-sizing:border-box;
-    width: clamp(280px, 72vw, 920px);
-    max-width:920px;
+    width: clamp(260px, 46vw, 620px);
+    max-width:620px;
     margin-left:auto;
     margin-right:auto;
-    height: clamp(64px, 11vh, 84px);
-    padding: 14px 22px;
-    border-radius: 14px;
+    padding: clamp(10px, 1.2vw, 16px) clamp(16px, 2.2vw, 22px);
+    border-radius: 16px;
     border: 2px solid rgba(0,230,255,.9);
     background: rgba(0,0,0,.25);
     box-shadow: 0 0 0 2px rgba(0,230,255,.15) inset, 0 6px 24px rgba(0,0,0,.35);
     color:#d9ffff; font-weight:800;
-    font-size: clamp(18px, 2.6vw, 28px);
+    font-size: clamp(18px, 2.1vw, 28px);
     line-height:1; text-decoration:none; text-align:center;
     transition: transform .12s ease, box-shadow .12s ease, background .12s ease;
   }


### PR DESCRIPTION
## Summary
- tighten the kinksurvey hero heading typography to better match the landing page
- resize the hero buttons for a more compact width, padding, and corner radius while keeping centering behavior

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9a6122968832c99021e442b1ec003