### PR TITLE
Retarget kink survey nav buttons to talkkink.org

### DIFF
--- a/js/tk_kinksurvey_enhance.js
+++ b/js/tk_kinksurvey_enhance.js
@@ -80,6 +80,19 @@
     toggle?.setAttribute?.('aria-expanded','false');
   }
 
+  function retargetKsvButtons(){
+    const buttons = $$("a.ksvBtn");
+    if (!buttons.length) return;
+
+    const findByLabel = (pattern) => buttons.find(btn => pattern.test((btn.textContent || "").trim())) || null;
+
+    const compat = findByLabel(/compat/i);
+    if (compat) compat.href = 'https://talkkink.org/compatibility.html';
+
+    const analysis = findByLabel(/individual\s*kink\s*analysis/i);
+    if (analysis) analysis.href = 'https://talkkink.org/individualkinkanalysis.html';
+  }
+
   function ensureHero(){
     $$('#tkHero, #tk-hero, .tk-hero, #ksvHeroStack').forEach(node => node.remove());
 
@@ -162,6 +175,7 @@
         setTimeout(() => realStart?.focus?.(), 280);
       });
     }
+    retargetKsvButtons();
   }
 
   function ensureObserver(listHost){
@@ -404,6 +418,7 @@
   function boot(){
     forceClosePanel();
     ensureHero();
+    retargetKsvButtons();
     enhancePanel();
     setupFullscreenDrawer();
   }


### PR DESCRIPTION
## Summary
- add a helper that retargets kink survey navigation buttons to the live talkkink.org compatibility and analysis pages
- invoke the helper after building the hero buttons and during boot so both static and injected markup point to the right URLs

## Testing
- Not run (frontend change only)


------
https://chatgpt.com/codex/tasks/task_e_68db6801e3bc832ca3e8f8fa5d43ff49