### PR TITLE
Add passive listener shim and scroll performance CSS

### DIFF
--- a/css/perf-tweaks.css
+++ b/css/perf-tweaks.css
@@ -1,0 +1,4 @@
+/* TK scroll/touch performance hints */
+html, body { overscroll-behavior: contain; }  /* avoid scroll chaining jank */
+.category-panel, .scroll-y, [data-scroll-y] { touch-action: pan-y; }
+.scroll-x, [data-scroll-x] { touch-action: pan-x; }

--- a/js/tk_passive.js
+++ b/js/tk_passive.js
@@ -1,0 +1,30 @@
+/* TK passive listeners — makes touch/wheel non-blocking by default.
+   Use {passive:false} only where you truly call event.preventDefault(). */
+(() => {
+  let supportsPassive = false;
+  try {
+    const opts = Object.defineProperty({}, 'passive', { get(){ supportsPassive = true; } });
+    window.addEventListener('tk-passive-test', () => {}, opts);
+    window.removeEventListener('tk-passive-test', () => {}, opts);
+  } catch {}
+  if (!supportsPassive) return;
+
+  const needsPassive = t => t === 'touchstart' || t === 'touchmove' || t === 'wheel';
+
+  const orig = EventTarget.prototype.addEventListener;
+  EventTarget.prototype.addEventListener = function(type, listener, options){
+    // Respect explicit opts (pass {passive:false} if you really need to block scroll)
+    if (!needsPassive(type)) return orig.call(this, type, listener, options);
+
+    let opts = options;
+    if (opts == null) {
+      opts = { passive: true };
+    } else if (typeof opts === 'boolean') {
+      // boolean means "capture" in legacy signature
+      opts = { capture: options, passive: true };
+    } else if (opts && opts.passive === undefined) {
+      opts = { ...opts, passive: true };
+    }
+    return orig.call(this, type, listener, opts);
+  };
+})();

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+  <!-- TK: passive listeners shim -->
+  <script src="/js/tk_passive.js"></script>
   <!-- TK: early diagnostics -->
   <script src="/js/tk_diag.js"></script>
   <!-- TK: passive event shim -->
@@ -114,6 +116,8 @@
   <link rel="stylesheet" href="/css/tk_diag_fallback.css">
   <link rel="stylesheet" href="/css/tk_unblock_clicks.css">
   <link rel="stylesheet" href="/css/tk_panel_passthrough.css">
+  <!-- TK: scroll/touch perf tweaks -->
+  <link rel="stylesheet" href="/css/perf-tweaks.css">
 </head>
 <body class="theme-dark has-category-panel">
   <script id="kinks-embedded-data" type="application/json">[]</script>


### PR DESCRIPTION
## Summary
- add a passive listener shim that defaults touch and wheel events to passive
- provide CSS hints for touch-action and overscroll behavior to reduce scroll jank
- reference the new assets from the kinks experience so they load in production

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db1be2c388832c9e23673ef18e9e6d