### PR TITLE
Update compatibility page patch scripts

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -704,42 +704,43 @@ RESULT
 </script>
 
 
-<!-- ===== TK compatibility page patch (place right before </body>) ===== -->
+<!-- ===== TK Compatibility Page Patch (place right before </body>) ===== -->
 
-<!-- 1) Load jsPDF + autoTable and expose window.jsPDF for your export -->
+<!-- 1) Load jsPDF + autoTable and expose window.jsPDF reliably -->
 <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js" defer></script>
 <script src="https://cdn.jsdelivr.net/npm/jspdf-autotable@3.8.1/dist/jspdf.plugin.autotable.min.js" defer></script>
 <script>
 (function ensureJsPDF(){
   function ready(){
-    // jsPDF 2.x UMD puts constructor at window.jspdf.jsPDF
+    // jsPDF 2.x UMD constructor lives at window.jspdf.jsPDF
     if (window.jspdf && window.jspdf.jsPDF) {
       window.jsPDF = window.jspdf.jsPDF;
-      // Nudge plugin to attach (some builds attach on first doc)
       try { new window.jsPDF({compress:false}); } catch(_) {}
     }
   }
   window.addEventListener('load', ready, {once:true});
+  // extra nudge in case load fires before CDN settles
   setTimeout(ready, 800);
 })();
 </script>
 
-<!-- 2) Safe helpers + survey normalizer to prevent `.trim()` on undefined -->
+<!-- 2) Canonical, safe survey normalizer + sanitizers -->
 <script>
 (function(){
+  // Safe coercers
   const S = v => (v == null ? '' : (typeof v === 'string' ? v : String(v)));
   const T = v => S(v).trim();
   const N = v => { const n = Number(v); return Number.isFinite(n) ? n : 0; };
 
-  // Normalize any uploaded survey object into a canonical, safe shape.
+  // Convert any plausible uploaded survey object into canonical shape
   function normalizeSurvey(raw){
     if (!raw || typeof raw !== 'object') throw new Error('bad survey');
 
-    // Canonical form produced by the kink survey export
+    // Already canonical?
     if (raw.schema === 'tk-survey.v1' && Array.isArray(raw.answers)) {
       const answers = raw.answers.map(a => ({
-        key:   T(a?.key),
-        label: T(a?.label),
+        key   : T(a?.key),
+        label : T(a?.label),
         rating: N(a?.rating)
       }));
       const answersByKey = Object.fromEntries(answers.map(a => [a.key, a.rating]));
@@ -747,81 +748,131 @@ RESULT
                answers, answersByKey };
     }
 
-    // Loose shapes: coerce to canonical
+    // Loose shapes -> canonical
     if (Array.isArray(raw.answers)) {
       const answers = raw.answers.map(a => ({ key:T(a?.key), label:T(a?.label), rating:N(a?.rating) }));
       const answersByKey = Object.fromEntries(answers.map(a => [a.key, a.rating]));
       return { schema:'tk-survey.v1', site:'', generatedAt:'', answers, answersByKey };
     }
     if (raw.answersByKey && typeof raw.answersByKey === 'object') {
-      const answers = Object.entries(raw.answersByKey).map(([k,v]) => ({ key:T(k), label:'', rating:N(v) }));
+      const answers = Object.entries(raw.answersByKey)
+        .map(([k,v]) => ({ key:T(k), label:'', rating:N(v) }));
       const answersByKey = Object.fromEntries(answers.map(a => [a.key, a.rating]));
       return { schema:'tk-survey.v1', site:'', generatedAt:'', answers, answersByKey };
     }
 
     throw new Error('unrecognized survey shape');
   }
+  window.TK_NORMALIZE_SURVEY = normalizeSurvey; // exposed for debugging
 
-  // Make available for the page code to call (we’ll also auto-use it below)
-  window.TK_NORMALIZE_SURVEY = normalizeSurvey;
-
-  // 3) Wrap the reader.onload handlers so Survey A/B are normalized before use
-  //    (works whether your code stores to window.SurveyA/B or other vars)
-  function wrapFileInput(id, storeTo){
-    const input = document.getElementById(id);
-    if (!input) return;
-    if (input._tkPatched) return; // avoid double patch
-    input._tkPatched = true;
-
-    input.addEventListener('change', function(ev){
-      const file = ev.target.files && ev.target.files[0];
-      if (!file) return;
-      const r = new FileReader();
-      r.onload = function(e){
-        try{
-          const obj = JSON.parse(String(e.target.result || '{}'));
-          const normalized = normalizeSurvey(obj);
-          // Try to publish where the existing code expects it
-          window[storeTo] = normalized; // e.g., "SurveyA" or "SurveyB"
-          // If your code expects answersByKey/cells elsewhere, it will derive them
-          // from this canonical object without hitting `.trim()`.
-        }catch(err){
-          alert('Invalid JSON for ' + storeTo.replace('Survey','Survey ') +
-                '. Please upload the unmodified JSON file exported from the survey.');
-          console.error(err);
-        }
-      };
-      r.readAsText(file);
-    }, true);
+  // Make sure all objects contain trimmed strings before your code uses them
+  function sanitizeSurvey(s){
+    if (!s || typeof s !== 'object') return;
+    s.answers = (Array.isArray(s.answers) ? s.answers : [])
+      .filter(Boolean)
+      .map(a => ({ key:T(a?.key), label:T(a?.label), rating:N(a?.rating) }));
+    s.answersByKey = Object.fromEntries(s.answers.map(a => [a.key, a.rating]));
   }
 
-  // These IDs should match your two upload inputs on the page
-  // (adjust if your element IDs differ)
-  wrapFileInput('uploadSurveyA', 'SurveyA');
-  wrapFileInput('uploadSurveyB', 'SurveyB');
+  // Some builds keep the union globally; guard it if we find it
+  function sanitizeUnion(u){
+    if (!Array.isArray(u)) return;
+    u.forEach(r => {
+      if (!r || typeof r !== 'object') return;
+      r.key   = T(r.key);
+      r.label = T(r.label);
+      r.group = T(r.group);
+      r.category = T(r.category);
+    });
+  }
 
-  // 4) Patch the function that appears in your stack trace so it only
-  //    ever receives strings (prevents "reading 'trim' of undefined").
-  function patchFilter(){
+  function sanitizeAll(){
+    sanitizeSurvey(window.SurveyA);
+    sanitizeSurvey(window.SurveyB);
+    // Try common union names used on this page
+    ['compatUnion','UNION','KSV_UNION','TK_UNION','gUnion'].forEach(n=>{
+      if (window[n]) sanitizeUnion(window[n]);
+    });
+  }
+
+  // 3) Bind to any JSON file inputs and normalize uploaded files.
+  function bindJsonInputs(){
+    const inputs = Array.from(document.querySelectorAll('input[type="file"][accept*="json" i]'));
+    let assignToA = true; // first upload -> A, next -> B (works with typical UI)
+    inputs.forEach(input=>{
+      if (input._tkPatched) return;
+      input._tkPatched = true;
+
+      input.addEventListener('change', function(ev){
+        const file = ev.target.files && ev.target.files[0];
+        if (!file) return;
+        const r = new FileReader();
+        r.onload = function(e){
+          try{
+            const obj = JSON.parse(String(e.target.result || '{}'));
+            const normalized = normalizeSurvey(obj);
+
+            // If your page uses explicit IDs, you can set them here too
+            // otherwise we assign first file to A, second to B (idempotent)
+            if (assignToA || !window.SurveyA) {
+              window.SurveyA = normalized;
+              assignToA = false;
+            } else {
+              window.SurveyB = normalized;
+            }
+
+            sanitizeAll(); // ensure no undefined fields remain
+            console.info('[compat] normalized upload:', assignToA ? 'B' : 'A',
+              'answers:', (assignToA ? window.SurveyB : window.SurveyA)?.answers?.length ?? 0);
+          }catch(err){
+            alert('Invalid JSON. Please upload the unmodified JSON file exported from the survey.');
+            console.error(err);
+          }
+        };
+        r.readAsText(file);
+      }, true);
+    });
+  }
+
+  // 4) Wrap the functions from your stack trace so they *always* see sanitized data.
+  function patchCompatRoutines(){
+    ['calculateCompatibility','updateComparison'].forEach(name=>{
+      const fn = window[name];
+      if (typeof fn === 'function' && !fn.__tkWrapped) {
+        const wrapped = function(...args){
+          try { sanitizeAll(); } catch(_){ }
+          return fn.apply(this, args);
+        };
+        wrapped.__tkWrapped = true;
+        window[name] = wrapped;
+      }
+    });
+
+    // If a helper applies trims over general options, guard it too (if present).
     if (typeof window.filterGeneralOptions === 'function' && !window._tkPatchedFilter) {
       const orig = window.filterGeneralOptions;
       window.filterGeneralOptions = function(arr){
-        if (Array.isArray(arr)) {
-          const safeArr = arr.map(x => T(x));
-          return orig.call(this, safeArr);
-        }
-        return orig.call(this, arr);
+        const safe = (arr || []).map(x => T(x));
+        return orig.call(this, safe);
       };
       window._tkPatchedFilter = true;
     }
   }
-  // Try now and also after load (in case the original is defined later)
-  patchFilter();
-  window.addEventListener('load', patchFilter, {once:true});
-  setTimeout(patchFilter, 600);
+
+  // 5) Initialize + watch for late-bound functions
+  function init(){
+    bindJsonInputs();
+    sanitizeAll();
+    patchCompatRoutines();
+  }
+  window.addEventListener('load', init, {once:true});
+  setTimeout(init, 700); // late scripts
+  const mo = new MutationObserver(()=>{ bindJsonInputs(); patchCompatRoutines(); });
+  mo.observe(document.documentElement, {subtree:true, childList:true});
+
 })();
 </script>
-<!-- ===== /TK compatibility page patch ===== -->
+<!-- ===== /TK Compatibility Page Patch ===== -->
 
 
 <!-- ✅ 1) Add this *once* near the end of every page that was freezing (before </body>) -->


### PR DESCRIPTION
## Summary
- replace the legacy compatibility page patch with the latest resilient loader
- ensure jsPDF/autoTable exposure and survey sanitization mirror the new toolkit helpers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc75d733e0832c9183b21b5a73cea6