### PR TITLE
Update hero navigation buttons

### DIFF
--- a/docs/kinksurvey/index.html
+++ b/docs/kinksurvey/index.html
@@ -271,11 +271,13 @@
 
 <section id="ksvHeroStack" data-ksv-fallback>
   <h1>Talk Kink Survey</h1>
-  <div class="ksvButtons">
-    <a class="ksvBtn" href="#categorySurveyPanel">Select Categories</a>
-    <a class="ksvBtn" href="/compat">Compatibility Page</a>
-    <a class="ksvBtn" href="/ika">Individual Kink Analysis</a>
-  </div>
+  <nav class="ksvButtons">
+    <a class="ksvBtn" id="btnStartSurvey" href="#start">Start Survey</a>
+
+    <!-- Force the two buttons to your direct URLs -->
+    <a class="ksvBtn" href="https://talkkink.org/compatibility.html">Compatibility Page</a>
+    <a class="ksvBtn" href="https://talkkink.org/individualkinkanalysis.html">Individual Kink Analysis</a>
+  </nav>
   <p class="ksvFallbackNote">The survey loads automatically when JavaScript is available. If nothing happens, scroll down to choose categories manually or refresh the page.</p>
   <noscript><p class="ksvFallbackNote">JavaScript is required to load the category list and run the survey.</p></noscript>
 </section>

--- a/kinksurvey/index.html
+++ b/kinksurvey/index.html
@@ -317,11 +317,13 @@
 
 <section id="ksvHeroStack" data-ksv-fallback>
   <h1>Talk Kink Survey</h1>
-  <div class="ksvButtons">
-    <a class="ksvBtn" href="#categorySurveyPanel">Select Categories</a>
-    <a class="ksvBtn" href="https://talkkink.org/compatibility.html">Compatibility</a>
+  <nav class="ksvButtons">
+    <a class="ksvBtn" id="btnStartSurvey" href="#start">Start Survey</a>
+
+    <!-- Force the two buttons to your direct URLs -->
+    <a class="ksvBtn" href="https://talkkink.org/compatibility.html">Compatibility Page</a>
     <a class="ksvBtn" href="https://talkkink.org/individualkinkanalysis.html">Individual Kink Analysis</a>
-  </div>
+  </nav>
   <p class="ksvFallbackNote">The survey loads automatically when JavaScript is available. If nothing happens, scroll down to choose categories manually or refresh the page.</p>
   <noscript><p class="ksvFallbackNote">JavaScript is required to load the category list and run the survey.</p></noscript>
 </section>


### PR DESCRIPTION
## Summary
- replace the hero action container with a `<nav>` element for accessibility
- add a Start Survey button and point the other buttons directly to the public URLs

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc40127b90832cb4bcdc035159b7c6