### PR TITLE
Ensure kink survey hero buttons use hard navigation

### DIFF
--- a/docs/kinksurvey/index.html
+++ b/docs/kinksurvey/index.html
@@ -275,8 +275,8 @@
     <a class="ksvBtn" id="btnStartSurvey" href="#start">Start Survey</a>
 
     <!-- Force the two buttons to your direct URLs -->
-    <a class="ksvBtn" href="https://talkkink.org/compatibility.html">Compatibility Page</a>
-    <a class="ksvBtn" href="https://talkkink.org/individualkinkanalysis.html">Individual Kink Analysis</a>
+    <a class="ksvBtn" id="btn-compat" href="https://talkkink.org/compatibility.html">Compatibility Page</a>
+    <a class="ksvBtn" id="btn-ika" href="https://talkkink.org/individualkinkanalysis.html">Individual Kink Analysis</a>
   </nav>
   <p class="ksvFallbackNote">The survey loads automatically when JavaScript is available. If nothing happens, scroll down to choose categories manually or refresh the page.</p>
   <noscript><p class="ksvFallbackNote">JavaScript is required to load the category list and run the survey.</p></noscript>

--- a/kinksurvey/index.html
+++ b/kinksurvey/index.html
@@ -321,8 +321,8 @@
     <a class="ksvBtn" id="btnStartSurvey" href="#start">Start Survey</a>
 
     <!-- Force the two buttons to your direct URLs -->
-    <a class="ksvBtn" href="https://talkkink.org/compatibility.html">Compatibility Page</a>
-    <a class="ksvBtn" href="https://talkkink.org/individualkinkanalysis.html">Individual Kink Analysis</a>
+    <a class="ksvBtn" id="btn-compat" href="https://talkkink.org/compatibility.html">Compatibility Page</a>
+    <a class="ksvBtn" id="btn-ika" href="https://talkkink.org/individualkinkanalysis.html">Individual Kink Analysis</a>
   </nav>
   <p class="ksvFallbackNote">The survey loads automatically when JavaScript is available. If nothing happens, scroll down to choose categories manually or refresh the page.</p>
   <noscript><p class="ksvFallbackNote">JavaScript is required to load the category list and run the survey.</p></noscript>

--- a/kinksurvey/index.html.bak
+++ b/kinksurvey/index.html.bak
@@ -319,8 +319,8 @@
   <h1>Talk Kink Survey</h1>
   <div class="ksvButtons">
     <a class="ksvBtn" href="#categorySurveyPanel">Select Categories</a>
-    <a class="ksvBtn" href="/compatibility/">Compatibility</a>
-    <a class="ksvBtn" href="/ika/">Individual Kink Analysis</a>
+    <a class="ksvBtn" id="btn-compat" href="/compatibility/">Compatibility</a>
+    <a class="ksvBtn" id="btn-ika" href="/ika/">Individual Kink Analysis</a>
   </div>
   <p class="ksvFallbackNote">The survey loads automatically when JavaScript is available. If nothing happens, scroll down to choose categories manually or refresh the page.</p>
   <noscript><p class="ksvFallbackNote">JavaScript is required to load the category list and run the survey.</p></noscript>


### PR DESCRIPTION
## Summary
- enforce hard-navigation behaviour for the kink survey hero buttons so they always reach the canonical compatibility and IKA HTML pages
- tag the fallback hero markup with stable IDs for the compatibility and IKA buttons to mirror the scripted behaviour

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc45cc6700832c9224dd87226cf2cb