### PR TITLE
Ensure mobile font fallback uses sans-serif

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -497,7 +497,7 @@ body.theme-forest:not(.exporting) .category-box {
 
 /* Header */
 h1 {
-  font-family: 'Fredoka One', cursive;
+  font-family: 'Fredoka One', 'Inter', 'Open Sans', system-ui, sans-serif;
   text-align: center;
   margin-bottom: 30px;
 }
@@ -1319,7 +1319,7 @@ body.light-mode .static-rating-legend {
 }
 
 .compatibility-button {
-  font-family: 'Fredoka One', cursive;
+  font-family: 'Fredoka One', 'Inter', 'Open Sans', system-ui, sans-serif;
   width: 260px;
   height: 50px;
   font-size: 16px;
@@ -3438,7 +3438,7 @@ body {
 
 /* Theme Selector */
 .theme-selector {
-  font-family: 'Fredoka One', cursive;
+  font-family: 'Fredoka One', 'Inter', 'Open Sans', system-ui, sans-serif;
   margin-top: 0.75rem;
   font-size: 1rem;
   padding: 10px;
@@ -3458,7 +3458,7 @@ input[type="file"] {
   color: var(--text-color) !important;
   padding: 10px;
   border-radius: 8px;
-  font-family: 'Fredoka One', cursive;
+  font-family: 'Fredoka One', 'Inter', 'Open Sans', system-ui, sans-serif;
 }
 .compatibility-link {
   margin-top: 1.5rem;

--- a/css/theme.css
+++ b/css/theme.css
@@ -99,7 +99,7 @@ body.theme-dark {
   --card-bg: #000000;
   background-color: var(--bg-color);
   color: var(--text-color) !important;
-  font-family: 'Fredoka One', cursive;
+  font-family: 'Fredoka One', 'Inter', 'Open Sans', system-ui, sans-serif;
 }
 body.theme-dark *,
 body.theme-dark *::before,

--- a/docs/kinks/css/style.css
+++ b/docs/kinks/css/style.css
@@ -499,7 +499,7 @@ body.theme-forest:not(.exporting) .category-box {
 
 /* Header */
 h1 {
-  font-family: 'Fredoka One', cursive;
+  font-family: 'Fredoka One', 'Inter', 'Open Sans', system-ui, sans-serif;
   text-align: center;
   margin-bottom: 30px;
 }
@@ -1321,7 +1321,7 @@ body.light-mode .static-rating-legend {
 }
 
 .compatibility-button {
-  font-family: 'Fredoka One', cursive;
+  font-family: 'Fredoka One', 'Inter', 'Open Sans', system-ui, sans-serif;
   width: 260px;
   height: 50px;
   font-size: 16px;
@@ -3440,7 +3440,7 @@ body {
 
 /* Theme Selector */
 .theme-selector {
-  font-family: 'Fredoka One', cursive;
+  font-family: 'Fredoka One', 'Inter', 'Open Sans', system-ui, sans-serif;
   margin-top: 0.75rem;
   font-size: 1rem;
   padding: 10px;
@@ -3460,7 +3460,7 @@ input[type="file"] {
   color: var(--text-color) !important;
   padding: 10px;
   border-radius: 8px;
-  font-family: 'Fredoka One', cursive;
+  font-family: 'Fredoka One', 'Inter', 'Open Sans', system-ui, sans-serif;
 }
 .compatibility-link {
   margin-top: 1.5rem;

--- a/docs/kinks/css/theme.css
+++ b/docs/kinks/css/theme.css
@@ -99,7 +99,7 @@ body.theme-dark {
   --card-bg: #000000;
   background-color: var(--bg-color);
   color: var(--text-color) !important;
-  font-family: 'Fredoka One', cursive;
+  font-family: 'Fredoka One', 'Inter', 'Open Sans', system-ui, sans-serif;
 }
 body.theme-dark *,
 body.theme-dark *::before,


### PR DESCRIPTION
## Summary
- replace cursive fallbacks for Fredoka One with a consistent sans-serif stack in shared CSS
- mirror the updated font stack in the generated docs bundle to keep parity

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68db56e8e2c8832c9c9c9381db80bb63