### PR TITLE
Default survey ratings to zero on load

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -697,6 +697,10 @@ function showKinks(category) {
       if (info.rating == i) opt.selected = true;
       ratingSelect.appendChild(opt);
     }
+    if (info.rating == null) {
+      ratingSelect.value = '0';
+      setItemRating(info, 0);
+    }
     ratingSelect.onchange = () => {
       const val = ratingSelect.value === '' ? null : Number(ratingSelect.value);
       setItemRating(info, val);
@@ -790,6 +794,10 @@ function renderPanelKinks(container, category) {
       opt.textContent = `${i} - ${RATING_LABELS[i]}`;
       if (info.rating == i) opt.selected = true;
       ratingSelect.appendChild(opt);
+    }
+    if (info.rating == null) {
+      ratingSelect.value = '0';
+      setItemRating(info, 0);
     }
     ratingSelect.onchange = () => {
       const val = ratingSelect.value === '' ? null : Number(ratingSelect.value);


### PR DESCRIPTION
## Summary
- default newly rendered rating selectors to 0 so the survey shows a rating immediately
- persist the zero default through the existing setItemRating helper when no prior rating exists

## Testing
- Not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68db485480bc832ca5a794dff09d16d2