### PR TITLE
Add compatibility navigation buttons to kink survey

### DIFF
--- a/kinksurvey/index.html
+++ b/kinksurvey/index.html
@@ -319,9 +319,8 @@
   <h1>Talk Kink Survey</h1>
   <div class="ksvButtons">
     <a class="ksvBtn" href="#categorySurveyPanel">Select Categories</a>
-git add kinksurvey/index.html
-git commit -m "Resolve links: use root-relative paths for Compatibility & Individual Kink Analysis"
-
+    <a class="ksvBtn" href="https://talkkink.org/compatibility.html">Compatibility</a>
+    <a class="ksvBtn" href="https://talkkink.org/individualkinkanalysis.html">Individual Kink Analysis</a>
   </div>
   <p class="ksvFallbackNote">The survey loads automatically when JavaScript is available. If nothing happens, scroll down to choose categories manually or refresh the page.</p>
   <noscript><p class="ksvFallbackNote">JavaScript is required to load the category list and run the survey.</p></noscript>


### PR DESCRIPTION
## Summary
- add hero buttons on the kink survey landing section that link to the compatibility and individual kink analysis pages
- clean up stray text that previously appeared inside the hero button container

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68db65379814832c9282242185777989