### PR TITLE
Prioritize local kinks dictionary path

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -2402,8 +2402,8 @@ document.getElementById('copyAtoB')?.addEventListener('click', () => {
   // --- 2) Try to load a site-wide dictionary (optional but recommended)
   async function tryLoadSiteDictionary() {
     const urls = [
-      "/kinksurvey/data/kinks.json",
       "/data/kinks.json",
+      "/kinksurvey/data/kinks.json",
       "/kinks.json",
     ];
     for (const url of urls) {


### PR DESCRIPTION
## Summary
- update the compatibility label helper to request `/data/kinks.json` before legacy fallbacks
- prevent the page from probing the missing `/kinksurvey/data/kinks.json` path and logging a 404

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcbd9dc5d4832ca100bc4e9c45e952