### PR TITLE
Add psychology play and breeding categories

### DIFF
--- a/data/kinks.json
+++ b/data/kinks.json
@@ -4705,5 +4705,239 @@
         ]
       }
     ]
+  },
+  {
+    "category": "Psychology Play",
+    "items": [
+      {
+        "id": "psychology-play-emotional-sadism-giving-teasing-feelings-orchestrating-reactions-savoring-anticipation-without-shame-based-harm",
+        "label": "Emotional Sadism (giving): teasing feelings, orchestrating reactions, savoring anticipation without shame-based harm",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-psychological-control-mind-games-double-binds-deliberate-pacing-and-strategic-ambiguity",
+        "label": "Psychological Control: mind games, double binds, deliberate pacing, and strategic ambiguity",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-sadistic-attention-enjoying-being-the-focal-point-of-a-partner-s-fear-arousal-or-resistance",
+        "label": "Sadistic Attention: enjoying being the focal point of a partner’s fear, arousal, or resistance",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-teasing-humiliation-playful-status-play-without-degradation-or-shame",
+        "label": "Teasing Humiliation: playful status play without degradation or shame",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-emotional-sadism-receiving-enjoying-engineered-emotional-intensity-such-as-fluster-exposure-or-playful-embarrassment",
+        "label": "Emotional Sadism (receiving): enjoying engineered emotional intensity such as fluster, exposure, or playful embarrassment",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-psychological-control-receiving-arousal-from-being-studied-contained-or-outmaneuvered",
+        "label": "Psychological Control (receiving): arousal from being studied, contained, or outmaneuvered",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-being-the-focus-enjoying-being-watched-tracked-or-held-in-a-partner-s-intense-focus",
+        "label": "Being the Focus: enjoying being watched, tracked, or held in a partner’s intense focus",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-teasing-humiliation-receiving-enjoying-playful-embarrassment-or-affectionate-mockery-that-builds-intimacy",
+        "label": "Teasing Humiliation (receiving): enjoying playful embarrassment or affectionate mockery that builds intimacy",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-prey-attention-neediness-craving-focus-pursuit-or-intense-awareness-from-a-partner",
+        "label": "Prey Attention/Neediness: craving focus, pursuit, or intense awareness from a partner",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-primal-recognition-being-seen-understood-or-tracked-without-needing-words",
+        "label": "Primal Recognition: being seen, understood, or tracked without needing words",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Breeding",
+    "items": [
+      {
+        "id": "breeding-impregnation-giving-arousal-from-attempting-to-impregnate-a-partner",
+        "label": "Impregnation (giving): arousal from attempting to impregnate a partner",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "breeding-feeding-milk-giving-arousal-from-producing-and-feeding-milk-to-a-partner",
+        "label": "Feeding Milk (giving): arousal from producing and feeding milk to a partner",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "breeding-impregnation-receiving-arousal-from-being-inseminated-pregnancy-risk-or-being-bred",
+        "label": "Impregnation (receiving): arousal from being inseminated, pregnancy risk, or being bred",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "breeding-feeding-milk-receiving-arousal-from-drinking-a-partner-s-milk",
+        "label": "Feeding Milk (receiving): arousal from drinking a partner’s milk",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "breeding-pregnancy-fantasy-erotic-focus-on-pregnancy-mine-partner-s-or-fictional-scenarios",
+        "label": "Pregnancy Fantasy: erotic focus on pregnancy (mine, partner’s, or fictional scenarios)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-primal-breeding-drive-animalistic-instinctual-framing-of-sex-reproduction-territory",
+        "label": "Primal Breeding Drive: animalistic/instinctual framing of sex, reproduction, territory",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-breeding-as-control-ownership-authority-expressed-through-breeding-talk-or-pregnancy-risk",
+        "label": "Breeding as Control: ownership/authority expressed through breeding talk or pregnancy risk",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-creampie-marking-erotic-meaning-placed-on-internal-ejaculation-or-visible-claimed-markers",
+        "label": "Creampie/Marking: erotic meaning placed on internal ejaculation or visible ‘claimed’ markers",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-risk-no-contraception-talk-fantasy-dirty-talk-about-risk-or-breeding-without-actual-risk",
+        "label": "Risk/‘No Contraception’ Talk (fantasy): dirty talk about risk or breeding without actual risk",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-heat-ovulation-tracking-timing-in-heat-roleplay-or-cycle-focused-arousal",
+        "label": "Heat/Ovulation Tracking: timing, ‘in heat’ roleplay, or cycle-focused arousal",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-artificial-insemination-device-play-syringes-cups-or-medical-style-scenarios-consensual-fantasy",
+        "label": "Artificial Insemination/Device Play: syringes, cups, or medical-style scenarios (consensual fantasy)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-breeding-denial-ruined-breeding-building-toward-impregnation-talk-then-denying-or-ruining-it",
+        "label": "Breeding Denial/Ruined Breeding: building toward impregnation talk then denying or ‘ruining’ it",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-pregnancy-body-focus-belly-worship-movement-weight-changes-glow-and-attention",
+        "label": "Pregnancy Body Focus: belly worship, movement/weight changes, glow, and attention",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-pregnancy-protocol-care-protective-rules-pedestal-treatment-dedicated-aftercare",
+        "label": "Pregnancy Protocol/Care: protective rules, pedestal treatment, dedicated aftercare",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-lactation-induction-maintenance-interest-in-inducing-or-sustaining-milk-production",
+        "label": "Lactation Induction/Maintenance: interest in inducing or sustaining milk production",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-milking-scenes-manual-oral-or-pump-based-milking-as-play-or-ritual",
+        "label": "Milking Scenes: manual, oral, or pump-based ‘milking’ as play or ritual",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-contraception-boundaries-preference-to-use-protection-bc-methods-or-simulation-only",
+        "label": "Contraception Boundaries: preference to use protection, BC methods, or simulation-only",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-sti-testing-medical-boundaries-testing-cadence-disclosures-and-comfort-levels",
+        "label": "STI/Testing & Medical Boundaries: testing cadence, disclosures, and comfort levels",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
   }
 ]

--- a/docs/data/kinks.json
+++ b/docs/data/kinks.json
@@ -4705,5 +4705,239 @@
         ]
       }
     ]
+  },
+  {
+    "category": "Psychology Play",
+    "items": [
+      {
+        "id": "psychology-play-emotional-sadism-giving-teasing-feelings-orchestrating-reactions-savoring-anticipation-without-shame-based-harm",
+        "label": "Emotional Sadism (giving): teasing feelings, orchestrating reactions, savoring anticipation without shame-based harm",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-psychological-control-mind-games-double-binds-deliberate-pacing-and-strategic-ambiguity",
+        "label": "Psychological Control: mind games, double binds, deliberate pacing, and strategic ambiguity",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-sadistic-attention-enjoying-being-the-focal-point-of-a-partner-s-fear-arousal-or-resistance",
+        "label": "Sadistic Attention: enjoying being the focal point of a partner’s fear, arousal, or resistance",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-teasing-humiliation-playful-status-play-without-degradation-or-shame",
+        "label": "Teasing Humiliation: playful status play without degradation or shame",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-emotional-sadism-receiving-enjoying-engineered-emotional-intensity-such-as-fluster-exposure-or-playful-embarrassment",
+        "label": "Emotional Sadism (receiving): enjoying engineered emotional intensity such as fluster, exposure, or playful embarrassment",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-psychological-control-receiving-arousal-from-being-studied-contained-or-outmaneuvered",
+        "label": "Psychological Control (receiving): arousal from being studied, contained, or outmaneuvered",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-being-the-focus-enjoying-being-watched-tracked-or-held-in-a-partner-s-intense-focus",
+        "label": "Being the Focus: enjoying being watched, tracked, or held in a partner’s intense focus",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-teasing-humiliation-receiving-enjoying-playful-embarrassment-or-affectionate-mockery-that-builds-intimacy",
+        "label": "Teasing Humiliation (receiving): enjoying playful embarrassment or affectionate mockery that builds intimacy",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-prey-attention-neediness-craving-focus-pursuit-or-intense-awareness-from-a-partner",
+        "label": "Prey Attention/Neediness: craving focus, pursuit, or intense awareness from a partner",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-primal-recognition-being-seen-understood-or-tracked-without-needing-words",
+        "label": "Primal Recognition: being seen, understood, or tracked without needing words",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Breeding",
+    "items": [
+      {
+        "id": "breeding-impregnation-giving-arousal-from-attempting-to-impregnate-a-partner",
+        "label": "Impregnation (giving): arousal from attempting to impregnate a partner",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "breeding-feeding-milk-giving-arousal-from-producing-and-feeding-milk-to-a-partner",
+        "label": "Feeding Milk (giving): arousal from producing and feeding milk to a partner",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "breeding-impregnation-receiving-arousal-from-being-inseminated-pregnancy-risk-or-being-bred",
+        "label": "Impregnation (receiving): arousal from being inseminated, pregnancy risk, or being bred",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "breeding-feeding-milk-receiving-arousal-from-drinking-a-partner-s-milk",
+        "label": "Feeding Milk (receiving): arousal from drinking a partner’s milk",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "breeding-pregnancy-fantasy-erotic-focus-on-pregnancy-mine-partner-s-or-fictional-scenarios",
+        "label": "Pregnancy Fantasy: erotic focus on pregnancy (mine, partner’s, or fictional scenarios)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-primal-breeding-drive-animalistic-instinctual-framing-of-sex-reproduction-territory",
+        "label": "Primal Breeding Drive: animalistic/instinctual framing of sex, reproduction, territory",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-breeding-as-control-ownership-authority-expressed-through-breeding-talk-or-pregnancy-risk",
+        "label": "Breeding as Control: ownership/authority expressed through breeding talk or pregnancy risk",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-creampie-marking-erotic-meaning-placed-on-internal-ejaculation-or-visible-claimed-markers",
+        "label": "Creampie/Marking: erotic meaning placed on internal ejaculation or visible ‘claimed’ markers",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-risk-no-contraception-talk-fantasy-dirty-talk-about-risk-or-breeding-without-actual-risk",
+        "label": "Risk/‘No Contraception’ Talk (fantasy): dirty talk about risk or breeding without actual risk",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-heat-ovulation-tracking-timing-in-heat-roleplay-or-cycle-focused-arousal",
+        "label": "Heat/Ovulation Tracking: timing, ‘in heat’ roleplay, or cycle-focused arousal",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-artificial-insemination-device-play-syringes-cups-or-medical-style-scenarios-consensual-fantasy",
+        "label": "Artificial Insemination/Device Play: syringes, cups, or medical-style scenarios (consensual fantasy)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-breeding-denial-ruined-breeding-building-toward-impregnation-talk-then-denying-or-ruining-it",
+        "label": "Breeding Denial/Ruined Breeding: building toward impregnation talk then denying or ‘ruining’ it",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-pregnancy-body-focus-belly-worship-movement-weight-changes-glow-and-attention",
+        "label": "Pregnancy Body Focus: belly worship, movement/weight changes, glow, and attention",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-pregnancy-protocol-care-protective-rules-pedestal-treatment-dedicated-aftercare",
+        "label": "Pregnancy Protocol/Care: protective rules, pedestal treatment, dedicated aftercare",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-lactation-induction-maintenance-interest-in-inducing-or-sustaining-milk-production",
+        "label": "Lactation Induction/Maintenance: interest in inducing or sustaining milk production",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-milking-scenes-manual-oral-or-pump-based-milking-as-play-or-ritual",
+        "label": "Milking Scenes: manual, oral, or pump-based ‘milking’ as play or ritual",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-contraception-boundaries-preference-to-use-protection-bc-methods-or-simulation-only",
+        "label": "Contraception Boundaries: preference to use protection, BC methods, or simulation-only",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-sti-testing-medical-boundaries-testing-cadence-disclosures-and-comfort-levels",
+        "label": "STI/Testing & Medical Boundaries: testing cadence, disclosures, and comfort levels",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
   }
 ]

--- a/docs/kinks.json
+++ b/docs/kinks.json
@@ -4705,5 +4705,239 @@
         ]
       }
     ]
+  },
+  {
+    "category": "Psychology Play",
+    "items": [
+      {
+        "id": "psychology-play-emotional-sadism-giving-teasing-feelings-orchestrating-reactions-savoring-anticipation-without-shame-based-harm",
+        "label": "Emotional Sadism (giving): teasing feelings, orchestrating reactions, savoring anticipation without shame-based harm",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-psychological-control-mind-games-double-binds-deliberate-pacing-and-strategic-ambiguity",
+        "label": "Psychological Control: mind games, double binds, deliberate pacing, and strategic ambiguity",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-sadistic-attention-enjoying-being-the-focal-point-of-a-partner-s-fear-arousal-or-resistance",
+        "label": "Sadistic Attention: enjoying being the focal point of a partner’s fear, arousal, or resistance",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-teasing-humiliation-playful-status-play-without-degradation-or-shame",
+        "label": "Teasing Humiliation: playful status play without degradation or shame",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-emotional-sadism-receiving-enjoying-engineered-emotional-intensity-such-as-fluster-exposure-or-playful-embarrassment",
+        "label": "Emotional Sadism (receiving): enjoying engineered emotional intensity such as fluster, exposure, or playful embarrassment",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-psychological-control-receiving-arousal-from-being-studied-contained-or-outmaneuvered",
+        "label": "Psychological Control (receiving): arousal from being studied, contained, or outmaneuvered",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-being-the-focus-enjoying-being-watched-tracked-or-held-in-a-partner-s-intense-focus",
+        "label": "Being the Focus: enjoying being watched, tracked, or held in a partner’s intense focus",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-teasing-humiliation-receiving-enjoying-playful-embarrassment-or-affectionate-mockery-that-builds-intimacy",
+        "label": "Teasing Humiliation (receiving): enjoying playful embarrassment or affectionate mockery that builds intimacy",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-prey-attention-neediness-craving-focus-pursuit-or-intense-awareness-from-a-partner",
+        "label": "Prey Attention/Neediness: craving focus, pursuit, or intense awareness from a partner",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-primal-recognition-being-seen-understood-or-tracked-without-needing-words",
+        "label": "Primal Recognition: being seen, understood, or tracked without needing words",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Breeding",
+    "items": [
+      {
+        "id": "breeding-impregnation-giving-arousal-from-attempting-to-impregnate-a-partner",
+        "label": "Impregnation (giving): arousal from attempting to impregnate a partner",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "breeding-feeding-milk-giving-arousal-from-producing-and-feeding-milk-to-a-partner",
+        "label": "Feeding Milk (giving): arousal from producing and feeding milk to a partner",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "breeding-impregnation-receiving-arousal-from-being-inseminated-pregnancy-risk-or-being-bred",
+        "label": "Impregnation (receiving): arousal from being inseminated, pregnancy risk, or being bred",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "breeding-feeding-milk-receiving-arousal-from-drinking-a-partner-s-milk",
+        "label": "Feeding Milk (receiving): arousal from drinking a partner’s milk",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "breeding-pregnancy-fantasy-erotic-focus-on-pregnancy-mine-partner-s-or-fictional-scenarios",
+        "label": "Pregnancy Fantasy: erotic focus on pregnancy (mine, partner’s, or fictional scenarios)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-primal-breeding-drive-animalistic-instinctual-framing-of-sex-reproduction-territory",
+        "label": "Primal Breeding Drive: animalistic/instinctual framing of sex, reproduction, territory",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-breeding-as-control-ownership-authority-expressed-through-breeding-talk-or-pregnancy-risk",
+        "label": "Breeding as Control: ownership/authority expressed through breeding talk or pregnancy risk",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-creampie-marking-erotic-meaning-placed-on-internal-ejaculation-or-visible-claimed-markers",
+        "label": "Creampie/Marking: erotic meaning placed on internal ejaculation or visible ‘claimed’ markers",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-risk-no-contraception-talk-fantasy-dirty-talk-about-risk-or-breeding-without-actual-risk",
+        "label": "Risk/‘No Contraception’ Talk (fantasy): dirty talk about risk or breeding without actual risk",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-heat-ovulation-tracking-timing-in-heat-roleplay-or-cycle-focused-arousal",
+        "label": "Heat/Ovulation Tracking: timing, ‘in heat’ roleplay, or cycle-focused arousal",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-artificial-insemination-device-play-syringes-cups-or-medical-style-scenarios-consensual-fantasy",
+        "label": "Artificial Insemination/Device Play: syringes, cups, or medical-style scenarios (consensual fantasy)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-breeding-denial-ruined-breeding-building-toward-impregnation-talk-then-denying-or-ruining-it",
+        "label": "Breeding Denial/Ruined Breeding: building toward impregnation talk then denying or ‘ruining’ it",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-pregnancy-body-focus-belly-worship-movement-weight-changes-glow-and-attention",
+        "label": "Pregnancy Body Focus: belly worship, movement/weight changes, glow, and attention",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-pregnancy-protocol-care-protective-rules-pedestal-treatment-dedicated-aftercare",
+        "label": "Pregnancy Protocol/Care: protective rules, pedestal treatment, dedicated aftercare",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-lactation-induction-maintenance-interest-in-inducing-or-sustaining-milk-production",
+        "label": "Lactation Induction/Maintenance: interest in inducing or sustaining milk production",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-milking-scenes-manual-oral-or-pump-based-milking-as-play-or-ritual",
+        "label": "Milking Scenes: manual, oral, or pump-based ‘milking’ as play or ritual",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-contraception-boundaries-preference-to-use-protection-bc-methods-or-simulation-only",
+        "label": "Contraception Boundaries: preference to use protection, BC methods, or simulation-only",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-sti-testing-medical-boundaries-testing-cadence-disclosures-and-comfort-levels",
+        "label": "STI/Testing & Medical Boundaries: testing cadence, disclosures, and comfort levels",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
   }
 ]

--- a/docs/kinks/data/kinks.json
+++ b/docs/kinks/data/kinks.json
@@ -4705,5 +4705,239 @@
         ]
       }
     ]
+  },
+  {
+    "category": "Psychology Play",
+    "items": [
+      {
+        "id": "psychology-play-emotional-sadism-giving-teasing-feelings-orchestrating-reactions-savoring-anticipation-without-shame-based-harm",
+        "label": "Emotional Sadism (giving): teasing feelings, orchestrating reactions, savoring anticipation without shame-based harm",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-psychological-control-mind-games-double-binds-deliberate-pacing-and-strategic-ambiguity",
+        "label": "Psychological Control: mind games, double binds, deliberate pacing, and strategic ambiguity",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-sadistic-attention-enjoying-being-the-focal-point-of-a-partner-s-fear-arousal-or-resistance",
+        "label": "Sadistic Attention: enjoying being the focal point of a partner’s fear, arousal, or resistance",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-teasing-humiliation-playful-status-play-without-degradation-or-shame",
+        "label": "Teasing Humiliation: playful status play without degradation or shame",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-emotional-sadism-receiving-enjoying-engineered-emotional-intensity-such-as-fluster-exposure-or-playful-embarrassment",
+        "label": "Emotional Sadism (receiving): enjoying engineered emotional intensity such as fluster, exposure, or playful embarrassment",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-psychological-control-receiving-arousal-from-being-studied-contained-or-outmaneuvered",
+        "label": "Psychological Control (receiving): arousal from being studied, contained, or outmaneuvered",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-being-the-focus-enjoying-being-watched-tracked-or-held-in-a-partner-s-intense-focus",
+        "label": "Being the Focus: enjoying being watched, tracked, or held in a partner’s intense focus",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-teasing-humiliation-receiving-enjoying-playful-embarrassment-or-affectionate-mockery-that-builds-intimacy",
+        "label": "Teasing Humiliation (receiving): enjoying playful embarrassment or affectionate mockery that builds intimacy",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-prey-attention-neediness-craving-focus-pursuit-or-intense-awareness-from-a-partner",
+        "label": "Prey Attention/Neediness: craving focus, pursuit, or intense awareness from a partner",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-primal-recognition-being-seen-understood-or-tracked-without-needing-words",
+        "label": "Primal Recognition: being seen, understood, or tracked without needing words",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Breeding",
+    "items": [
+      {
+        "id": "breeding-impregnation-giving-arousal-from-attempting-to-impregnate-a-partner",
+        "label": "Impregnation (giving): arousal from attempting to impregnate a partner",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "breeding-feeding-milk-giving-arousal-from-producing-and-feeding-milk-to-a-partner",
+        "label": "Feeding Milk (giving): arousal from producing and feeding milk to a partner",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "breeding-impregnation-receiving-arousal-from-being-inseminated-pregnancy-risk-or-being-bred",
+        "label": "Impregnation (receiving): arousal from being inseminated, pregnancy risk, or being bred",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "breeding-feeding-milk-receiving-arousal-from-drinking-a-partner-s-milk",
+        "label": "Feeding Milk (receiving): arousal from drinking a partner’s milk",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "breeding-pregnancy-fantasy-erotic-focus-on-pregnancy-mine-partner-s-or-fictional-scenarios",
+        "label": "Pregnancy Fantasy: erotic focus on pregnancy (mine, partner’s, or fictional scenarios)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-primal-breeding-drive-animalistic-instinctual-framing-of-sex-reproduction-territory",
+        "label": "Primal Breeding Drive: animalistic/instinctual framing of sex, reproduction, territory",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-breeding-as-control-ownership-authority-expressed-through-breeding-talk-or-pregnancy-risk",
+        "label": "Breeding as Control: ownership/authority expressed through breeding talk or pregnancy risk",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-creampie-marking-erotic-meaning-placed-on-internal-ejaculation-or-visible-claimed-markers",
+        "label": "Creampie/Marking: erotic meaning placed on internal ejaculation or visible ‘claimed’ markers",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-risk-no-contraception-talk-fantasy-dirty-talk-about-risk-or-breeding-without-actual-risk",
+        "label": "Risk/‘No Contraception’ Talk (fantasy): dirty talk about risk or breeding without actual risk",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-heat-ovulation-tracking-timing-in-heat-roleplay-or-cycle-focused-arousal",
+        "label": "Heat/Ovulation Tracking: timing, ‘in heat’ roleplay, or cycle-focused arousal",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-artificial-insemination-device-play-syringes-cups-or-medical-style-scenarios-consensual-fantasy",
+        "label": "Artificial Insemination/Device Play: syringes, cups, or medical-style scenarios (consensual fantasy)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-breeding-denial-ruined-breeding-building-toward-impregnation-talk-then-denying-or-ruining-it",
+        "label": "Breeding Denial/Ruined Breeding: building toward impregnation talk then denying or ‘ruining’ it",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-pregnancy-body-focus-belly-worship-movement-weight-changes-glow-and-attention",
+        "label": "Pregnancy Body Focus: belly worship, movement/weight changes, glow, and attention",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-pregnancy-protocol-care-protective-rules-pedestal-treatment-dedicated-aftercare",
+        "label": "Pregnancy Protocol/Care: protective rules, pedestal treatment, dedicated aftercare",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-lactation-induction-maintenance-interest-in-inducing-or-sustaining-milk-production",
+        "label": "Lactation Induction/Maintenance: interest in inducing or sustaining milk production",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-milking-scenes-manual-oral-or-pump-based-milking-as-play-or-ritual",
+        "label": "Milking Scenes: manual, oral, or pump-based ‘milking’ as play or ritual",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-contraception-boundaries-preference-to-use-protection-bc-methods-or-simulation-only",
+        "label": "Contraception Boundaries: preference to use protection, BC methods, or simulation-only",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-sti-testing-medical-boundaries-testing-cadence-disclosures-and-comfort-levels",
+        "label": "STI/Testing & Medical Boundaries: testing cadence, disclosures, and comfort levels",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
   }
 ]

--- a/docs/kinks/embedded-kinks.js
+++ b/docs/kinks/embedded-kinks.js
@@ -4706,5 +4706,239 @@ window.KINKS_BANK = [
         ]
       }
     ]
+  },
+  {
+    "category": "Psychology Play",
+    "items": [
+      {
+        "id": "psychology-play-emotional-sadism-giving-teasing-feelings-orchestrating-reactions-savoring-anticipation-without-shame-based-harm",
+        "label": "Emotional Sadism (giving): teasing feelings, orchestrating reactions, savoring anticipation without shame-based harm",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-psychological-control-mind-games-double-binds-deliberate-pacing-and-strategic-ambiguity",
+        "label": "Psychological Control: mind games, double binds, deliberate pacing, and strategic ambiguity",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-sadistic-attention-enjoying-being-the-focal-point-of-a-partner-s-fear-arousal-or-resistance",
+        "label": "Sadistic Attention: enjoying being the focal point of a partner’s fear, arousal, or resistance",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-teasing-humiliation-playful-status-play-without-degradation-or-shame",
+        "label": "Teasing Humiliation: playful status play without degradation or shame",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-emotional-sadism-receiving-enjoying-engineered-emotional-intensity-such-as-fluster-exposure-or-playful-embarrassment",
+        "label": "Emotional Sadism (receiving): enjoying engineered emotional intensity such as fluster, exposure, or playful embarrassment",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-psychological-control-receiving-arousal-from-being-studied-contained-or-outmaneuvered",
+        "label": "Psychological Control (receiving): arousal from being studied, contained, or outmaneuvered",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-being-the-focus-enjoying-being-watched-tracked-or-held-in-a-partner-s-intense-focus",
+        "label": "Being the Focus: enjoying being watched, tracked, or held in a partner’s intense focus",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-teasing-humiliation-receiving-enjoying-playful-embarrassment-or-affectionate-mockery-that-builds-intimacy",
+        "label": "Teasing Humiliation (receiving): enjoying playful embarrassment or affectionate mockery that builds intimacy",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-prey-attention-neediness-craving-focus-pursuit-or-intense-awareness-from-a-partner",
+        "label": "Prey Attention/Neediness: craving focus, pursuit, or intense awareness from a partner",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-primal-recognition-being-seen-understood-or-tracked-without-needing-words",
+        "label": "Primal Recognition: being seen, understood, or tracked without needing words",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Breeding",
+    "items": [
+      {
+        "id": "breeding-impregnation-giving-arousal-from-attempting-to-impregnate-a-partner",
+        "label": "Impregnation (giving): arousal from attempting to impregnate a partner",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "breeding-feeding-milk-giving-arousal-from-producing-and-feeding-milk-to-a-partner",
+        "label": "Feeding Milk (giving): arousal from producing and feeding milk to a partner",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "breeding-impregnation-receiving-arousal-from-being-inseminated-pregnancy-risk-or-being-bred",
+        "label": "Impregnation (receiving): arousal from being inseminated, pregnancy risk, or being bred",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "breeding-feeding-milk-receiving-arousal-from-drinking-a-partner-s-milk",
+        "label": "Feeding Milk (receiving): arousal from drinking a partner’s milk",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "breeding-pregnancy-fantasy-erotic-focus-on-pregnancy-mine-partner-s-or-fictional-scenarios",
+        "label": "Pregnancy Fantasy: erotic focus on pregnancy (mine, partner’s, or fictional scenarios)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-primal-breeding-drive-animalistic-instinctual-framing-of-sex-reproduction-territory",
+        "label": "Primal Breeding Drive: animalistic/instinctual framing of sex, reproduction, territory",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-breeding-as-control-ownership-authority-expressed-through-breeding-talk-or-pregnancy-risk",
+        "label": "Breeding as Control: ownership/authority expressed through breeding talk or pregnancy risk",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-creampie-marking-erotic-meaning-placed-on-internal-ejaculation-or-visible-claimed-markers",
+        "label": "Creampie/Marking: erotic meaning placed on internal ejaculation or visible ‘claimed’ markers",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-risk-no-contraception-talk-fantasy-dirty-talk-about-risk-or-breeding-without-actual-risk",
+        "label": "Risk/‘No Contraception’ Talk (fantasy): dirty talk about risk or breeding without actual risk",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-heat-ovulation-tracking-timing-in-heat-roleplay-or-cycle-focused-arousal",
+        "label": "Heat/Ovulation Tracking: timing, ‘in heat’ roleplay, or cycle-focused arousal",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-artificial-insemination-device-play-syringes-cups-or-medical-style-scenarios-consensual-fantasy",
+        "label": "Artificial Insemination/Device Play: syringes, cups, or medical-style scenarios (consensual fantasy)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-breeding-denial-ruined-breeding-building-toward-impregnation-talk-then-denying-or-ruining-it",
+        "label": "Breeding Denial/Ruined Breeding: building toward impregnation talk then denying or ‘ruining’ it",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-pregnancy-body-focus-belly-worship-movement-weight-changes-glow-and-attention",
+        "label": "Pregnancy Body Focus: belly worship, movement/weight changes, glow, and attention",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-pregnancy-protocol-care-protective-rules-pedestal-treatment-dedicated-aftercare",
+        "label": "Pregnancy Protocol/Care: protective rules, pedestal treatment, dedicated aftercare",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-lactation-induction-maintenance-interest-in-inducing-or-sustaining-milk-production",
+        "label": "Lactation Induction/Maintenance: interest in inducing or sustaining milk production",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-milking-scenes-manual-oral-or-pump-based-milking-as-play-or-ritual",
+        "label": "Milking Scenes: manual, oral, or pump-based ‘milking’ as play or ritual",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-contraception-boundaries-preference-to-use-protection-bc-methods-or-simulation-only",
+        "label": "Contraception Boundaries: preference to use protection, BC methods, or simulation-only",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-sti-testing-medical-boundaries-testing-cadence-disclosures-and-comfort-levels",
+        "label": "STI/Testing & Medical Boundaries: testing cadence, disclosures, and comfort levels",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
   }
 ];

--- a/docs/kinks/js/template-survey.js
+++ b/docs/kinks/js/template-survey.js
@@ -2648,6 +2648,30 @@ window.templateSurvey =
       {
         "name": "Emotional trickery as arousal",
         "rating": null
+      },
+      {
+        "name": "Being misled or deceived on purpose during play",
+        "rating": null
+      },
+      {
+        "name": "Surprise rule changes or twists mid-scene",
+        "rating": null
+      },
+      {
+        "name": "False safeword games (with negotiated limits)",
+        "rating": null
+      },
+      {
+        "name": "Withholding or delaying aftercare for effect",
+        "rating": null
+      },
+      {
+        "name": "Being gaslit or doubted in a controlled roleplay",
+        "rating": null
+      },
+      {
+        "name": "Told 'you asked for this' or 'you love this' when resisting",
+        "rating": null
       }
     ],
     "Receiving": [
@@ -2700,6 +2724,30 @@ window.templateSurvey =
       {
         "name": "Emotional trickery as arousal",
         "rating": null
+      },
+      {
+        "name": "Being misled or deceived on purpose during play",
+        "rating": null
+      },
+      {
+        "name": "Surprise rule changes or twists mid-scene",
+        "rating": null
+      },
+      {
+        "name": "False safeword games (with negotiated limits)",
+        "rating": null
+      },
+      {
+        "name": "Withholding or delaying aftercare for effect",
+        "rating": null
+      },
+      {
+        "name": "Being gaslit or doubted in a controlled roleplay",
+        "rating": null
+      },
+      {
+        "name": "Told 'you asked for this' or 'you love this' when resisting",
+        "rating": null
       }
     ],
     "General": []
@@ -2737,6 +2785,30 @@ window.templateSurvey =
       {
         "name": "Leash held in mouth",
         "rating": null
+      },
+      {
+        "name": "Being gagged or forced silent",
+        "rating": null
+      },
+      {
+        "name": "Having to hold objects in your mouth (spoon, hairbrush, leash)",
+        "rating": null
+      },
+      {
+        "name": "Being used for oral service without reciprocal pleasure",
+        "rating": null
+      },
+      {
+        "name": "Being fed by hand, mouth-to-mouth, or with utensils",
+        "rating": null
+      },
+      {
+        "name": "Verbal control (e.g., only speak when spoken to)",
+        "rating": null
+      },
+      {
+        "name": "Mouth as a symbol of ownership or control",
+        "rating": null
       }
     ],
     "Receiving": [
@@ -2770,6 +2842,30 @@ window.templateSurvey =
       },
       {
         "name": "Leash held in mouth",
+        "rating": null
+      },
+      {
+        "name": "Being gagged or forced silent",
+        "rating": null
+      },
+      {
+        "name": "Having to hold objects in your mouth (spoon, hairbrush, leash)",
+        "rating": null
+      },
+      {
+        "name": "Being used for oral service without reciprocal pleasure",
+        "rating": null
+      },
+      {
+        "name": "Being fed by hand, mouth-to-mouth, or with utensils",
+        "rating": null
+      },
+      {
+        "name": "Verbal control (e.g., only speak when spoken to)",
+        "rating": null
+      },
+      {
+        "name": "Mouth as a symbol of ownership or control",
         "rating": null
       }
     ],
@@ -2913,8 +3009,8 @@ window.templateSurvey =
       { "name": "Open with boundaries", "rating": null },
       { "name": "Closed but kinky with others", "rating": null },
       { "name": "Switch-friendly dynamics", "rating": null }
-      ]
-    },
+    ]
+  },
   "Gender Play & Transformation": {
     "Giving": [
       { "name": "Crossdressing", "rating": null },
@@ -3110,5 +3206,49 @@ window.templateSurvey =
       { "name": "Formal appearance protocols for scenes or dynamics", "rating": null },
       { "name": "Using clothing or style to embody emotional or power roles", "rating": null }
     ]
+  },
+  "Psychology Play": {
+    "Giving": [
+      { "name": "Emotional Sadism (giving): teasing feelings, orchestrating reactions, savoring anticipation without shame-based harm", "rating": null },
+      { "name": "Psychological Control: mind games, double binds, deliberate pacing, and strategic ambiguity", "rating": null },
+      { "name": "Sadistic Attention: enjoying being the focal point of a partner’s fear, arousal, or resistance", "rating": null },
+      { "name": "Teasing Humiliation: playful status play without degradation or shame", "rating": null }
+    ],
+    "Receiving": [
+      { "name": "Emotional Sadism (receiving): enjoying engineered emotional intensity such as fluster, exposure, or playful embarrassment", "rating": null },
+      { "name": "Psychological Control (receiving): arousal from being studied, contained, or outmaneuvered", "rating": null },
+      { "name": "Being the Focus: enjoying being watched, tracked, or held in a partner’s intense focus", "rating": null },
+      { "name": "Teasing Humiliation (receiving): enjoying playful embarrassment or affectionate mockery that builds intimacy", "rating": null },
+      { "name": "Prey Attention/Neediness: craving focus, pursuit, or intense awareness from a partner", "rating": null }
+    ],
+    "General": [
+      { "name": "Primal Recognition: being seen, understood, or tracked without needing words", "rating": null }
+    ]
+  },
+  "Breeding": {
+    "Giving": [
+      { "name": "Impregnation (giving): arousal from attempting to impregnate a partner", "rating": null },
+      { "name": "Feeding Milk (giving): arousal from producing and feeding milk to a partner", "rating": null }
+    ],
+    "Receiving": [
+      { "name": "Impregnation (receiving): arousal from being inseminated, pregnancy risk, or being bred", "rating": null },
+      { "name": "Feeding Milk (receiving): arousal from drinking a partner’s milk", "rating": null }
+    ],
+    "General": [
+      { "name": "Pregnancy Fantasy: erotic focus on pregnancy (mine, partner’s, or fictional scenarios)", "rating": null },
+      { "name": "Primal Breeding Drive: animalistic/instinctual framing of sex, reproduction, territory", "rating": null },
+      { "name": "Breeding as Control: ownership/authority expressed through breeding talk or pregnancy risk", "rating": null },
+      { "name": "Creampie/Marking: erotic meaning placed on internal ejaculation or visible ‘claimed’ markers", "rating": null },
+      { "name": "Risk/‘No Contraception’ Talk (fantasy): dirty talk about risk or breeding without actual risk", "rating": null },
+      { "name": "Heat/Ovulation Tracking: timing, ‘in heat’ roleplay, or cycle-focused arousal", "rating": null },
+      { "name": "Artificial Insemination/Device Play: syringes, cups, or medical-style scenarios (consensual fantasy)", "rating": null },
+      { "name": "Breeding Denial/Ruined Breeding: building toward impregnation talk then denying or ‘ruining’ it", "rating": null },
+      { "name": "Pregnancy Body Focus: belly worship, movement/weight changes, glow, and attention", "rating": null },
+      { "name": "Pregnancy Protocol/Care: protective rules, pedestal treatment, dedicated aftercare", "rating": null },
+      { "name": "Lactation Induction/Maintenance: interest in inducing or sustaining milk production", "rating": null },
+      { "name": "Milking Scenes: manual, oral, or pump-based ‘milking’ as play or ritual", "rating": null },
+      { "name": "Contraception Boundaries: preference to use protection, BC methods, or simulation-only", "rating": null },
+      { "name": "STI/Testing & Medical Boundaries: testing cadence, disclosures, and comfort levels", "rating": null }
+    ]
   }
-};
+}

--- a/docs/survey/data/kinks.json
+++ b/docs/survey/data/kinks.json
@@ -4705,5 +4705,239 @@
         ]
       }
     ]
+  },
+  {
+    "category": "Psychology Play",
+    "items": [
+      {
+        "id": "psychology-play-emotional-sadism-giving-teasing-feelings-orchestrating-reactions-savoring-anticipation-without-shame-based-harm",
+        "label": "Emotional Sadism (giving): teasing feelings, orchestrating reactions, savoring anticipation without shame-based harm",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-psychological-control-mind-games-double-binds-deliberate-pacing-and-strategic-ambiguity",
+        "label": "Psychological Control: mind games, double binds, deliberate pacing, and strategic ambiguity",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-sadistic-attention-enjoying-being-the-focal-point-of-a-partner-s-fear-arousal-or-resistance",
+        "label": "Sadistic Attention: enjoying being the focal point of a partner’s fear, arousal, or resistance",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-teasing-humiliation-playful-status-play-without-degradation-or-shame",
+        "label": "Teasing Humiliation: playful status play without degradation or shame",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-emotional-sadism-receiving-enjoying-engineered-emotional-intensity-such-as-fluster-exposure-or-playful-embarrassment",
+        "label": "Emotional Sadism (receiving): enjoying engineered emotional intensity such as fluster, exposure, or playful embarrassment",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-psychological-control-receiving-arousal-from-being-studied-contained-or-outmaneuvered",
+        "label": "Psychological Control (receiving): arousal from being studied, contained, or outmaneuvered",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-being-the-focus-enjoying-being-watched-tracked-or-held-in-a-partner-s-intense-focus",
+        "label": "Being the Focus: enjoying being watched, tracked, or held in a partner’s intense focus",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-teasing-humiliation-receiving-enjoying-playful-embarrassment-or-affectionate-mockery-that-builds-intimacy",
+        "label": "Teasing Humiliation (receiving): enjoying playful embarrassment or affectionate mockery that builds intimacy",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-prey-attention-neediness-craving-focus-pursuit-or-intense-awareness-from-a-partner",
+        "label": "Prey Attention/Neediness: craving focus, pursuit, or intense awareness from a partner",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-primal-recognition-being-seen-understood-or-tracked-without-needing-words",
+        "label": "Primal Recognition: being seen, understood, or tracked without needing words",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Breeding",
+    "items": [
+      {
+        "id": "breeding-impregnation-giving-arousal-from-attempting-to-impregnate-a-partner",
+        "label": "Impregnation (giving): arousal from attempting to impregnate a partner",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "breeding-feeding-milk-giving-arousal-from-producing-and-feeding-milk-to-a-partner",
+        "label": "Feeding Milk (giving): arousal from producing and feeding milk to a partner",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "breeding-impregnation-receiving-arousal-from-being-inseminated-pregnancy-risk-or-being-bred",
+        "label": "Impregnation (receiving): arousal from being inseminated, pregnancy risk, or being bred",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "breeding-feeding-milk-receiving-arousal-from-drinking-a-partner-s-milk",
+        "label": "Feeding Milk (receiving): arousal from drinking a partner’s milk",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "breeding-pregnancy-fantasy-erotic-focus-on-pregnancy-mine-partner-s-or-fictional-scenarios",
+        "label": "Pregnancy Fantasy: erotic focus on pregnancy (mine, partner’s, or fictional scenarios)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-primal-breeding-drive-animalistic-instinctual-framing-of-sex-reproduction-territory",
+        "label": "Primal Breeding Drive: animalistic/instinctual framing of sex, reproduction, territory",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-breeding-as-control-ownership-authority-expressed-through-breeding-talk-or-pregnancy-risk",
+        "label": "Breeding as Control: ownership/authority expressed through breeding talk or pregnancy risk",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-creampie-marking-erotic-meaning-placed-on-internal-ejaculation-or-visible-claimed-markers",
+        "label": "Creampie/Marking: erotic meaning placed on internal ejaculation or visible ‘claimed’ markers",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-risk-no-contraception-talk-fantasy-dirty-talk-about-risk-or-breeding-without-actual-risk",
+        "label": "Risk/‘No Contraception’ Talk (fantasy): dirty talk about risk or breeding without actual risk",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-heat-ovulation-tracking-timing-in-heat-roleplay-or-cycle-focused-arousal",
+        "label": "Heat/Ovulation Tracking: timing, ‘in heat’ roleplay, or cycle-focused arousal",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-artificial-insemination-device-play-syringes-cups-or-medical-style-scenarios-consensual-fantasy",
+        "label": "Artificial Insemination/Device Play: syringes, cups, or medical-style scenarios (consensual fantasy)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-breeding-denial-ruined-breeding-building-toward-impregnation-talk-then-denying-or-ruining-it",
+        "label": "Breeding Denial/Ruined Breeding: building toward impregnation talk then denying or ‘ruining’ it",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-pregnancy-body-focus-belly-worship-movement-weight-changes-glow-and-attention",
+        "label": "Pregnancy Body Focus: belly worship, movement/weight changes, glow, and attention",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-pregnancy-protocol-care-protective-rules-pedestal-treatment-dedicated-aftercare",
+        "label": "Pregnancy Protocol/Care: protective rules, pedestal treatment, dedicated aftercare",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-lactation-induction-maintenance-interest-in-inducing-or-sustaining-milk-production",
+        "label": "Lactation Induction/Maintenance: interest in inducing or sustaining milk production",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-milking-scenes-manual-oral-or-pump-based-milking-as-play-or-ritual",
+        "label": "Milking Scenes: manual, oral, or pump-based ‘milking’ as play or ritual",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-contraception-boundaries-preference-to-use-protection-bc-methods-or-simulation-only",
+        "label": "Contraception Boundaries: preference to use protection, BC methods, or simulation-only",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-sti-testing-medical-boundaries-testing-cadence-disclosures-and-comfort-levels",
+        "label": "STI/Testing & Medical Boundaries: testing cadence, disclosures, and comfort levels",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
   }
 ]

--- a/js/template-survey.js
+++ b/js/template-survey.js
@@ -2648,6 +2648,30 @@ window.templateSurvey =
       {
         "name": "Emotional trickery as arousal",
         "rating": null
+      },
+      {
+        "name": "Being misled or deceived on purpose during play",
+        "rating": null
+      },
+      {
+        "name": "Surprise rule changes or twists mid-scene",
+        "rating": null
+      },
+      {
+        "name": "False safeword games (with negotiated limits)",
+        "rating": null
+      },
+      {
+        "name": "Withholding or delaying aftercare for effect",
+        "rating": null
+      },
+      {
+        "name": "Being gaslit or doubted in a controlled roleplay",
+        "rating": null
+      },
+      {
+        "name": "Told 'you asked for this' or 'you love this' when resisting",
+        "rating": null
       }
     ],
     "Receiving": [
@@ -2700,6 +2724,30 @@ window.templateSurvey =
       {
         "name": "Emotional trickery as arousal",
         "rating": null
+      },
+      {
+        "name": "Being misled or deceived on purpose during play",
+        "rating": null
+      },
+      {
+        "name": "Surprise rule changes or twists mid-scene",
+        "rating": null
+      },
+      {
+        "name": "False safeword games (with negotiated limits)",
+        "rating": null
+      },
+      {
+        "name": "Withholding or delaying aftercare for effect",
+        "rating": null
+      },
+      {
+        "name": "Being gaslit or doubted in a controlled roleplay",
+        "rating": null
+      },
+      {
+        "name": "Told 'you asked for this' or 'you love this' when resisting",
+        "rating": null
       }
     ],
     "General": []
@@ -2737,6 +2785,30 @@ window.templateSurvey =
       {
         "name": "Leash held in mouth",
         "rating": null
+      },
+      {
+        "name": "Being gagged or forced silent",
+        "rating": null
+      },
+      {
+        "name": "Having to hold objects in your mouth (spoon, hairbrush, leash)",
+        "rating": null
+      },
+      {
+        "name": "Being used for oral service without reciprocal pleasure",
+        "rating": null
+      },
+      {
+        "name": "Being fed by hand, mouth-to-mouth, or with utensils",
+        "rating": null
+      },
+      {
+        "name": "Verbal control (e.g., only speak when spoken to)",
+        "rating": null
+      },
+      {
+        "name": "Mouth as a symbol of ownership or control",
+        "rating": null
       }
     ],
     "Receiving": [
@@ -2770,6 +2842,30 @@ window.templateSurvey =
       },
       {
         "name": "Leash held in mouth",
+        "rating": null
+      },
+      {
+        "name": "Being gagged or forced silent",
+        "rating": null
+      },
+      {
+        "name": "Having to hold objects in your mouth (spoon, hairbrush, leash)",
+        "rating": null
+      },
+      {
+        "name": "Being used for oral service without reciprocal pleasure",
+        "rating": null
+      },
+      {
+        "name": "Being fed by hand, mouth-to-mouth, or with utensils",
+        "rating": null
+      },
+      {
+        "name": "Verbal control (e.g., only speak when spoken to)",
+        "rating": null
+      },
+      {
+        "name": "Mouth as a symbol of ownership or control",
         "rating": null
       }
     ],
@@ -2913,8 +3009,8 @@ window.templateSurvey =
       { "name": "Open with boundaries", "rating": null },
       { "name": "Closed but kinky with others", "rating": null },
       { "name": "Switch-friendly dynamics", "rating": null }
-      ]
-    },
+    ]
+  },
   "Gender Play & Transformation": {
     "Giving": [
       { "name": "Crossdressing", "rating": null },
@@ -3110,5 +3206,49 @@ window.templateSurvey =
       { "name": "Formal appearance protocols for scenes or dynamics", "rating": null },
       { "name": "Using clothing or style to embody emotional or power roles", "rating": null }
     ]
+  },
+  "Psychology Play": {
+    "Giving": [
+      { "name": "Emotional Sadism (giving): teasing feelings, orchestrating reactions, savoring anticipation without shame-based harm", "rating": null },
+      { "name": "Psychological Control: mind games, double binds, deliberate pacing, and strategic ambiguity", "rating": null },
+      { "name": "Sadistic Attention: enjoying being the focal point of a partner’s fear, arousal, or resistance", "rating": null },
+      { "name": "Teasing Humiliation: playful status play without degradation or shame", "rating": null }
+    ],
+    "Receiving": [
+      { "name": "Emotional Sadism (receiving): enjoying engineered emotional intensity such as fluster, exposure, or playful embarrassment", "rating": null },
+      { "name": "Psychological Control (receiving): arousal from being studied, contained, or outmaneuvered", "rating": null },
+      { "name": "Being the Focus: enjoying being watched, tracked, or held in a partner’s intense focus", "rating": null },
+      { "name": "Teasing Humiliation (receiving): enjoying playful embarrassment or affectionate mockery that builds intimacy", "rating": null },
+      { "name": "Prey Attention/Neediness: craving focus, pursuit, or intense awareness from a partner", "rating": null }
+    ],
+    "General": [
+      { "name": "Primal Recognition: being seen, understood, or tracked without needing words", "rating": null }
+    ]
+  },
+  "Breeding": {
+    "Giving": [
+      { "name": "Impregnation (giving): arousal from attempting to impregnate a partner", "rating": null },
+      { "name": "Feeding Milk (giving): arousal from producing and feeding milk to a partner", "rating": null }
+    ],
+    "Receiving": [
+      { "name": "Impregnation (receiving): arousal from being inseminated, pregnancy risk, or being bred", "rating": null },
+      { "name": "Feeding Milk (receiving): arousal from drinking a partner’s milk", "rating": null }
+    ],
+    "General": [
+      { "name": "Pregnancy Fantasy: erotic focus on pregnancy (mine, partner’s, or fictional scenarios)", "rating": null },
+      { "name": "Primal Breeding Drive: animalistic/instinctual framing of sex, reproduction, territory", "rating": null },
+      { "name": "Breeding as Control: ownership/authority expressed through breeding talk or pregnancy risk", "rating": null },
+      { "name": "Creampie/Marking: erotic meaning placed on internal ejaculation or visible ‘claimed’ markers", "rating": null },
+      { "name": "Risk/‘No Contraception’ Talk (fantasy): dirty talk about risk or breeding without actual risk", "rating": null },
+      { "name": "Heat/Ovulation Tracking: timing, ‘in heat’ roleplay, or cycle-focused arousal", "rating": null },
+      { "name": "Artificial Insemination/Device Play: syringes, cups, or medical-style scenarios (consensual fantasy)", "rating": null },
+      { "name": "Breeding Denial/Ruined Breeding: building toward impregnation talk then denying or ‘ruining’ it", "rating": null },
+      { "name": "Pregnancy Body Focus: belly worship, movement/weight changes, glow, and attention", "rating": null },
+      { "name": "Pregnancy Protocol/Care: protective rules, pedestal treatment, dedicated aftercare", "rating": null },
+      { "name": "Lactation Induction/Maintenance: interest in inducing or sustaining milk production", "rating": null },
+      { "name": "Milking Scenes: manual, oral, or pump-based ‘milking’ as play or ritual", "rating": null },
+      { "name": "Contraception Boundaries: preference to use protection, BC methods, or simulation-only", "rating": null },
+      { "name": "STI/Testing & Medical Boundaries: testing cadence, disclosures, and comfort levels", "rating": null }
+    ]
   }
-};
+}

--- a/kinks.json
+++ b/kinks.json
@@ -4705,5 +4705,239 @@
         ]
       }
     ]
+  },
+  {
+    "category": "Psychology Play",
+    "items": [
+      {
+        "id": "psychology-play-emotional-sadism-giving-teasing-feelings-orchestrating-reactions-savoring-anticipation-without-shame-based-harm",
+        "label": "Emotional Sadism (giving): teasing feelings, orchestrating reactions, savoring anticipation without shame-based harm",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-psychological-control-mind-games-double-binds-deliberate-pacing-and-strategic-ambiguity",
+        "label": "Psychological Control: mind games, double binds, deliberate pacing, and strategic ambiguity",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-sadistic-attention-enjoying-being-the-focal-point-of-a-partner-s-fear-arousal-or-resistance",
+        "label": "Sadistic Attention: enjoying being the focal point of a partner’s fear, arousal, or resistance",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-teasing-humiliation-playful-status-play-without-degradation-or-shame",
+        "label": "Teasing Humiliation: playful status play without degradation or shame",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-emotional-sadism-receiving-enjoying-engineered-emotional-intensity-such-as-fluster-exposure-or-playful-embarrassment",
+        "label": "Emotional Sadism (receiving): enjoying engineered emotional intensity such as fluster, exposure, or playful embarrassment",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-psychological-control-receiving-arousal-from-being-studied-contained-or-outmaneuvered",
+        "label": "Psychological Control (receiving): arousal from being studied, contained, or outmaneuvered",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-being-the-focus-enjoying-being-watched-tracked-or-held-in-a-partner-s-intense-focus",
+        "label": "Being the Focus: enjoying being watched, tracked, or held in a partner’s intense focus",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-teasing-humiliation-receiving-enjoying-playful-embarrassment-or-affectionate-mockery-that-builds-intimacy",
+        "label": "Teasing Humiliation (receiving): enjoying playful embarrassment or affectionate mockery that builds intimacy",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-prey-attention-neediness-craving-focus-pursuit-or-intense-awareness-from-a-partner",
+        "label": "Prey Attention/Neediness: craving focus, pursuit, or intense awareness from a partner",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-primal-recognition-being-seen-understood-or-tracked-without-needing-words",
+        "label": "Primal Recognition: being seen, understood, or tracked without needing words",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Breeding",
+    "items": [
+      {
+        "id": "breeding-impregnation-giving-arousal-from-attempting-to-impregnate-a-partner",
+        "label": "Impregnation (giving): arousal from attempting to impregnate a partner",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "breeding-feeding-milk-giving-arousal-from-producing-and-feeding-milk-to-a-partner",
+        "label": "Feeding Milk (giving): arousal from producing and feeding milk to a partner",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "breeding-impregnation-receiving-arousal-from-being-inseminated-pregnancy-risk-or-being-bred",
+        "label": "Impregnation (receiving): arousal from being inseminated, pregnancy risk, or being bred",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "breeding-feeding-milk-receiving-arousal-from-drinking-a-partner-s-milk",
+        "label": "Feeding Milk (receiving): arousal from drinking a partner’s milk",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "breeding-pregnancy-fantasy-erotic-focus-on-pregnancy-mine-partner-s-or-fictional-scenarios",
+        "label": "Pregnancy Fantasy: erotic focus on pregnancy (mine, partner’s, or fictional scenarios)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-primal-breeding-drive-animalistic-instinctual-framing-of-sex-reproduction-territory",
+        "label": "Primal Breeding Drive: animalistic/instinctual framing of sex, reproduction, territory",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-breeding-as-control-ownership-authority-expressed-through-breeding-talk-or-pregnancy-risk",
+        "label": "Breeding as Control: ownership/authority expressed through breeding talk or pregnancy risk",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-creampie-marking-erotic-meaning-placed-on-internal-ejaculation-or-visible-claimed-markers",
+        "label": "Creampie/Marking: erotic meaning placed on internal ejaculation or visible ‘claimed’ markers",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-risk-no-contraception-talk-fantasy-dirty-talk-about-risk-or-breeding-without-actual-risk",
+        "label": "Risk/‘No Contraception’ Talk (fantasy): dirty talk about risk or breeding without actual risk",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-heat-ovulation-tracking-timing-in-heat-roleplay-or-cycle-focused-arousal",
+        "label": "Heat/Ovulation Tracking: timing, ‘in heat’ roleplay, or cycle-focused arousal",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-artificial-insemination-device-play-syringes-cups-or-medical-style-scenarios-consensual-fantasy",
+        "label": "Artificial Insemination/Device Play: syringes, cups, or medical-style scenarios (consensual fantasy)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-breeding-denial-ruined-breeding-building-toward-impregnation-talk-then-denying-or-ruining-it",
+        "label": "Breeding Denial/Ruined Breeding: building toward impregnation talk then denying or ‘ruining’ it",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-pregnancy-body-focus-belly-worship-movement-weight-changes-glow-and-attention",
+        "label": "Pregnancy Body Focus: belly worship, movement/weight changes, glow, and attention",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-pregnancy-protocol-care-protective-rules-pedestal-treatment-dedicated-aftercare",
+        "label": "Pregnancy Protocol/Care: protective rules, pedestal treatment, dedicated aftercare",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-lactation-induction-maintenance-interest-in-inducing-or-sustaining-milk-production",
+        "label": "Lactation Induction/Maintenance: interest in inducing or sustaining milk production",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-milking-scenes-manual-oral-or-pump-based-milking-as-play-or-ritual",
+        "label": "Milking Scenes: manual, oral, or pump-based ‘milking’ as play or ritual",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-contraception-boundaries-preference-to-use-protection-bc-methods-or-simulation-only",
+        "label": "Contraception Boundaries: preference to use protection, BC methods, or simulation-only",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-sti-testing-medical-boundaries-testing-cadence-disclosures-and-comfort-levels",
+        "label": "STI/Testing & Medical Boundaries: testing cadence, disclosures, and comfort levels",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
   }
 ]

--- a/kinks/embedded-kinks.js
+++ b/kinks/embedded-kinks.js
@@ -4706,5 +4706,239 @@ window.KINKS_BANK = [
         ]
       }
     ]
+  },
+  {
+    "category": "Psychology Play",
+    "items": [
+      {
+        "id": "psychology-play-emotional-sadism-giving-teasing-feelings-orchestrating-reactions-savoring-anticipation-without-shame-based-harm",
+        "label": "Emotional Sadism (giving): teasing feelings, orchestrating reactions, savoring anticipation without shame-based harm",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-psychological-control-mind-games-double-binds-deliberate-pacing-and-strategic-ambiguity",
+        "label": "Psychological Control: mind games, double binds, deliberate pacing, and strategic ambiguity",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-sadistic-attention-enjoying-being-the-focal-point-of-a-partner-s-fear-arousal-or-resistance",
+        "label": "Sadistic Attention: enjoying being the focal point of a partner’s fear, arousal, or resistance",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-teasing-humiliation-playful-status-play-without-degradation-or-shame",
+        "label": "Teasing Humiliation: playful status play without degradation or shame",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-emotional-sadism-receiving-enjoying-engineered-emotional-intensity-such-as-fluster-exposure-or-playful-embarrassment",
+        "label": "Emotional Sadism (receiving): enjoying engineered emotional intensity such as fluster, exposure, or playful embarrassment",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-psychological-control-receiving-arousal-from-being-studied-contained-or-outmaneuvered",
+        "label": "Psychological Control (receiving): arousal from being studied, contained, or outmaneuvered",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-being-the-focus-enjoying-being-watched-tracked-or-held-in-a-partner-s-intense-focus",
+        "label": "Being the Focus: enjoying being watched, tracked, or held in a partner’s intense focus",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-teasing-humiliation-receiving-enjoying-playful-embarrassment-or-affectionate-mockery-that-builds-intimacy",
+        "label": "Teasing Humiliation (receiving): enjoying playful embarrassment or affectionate mockery that builds intimacy",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-prey-attention-neediness-craving-focus-pursuit-or-intense-awareness-from-a-partner",
+        "label": "Prey Attention/Neediness: craving focus, pursuit, or intense awareness from a partner",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-primal-recognition-being-seen-understood-or-tracked-without-needing-words",
+        "label": "Primal Recognition: being seen, understood, or tracked without needing words",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Breeding",
+    "items": [
+      {
+        "id": "breeding-impregnation-giving-arousal-from-attempting-to-impregnate-a-partner",
+        "label": "Impregnation (giving): arousal from attempting to impregnate a partner",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "breeding-feeding-milk-giving-arousal-from-producing-and-feeding-milk-to-a-partner",
+        "label": "Feeding Milk (giving): arousal from producing and feeding milk to a partner",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "breeding-impregnation-receiving-arousal-from-being-inseminated-pregnancy-risk-or-being-bred",
+        "label": "Impregnation (receiving): arousal from being inseminated, pregnancy risk, or being bred",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "breeding-feeding-milk-receiving-arousal-from-drinking-a-partner-s-milk",
+        "label": "Feeding Milk (receiving): arousal from drinking a partner’s milk",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "breeding-pregnancy-fantasy-erotic-focus-on-pregnancy-mine-partner-s-or-fictional-scenarios",
+        "label": "Pregnancy Fantasy: erotic focus on pregnancy (mine, partner’s, or fictional scenarios)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-primal-breeding-drive-animalistic-instinctual-framing-of-sex-reproduction-territory",
+        "label": "Primal Breeding Drive: animalistic/instinctual framing of sex, reproduction, territory",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-breeding-as-control-ownership-authority-expressed-through-breeding-talk-or-pregnancy-risk",
+        "label": "Breeding as Control: ownership/authority expressed through breeding talk or pregnancy risk",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-creampie-marking-erotic-meaning-placed-on-internal-ejaculation-or-visible-claimed-markers",
+        "label": "Creampie/Marking: erotic meaning placed on internal ejaculation or visible ‘claimed’ markers",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-risk-no-contraception-talk-fantasy-dirty-talk-about-risk-or-breeding-without-actual-risk",
+        "label": "Risk/‘No Contraception’ Talk (fantasy): dirty talk about risk or breeding without actual risk",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-heat-ovulation-tracking-timing-in-heat-roleplay-or-cycle-focused-arousal",
+        "label": "Heat/Ovulation Tracking: timing, ‘in heat’ roleplay, or cycle-focused arousal",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-artificial-insemination-device-play-syringes-cups-or-medical-style-scenarios-consensual-fantasy",
+        "label": "Artificial Insemination/Device Play: syringes, cups, or medical-style scenarios (consensual fantasy)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-breeding-denial-ruined-breeding-building-toward-impregnation-talk-then-denying-or-ruining-it",
+        "label": "Breeding Denial/Ruined Breeding: building toward impregnation talk then denying or ‘ruining’ it",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-pregnancy-body-focus-belly-worship-movement-weight-changes-glow-and-attention",
+        "label": "Pregnancy Body Focus: belly worship, movement/weight changes, glow, and attention",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-pregnancy-protocol-care-protective-rules-pedestal-treatment-dedicated-aftercare",
+        "label": "Pregnancy Protocol/Care: protective rules, pedestal treatment, dedicated aftercare",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-lactation-induction-maintenance-interest-in-inducing-or-sustaining-milk-production",
+        "label": "Lactation Induction/Maintenance: interest in inducing or sustaining milk production",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-milking-scenes-manual-oral-or-pump-based-milking-as-play-or-ritual",
+        "label": "Milking Scenes: manual, oral, or pump-based ‘milking’ as play or ritual",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-contraception-boundaries-preference-to-use-protection-bc-methods-or-simulation-only",
+        "label": "Contraception Boundaries: preference to use protection, BC methods, or simulation-only",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-sti-testing-medical-boundaries-testing-cadence-disclosures-and-comfort-levels",
+        "label": "STI/Testing & Medical Boundaries: testing cadence, disclosures, and comfort levels",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
   }
 ];

--- a/survey/data/kinks.json
+++ b/survey/data/kinks.json
@@ -4705,5 +4705,239 @@
         ]
       }
     ]
+  },
+  {
+    "category": "Psychology Play",
+    "items": [
+      {
+        "id": "psychology-play-emotional-sadism-giving-teasing-feelings-orchestrating-reactions-savoring-anticipation-without-shame-based-harm",
+        "label": "Emotional Sadism (giving): teasing feelings, orchestrating reactions, savoring anticipation without shame-based harm",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-psychological-control-mind-games-double-binds-deliberate-pacing-and-strategic-ambiguity",
+        "label": "Psychological Control: mind games, double binds, deliberate pacing, and strategic ambiguity",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-sadistic-attention-enjoying-being-the-focal-point-of-a-partner-s-fear-arousal-or-resistance",
+        "label": "Sadistic Attention: enjoying being the focal point of a partner’s fear, arousal, or resistance",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-teasing-humiliation-playful-status-play-without-degradation-or-shame",
+        "label": "Teasing Humiliation: playful status play without degradation or shame",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-emotional-sadism-receiving-enjoying-engineered-emotional-intensity-such-as-fluster-exposure-or-playful-embarrassment",
+        "label": "Emotional Sadism (receiving): enjoying engineered emotional intensity such as fluster, exposure, or playful embarrassment",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-psychological-control-receiving-arousal-from-being-studied-contained-or-outmaneuvered",
+        "label": "Psychological Control (receiving): arousal from being studied, contained, or outmaneuvered",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-being-the-focus-enjoying-being-watched-tracked-or-held-in-a-partner-s-intense-focus",
+        "label": "Being the Focus: enjoying being watched, tracked, or held in a partner’s intense focus",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-teasing-humiliation-receiving-enjoying-playful-embarrassment-or-affectionate-mockery-that-builds-intimacy",
+        "label": "Teasing Humiliation (receiving): enjoying playful embarrassment or affectionate mockery that builds intimacy",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-prey-attention-neediness-craving-focus-pursuit-or-intense-awareness-from-a-partner",
+        "label": "Prey Attention/Neediness: craving focus, pursuit, or intense awareness from a partner",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-primal-recognition-being-seen-understood-or-tracked-without-needing-words",
+        "label": "Primal Recognition: being seen, understood, or tracked without needing words",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Breeding",
+    "items": [
+      {
+        "id": "breeding-impregnation-giving-arousal-from-attempting-to-impregnate-a-partner",
+        "label": "Impregnation (giving): arousal from attempting to impregnate a partner",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "breeding-feeding-milk-giving-arousal-from-producing-and-feeding-milk-to-a-partner",
+        "label": "Feeding Milk (giving): arousal from producing and feeding milk to a partner",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "breeding-impregnation-receiving-arousal-from-being-inseminated-pregnancy-risk-or-being-bred",
+        "label": "Impregnation (receiving): arousal from being inseminated, pregnancy risk, or being bred",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "breeding-feeding-milk-receiving-arousal-from-drinking-a-partner-s-milk",
+        "label": "Feeding Milk (receiving): arousal from drinking a partner’s milk",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "breeding-pregnancy-fantasy-erotic-focus-on-pregnancy-mine-partner-s-or-fictional-scenarios",
+        "label": "Pregnancy Fantasy: erotic focus on pregnancy (mine, partner’s, or fictional scenarios)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-primal-breeding-drive-animalistic-instinctual-framing-of-sex-reproduction-territory",
+        "label": "Primal Breeding Drive: animalistic/instinctual framing of sex, reproduction, territory",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-breeding-as-control-ownership-authority-expressed-through-breeding-talk-or-pregnancy-risk",
+        "label": "Breeding as Control: ownership/authority expressed through breeding talk or pregnancy risk",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-creampie-marking-erotic-meaning-placed-on-internal-ejaculation-or-visible-claimed-markers",
+        "label": "Creampie/Marking: erotic meaning placed on internal ejaculation or visible ‘claimed’ markers",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-risk-no-contraception-talk-fantasy-dirty-talk-about-risk-or-breeding-without-actual-risk",
+        "label": "Risk/‘No Contraception’ Talk (fantasy): dirty talk about risk or breeding without actual risk",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-heat-ovulation-tracking-timing-in-heat-roleplay-or-cycle-focused-arousal",
+        "label": "Heat/Ovulation Tracking: timing, ‘in heat’ roleplay, or cycle-focused arousal",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-artificial-insemination-device-play-syringes-cups-or-medical-style-scenarios-consensual-fantasy",
+        "label": "Artificial Insemination/Device Play: syringes, cups, or medical-style scenarios (consensual fantasy)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-breeding-denial-ruined-breeding-building-toward-impregnation-talk-then-denying-or-ruining-it",
+        "label": "Breeding Denial/Ruined Breeding: building toward impregnation talk then denying or ‘ruining’ it",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-pregnancy-body-focus-belly-worship-movement-weight-changes-glow-and-attention",
+        "label": "Pregnancy Body Focus: belly worship, movement/weight changes, glow, and attention",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-pregnancy-protocol-care-protective-rules-pedestal-treatment-dedicated-aftercare",
+        "label": "Pregnancy Protocol/Care: protective rules, pedestal treatment, dedicated aftercare",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-lactation-induction-maintenance-interest-in-inducing-or-sustaining-milk-production",
+        "label": "Lactation Induction/Maintenance: interest in inducing or sustaining milk production",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-milking-scenes-manual-oral-or-pump-based-milking-as-play-or-ritual",
+        "label": "Milking Scenes: manual, oral, or pump-based ‘milking’ as play or ritual",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-contraception-boundaries-preference-to-use-protection-bc-methods-or-simulation-only",
+        "label": "Contraception Boundaries: preference to use protection, BC methods, or simulation-only",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-sti-testing-medical-boundaries-testing-cadence-disclosures-and-comfort-levels",
+        "label": "STI/Testing & Medical Boundaries: testing cadence, disclosures, and comfort levels",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
   }
 ]

--- a/template-survey.json
+++ b/template-survey.json
@@ -3205,5 +3205,49 @@
       { "name": "Formal appearance protocols for scenes or dynamics", "rating": null },
       { "name": "Using clothing or style to embody emotional or power roles", "rating": null }
     ]
+  },
+  "Psychology Play": {
+    "Giving": [
+      { "name": "Emotional Sadism (giving): teasing feelings, orchestrating reactions, savoring anticipation without shame-based harm", "rating": null },
+      { "name": "Psychological Control: mind games, double binds, deliberate pacing, and strategic ambiguity", "rating": null },
+      { "name": "Sadistic Attention: enjoying being the focal point of a partner’s fear, arousal, or resistance", "rating": null },
+      { "name": "Teasing Humiliation: playful status play without degradation or shame", "rating": null }
+    ],
+    "Receiving": [
+      { "name": "Emotional Sadism (receiving): enjoying engineered emotional intensity such as fluster, exposure, or playful embarrassment", "rating": null },
+      { "name": "Psychological Control (receiving): arousal from being studied, contained, or outmaneuvered", "rating": null },
+      { "name": "Being the Focus: enjoying being watched, tracked, or held in a partner’s intense focus", "rating": null },
+      { "name": "Teasing Humiliation (receiving): enjoying playful embarrassment or affectionate mockery that builds intimacy", "rating": null },
+      { "name": "Prey Attention/Neediness: craving focus, pursuit, or intense awareness from a partner", "rating": null }
+    ],
+    "General": [
+      { "name": "Primal Recognition: being seen, understood, or tracked without needing words", "rating": null }
+    ]
+  },
+  "Breeding": {
+    "Giving": [
+      { "name": "Impregnation (giving): arousal from attempting to impregnate a partner", "rating": null },
+      { "name": "Feeding Milk (giving): arousal from producing and feeding milk to a partner", "rating": null }
+    ],
+    "Receiving": [
+      { "name": "Impregnation (receiving): arousal from being inseminated, pregnancy risk, or being bred", "rating": null },
+      { "name": "Feeding Milk (receiving): arousal from drinking a partner’s milk", "rating": null }
+    ],
+    "General": [
+      { "name": "Pregnancy Fantasy: erotic focus on pregnancy (mine, partner’s, or fictional scenarios)", "rating": null },
+      { "name": "Primal Breeding Drive: animalistic/instinctual framing of sex, reproduction, territory", "rating": null },
+      { "name": "Breeding as Control: ownership/authority expressed through breeding talk or pregnancy risk", "rating": null },
+      { "name": "Creampie/Marking: erotic meaning placed on internal ejaculation or visible ‘claimed’ markers", "rating": null },
+      { "name": "Risk/‘No Contraception’ Talk (fantasy): dirty talk about risk or breeding without actual risk", "rating": null },
+      { "name": "Heat/Ovulation Tracking: timing, ‘in heat’ roleplay, or cycle-focused arousal", "rating": null },
+      { "name": "Artificial Insemination/Device Play: syringes, cups, or medical-style scenarios (consensual fantasy)", "rating": null },
+      { "name": "Breeding Denial/Ruined Breeding: building toward impregnation talk then denying or ‘ruining’ it", "rating": null },
+      { "name": "Pregnancy Body Focus: belly worship, movement/weight changes, glow, and attention", "rating": null },
+      { "name": "Pregnancy Protocol/Care: protective rules, pedestal treatment, dedicated aftercare", "rating": null },
+      { "name": "Lactation Induction/Maintenance: interest in inducing or sustaining milk production", "rating": null },
+      { "name": "Milking Scenes: manual, oral, or pump-based ‘milking’ as play or ritual", "rating": null },
+      { "name": "Contraception Boundaries: preference to use protection, BC methods, or simulation-only", "rating": null },
+      { "name": "STI/Testing & Medical Boundaries: testing cadence, disclosures, and comfort levels", "rating": null }
+    ]
   }
 }


### PR DESCRIPTION
## Summary
- add Psychology Play and Breeding categories to the survey template
- regenerate the published kink datasets and embedded fallbacks so the new sections are available everywhere

## Testing
- not run (data-only change)


------
https://chatgpt.com/codex/tasks/task_e_68db12d88654832c87c2d46ba4c6eb12