### PR TITLE
Enhance compatibility match display with chips

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -98,6 +98,39 @@
     }
     .tk-compat td.ta-c{ text-align:center; }
   </style>
+  <style>
+  /* ====== Match % chip (compact, no layout shift) ====== */
+  .tk-match-chip{
+    display:inline-flex; flex-direction:column; align-items:center; gap:6px;
+    min-width:70px; line-height:1; vertical-align:middle;
+  }
+  .tk-match-num{ font-weight:800; letter-spacing:.02em; }
+  .tk-match-bar{
+    position:relative; width:90px; height:7px; border-radius:999px;
+    outline:1px solid rgba(0,230,255,.35);
+    background:rgba(0,230,255,.10); overflow:hidden;
+  }
+  .tk-match-fill{
+    display:block; height:100%; width:var(--w,0%);
+    background:linear-gradient(90deg,#00e6ff,#3bffc4);
+    border-radius:inherit; transition:width .25s ease;
+  }
+  /* Dim the bar if the value is “missing” on that row */
+  .tk-match-chip[data-missing="1"] .tk-match-bar{ opacity:.38; }
+
+  /* ====== Category main + tiny subline (summary) ====== */
+  .tk-cat-wrap{ display:flex; flex-direction:column; gap:3px; }
+  .tk-cat-main{ white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+  .tk-cat-sub{
+    font-size:.82em; color:#9beff7; opacity:.78;
+    white-space:nowrap; overflow:hidden; text-overflow:ellipsis;
+    max-width:48ch;  /* keep it subtle; doesn’t stretch your layout */
+  }
+  /* On narrow screens you can hide the subline if you want */
+  @media (max-width: 680px){
+    .tk-cat-sub{ display:none; }
+  }
+  </style>
 </head>
 <body class="theme-dark">
   <div class="main-container themed">
@@ -417,17 +450,41 @@
       if (current && !/^[-–—]$/.test(current)) return; // don't overwrite real values
       const val = pickValue(rowKeyBundle(tr), lookup);
       if (val == null) return;
-      td.textContent = String(val);
+      const renderScore = typeof window.tkRenderScoreCell === 'function'
+        ? window.tkRenderScoreCell
+        : v => (v === null || v === undefined || v === '' ? '—' : String(v));
+      td.textContent = renderScore(val);
       wrote++;
     });
     return wrote;
   }
 
   function computeMatch(a, b){
-    const na = Number(a), nb = Number(b);
-    if (!Number.isFinite(na) || !Number.isFinite(nb)) return '';
-    const diff = Math.abs(na - nb);                      // 0..4
-    return Math.round((1 - diff/4) * 100) + '%';         // 100..0
+    if (typeof window.tkRenderMatchCell === 'function') {
+      return window.tkRenderMatchCell(a, b);
+    }
+    const calc = typeof window.tkMatchPercent === 'function'
+      ? window.tkMatchPercent
+      : (va, vb) => {
+          const na = Number(va);
+          const nb = Number(vb);
+          if (!Number.isFinite(na) || !Number.isFinite(nb)) return null;
+          if (na === 0 || nb === 0) return 0;
+          const diff = Math.abs(na - nb);
+          return Math.round((1 - diff / 5) * 100);
+        };
+    const pct = calc(a, b);
+    if (pct === null) {
+      return '<div class="tk-match-chip" data-missing="1" aria-label="No match data">—</div>';
+    }
+    return `
+      <div class="tk-match-chip" role="img" aria-label="Match ${pct}%">
+        <div class="tk-match-num">${pct}%</div>
+        <div class="tk-match-bar" aria-hidden="true">
+          <i class="tk-match-fill" style="--w:${pct}%"></i>
+        </div>
+      </div>
+    `;
   }
 
   function recomputeMatches(root){
@@ -435,7 +492,7 @@
       const a = tr.querySelector('td[data-partner-a], td.pa')?.textContent;
       const b = tr.querySelector('td[data-partner-b], td.pb')?.textContent;
       const m = tr.querySelector('td[data-match]') || tr.children[2]; // assume 3rd col if standard
-      if (m && m.tagName === 'TD') m.textContent = computeMatch(a, b);
+      if (m && m.tagName === 'TD') m.innerHTML = computeMatch(a, b);
     });
   }
 

--- a/docs/kinks/js/compatibilityPage.js
+++ b/docs/kinks/js/compatibilityPage.js
@@ -98,6 +98,94 @@ function colorClass(percent) {
   return 'red';
 }
 
+function tkEscape(s) {
+  return String(s ?? '').replace(/[&<>"']/g, m => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;'
+  })[m]);
+}
+
+function tkNormScore(v) {
+  if (v === null || v === undefined || v === '') return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? Math.max(0, Math.min(5, n)) : null;
+}
+
+function tkMatchPercent(aRaw, bRaw) {
+  const a = tkNormScore(aRaw);
+  const b = tkNormScore(bRaw);
+  if (a === null || b === null) return null;
+  if (a === 0 || b === 0) return 0;
+  const diff = Math.abs(a - b);
+  return Math.round((1 - diff / 5) * 100);
+}
+
+function tkSummarizeQuestion(full, fallback) {
+  let s = (full || fallback || '').trim();
+  if (!s) return '';
+  s = s.replace(/\(.*?\)/g, '');
+  s = s.replace(/\s+/g, ' ').trim();
+  s = s
+    .replace(/^Using\s+/i, 'Using ')
+    .replace(/^Wearing\s+/i, 'Wearing ')
+    .replace(/^Receiving\s+/i, 'Receiving ')
+    .replace(/^Giving\s+/i, 'Giving ');
+  if (s.length > 64) s = s.slice(0, 61).trimEnd() + '…';
+  return s;
+}
+
+const TK_SUMMARY_OVERRIDES = {};
+
+function renderCategoryCell(row) {
+  const main = row.category || row.key || row.id || row.name || '';
+  const sourceText = row.title || row.prompt || row.question || '';
+  const overrideKey = typeof main === 'string' ? main : '';
+  const summaryRaw = tkSummarizeQuestion(sourceText, TK_SUMMARY_OVERRIDES[overrideKey]);
+  const summary = summaryRaw && summaryRaw !== main ? summaryRaw : '';
+  const titleText = sourceText || main;
+
+  return `
+    <div class="tk-cat-wrap">
+      <div class="tk-cat-main" title="${tkEscape(titleText)}">${tkEscape(main)}</div>
+      ${summary ? `<div class="tk-cat-sub" title="${tkEscape(sourceText)}">${tkEscape(summary)}</div>` : ''}
+    </div>
+  `;
+}
+
+function renderMatchCell(a, b) {
+  const pct = tkMatchPercent(a, b);
+  if (pct === null) {
+    return `
+      <div class="tk-match-chip" data-missing="1" aria-label="No match data">—</div>
+    `;
+  }
+  return `
+    <div class="tk-match-chip" role="img" aria-label="Match ${pct}%">
+      <div class="tk-match-num">${pct}%</div>
+      <div class="tk-match-bar" aria-hidden="true">
+        <i class="tk-match-fill" style="--w:${pct}%"></i>
+      </div>
+    </div>
+  `;
+}
+
+function renderScoreCell(v) {
+  const n = tkNormScore(v);
+  if (n === null) return '—';
+  return String(n);
+}
+
+if (typeof window !== 'undefined') {
+  window.tkRenderCategoryCell = renderCategoryCell;
+  window.tkRenderMatchCell = renderMatchCell;
+  window.tkRenderScoreCell = renderScoreCell;
+  window.tkMatchPercent = tkMatchPercent;
+  window.tkNormScore = tkNormScore;
+}
+
 function compatNormalizeKey(s){
   return String(s || '')
     .replace(/[\u2018\u2019\u2032]/g,"'")
@@ -352,11 +440,6 @@ function loadFileB(file) {
   reader.readAsText(file);
 }
 
-function calculateMatchPercent(a, b) {
-  if (!Number.isFinite(a) || !Number.isFinite(b)) return null;
-  return Math.max(0, 100 - Math.abs(a - b) * 20);
-}
-
 function getFlagOrStar(match, scoreA, scoreB) {
   if (match >= 90) return '⭐';
   const high = val => Number.isFinite(val) && val >= 4;
@@ -368,16 +451,11 @@ function getFlagOrStar(match, scoreA, scoreB) {
 function renderFlags(root = document) {
   const rows = root.querySelectorAll('.item-row');
   rows.forEach(row => {
-    const a = Number(row.dataset.a);
-    const b = Number(row.dataset.b);
     const matchCell = row.querySelector('.match');
     if (!matchCell) return;
-    matchCell.textContent = '-';
-
-    const match = calculateMatchPercent(a, b);
-    if (match !== null) {
-      matchCell.textContent = match + '%';
-    }
+    const a = row.dataset.a;
+    const b = row.dataset.b;
+    matchCell.innerHTML = renderMatchCell(a, b);
   });
 }
 
@@ -501,18 +579,31 @@ function updateComparison() {
       row.setAttribute('data-id', key);
       row.setAttribute('data-key', key);
       row.setAttribute('data-full', fullLabel);
-      row.innerHTML = `
-        <td class="label">${kink.name}</td>
-        <td class="pa" data-partner-a>${kink.partnerA ?? '-'}</td>
-        <td class="match" data-match>-</td>
-        <td class="pb" data-partner-b>${kink.partnerB ?? '-'}</td>
-      `;
-      const firstCell = row.querySelector('td.label');
+      const labelCell = document.createElement('td');
+      labelCell.className = 'label';
+      labelCell.innerHTML = renderCategoryCell({ category: kink.name, title: fullLabel });
       const hidden = document.createElement('span');
       hidden.className = 'full-label';
       hidden.textContent = fullLabel;
       hidden.hidden = true;
-      firstCell.appendChild(hidden);
+      labelCell.appendChild(hidden);
+
+      const aCell = document.createElement('td');
+      aCell.className = 'pa';
+      aCell.setAttribute('data-partner-a', '');
+      aCell.textContent = renderScoreCell(kink.partnerA);
+
+      const matchCell = document.createElement('td');
+      matchCell.className = 'match';
+      matchCell.setAttribute('data-match', '');
+      matchCell.innerHTML = renderMatchCell(kink.partnerA, kink.partnerB);
+
+      const bCell = document.createElement('td');
+      bCell.className = 'pb';
+      bCell.setAttribute('data-partner-b', '');
+      bCell.textContent = renderScoreCell(kink.partnerB);
+
+      row.append(labelCell, aCell, matchCell, bCell);
       block.appendChild(row);
     });
 


### PR DESCRIPTION
## Summary
- add match chip and category summary styles to the compatibility page
- add shared helpers to render category, match, and score cells in compatibility tables
- mirror the updates in the documentation build and ensure auto-fill scripts output the new markup

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc8d9e3590832c86b4c944a3ad9dc6