### PR TITLE
Align kinksurvey styling with active theme

### DIFF
--- a/kinksurvey/index.html
+++ b/kinksurvey/index.html
@@ -50,7 +50,7 @@
     line-height: 1.06;
     font-weight: 800;
     letter-spacing:.02em;
-    color:#fff;
+    color:var(--tk-ksv-fg, #fff);
     text-align:center;
   }
   .ksvButtons{
@@ -61,7 +61,7 @@
     gap: clamp(14px, 1.8vh, 18px);
   }
   .ksvFallbackNote{
-    color:#8fefff;
+    color:var(--tk-ksv-accent, #8fefff);
     font-weight:600;
     max-width:720px;
     margin:4px auto 0;
@@ -76,15 +76,15 @@
     margin-right:auto;
     padding: clamp(10px, 1.2vw, 16px) clamp(16px, 2.2vw, 22px);
     border-radius: 16px;
-    border: 2px solid rgba(0,230,255,.9);
-    background: rgba(0,0,0,.25);
+    border: 2px solid var(--tk-ksv-accent, rgba(0,230,255,.9));
+    background: var(--tk-ksv-btn-bg, rgba(0,0,0,.25));
     box-shadow: 0 0 0 2px rgba(0,230,255,.15) inset, 0 6px 24px rgba(0,0,0,.35);
-    color:#d9ffff; font-weight:800;
+    color:var(--tk-ksv-btn-fg, var(--tk-ksv-fg, #d9ffff)); font-weight:800;
     font-size: clamp(18px, 2.1vw, 28px);
     line-height:1; text-decoration:none; text-align:center;
     transition: transform .12s ease, box-shadow .12s ease, background .12s ease;
   }
-  .ksvBtn:hover{ transform: translateY(-1px); background: rgba(0,230,255,.08); }
+  .ksvBtn:hover{ transform: translateY(-1px); background: var(--tk-ksv-btn-hover-bg, rgba(0,230,255,.08)); }
   .ksvBtn:active{ transform: translateY(0); }
 
   .ksvThemeRow{
@@ -100,7 +100,7 @@
     gap:6px;
     align-items:center;
     font-weight:600;
-    color:#d9ffff;
+    color:var(--tk-ksv-fg, #d9ffff);
   }
 
   /* OFF-CANVAS CATEGORY PANEL (real off-canvas so it doesn't push hero) */
@@ -108,7 +108,7 @@
     position: fixed !important; top:0; left:0;
     height:100vh; width: clamp(320px, 36vw, 520px); max-width:92vw;
     background: var(--tk-panel-bg, rgba(5,18,24,.98));
-    border-right: 1px solid rgba(0,230,255,.35);
+    border-right: 1px solid var(--tk-ksv-line);
     overflow:auto; -webkit-overflow-scrolling:touch;
     transform: translateX(-110%); visibility:hidden; pointer-events:none;
     transition: transform 280ms ease, visibility 0s linear 280ms;
@@ -129,12 +129,23 @@
 </style>
 
 <style>
-  :root { --panel-w: 320px; --tk-drawer-w: clamp(340px, 92vw, 980px); --bg:#000; --fg:#e6ffff; --accent:#00e6ff; --line:#00e5ff33; }
+  :root {
+    --panel-w: 320px;
+    --tk-drawer-w: clamp(340px, 92vw, 980px);
+    --tk-ksv-bg: var(--bg-color, #000);
+    --tk-ksv-fg: var(--text-color, #e6ffff);
+    --tk-ksv-accent: var(--accent-color, #00e6ff);
+    --tk-ksv-btn-bg: var(--button-bg, rgba(0,0,0,.25));
+    --tk-ksv-btn-hover-bg: var(--button-hover-bg, rgba(0,230,255,.08));
+    --tk-ksv-btn-fg: var(--button-text, var(--tk-ksv-fg));
+    --tk-ksv-line: rgba(0,230,255,.35);
+    --tk-panel-bg: var(--panel-bg, rgba(5,18,24,.98));
+  }
   html,body{height:100%}
   body{
     margin:0;
-    background:#000;
-    color:var(--fg);
+    background:var(--tk-ksv-bg, #000);
+    color:var(--tk-ksv-fg, #e6ffff);
     font:16px/1.5 system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
     display:flex;
     flex-direction:column;
@@ -145,14 +156,15 @@
   /* LEFT SIDE PANEL (classic /kinks/ feel) */
   body.tk-js #panelToggle{
     position:fixed; left:12px; top:12px; z-index:2147483648;
-    background:#06161a; border:1px solid var(--line); color:var(--fg);
+    background:#06161a; border:1px solid var(--tk-ksv-line); color:var(--tk-ksv-fg);
     border-radius:10px; padding:8px 12px; cursor:pointer;
   }
   .category-panel{
-    background:#071317;
+    background:var(--tk-panel-bg, #071317);
     padding:14px 14px 18px;
     overflow:auto;
     text-align:center;
+    color:var(--tk-ksv-fg);
   }
 
   body.tk-js.panel-open,
@@ -244,7 +256,7 @@
   .category-list{ display:grid; grid-template-columns:1fr; gap:10px; justify-items:center; }
   .category-list label{
     display:flex; gap:10px; align-items:center; justify-content:center; padding:8px 10px;
-    border:1px solid var(--line); border-radius:10px; background:#060b0f; cursor:pointer;
+    border:1px solid var(--tk-ksv-line); border-radius:10px; background:var(--tk-panel-bg, #060b0f); cursor:pointer;
     text-align:center;
   }
 
@@ -254,16 +266,16 @@
   .panel-title, #statusMsg, #diag{ text-align:center; }
 
   .survey-box{
-    border:1px solid var(--line); border-radius:12px; background:#0a0f14; padding:16px;
+    border:1px solid var(--tk-ksv-line); border-radius:12px; background:var(--tk-panel-bg, #0a0f14); padding:16px;
     max-width:1000px; margin:0 auto;
     text-align:center;
   }
   .catTitle{ margin:0 0 8px; color:#7ef9ff }
-  .item{ display:flex; align-items:center; justify-content:center; gap:10px; padding:8px 0; border-top:1px dashed #00e5ff22; text-align:center; flex-wrap:wrap; }
+  .item{ display:flex; align-items:center; justify-content:center; gap:10px; padding:8px 0; border-top:1px dashed rgba(0,230,255,.18); text-align:center; flex-wrap:wrap; }
   .item:first-child{ border-top:0; }
-  select,input[type=text]{ padding:6px 8px; border:1px solid #115; border-radius:8px; background:#06161a; color:var(--fg); }
+  select,input[type=text]{ padding:6px 8px; border:1px solid var(--tk-ksv-line); border-radius:8px; background:var(--tk-panel-bg, #06161a); color:var(--tk-ksv-fg); }
 
-  .notice{ margin:14px 0; padding:10px 12px; border:1px dashed var(--line); border-radius:10px; background:#071317; text-align:center; }
+  .notice{ margin:14px 0; padding:10px 12px; border:1px dashed var(--tk-ksv-line); border-radius:10px; background:var(--tk-panel-bg, #071317); text-align:center; }
 </style>
 </head>
 <body class="theme-dark has-category-panel tk-no-js">


### PR DESCRIPTION
## Summary
- allow the kinksurvey hero and buttons to inherit the site text, accent, and button variables so light themes remain legible
- update the category panel and form elements to use shared panel/background variables instead of forcing a black palette

## Testing
- not run (css change)


------
https://chatgpt.com/codex/tasks/task_e_68d9ca979570832cb9c5fe835b05bd55