### PR TITLE
Add tk-survey schema and enrich survey export payload

### DIFF
--- a/docs/schemas/tk-survey.v1.json
+++ b/docs/schemas/tk-survey.v1.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://talkkink.org/schemas/tk-survey.v1.json",
+  "title": "Talk Kink Survey Export",
+  "description": "Schema describing the normalized survey export produced by the Talk Kink kinksurvey tool.",
+  "type": "object",
+  "required": ["schema", "generatedAt", "answers"],
+  "properties": {
+    "schema": {
+      "type": "string",
+      "const": "tk-survey.v1"
+    },
+    "$schema": {
+      "type": "string",
+      "format": "uri"
+    },
+    "app": {
+      "type": "string",
+      "description": "Application that generated the payload.",
+      "default": "talkkink"
+    },
+    "tool": {
+      "type": "string",
+      "description": "Tool identifier within the application.",
+      "default": "kinksurvey"
+    },
+    "type": {
+      "type": "string",
+      "description": "Export type identifier.",
+      "default": "kink-survey-export"
+    },
+    "version": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "site": {
+      "type": "string",
+      "description": "Origin of the site where the survey was captured.",
+      "format": "uri"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "answers": {
+      "type": "array",
+      "description": "Flattened list of survey answers keyed by kink identifier.",
+      "items": {
+        "type": "object",
+        "required": ["rating"],
+        "properties": {
+          "id": {
+            "type": ["string", "null"],
+            "description": "DOM identifier associated with the item, if present."
+          },
+          "key": {
+            "type": ["string", "null"],
+            "description": "Canonical kink key."
+          },
+          "label": {
+            "type": ["string", "null"],
+            "description": "Human readable label scraped from the survey UI."
+          },
+          "rating": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 5
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "answersByKey": {
+      "type": "object",
+      "description": "Fast lookup map keyed by canonical kink key.",
+      "propertyNames": {
+        "type": "string",
+        "minLength": 1
+      },
+      "additionalProperties": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 5
+      }
+    },
+    "answersById": {
+      "type": "object",
+      "description": "Lookup map keyed by DOM identifier.",
+      "propertyNames": {
+        "type": "string",
+        "minLength": 1
+      },
+      "additionalProperties": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 5
+      }
+    },
+    "ratings": {
+      "type": "object",
+      "description": "Alias for answersByKey maintained for backward compatibility.",
+      "propertyNames": {
+        "type": "string",
+        "minLength": 1
+      },
+      "additionalProperties": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 5
+      }
+    },
+    "keys": {
+      "type": "array",
+      "description": "Ordered list of kink keys used to align the cells matrix.",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "cells": {
+      "type": "array",
+      "description": "Matrix representation of the ratings aligned with the keys array.",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": ["number", "null"],
+          "minimum": 0,
+          "maximum": 5
+        }
+      }
+    },
+    "kinksSource": {
+      "type": "string",
+      "description": "Describes how the canonical kink metadata was resolved."
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/tk-survey.v1.json
+++ b/schemas/tk-survey.v1.json
@@ -1,0 +1,138 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://talkkink.org/schemas/tk-survey.v1.json",
+  "title": "Talk Kink Survey Export",
+  "description": "Schema describing the normalized survey export produced by the Talk Kink kinksurvey tool.",
+  "type": "object",
+  "required": ["schema", "generatedAt", "answers"],
+  "properties": {
+    "schema": {
+      "type": "string",
+      "const": "tk-survey.v1"
+    },
+    "$schema": {
+      "type": "string",
+      "format": "uri"
+    },
+    "app": {
+      "type": "string",
+      "description": "Application that generated the payload.",
+      "default": "talkkink"
+    },
+    "tool": {
+      "type": "string",
+      "description": "Tool identifier within the application.",
+      "default": "kinksurvey"
+    },
+    "type": {
+      "type": "string",
+      "description": "Export type identifier.",
+      "default": "kink-survey-export"
+    },
+    "version": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "site": {
+      "type": "string",
+      "description": "Origin of the site where the survey was captured.",
+      "format": "uri"
+    },
+    "generatedAt": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "answers": {
+      "type": "array",
+      "description": "Flattened list of survey answers keyed by kink identifier.",
+      "items": {
+        "type": "object",
+        "required": ["rating"],
+        "properties": {
+          "id": {
+            "type": ["string", "null"],
+            "description": "DOM identifier associated with the item, if present."
+          },
+          "key": {
+            "type": ["string", "null"],
+            "description": "Canonical kink key."
+          },
+          "label": {
+            "type": ["string", "null"],
+            "description": "Human readable label scraped from the survey UI."
+          },
+          "rating": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 5
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "answersByKey": {
+      "type": "object",
+      "description": "Fast lookup map keyed by canonical kink key.",
+      "propertyNames": {
+        "type": "string",
+        "minLength": 1
+      },
+      "additionalProperties": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 5
+      }
+    },
+    "answersById": {
+      "type": "object",
+      "description": "Lookup map keyed by DOM identifier.",
+      "propertyNames": {
+        "type": "string",
+        "minLength": 1
+      },
+      "additionalProperties": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 5
+      }
+    },
+    "ratings": {
+      "type": "object",
+      "description": "Alias for answersByKey maintained for backward compatibility.",
+      "propertyNames": {
+        "type": "string",
+        "minLength": 1
+      },
+      "additionalProperties": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 5
+      }
+    },
+    "keys": {
+      "type": "array",
+      "description": "Ordered list of kink keys used to align the cells matrix.",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "cells": {
+      "type": "array",
+      "description": "Matrix representation of the ratings aligned with the keys array.",
+      "items": {
+        "type": "array",
+        "items": {
+          "type": ["number", "null"],
+          "minimum": 0,
+          "maximum": 5
+        }
+      }
+    },
+    "kinksSource": {
+      "type": "string",
+      "description": "Describes how the canonical kink metadata was resolved."
+    }
+  },
+  "additionalProperties": true
+}

--- a/talk-kink-new-survey.html
+++ b/talk-kink-new-survey.html
@@ -595,17 +595,19 @@
     rows.forEach(row => {
       const id  = row.getAttribute('data-kink-id')  || row.dataset.kinkId  || row.dataset.id  || row.id || null;
       let   key = row.getAttribute('data-kink-key') || row.dataset.kinkKey || row.dataset.key || null;
+      const labelText = inferRowLabel(row);
 
       const ctl = row.querySelector('select, input[type="range"], input[type="number"]');
       const rating = Number((ctl && ctl.value) || 0);
 
       if (!key && keyLookup){
-        const lab = normLabel(inferRowLabel(row));
+        const lab = normLabel(labelText);
         key = keyLookup.byLabel[lab] || null;
       }
 
       if (id || key){
-        answers.push({ id:id ?? null, key:key ?? null, rating });
+        const label = labelText ? labelText.trim() : null;
+        answers.push({ id:id ?? null, key:key ?? null, label, rating });
         if (id)  answersById[id]  = rating;
         if (key) answersByKey[key] = rating;
       }
@@ -640,14 +642,22 @@
     }
 
     const now = new Date().toISOString();
+    const schemaId = 'tk-survey.v1';
+    let site = '';
+    try{
+      site = window.location && window.location.origin ? window.location.origin : '';
+    }catch(_e){ site = ''; }
+    if (site === 'file://') site = '';
     return {
       // meta / identity
       $schema: "https://talkkink.org/schemas/kink-survey-result.v1.json",
+      schema: schemaId,
       app: "talkkink",
       tool: "kinksurvey",
       type: "kink-survey-export",
       version: 1,
       generatedAt: now,
+      site: site || undefined,
 
       // preferred fast path for compatibility/IKA
       answersByKey,         // { key: rating }


### PR DESCRIPTION
## Summary
- add a published JSON Schema for the tk-survey.v1 export and mirror it under docs/
- include human-readable labels plus schema and site metadata in the survey download payload

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc55e231cc832c9029d33ab2328ddc