### PR TITLE
Ensure kinksurvey overlay exposes global handlers

### DIFF
--- a/kinksurvey/index.html
+++ b/kinksurvey/index.html
@@ -762,6 +762,13 @@ setTimeout(() => {
     });
   }
 
+  const legacyOpen = typeof window.tkKinksurveyOpenPanel === 'function'
+    ? window.tkKinksurveyOpenPanel
+    : null;
+  const legacyClose = typeof window.tkKinksurveyClosePanel === 'function'
+    ? window.tkKinksurveyClosePanel
+    : null;
+
   function openPanel(){
     forceUndim();
     scrubInteractivityBlocks(panel);
@@ -770,8 +777,11 @@ setTimeout(() => {
     panel.setAttribute('aria-hidden','false');
     document.body.classList.add('ksv-lock');
     setTimeout(() => {
-      (panel.querySelector('input,select,textarea,button,[tabindex]:not([tabindex="-1"])') || closeBtn)
-        ?.focus({preventScroll:true});
+      (
+        panel.querySelector('input[type="checkbox"]:not([disabled])') ||
+        panel.querySelector('input,select,textarea,button,[tabindex]:not([tabindex="-1"])') ||
+        closeBtn
+      )?.focus({preventScroll:true});
     }, 10);
   }
 
@@ -784,7 +794,30 @@ setTimeout(() => {
     startBtn?.focus?.({preventScroll:true});
   }
 
-  startBtn?.addEventListener('click', (e) => { e.preventDefault(); openPanel(); });
+  const overlayAwareOpen = (opts) => {
+    if (panel){
+      openPanel(opts);
+    }else if (legacyOpen){
+      legacyOpen(opts);
+    }
+  };
+
+  const overlayAwareClose = (opts) => {
+    if (panel){
+      closePanel(opts);
+    }else if (legacyClose){
+      legacyClose(opts);
+    }
+  };
+
+  window.tkKinksurveyOpenPanel = overlayAwareOpen;
+  window.tkKinksurveyClosePanel = overlayAwareClose;
+
+  startBtn?.addEventListener('click', (e) => {
+    e.preventDefault();
+    e.stopImmediatePropagation();
+    overlayAwareOpen({ trigger: startBtn });
+  });
   closeBtn.addEventListener('click', closePanel);
   backdrop.addEventListener('click', closePanel);
   document.addEventListener('keydown', (e) => { if (e.key === 'Escape' && backdrop.classList.contains('is-open')) closePanel(); });


### PR DESCRIPTION
## Summary
- expose overlay-aware wrappers on window.tkKinksurveyOpenPanel/ClosePanel so globals match the new panel
- prioritize the overlay handler for the hero Start Survey button and stop legacy drawer fallbacks from firing
- focus the first category checkbox when the overlay opens to match the expected UX

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9bf993bdc832c94b632dfb362b1b8