### PR TITLE
Align survey item rows to left

### DIFF
--- a/docs/kinksurvey/index.html
+++ b/docs/kinksurvey/index.html
@@ -259,7 +259,8 @@
     text-align:center;
   }
   .catTitle{ margin:0 0 8px; color:#7ef9ff }
-  .item{ display:flex; align-items:center; justify-content:center; gap:10px; padding:8px 0; border-top:1px dashed #00e5ff22; text-align:center; flex-wrap:wrap; }
+  .item{ display:flex; align-items:flex-start; justify-content:flex-start; gap:10px; padding:8px 0; border-top:1px dashed #00e5ff22; text-align:left; flex-wrap:wrap; }
+  .item label{ flex:1 1 auto; text-align:left; }
   .item:first-child{ border-top:0; }
   select,input[type=text]{ padding:6px 8px; border:1px solid #115; border-radius:8px; background:#06161a; color:var(--fg); }
 

--- a/kinksurvey/index.html
+++ b/kinksurvey/index.html
@@ -259,7 +259,8 @@
     text-align:center;
   }
   .catTitle{ margin:0 0 8px; color:#7ef9ff }
-  .item{ display:flex; align-items:center; justify-content:center; gap:10px; padding:8px 0; border-top:1px dashed #00e5ff22; text-align:center; flex-wrap:wrap; }
+  .item{ display:flex; align-items:flex-start; justify-content:flex-start; gap:10px; padding:8px 0; border-top:1px dashed #00e5ff22; text-align:left; flex-wrap:wrap; }
+  .item label{ flex:1 1 auto; text-align:left; }
   .item:first-child{ border-top:0; }
   select,input[type=text]{ padding:6px 8px; border:1px solid #115; border-radius:8px; background:#06161a; color:var(--fg); }
 


### PR DESCRIPTION
## Summary
- align kink survey item rows to flex-start so numbered labels line up on the left
- allow labels to grow and keep left text alignment for consistent numbering layout

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68db486522e4832cadb00baa8c5af3df