### PR TITLE
Allow overriding kink data fetch targets

### DIFF
--- a/docs/kinksurvey/index.html
+++ b/docs/kinksurvey/index.html
@@ -316,14 +316,24 @@
   // Keep your existing data sources (will use your published dataset when present)
   const here = new URL(window.location.href);
   const pathPrefix = here.pathname.replace(/[^/]*$/, '');
-  const DATA_URLS=[
+  const DEFAULT_URLS=[
     new URL('data/kinks.json', here).pathname,
     new URL('kinks.json', here).pathname,
     pathPrefix + 'data/kinks.json',
     pathPrefix + 'kinks.json',
     '/data/kinks.json',
     '/kinks.json'
-  ].filter((v, i, arr)=>v && arr.indexOf(v) === i);
+  ];
+  const overrideUrls = Array.isArray(window.KSV?.KINKS_URLS) ? window.KSV.KINKS_URLS : null;
+  const DATA_URLS = Array.from(new Set(
+    (overrideUrls && overrideUrls.length ? overrideUrls : DEFAULT_URLS)
+      .map(url => {
+        try { return new URL(url, here).pathname; }
+        catch { return url; }
+      })
+      .filter(Boolean)
+  ));
+  if (!DATA_URLS.length) DATA_URLS.push('/data/kinks.json');
 
   // Elements
   const $ = (id)=>document.getElementById(id);
@@ -490,7 +500,7 @@
     return /localhost|127\.0\.0\.1/.test(location.hostname);
   })();
 
-  const FETCH_NOTE_ID = 'ksv-fetch-notes';
+  const FETCH_NOTE_ID = 'tkFetchNote';
 
   function removeFetchNote(){
     const existing = document.getElementById(FETCH_NOTE_ID);
@@ -518,8 +528,9 @@
     note.textContent = 'Fetch notes: ' + notes.join('  -  ');
     if (!note.isConnected) document.body?.appendChild(note);
   }
+  window.showFetchNote = showFetchNote;
 
-  async function fetchFirst(urls){
+  async function fetchFirstInternal(urls){
     const notes = [];
     for (const url of urls){
       try{
@@ -538,7 +549,7 @@
         const json = JSON.parse(text);
         console.info('[kinksurvey] Loaded:', url);
         removeFetchNote();
-        return { json, src: url, errs: notes };
+        return { json, src: url, errs: [] };
       }catch(err){
         const message = err?.message || String(err);
         notes.push(`${url}: ${message}`);
@@ -550,9 +561,13 @@
     error.notes = notes;
     throw error;
   }
+  window.fetchFirst = fetchFirstInternal;
 
   async function fetchData(){
-    return fetchFirst(DATA_URLS);
+    const fetcher = typeof window.fetchFirst === 'function' ? window.fetchFirst : fetchFirstInternal;
+    const result = await fetcher(DATA_URLS);
+    if (result && typeof result === 'object' && 'json' in result) return result;
+    return { json: result, src: DATA_URLS[0], errs: [] };
   }
 
   function normalize(raw){

--- a/kinksurvey/index.html
+++ b/kinksurvey/index.html
@@ -362,14 +362,24 @@
   // Keep your existing data sources (will use your published dataset when present)
   const here = new URL(window.location.href);
   const pathPrefix = here.pathname.replace(/[^/]*$/, '');
-  const DATA_URLS=[
+  const DEFAULT_URLS=[
     new URL('data/kinks.json', here).pathname,
     new URL('kinks.json', here).pathname,
     pathPrefix + 'data/kinks.json',
     pathPrefix + 'kinks.json',
     '/data/kinks.json',
     '/kinks.json'
-  ].filter((v, i, arr)=>v && arr.indexOf(v) === i);
+  ];
+  const overrideUrls = Array.isArray(window.KSV?.KINKS_URLS) ? window.KSV.KINKS_URLS : null;
+  const DATA_URLS = Array.from(new Set(
+    (overrideUrls && overrideUrls.length ? overrideUrls : DEFAULT_URLS)
+      .map(url => {
+        try { return new URL(url, here).pathname; }
+        catch { return url; }
+      })
+      .filter(Boolean)
+  ));
+  if (!DATA_URLS.length) DATA_URLS.push('/data/kinks.json');
 
   // Elements
   const $ = (id)=>document.getElementById(id);
@@ -536,7 +546,7 @@
     return /localhost|127\.0\.0\.1/.test(location.hostname);
   })();
 
-  const FETCH_NOTE_ID = 'ksv-fetch-notes';
+  const FETCH_NOTE_ID = 'tkFetchNote';
 
   function removeFetchNote(){
     const existing = document.getElementById(FETCH_NOTE_ID);
@@ -564,8 +574,9 @@
     note.textContent = 'Fetch notes: ' + notes.join('  -  ');
     if (!note.isConnected) document.body?.appendChild(note);
   }
+  window.showFetchNote = showFetchNote;
 
-  async function fetchFirst(urls){
+  async function fetchFirstInternal(urls){
     const notes = [];
     for (const url of urls){
       try{
@@ -584,7 +595,7 @@
         const json = JSON.parse(text);
         console.info('[kinksurvey] Loaded:', url);
         removeFetchNote();
-        return { json, src: url, errs: notes };
+        return { json, src: url, errs: [] };
       }catch(err){
         const message = err?.message || String(err);
         notes.push(`${url}: ${message}`);
@@ -596,9 +607,13 @@
     error.notes = notes;
     throw error;
   }
+  window.fetchFirst = fetchFirstInternal;
 
   async function fetchData(){
-    return fetchFirst(DATA_URLS);
+    const fetcher = typeof window.fetchFirst === 'function' ? window.fetchFirst : fetchFirstInternal;
+    const result = await fetcher(DATA_URLS);
+    if (result && typeof result === 'object' && 'json' in result) return result;
+    return { json: result, src: DATA_URLS[0], errs: [] };
   }
 
   function normalize(raw){


### PR DESCRIPTION
## Summary
- let the kink survey loader honor `window.KSV.KINKS_URLS` overrides when present while keeping a sane default list
- expose the fetch helpers on `window`, suppress fetch-note noise after successful loads, and align the banner id so external shims can clean it up

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db3bb9b56c832cba34a1623a37c749