### PR TITLE
Simplify kink dataset source list

### DIFF
--- a/docs/kinksurvey/index.html
+++ b/docs/kinksurvey/index.html
@@ -318,14 +318,8 @@
 (async function(){
   // Keep your existing data sources (will use your published dataset when present)
   const here = new URL(window.location.href);
-  const pathPrefix = here.pathname.replace(/[^/]*$/, '');
   const DEFAULT_URLS=[
-    new URL('data/kinks.json', here).pathname,
-    new URL('kinks.json', here).pathname,
-    pathPrefix + 'data/kinks.json',
-    pathPrefix + 'kinks.json',
-    '/data/kinks.json',
-    '/kinks.json'
+    '/data/kinks.json'
   ];
   const overrideUrls = Array.isArray(window.KSV?.KINKS_URLS) ? window.KSV.KINKS_URLS : null;
   const DATA_URLS = Array.from(new Set(

--- a/kinksurvey/index.html
+++ b/kinksurvey/index.html
@@ -364,14 +364,8 @@
 (async function(){
   // Keep your existing data sources (will use your published dataset when present)
   const here = new URL(window.location.href);
-  const pathPrefix = here.pathname.replace(/[^/]*$/, '');
   const DEFAULT_URLS=[
-    new URL('data/kinks.json', here).pathname,
-    new URL('kinks.json', here).pathname,
-    pathPrefix + 'data/kinks.json',
-    pathPrefix + 'kinks.json',
-    '/data/kinks.json',
-    '/kinks.json'
+    '/data/kinks.json'
   ];
   const overrideUrls = Array.isArray(window.KSV?.KINKS_URLS) ? window.KSV.KINKS_URLS : null;
   const DATA_URLS = Array.from(new Set(


### PR DESCRIPTION
## Summary
- limit the kink survey loader to request only the published /data/kinks.json dataset
- remove unused path prefix calculation now that fallback URLs are gone

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc429bfed8832c8eef4b6f23d65e5d