### PR TITLE
Fix kink survey links for compatibility tools

### DIFF
--- a/js/tk_kinksurvey_enhance.js
+++ b/js/tk_kinksurvey_enhance.js
@@ -87,10 +87,10 @@
     const findByLabel = (pattern) => buttons.find(btn => pattern.test((btn.textContent || "").trim())) || null;
 
     const compat = findByLabel(/compat/i);
-    if (compat) compat.href = 'https://talkkink.org/compatibility.html';
+    if (compat) compat.href = '/compatibility/';
 
     const analysis = findByLabel(/individual\s*kink\s*analysis/i);
-    if (analysis) analysis.href = 'https://talkkink.org/individualkinkanalysis.html';
+    if (analysis) analysis.href = '/ika/';
   }
 
   function ensureHero(){
@@ -116,10 +116,10 @@
     startNode.removeAttribute('disabled');
     stack.appendChild(startNode);
 
-    const compatNode = el('a',{class:'ksvBtn', href:'/compat'},'Compatibility Page');
+    const compatNode = el('a',{class:'ksvBtn', href:'/compatibility/'},'Compatibility Page');
     stack.appendChild(compatNode);
 
-    const analysisNode = el('a',{class:'ksvBtn', href:'/ika'},'Individual Kink Analysis');
+    const analysisNode = el('a',{class:'ksvBtn', href:'/ika/'},'Individual Kink Analysis');
     stack.appendChild(analysisNode);
 
     const themeRow = el('div',{class:'ksvThemeRow', id:'tkThemeRow'});

--- a/kinksurvey/index.html
+++ b/kinksurvey/index.html
@@ -319,8 +319,8 @@
   <h1>Talk Kink Survey</h1>
   <div class="ksvButtons">
     <a class="ksvBtn" href="#categorySurveyPanel">Select Categories</a>
-    <a class="ksvBtn" href="https://talkkink.org/compatibility.html">Compatibility</a>
-    <a class="ksvBtn" href="https://talkkink.org/individualkinkanalysis.html">Individual Kink Analysis</a>
+    <a class="ksvBtn" href="/compatibility/">Compatibility</a>
+    <a class="ksvBtn" href="/ika/">Individual Kink Analysis</a>
   </div>
   <p class="ksvFallbackNote">The survey loads automatically when JavaScript is available. If nothing happens, scroll down to choose categories manually or refresh the page.</p>
   <noscript><p class="ksvFallbackNote">JavaScript is required to load the category list and run the survey.</p></noscript>


### PR DESCRIPTION
## Summary
- update the kink survey hero buttons to use the new /compatibility/ and /ika/ routes
- align the enhancement script so dynamically inserted CTA buttons point to the same routes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68db68fd2aec832c98c1fc51461fd71d