### PR TITLE
Add test to guard against duplicate survey questions

### DIFF
--- a/test/surveyQuestionsUnique.test.js
+++ b/test/surveyQuestionsUnique.test.js
@@ -1,0 +1,41 @@
+import fs from 'node:fs';
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+const survey = JSON.parse(
+  fs.readFileSync(new URL('../survey.json', import.meta.url), 'utf8')
+);
+
+const questions = survey.sections.flatMap((section) => section.questions);
+
+const findDuplicates = (values) => {
+  const seen = new Set();
+  const duplicates = new Set();
+
+  for (const value of values) {
+    if (seen.has(value)) {
+      duplicates.add(value);
+    }
+    seen.add(value);
+  }
+
+  return [...duplicates];
+};
+
+test('survey question ids are unique', () => {
+  const duplicates = findDuplicates(questions.map((question) => question.id));
+  assert.deepStrictEqual(
+    duplicates,
+    [],
+    `Duplicate question id(s) found: ${duplicates.join(', ')}`
+  );
+});
+
+test('survey question text is unique', () => {
+  const duplicates = findDuplicates(questions.map((question) => question.q.trim()));
+  assert.deepStrictEqual(
+    duplicates,
+    [],
+    `Duplicate question text found: ${duplicates.join(', ')}`
+  );
+});


### PR DESCRIPTION
## Summary
- add a Node test that loads `survey.json`
- ensure survey question IDs and text remain unique to catch duplicates early

## Testing
- node --test test/surveyQuestionsUnique.test.js

------
https://chatgpt.com/codex/tasks/task_e_68daffb32b84832cbc7c58e79674e4de