### PR TITLE
Expand kink data fallbacks

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -337,9 +337,11 @@
   // Progressive enhancement for fallback compatibility tables
   (function(){
     const META_URLS = [
+      '/data/kinks.json',
       '/kinksurvey/data/kinks.json',
       '/kinksurvey/kinks.json',
-      '/data/kinks.json'
+      '/kinks.json',
+      '/assets/kinks.json'
     ];
 
     let labelPromise = null;

--- a/docs/kinksurvey/index.html
+++ b/docs/kinksurvey/index.html
@@ -319,7 +319,11 @@
   // Keep your existing data sources (will use your published dataset when present)
   const here = new URL(window.location.href);
   const DEFAULT_URLS=[
-    '/data/kinks.json'
+    '/data/kinks.json',
+    '/kinksurvey/data/kinks.json',
+    '/kinksurvey/kinks.json',
+    '/kinks.json',
+    '/assets/kinks.json'
   ];
   const overrideUrls = Array.isArray(window.KSV?.KINKS_URLS) ? window.KSV.KINKS_URLS : null;
   const DATA_URLS = Array.from(new Set(

--- a/js/tk-emergency-reveal.js
+++ b/js/tk-emergency-reveal.js
@@ -22,12 +22,23 @@
   }
 
   // 3) Log a quick status for data
+  const KINK_URLS = [
+    '/data/kinks.json',
+    '/kinksurvey/data/kinks.json',
+    '/kinksurvey/kinks.json',
+    '/kinks.json',
+    '/assets/kinks.json'
+  ];
+
   (async () => {
-    try {
-      const response = await fetch('/data/kinks.json', { cache: 'no-store' });
-      console.log('[TK] kinks.json ->', response.status, response.headers.get('content-type'));
-    } catch (error) {
-      console.log('[TK] kinks.json fetch failed:', error);
+    for (const url of KINK_URLS) {
+      try {
+        const response = await fetch(url, { cache: 'no-store' });
+        console.log('[TK] kinks.json candidate', url, '→', response.status, response.headers.get('content-type'));
+        if (response.ok) break;
+      } catch (error) {
+        console.log('[TK] kinks.json fetch failed for', url, ':', error);
+      }
     }
   })();
 })();

--- a/js/tk_diag.js
+++ b/js/tk_diag.js
@@ -58,16 +58,34 @@
 
       // 3) Data check
       if (typeof fetch === 'function') {
-        fetch('/data/kinks.json', {cache:'no-store'}).then(r=>{
-          log('kinks.json', r.status, r.headers.get('content-type')||'');
-          if(!r.ok) return;
-          return r.json().then(j=>{
-            const items = Array.isArray(j) ? j.length
-                       : Array.isArray(j?.kinks) ? j.kinks.length
-                       : Array.isArray(j?.[0]?.items) ? j[0].items.length : 0;
-            log('kinks items (approx):', String(items));
-          }).catch(e=>log('kinks.json parse failed:', String(e)));
-        }).catch(e=>log('kinks.json fetch failed:', String(e)));
+        const KINK_URLS = [
+          '/data/kinks.json',
+          '/kinksurvey/data/kinks.json',
+          '/kinksurvey/kinks.json',
+          '/kinks.json',
+          '/assets/kinks.json'
+        ];
+        (async () => {
+          for (const url of KINK_URLS) {
+            try {
+              const r = await fetch(url, {cache:'no-store'});
+              log('kinks.json', url, r.status, r.headers.get('content-type')||'');
+              if(!r.ok) continue;
+              try {
+                const j = await r.json();
+                const items = Array.isArray(j) ? j.length
+                           : Array.isArray(j?.kinks) ? j.kinks.length
+                           : Array.isArray(j?.[0]?.items) ? j[0].items.length : 0;
+                log('kinks items (approx):', String(items));
+              } catch(e){
+                log('kinks.json parse failed:', String(e));
+              }
+              break;
+            } catch(e){
+              log('kinks.json fetch failed:', String(e));
+            }
+          }
+        })();
       } else {
         log('fetch unavailable in environment');
       }

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -612,10 +612,14 @@
 
   /* --------------- 1) CONFIG: where to look for data --------------- */
   const DATA_URLS = [
-    "/data/kinks.json",
-    "/kinks.json",
-    "./data/kinks.json",
-    "./kinks.json"
+    '/data/kinks.json',
+    '/kinksurvey/data/kinks.json',
+    '/kinksurvey/kinks.json',
+    '/kinks.json',
+    '/assets/kinks.json',
+    './data/kinks.json',
+    './kinks.json',
+    './assets/kinks.json'
   ];
 
   /* --------------- 2) UTILITIES --------------- */

--- a/kinksurvey/index.html
+++ b/kinksurvey/index.html
@@ -365,7 +365,11 @@
   // Keep your existing data sources (will use your published dataset when present)
   const here = new URL(window.location.href);
   const DEFAULT_URLS=[
-    '/data/kinks.json'
+    '/data/kinks.json',
+    '/kinksurvey/data/kinks.json',
+    '/kinksurvey/kinks.json',
+    '/kinks.json',
+    '/assets/kinks.json'
   ];
   const overrideUrls = Array.isArray(window.KSV?.KINKS_URLS) ? window.KSV.KINKS_URLS : null;
   const DATA_URLS = Array.from(new Set(

--- a/kinksurvey/index.html.bak
+++ b/kinksurvey/index.html.bak
@@ -369,7 +369,10 @@
     pathPrefix + 'data/kinks.json',
     pathPrefix + 'kinks.json',
     '/data/kinks.json',
-    '/kinks.json'
+    '/kinksurvey/data/kinks.json',
+    '/kinksurvey/kinks.json',
+    '/kinks.json',
+    '/assets/kinks.json'
   ];
   const overrideUrls = Array.isArray(window.KSV?.KINKS_URLS) ? window.KSV.KINKS_URLS : null;
   const DATA_URLS = Array.from(new Set(

--- a/scripts/kinks_hotfix.js
+++ b/scripts/kinks_hotfix.js
@@ -40,12 +40,28 @@ const HOTFIX_DIAG = `
   if(!window.__TK_BOOT_RAN){
     window.__TK_BOOT_RAN = true;
     (async () => {
-      try{
-        const r = await fetch('/data/kinks.json', { cache:'no-store' });
-        if(!r.ok) throw new Error('kinks.json ' + r.status);
-        const data = await r.json();
-        if (typeof window.KINKS_boot === 'function') { window.KINKS_boot(data); }
-      }catch(e){ show('Data bootstrap failed: ' + e.message); }
+      const urls = [
+        '/data/kinks.json',
+        '/kinksurvey/data/kinks.json',
+        '/kinksurvey/kinks.json',
+        '/kinks.json',
+        '/assets/kinks.json'
+      ];
+      let data = null;
+      let lastErr = null;
+      for (const url of urls){
+        try{
+          const r = await fetch(url, { cache:'no-store' });
+          if(!r.ok) throw new Error(url + ' ' + r.status);
+          data = await r.json();
+          break;
+        }catch(e){ lastErr = e; }
+      }
+      if (data && typeof window.KINKS_boot === 'function') {
+        window.KINKS_boot(data);
+      } else if (lastErr) {
+        show('Data bootstrap failed: ' + lastErr.message);
+      }
     })();
   }
 })();

--- a/server.js
+++ b/server.js
@@ -354,7 +354,11 @@ app.use((req, res, next) => {
   }
   if (
     (req.method === 'GET' || req.method === 'HEAD') &&
-    (req.url === '/data/kinks.json' || req.url === '/kinks.json')
+    (req.url === '/data/kinks.json' ||
+      req.url === '/kinks.json' ||
+      req.url === '/assets/kinks.json' ||
+      req.url === '/kinksurvey/data/kinks.json' ||
+      req.url === '/kinksurvey/kinks.json')
   ) {
     readFile(path.join(__dirname, 'data', 'kinks.json'))
       .then(data => {

--- a/simple-compatibility.html
+++ b/simple-compatibility.html
@@ -66,7 +66,13 @@ function tkSlug(s){
 }
 
 /* ---------- Fetch shared kink labels (for nicer Category text) ---------- */
-const TK_UNION_PATHS = ['/data/kinks.json','/kinksurvey/data/kinks.json','/kinksurvey/kinks.json'];
+const TK_UNION_PATHS = [
+  '/data/kinks.json',
+  '/kinksurvey/data/kinks.json',
+  '/kinksurvey/kinks.json',
+  '/kinks.json',
+  '/assets/kinks.json'
+];
 let tkLabelPromise = null;
 let tkKeyLabelMap = null;
 

--- a/talk-kink-new-survey.html
+++ b/talk-kink-new-survey.html
@@ -207,7 +207,16 @@
 <script>
 (async function(){
   /* ---------- data fetch ---------- */
-  const DATA_URLS = ['/data/kinks.json','/kinks.json','./data/kinks.json','./kinks.json'];
+  const DATA_URLS = [
+    '/data/kinks.json',
+    '/kinksurvey/data/kinks.json',
+    '/kinksurvey/kinks.json',
+    '/kinks.json',
+    '/assets/kinks.json',
+    './data/kinks.json',
+    './kinks.json',
+    './assets/kinks.json'
+  ];
 
   const el = (id)=>document.getElementById(id);
   const $panel = el('categoryPanel');
@@ -555,10 +564,11 @@
 
   /* ----------------------- 2) Load canonical keys from kinks.json ----------------------- */
   const KINKS_URLS = [
-    '/kinksurvey/data/kinks.json',
     '/data/kinks.json',
+    '/kinksurvey/data/kinks.json',
     '/kinksurvey/kinks.json',
-    '/kinks.json'
+    '/kinks.json',
+    '/assets/kinks.json'
   ];
 
   function flattenKinks(kjson){


### PR DESCRIPTION
## Summary
- include /assets/kinks.json in every kink data fallback list so UI helpers and surveys can find the dataset regardless of deployment path
- extend diagnostics, emergency scripts, and the hotfix bootstrap to try the expanded list of kink data URLs
- allow the server to serve the shared dataset from the new asset URL alongside existing aliases

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc97ebb468832caaf82eeb35ea76e3