### PR TITLE
Ensure fetch diagnostics note clears after successful kink data load

### DIFF
--- a/kinksurvey/index.html
+++ b/kinksurvey/index.html
@@ -481,14 +481,23 @@
   const tidy = s=>String(s??'').replace(/\s+/g,' ').trim();
   const looksHTML = t => /^\s*<!doctype html/i.test(t) || /<html[\s>]/i.test(t);
 
+  const FETCH_NOTE_ID = 'ksv-fetch-notes';
+
+  function removeFetchNote(){
+    const existing = document.getElementById(FETCH_NOTE_ID);
+    if (existing) existing.remove();
+  }
+
   function showFetchNote(notes){
     if (!notes?.length) return;
-    if (document.getElementById('kinksFetchNotes')) return;
-    const note = document.createElement('div');
-    note.id = 'kinksFetchNotes';
-    note.style.cssText = 'position:fixed;left:0;right:0;bottom:0;padding:.5rem 1rem;background:#001316;color:#57f7ff;border-top:1px solid #00e6ff33;font:600 14px/1.35 system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;z-index:2147483600;text-align:center';
+    let note = document.getElementById(FETCH_NOTE_ID);
+    if (!note){
+      note = document.createElement('div');
+      note.id = FETCH_NOTE_ID;
+      note.style.cssText = 'position:fixed;left:0;right:0;bottom:0;padding:.5rem 1rem;background:#001316;color:#57f7ff;border-top:1px solid #00e6ff33;font:600 14px/1.35 system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;z-index:2147483600;text-align:center';
+    }
     note.textContent = 'Fetch notes: ' + notes.join('  -  ');
-    document.body?.appendChild(note);
+    if (!note.isConnected) document.body?.appendChild(note);
   }
 
   async function fetchFirst(urls){
@@ -509,6 +518,7 @@
         }
         const json = JSON.parse(text);
         console.info('[kinksurvey] Loaded:', url);
+        removeFetchNote();
         return { json, src: url, errs: notes };
       }catch(err){
         const message = err?.message || String(err);


### PR DESCRIPTION
## Summary
- add a reusable fetch note element for the kinksurvey loader
- remove the diagnostics note once data loads successfully so it only appears on failures

## Testing
- not run (HTML change only)

------
https://chatgpt.com/codex/tasks/task_e_68db199f3530832ca45449df3ab703ba