### PR TITLE
Add compatibility label dictionary and update kink data readers

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -2834,8 +2834,8 @@ document.getElementById('copyAtoB')?.addEventListener('click', () => {
     setTimeout(scheduleRelabel, 400);
     setTimeout(scheduleRelabel, 1200);
   });
-})();
 </script>
+<script src="/js/tk-labels.js" defer></script>
 
 </body>
 </html>

--- a/data/kinks.json
+++ b/data/kinks.json
@@ -1,4943 +1,10247 @@
-[
-  {
-    "category": "Body Part Torture",
-    "items": [
-      {
-        "id": "body-part-torture-nipple-clips",
-        "label": "Nipple clips",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-nipple-weights",
-        "label": "Nipple weights",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-nipple-suction-cups",
-        "label": "Nipple suction cups",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-cock-ball-torture-cbt",
-        "label": "Cock, Ball Torture (CBT)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-clit-clips-weights-suction",
-        "label": "Clit clips/weights/suction",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-hair-pulling",
-        "label": "Hair pulling",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-face-slapping",
-        "label": "Face slapping",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-butt-slapping",
-        "label": "Butt slapping",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-breast-slapping",
-        "label": "Breast slapping",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-genital-slapping",
-        "label": "Genital slapping",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
+{
+  "labels": {
+    "cb_169ma": "Time-period dress-up",
+    "cb_2c0f9": "Hair-based play (brushing, ribbons, tying)",
+    "cb_2gxmo": "Uniforms (school, military, nurse, etc.)",
+    "cb_3ozhq": "Praise for pleasing visual display",
+    "cb_4yyxa": "Dollification / polished object aesthetics",
+    "cb_065gv": "Formal appearance protocols",
+    "cb_6jd2f": "Pick lingerie / base layers",
+    "cb_fsnmj": "Praise for pleasing visual display",
+    "cb_gkzbu": "Hair-based play (brushing, ribbons, tying)",
+    "cb_hqakm": "Formal appearance protocols",
+    "cb_ifkmg": "Clothing as power-role signal",
+    "cb_kaku7": "Time-period dress-up",
+    "cb_kgrnn": "Uniforms (school, military, nurse, etc.)",
+    "cb_kua8l": "Dress partner’s outfit",
+    "cb_qflrp": "Dollification / polished object aesthetics",
+    "cb_qw9jg": "Ritualized grooming",
+    "cb_qwnhi": "Head coverings / symbolic hoods",
+    "cb_r7cwr": "Head coverings / symbolic hoods",
+    "cb_rn136": "Clothing as power-role signal",
+    "cb_ss4gf": "Ritualized grooming",
+    "cb_w2dc1": "Coordinated looks / dress codes",
+    "cb_yzegd": "Pick lingerie / base layers",
+    "cb_zsnrb": "Dress partner’s outfit",
+    "cb_zvchg": "Coordinated looks / dress codes"
   },
-  {
-    "category": "Bondage and Suspension",
-    "items": [
-      {
-        "id": "bondage-and-suspension-blindfolds",
-        "label": "Blindfolds",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-bondage-heavy",
-        "label": "Bondage (heavy)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-bondage-light",
-        "label": "Bondage (light)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-immobilisation",
-        "label": "Immobilisation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-bondage-multi-day",
-        "label": "Bondage (multi-day)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-bondage-public-under-clothing",
-        "label": "Bondage (public, under clothing)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-leather-restraints",
-        "label": "Leather restraints",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-chains",
-        "label": "Chains",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-ropes",
-        "label": "Ropes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-intricate-japanese-rope-bondage",
-        "label": "Intricate (Japanese) rope bondage",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-rope-body-harness",
-        "label": "Rope body harness",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-arm-leg-sleeves-armbinders",
-        "label": "Arm & leg sleeves (armbinders)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-harnesses-leather",
-        "label": "Harnesses (leather)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-harnesses-rope",
-        "label": "Harnesses (rope)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-cuffs-leather",
-        "label": "Cuffs (leather)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-cuffs-metal",
-        "label": "Cuffs (metal)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-manacles-irons",
-        "label": "Manacles & Irons",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-gags-cloth",
-        "label": "Gags (cloth)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-gags-rubber",
-        "label": "Gags (rubber)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-gags-tape",
-        "label": "Gags (tape)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-gags-phallic",
-        "label": "Gags (phallic)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-gags-ring",
-        "label": "Gags (ring)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-gags-ball",
-        "label": "Gags (ball)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-mouth-bits",
-        "label": "Mouth bits",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-full-head-hoods",
-        "label": "Full head hoods",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-mummification-saran-wrapping",
-        "label": "Mummification/saran wrapping",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-straight-jackets",
-        "label": "Straight jackets",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-suspension-upright",
-        "label": "Suspension (upright)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-suspension-horizontal",
-        "label": "Suspension (horizontal)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-suspension-inverted",
-        "label": "Suspension (inverted)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-breath-play",
-        "label": "Breath play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-smothering",
-        "label": "Smothering",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-forced-self-breath-control",
-        "label": "Forced self-breath-control",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-gas-mask",
-        "label": "Gas mask",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Breath Play",
-    "items": [
-      {
-        "id": "breath-play-asphyxiation",
-        "label": "Asphyxiation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "breath-play-breath-control",
-        "label": "Breath control",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "breath-play-choking",
-        "label": "Choking",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "breath-play-drowning",
-        "label": "Drowning",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "breath-play-rebreathing-into-a-bag-or-object",
-        "label": "Rebreathing into a bag or object",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "breath-play-verbal-control-of-breath-e-g-hold-it-on-command",
-        "label": "Verbal control of breath (e.g., 'hold it' on command)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Sexual Activity",
-    "items": [
-      {
-        "id": "sexual-activity-licking",
-        "label": "Licking",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-fellatio-cunnilingus",
-        "label": "Fellatio/Cunnilingus",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-swallowing-semen",
-        "label": "Swallowing semen",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-cumming-on-partner",
-        "label": "Cumming on Partner",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-hand-jobs",
-        "label": "Hand jobs",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-anal-sex",
-        "label": "Anal sex",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-anal-plugs-small",
-        "label": "Anal plugs (small)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-anal-plugs-large",
-        "label": "Anal plugs (large)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-anal-beads",
-        "label": "Anal beads",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-vibrator-on-genitals",
-        "label": "Vibrator on genitals",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-fisting",
-        "label": "Fisting",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-oral-anal-play-rimming",
-        "label": "Oral/anal play (rimming)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-double-penetration-oral-and-vaginal",
-        "label": "Double penetration (oral and vaginal)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-double-penetration-oral-and-anal",
-        "label": "Double penetration (oral and anal)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-double-penetration-anal-and-vaginal",
-        "label": "Double penetration (anal and vaginal)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-triple-oral-vaginal-and-anal",
-        "label": "Triple (Oral, Vaginal and Anal)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Sensation Play",
-    "items": [
-      {
-        "id": "sensation-play-abrasion",
-        "label": "Abrasion",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-scratching",
-        "label": "Scratching",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-biting",
-        "label": "Biting",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-tickling",
-        "label": "Tickling",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-kissing",
-        "label": "Kissing",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-zapping-e-g-electric-fly-swatter",
-        "label": "Zapping (e.g. electric fly swatter)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-ice-cubes",
-        "label": "Ice cubes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-wax-play",
-        "label": "Wax Play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-fire",
-        "label": "Fire",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-clothespins",
-        "label": "Clothespins",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-needles",
-        "label": "Needles",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-sensory-deprivation",
-        "label": "Sensory deprivation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-physical-overpowering-manhandling",
-        "label": "Physical overpowering / Manhandling",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-figging",
-        "label": "Figging",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Other",
-    "items": [
-      {
-        "id": "other-feet",
-        "label": "Feet",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-boots",
-        "label": "Boots",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-underwear",
-        "label": "Underwear",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-chastity-devices",
-        "label": "Chastity devices",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-masks",
-        "label": "Masks",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-breeding",
-        "label": "Breeding",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-leather-clothing",
-        "label": "Leather clothing",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-training-protocols-outside-scenes-e-g-etiquette-memory",
-        "label": "Training protocols outside scenes (e.g., etiquette, memory)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-long-distance-training-structure",
-        "label": "Long-distance training/structure",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-scene-journaling-and-reflection",
-        "label": "Scene journaling and reflection",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Roleplaying",
-    "items": [
-      {
-        "id": "roleplaying-fantasy-abandonment",
-        "label": "Fantasy abandonment",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-kidnapping",
-        "label": "Kidnapping",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-interrogation",
-        "label": "Interrogation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-sleep-deprivation",
-        "label": "Sleep deprivation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-cnc",
-        "label": "CNC",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-gang-bang",
-        "label": "Gang bang",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-initiation-rites",
-        "label": "Initiation rites",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-religious-scenes",
-        "label": "Religious scenes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-medical-scenes",
-        "label": "Medical scenes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-prison-scenes",
-        "label": "Prison scenes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-primal-prey",
-        "label": "Primal/Prey",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-schoolroom-scenes",
-        "label": "Schoolroom scenes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Service and Restrictive Behaviour",
-    "items": [
-      {
-        "id": "service-and-restrictive-behaviour-following-orders",
-        "label": "(Following) orders",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-forced-servitude",
-        "label": "Forced servitude",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-restrictive-rules-on-behaviour",
-        "label": "Restrictive rules on behaviour",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-eye-contact-restrictions",
-        "label": "Eye contact restrictions",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-speech-restrictions-when-what-to-whom",
-        "label": "Speech restrictions (when, what, to whom)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-washroom-restrictions",
-        "label": "Washroom restrictions",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-punishments",
-        "label": "Punishments",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-tasks",
-        "label": "Tasks",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-massage",
-        "label": "Massage",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-domestic-tasks",
-        "label": "Domestic tasks",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-serving-food-and-drink",
-        "label": "Serving food and drink",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-personal-care-rituals",
-        "label": "Personal care rituals",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-being-on-call-at-specified-times",
-        "label": "Being on-call at specified times",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-daily-task-assignments",
-        "label": "Daily task assignments",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-corrections-for-imperfection",
-        "label": "Corrections for imperfection",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-uniforms-dress-codes",
-        "label": "Uniforms / Dress codes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-kneeling-posture-presentation",
-        "label": "Kneeling / Posture presentation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-silent-service",
-        "label": "Silent service",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-public-service-at-parties-or-events",
-        "label": "Public service (at parties or events)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-erotic-service-pleasure-on-command-without-seeking-your-own",
-        "label": "Erotic service (pleasure on command, without seeking your own)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Voyeurism/Exhibitionism",
-    "items": [
-      {
-        "id": "voyeurism-exhibitionism-forced-nudity-private",
-        "label": "Forced nudity (private)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "voyeurism-exhibitionism-forced-nudity-around-others",
-        "label": "Forced nudity (around others)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "voyeurism-exhibitionism-exhibitionism-friends",
-        "label": "Exhibitionism (friends)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "voyeurism-exhibitionism-exhibitionism-strangers",
-        "label": "Exhibitionism (strangers)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "voyeurism-exhibitionism-modelling-for-erotic-photos",
-        "label": "Modelling for erotic photos",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "voyeurism-exhibitionism-toys-under-clothes-in-public",
-        "label": "Toys under clothes in public",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Virtual & Long-Distance Play",
-    "items": [
-      {
-        "id": "virtual-long-distance-play-sending-tasks-or-orders-digitally",
-        "label": "Sending tasks or orders digitally",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-recording-dominant-voice-clips-commands-edging-praise-degradation-etc",
-        "label": "Recording dominant voice clips (commands, edging, praise, degradation, etc.)",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-remote-control-of-a-sex-toy",
-        "label": "Remote control of a sex toy",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-monitoring-behavior-via-app-or-shared-doc",
-        "label": "Monitoring behavior via app or shared doc",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-giving-punishment-assignments-remotely",
-        "label": "Giving punishment assignments remotely",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-creating-countdowns-timers-or-denial-periods",
-        "label": "Creating countdowns, timers, or denial periods",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-sending-written-instructions-with-delayed-permissions",
-        "label": "Sending written instructions with delayed permissions",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-creating-custom-video-or-audio-tasks",
-        "label": "Creating custom video or audio tasks",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-voice-message-control-during-scenes",
-        "label": "Voice message control during scenes",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-being-on-call-at-specified-times",
-        "label": "Being on-call at specified times",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-receiving-tasks-or-orders-digitally",
-        "label": "Receiving tasks or orders digitally",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-listening-to-dominant-voice-clips",
-        "label": "Listening to dominant voice clips",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-using-a-remote-controlled-toy-controlled-by-another",
-        "label": "Using a remote-controlled toy controlled by another",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-completing-daily-protocol-assignments",
-        "label": "Completing daily protocol assignments",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-submitting-proof-photo-video-text",
-        "label": "Submitting proof (photo, video, text)",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-following-recorded-or-timed-commands",
-        "label": "Following recorded or timed commands",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-receiving-surprise-instructions",
-        "label": "Receiving surprise instructions",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-hearing-name-praise-spoken-in-a-custom-clip",
-        "label": "Hearing name/praise spoken in a custom clip",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-sending-submissive-voice-clips-obedience-begging-thank-you-messages-affirmations-etc",
-        "label": "Sending submissive voice clips (obedience, begging, thank-you messages, affirmations, etc.)",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-scheduling-digital-rituals-or-reminders",
-        "label": "Scheduling digital rituals or reminders",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-using-training-habit-or-behavior-tracking-apps",
-        "label": "Using training, habit, or behavior-tracking apps",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-online-rituals-digital-kneeling-posture-protocols",
-        "label": "Online rituals (digital kneeling, posture protocols)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-role-based-texting-e-g-use-honorifics-in-chat",
-        "label": "Role-based texting (e.g., \"Use honorifics in chat\")",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-shared-playlists-affirmations-or-mantras",
-        "label": "Shared playlists, affirmations, or mantras",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-countdown-timers-to-next-task-release-or-interaction",
-        "label": "Countdown timers to next task, release, or interaction",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-scheduled-good-morning-night-rituals",
-        "label": "Scheduled good morning/night rituals",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-participating-in-video-call-scenes",
-        "label": "Participating in video call scenes",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-digital-aftercare-texts-voice-images",
-        "label": "Digital aftercare (texts, voice, images)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-sexting-or-digital-roleplay-scenes",
-        "label": "Sexting or digital roleplay scenes",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-voice-notes-or-submissive-dominant-affirmations",
-        "label": "Voice notes or submissive/dominant affirmations",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Communication",
-    "items": [
-      {
-        "id": "communication-playful-and-teasing",
-        "label": "Playful and teasing",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-quiet-and-intense",
-        "label": "Quiet and intense",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-observant-and-intentional",
-        "label": "Observant and intentional",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-praise-heavy",
-        "label": "Praise-heavy",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-blunt-and-efficient",
-        "label": "Blunt and efficient",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-affirming-and-soft",
-        "label": "Affirming and soft",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-psychological-interrogation",
-        "label": "Psychological interrogation",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-verbal-coercion-teasing-traps",
-        "label": "Verbal coercion / teasing traps",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-verbal-misdirection",
-        "label": "Verbal misdirection",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-mocking-shaming",
-        "label": "Mocking / shaming",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-predatory-pacing",
-        "label": "Predatory pacing",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-reluctant-obedience",
-        "label": "Reluctant obedience",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-stammering-submission",
-        "label": "Stammering submission",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-challenging-until-caught",
-        "label": "Challenging until caught",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-quiet-surrender",
-        "label": "Quiet surrender",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-sarcastic-teasing",
-        "label": "Sarcastic teasing",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-provoking-tone",
-        "label": "Provoking tone",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-challenge-based-dialogue",
-        "label": "Challenge-based dialogue",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-double-meaning-banter",
-        "label": "Double-meaning banter",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-soft-spoken-guidance",
-        "label": "Soft-spoken guidance",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-protective-but-firm-tone",
-        "label": "Protective but firm tone",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-emotional-redirection",
-        "label": "Emotional redirection",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-steady-reassurance",
-        "label": "Steady reassurance",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-direct-and-clear",
-        "label": "Direct and clear",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-gentle-and-nurturing",
-        "label": "Gentle and nurturing",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-commanding-and-firm",
-        "label": "Commanding and firm",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-quiet-and-observant",
-        "label": "Quiet and observant",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-instructive-teacher-like",
-        "label": "Instructive / teacher-like",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-emotionally-intense",
-        "label": "Emotionally intense",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-dismissive-withholding",
-        "label": "Dismissive / withholding",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-mocking-sarcastic",
-        "label": "Mocking / sarcastic",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-blunt-tactless",
-        "label": "Blunt / tactless",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-predatory-hunting-tone",
-        "label": "Predatory / hunting tone",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-stalking-or-circling-speech",
-        "label": "Stalking or circling speech",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-you-re-mine-control-language",
-        "label": "You’re mine / control language",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-threatening-consensual",
-        "label": "Threatening (consensual)",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-verbal-cornering-coaxing",
-        "label": "Verbal cornering / coaxing",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-watching-you-unravel",
-        "label": "Watching you unravel",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-cruel-and-cutting",
-        "label": "Cruel and cutting",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-psychological-baiting",
-        "label": "Psychological baiting",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-brat-breaking-language",
-        "label": "Brat-breaking language",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-mock-affection",
-        "label": "Mock affection",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-shaming-or-emotional-edge",
-        "label": "Shaming or emotional edge",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-disappointed-dom-voice",
-        "label": "Disappointed dom voice",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-mild-scolding-mocking-affection",
-        "label": "Mild scolding / mocking affection",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-verbal-power-struggle",
-        "label": "Verbal power struggle",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-challenge-response-dynamics",
-        "label": "Challenge-response dynamics",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-warm-tone-with-expectation",
-        "label": "Warm tone with expectation",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-nurturing-dominance",
-        "label": "Nurturing dominance",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-reassuring-commands",
-        "label": "Reassuring commands",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-phrases-that-work-on-you",
-        "label": "Phrases that work on you",
-        "type": "text",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "communication-phrases-you-use-or-like-to-give",
-        "label": "Phrases you use or like to give",
-        "type": "text",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "communication-what-helps-you-feel-emotionally-safe",
-        "label": "What helps you feel emotionally safe",
-        "type": "text",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "communication-how-you-tend-to-show-affection",
-        "label": "How you tend to show affection",
-        "type": "text",
-        "options": [
-          "Words of affirmation",
-          "Acts of service",
-          "Through teasing / play",
-          "Through obedience",
-          "Through caretaking",
-          "Withholding / teasing love",
-          "Physical closeness",
-          "Quality time"
-        ],
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "communication-emotional-check-in-style",
-        "label": "Emotional check-in style",
-        "type": "text",
-        "options": [
-          "Daily texting",
-          "After-scene debriefs",
-          "Scheduled check-ins",
-          "Mix of text/video check-ins",
-          "In-person check-ins",
-          "Journaling together",
-          "Minimal / low contact",
-          "Other"
-        ],
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "communication-when-emotionally-activated-i-tend-to",
-        "label": "When emotionally activated, I tend to...",
-        "type": "text",
-        "options": [
-          "Shut down",
-          "Overexplain / fawn",
-          "Get sarcastic / prickly",
-          "Spiral internally",
-          "Ask for reassurance",
-          "Withdraw",
-          "Other"
-        ],
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Body Fluids and Functions",
-    "items": [
-      {
-        "id": "body-fluids-and-functions-watersports-golden-showers",
-        "label": "Watersports/golden showers",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-fluids-and-functions-cum",
-        "label": "Cum",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-fluids-and-functions-blood",
-        "label": "Blood",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-fluids-and-functions-scat",
-        "label": "Scat",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-fluids-and-functions-sweat",
-        "label": "Sweat",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-fluids-and-functions-vomit",
-        "label": "Vomit",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-fluids-and-functions-tears-crying",
-        "label": "Tears/crying",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Psychological Primal / Prey",
-    "items": [
-      {
-        "id": "psychological-primal-prey-primal-prey",
-        "label": "Primal/Prey",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-conditioning",
-        "label": "Conditioning",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-coc",
-        "label": "COC",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-psycholagny-hands-free-mentally-stimulated-orgasm",
-        "label": "Psycholagny (hands free, mentally stimulated orgasm)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-hypno-play",
-        "label": "Hypno Play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-praise",
-        "label": "Praise",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-degradation",
-        "label": "Degradation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-traditional-primal-prey",
-        "label": "Traditional primal/prey",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-fear-play",
-        "label": "Fear play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-objectification",
-        "label": "Objectification",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-gaslighting",
-        "label": "Gaslighting",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-role-erosion-identity-play-loss-of-self",
-        "label": "Role erosion (identity play / loss of self)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-jealousy-play",
-        "label": "Jealousy play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-manipulation",
-        "label": "Manipulation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Body Part / Fetish Play",
-    "items": [
-      {
-        "id": "body-part-fetish-play-belly-fucking",
-        "label": "Belly fucking",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-navel-play",
-        "label": "Navel play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-feet-foot-worship",
-        "label": "Feet / Foot worship",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-hands",
-        "label": "Hands",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-hair",
-        "label": "Hair",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-thighs",
-        "label": "Thighs",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-neck",
-        "label": "Neck",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-ears",
-        "label": "Ears",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-belly",
-        "label": "Belly",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-voice-fetish",
-        "label": "Voice fetish",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-nails-makeup-fetish",
-        "label": "Nails / Makeup fetish",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-cuddles",
-        "label": "Cuddles",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-food-play",
-        "label": "Food Play",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-kisses",
-        "label": "Kisses",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-masturbation",
-        "label": "Masturbation",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-romance-affection",
-        "label": "Romance / affection",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-sex-toys",
-        "label": "Sex toys",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-sexting-chat-etc",
-        "label": "Sexting /Chat etc",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-sexting-via-phone-or-video-call",
-        "label": "Sexting via phone or video call",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-strip-tease",
-        "label": "Strip tease",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-vanilla-sex",
-        "label": "Vanilla Sex",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-voice-notes",
-        "label": "Voice Notes",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-shaving-body-hair",
-        "label": "Shaving (body hair)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-sexy-clothing-private",
-        "label": "Sexy clothing (private)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-sexy-clothing-public",
-        "label": "Sexy clothing (public)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-outdoor-scenes",
-        "label": "Outdoor scenes",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-public-exposure",
-        "label": "Public exposure",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Orgasm Control & Sexual Manipulation",
-    "items": [
-      {
-        "id": "orgasm-control-sexual-manipulation-edging",
-        "label": "Edging",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-short-term-denial",
-        "label": "Short term denial",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-long-term-denial",
-        "label": "Long term denial",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-forced-orgasms-overstimulation",
-        "label": "Forced orgasms / Overstimulation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-ruined-orgasms",
-        "label": "Ruined orgasms",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-no-touch-periods",
-        "label": "No touch periods",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-milking",
-        "label": "Milking",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-chastity-devices",
-        "label": "Chastity devices",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-consensual-orgasm-control",
-        "label": "Consensual orgasm control",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-forced-masturbation",
-        "label": "Forced masturbation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Protocol and Ritual",
-    "items": [
-      {
-        "id": "protocol-and-ritual-formal-language",
-        "label": "Formal language",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-greeting-and-departure-rituals-kneeling-verbal-scripts-gestures",
-        "label": "Greeting and departure rituals (kneeling, verbal scripts, gestures)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-requiring-permission-for-things-speech-movement-attire",
-        "label": "Requiring permission for things (speech, movement, attire)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-daily-rituals-morning-check-ins-status-reports-mantra-repetitions",
-        "label": "Daily rituals (morning check-ins, status reports, mantra repetitions)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-specific-postures-for-rest-attention-punishment-waiting",
-        "label": "Specific postures for rest, attention, punishment, waiting",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-restricted-behavior-no-eye-contact-silence-no-questions",
-        "label": "Restricted behavior (no eye contact, silence, no questions)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-ritual-object-use-collar-cuffs-leash-tokens",
-        "label": "Ritual object use (collar, cuffs, leash, tokens)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-tracking-obedience-journals-apps",
-        "label": "Tracking obedience (journals, apps)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-formalized-rules-for-misbehavior-and-correction",
-        "label": "Formalized rules for misbehavior and correction",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-ritualized-aftercare-or-scene-closure",
-        "label": "Ritualized aftercare or scene closure",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-object-retrieval-on-all-fours-with-item-in-mouth",
-        "label": "Object retrieval on all fours with item in mouth",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-fetching-hairbrush-or-punishment-tool-from-dresser-while-crawling",
-        "label": "Fetching hairbrush or punishment tool from dresser while crawling",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-presenting-chosen-discipline-tool-in-kneeling-posture",
-        "label": "Presenting chosen discipline tool in kneeling posture",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-assigned-posture-or-kneeling-positions-as-ritual",
-        "label": "Assigned posture or kneeling positions as ritual",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-requesting-permission-using-specific-protocol-phrases",
-        "label": "Requesting permission using specific protocol phrases",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-carrying-items-in-mouth-as-submissive-gesture",
-        "label": "Carrying items in mouth as submissive gesture",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-crawling-back-with-object-to-dominant-after-retrieval",
-        "label": "Crawling back with object to Dominant after retrieval",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-following-via-nipple-leash-as-protocol-or-punishment",
-        "label": "Following via nipple leash as protocol or punishment",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-crawling-assigned-paths-as-ritual-or-obedience-training",
-        "label": "Crawling assigned paths as ritual or obedience training",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-crawling-rituals-e-g-object-retrieval",
-        "label": "Crawling rituals (e.g., object retrieval)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-carrying-objects-in-mouth-as-obedience",
-        "label": "Carrying objects in mouth as obedience",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-presenting-tools-or-toys-in-posture",
-        "label": "Presenting tools or toys in posture",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-using-honorifics-or-preset-protocol-language",
-        "label": "Using honorifics or preset protocol language",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-greeting-rituals-e-g-kneeling-kissing-feet",
-        "label": "Greeting rituals (e.g., kneeling, kissing feet)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-daily-check-ins-or-structured-reports",
-        "label": "Daily check-ins or structured reports",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-clothing-restrictions-or-uniforms",
-        "label": "Clothing restrictions or uniforms",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-posture-training-sitting-kneeling-standing",
-        "label": "Posture training (sitting, kneeling, standing)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-punishments-for-incorrect-behavior-or-tone",
-        "label": "Punishments for incorrect behavior or tone",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-crawling-with-items-in-mouth-e-g-hairbrush-spoon",
-        "label": "Crawling with items in mouth (e.g., hairbrush, spoon)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-earning-permission-for-meals-bathroom-use-or-rest",
-        "label": "Earning permission for meals, bathroom use, or rest",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-following-daily-rituals-or-protocol",
-        "label": "Following daily rituals or protocol",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-structured-speech-rules-e-g-titles-third-person",
-        "label": "Structured speech rules (e.g., titles, third person)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-receiving-correction-when-out-of-line",
-        "label": "Receiving correction when out of line",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-inspection-rituals-or-readiness-checks",
-        "label": "Inspection rituals or readiness checks",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Primal & Bratting",
-    "items": [
-      {
-        "id": "primal-bratting-chase-and-capture-play",
-        "label": "Chase and capture play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-bratting-for-punishment",
-        "label": "Bratting for punishment",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-playful-growling-and-biting",
-        "label": "Playful growling and biting",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-provoking-with-teasing-or-taunts",
-        "label": "Provoking with teasing or taunts",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-escaping-or-hiding-to-encourage-pursuit",
-        "label": "Escaping or hiding to encourage pursuit",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-refusing-commands-just-for-fun",
-        "label": "Refusing commands just for fun",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-provoking-your-partner-to-chase-or-discipline-you",
-        "label": "Provoking your partner to chase or discipline you",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-taunting-or-teasing-as-a-form-of-play",
-        "label": "Taunting or teasing as a form of play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-intentional-resistance-during-power-exchange",
-        "label": "Intentional resistance during power exchange",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-being-caught-and-overpowered",
-        "label": "Being caught and overpowered",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Headspace & Regression",
-    "items": [
-      {
-        "id": "headspace-regression-caregiver-little-regression-play",
-        "label": "Caregiver/little regression play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-using-pacifiers-or-sippy-cups",
-        "label": "Using pacifiers or sippy cups",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-coloring-or-childlike-crafts",
-        "label": "Coloring or childlike crafts",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-stuffed-animal-comfort",
-        "label": "Stuffed animal comfort",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-speaking-in-a-childlike-voice",
-        "label": "Speaking in a childlike voice",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-bedtime-stories-or-lullabies",
-        "label": "Bedtime stories or lullabies",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-entering-altered-headspaces-e-g-prey-pet-little",
-        "label": "Entering altered headspaces (e.g., prey, pet, little)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-regressive-behaviors-as-comfort-coloring-babytalk",
-        "label": "Regressive behaviors as comfort (coloring, babytalk)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-being-cared-for-during-emotional-vulnerability",
-        "label": "Being cared for during emotional vulnerability",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-guided-emotional-headspace-entry",
-        "label": "Guided emotional headspace entry",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Performance & Internal Struggle",
-    "items": [
-      {
-        "id": "performance-internal-struggle-obedience-under-observation",
-        "label": "Obedience under observation",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-speech-restriction-and-self-denial",
-        "label": "Speech restriction and self-denial",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-maintaining-composure-during-humiliation",
-        "label": "Maintaining composure during humiliation",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-obedience-drills-for-an-audience",
-        "label": "Obedience drills for an audience",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-struggling-against-personal-urges",
-        "label": "Struggling against personal urges",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-displaying-submission-despite-conflict",
-        "label": "Displaying submission despite conflict",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-being-told-to-act-normal-while-struggling-internally",
-        "label": "Being told to act normal while struggling internally",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-pleasing-through-high-functioning-obedience",
-        "label": "Pleasing through high-functioning obedience",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-performing-submission-while-masking-resistance",
-        "label": "Performing submission while masking resistance",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-the-pressure-of-appearing-good-while-feeling-conflicted",
-        "label": "The pressure of appearing 'good' while feeling conflicted",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-being-made-to-perform-emotions-on-command-cry-beg-moan",
-        "label": "Being made to perform emotions on command (cry, beg, moan)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-struggling-openly-while-still-obeying",
-        "label": "Struggling openly while still obeying",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-performing-exaggerated-resistance-or-denial",
-        "label": "Performing exaggerated resistance or denial",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-being-punished-for-breaking-character",
-        "label": "Being punished for 'breaking character'",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-putting-on-a-show-for-someone-else-s-pleasure",
-        "label": "Putting on a show for someone else’s pleasure",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-rehearsed-degradation-or-humiliation-scripts",
-        "label": "Rehearsed degradation or humiliation scripts",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Mindfuck & Manipulation",
-    "items": [
-      {
-        "id": "mindfuck-manipulation-confusing-commands-and-reality-shifts",
-        "label": "Confusing commands and reality shifts",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-gaslighting-or-contradictory-cues",
-        "label": "Gaslighting or contradictory cues",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-presenting-false-choices",
-        "label": "Presenting false choices",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-hidden-motives-or-secret-tasks",
-        "label": "Hidden motives or secret tasks",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-illogical-rules-meant-to-confuse",
-        "label": "Illogical rules meant to confuse",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-gaslight-style-scenes-with-consent-and-clarity",
-        "label": "Gaslight-style scenes (with consent and clarity)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-false-threats-or-staged-surprises",
-        "label": "False threats or staged surprises",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-confusing-commands-to-prompt-hesitation",
-        "label": "Confusing commands to prompt hesitation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-emotional-trickery-as-arousal",
-        "label": "Emotional trickery as arousal",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-being-misled-or-deceived-on-purpose-during-play",
-        "label": "Being misled or deceived on purpose during play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-surprise-rule-changes-or-twists-mid-scene",
-        "label": "Surprise rule changes or twists mid-scene",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-false-safeword-games-with-negotiated-limits",
-        "label": "False safeword games (with negotiated limits)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-withholding-or-delaying-aftercare-for-effect",
-        "label": "Withholding or delaying aftercare for effect",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-being-gaslit-or-doubted-in-a-controlled-roleplay",
-        "label": "Being gaslit or doubted in a controlled roleplay",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-told-you-asked-for-this-or-you-love-this-when-resisting",
-        "label": "Told 'you asked for this' or 'you love this' when resisting",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Mouth Play",
-    "items": [
-      {
-        "id": "mouth-play-holding-tools-or-restraints-in-teeth-while-crawling",
-        "label": "Holding tools or restraints in teeth while crawling",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-placing-objects-from-mouth-into-dominant-s-palm",
-        "label": "Placing objects from mouth into Dominant’s palm",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-using-mouth-instead-of-hands-for-service-rituals",
-        "label": "Using mouth instead of hands for service rituals",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-gag-presentation-and-silent-waiting-protocol",
-        "label": "Gag presentation and silent waiting protocol",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-holding-objects-in-teeth-while-crawling",
-        "label": "Holding objects in teeth while crawling",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-returning-items-using-mouth-only",
-        "label": "Returning items using mouth only",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-gag-rituals-or-waiting-silently",
-        "label": "Gag rituals or waiting silently",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-leash-held-in-mouth",
-        "label": "Leash held in mouth",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-being-gagged-or-forced-silent",
-        "label": "Being gagged or forced silent",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-having-to-hold-objects-in-your-mouth-spoon-hairbrush-leash",
-        "label": "Having to hold objects in your mouth (spoon, hairbrush, leash)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-being-used-for-oral-service-without-reciprocal-pleasure",
-        "label": "Being used for oral service without reciprocal pleasure",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-being-fed-by-hand-mouth-to-mouth-or-with-utensils",
-        "label": "Being fed by hand, mouth-to-mouth, or with utensils",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-verbal-control-e-g-only-speak-when-spoken-to",
-        "label": "Verbal control (e.g., only speak when spoken to)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-mouth-as-a-symbol-of-ownership-or-control",
-        "label": "Mouth as a symbol of ownership or control",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Impact Play",
-    "items": [
-      {
-        "id": "impact-play-hand-spanking",
-        "label": "Hand spanking",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "impact-play-paddle-strikes",
-        "label": "Paddle strikes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "impact-play-crop-snaps",
-        "label": "Crop snaps",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "impact-play-flogger-swings",
-        "label": "Flogger swings",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "impact-play-cane-strokes",
-        "label": "Cane strokes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "impact-play-belt-or-strap-hits",
-        "label": "Belt or strap hits",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "impact-play-whip-cracks",
-        "label": "Whip cracks",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "impact-play-preferred-intensity-levels",
-        "label": "Preferred intensity levels",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "impact-play-aftercare-for-bruises",
-        "label": "Aftercare for bruises",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "impact-play-target-body-areas",
-        "label": "Target body areas",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "impact-play-implement-selection",
-        "label": "Implement selection",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Medical Play",
-    "items": [
-      {
-        "id": "medical-play-needle-play",
-        "label": "Needle play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "medical-play-catheter-insertion",
-        "label": "Catheter insertion",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "medical-play-speculum-exams",
-        "label": "Speculum exams",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "medical-play-enema-administration",
-        "label": "Enema administration",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "medical-play-temperature-taking",
-        "label": "Temperature taking",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "medical-play-medical-restraints",
-        "label": "Medical restraints",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "medical-play-doctor-nurse-roleplay",
-        "label": "Doctor/nurse roleplay",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "medical-play-sterilization-procedures",
-        "label": "Sterilization procedures",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "medical-play-professional-vs-roleplay-scenes",
-        "label": "Professional vs roleplay scenes",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "medical-play-consent-for-invasive-acts",
-        "label": "Consent for invasive acts",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "medical-play-access-to-medical-equipment",
-        "label": "Access to medical equipment",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Pet Play",
-    "items": [
-      {
-        "id": "pet-play-puppy-or-kitten-play",
-        "label": "Puppy or kitten play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "pet-play-pony-play",
-        "label": "Pony play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "pet-play-wearing-collar-and-leash",
-        "label": "Wearing collar and leash",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "pet-play-eating-from-a-bowl",
-        "label": "Eating from a bowl",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "pet-play-kenneling-or-caging",
-        "label": "Kenneling or caging",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "pet-play-pet-training-commands",
-        "label": "Pet training commands",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "pet-play-animal-costumes-or-gear",
-        "label": "Animal costumes or gear",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "pet-play-preferred-animal-identities",
-        "label": "Preferred animal identities",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "pet-play-public-vs-private-play",
-        "label": "Public vs private play",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "pet-play-training-style-and-discipline",
-        "label": "Training style and discipline",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "pet-play-use-of-pet-names-and-commands",
-        "label": "Use of pet names and commands",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Body Modification",
-    "items": [
-      {
-        "id": "body-modification-piercings",
-        "label": "Piercings",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-modification-tattoos",
-        "label": "Tattoos",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-modification-branding",
-        "label": "Branding",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-modification-scarification",
-        "label": "Scarification",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-modification-permanent-chastity-devices",
-        "label": "Permanent chastity devices",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-modification-cosmetic-implants",
-        "label": "Cosmetic implants",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-modification-stretching-or-gauges",
-        "label": "Stretching or gauges",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-modification-temporary-vs-permanent-changes",
-        "label": "Temporary vs permanent changes",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-modification-professional-vs-diy-methods",
-        "label": "Professional vs DIY methods",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-modification-body-placement-considerations",
-        "label": "Body placement considerations",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-modification-healing-and-aftercare",
-        "label": "Healing and aftercare",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Relationship Preferences",
-    "items": [
-      {
-        "id": "relationship-preferences-preferred-relationship-style",
-        "label": "Preferred relationship style",
-        "type": "text",
-        "options": [
-          "Monogamous",
-          "Open relationship",
-          "Polyamorous",
-          "No preference"
-        ],
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-relationship-goals",
-        "label": "Relationship goals",
-        "type": "text",
-        "options": [
-          "One night stand",
-          "Short-term play",
-          "Long-term relationship",
-          "Platonic play partners",
-          "Romantic partners",
-          "Kink partners"
-        ],
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-monogamous",
-        "label": "Monogamous",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-polyamorous",
-        "label": "Polyamorous",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-hierarchical-dynamics",
-        "label": "Hierarchical dynamics",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-non-hierarchical-poly",
-        "label": "Non-hierarchical poly",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-solo-poly",
-        "label": "Solo-poly",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-open-with-boundaries",
-        "label": "Open with boundaries",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-closed-but-kinky-with-others",
-        "label": "Closed but kinky with others",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-switch-friendly-dynamics",
-        "label": "Switch-friendly dynamics",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Gender Play & Transformation",
-    "items": [
-      {
-        "id": "gender-play-transformation-crossdressing",
-        "label": "Crossdressing",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-forced-feminization",
-        "label": "Forced feminization",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-forced-masculinization",
-        "label": "Forced masculinization",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-gender-role-reversal",
-        "label": "Gender role reversal",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-pronoun-changes",
-        "label": "Pronoun changes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-voice-or-mannerism-training",
-        "label": "Voice or mannerism training",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-sissy-or-tomboy-persona",
-        "label": "Sissy or tomboy persona",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-preferred-pronouns-and-names",
-        "label": "Preferred pronouns and names",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-public-presentation-comfort",
-        "label": "Public presentation comfort",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-clothing-and-appearance",
-        "label": "Clothing and appearance",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-exploration-of-identity",
-        "label": "Exploration of identity",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Chastity Devices",
-    "items": [
-      {
-        "id": "chastity-devices-wearing-a-chastity-cage-short-term",
-        "label": "Wearing a chastity cage (short term)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-long-term-chastity-training",
-        "label": "Long-term chastity training",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-chastity-device-control-with-permission-to-unlock",
-        "label": "Chastity device control with permission to unlock",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-locked-remotely-by-another-person",
-        "label": "Locked remotely by another person",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-orgasm-denial-enforced-by-chastity",
-        "label": "Orgasm denial enforced by chastity",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-wearing-a-belt-style-chastity-device",
-        "label": "Wearing a belt-style chastity device",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-humiliation-while-locked-in-chastity",
-        "label": "Humiliation while locked in chastity",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-sleep-in-chastity-overnight",
-        "label": "Sleep in chastity (overnight)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-being-teased-while-unable-to-touch-yourself",
-        "label": "Being teased while unable to touch yourself",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-begging-for-release-from-chastity",
-        "label": "Begging for release from chastity",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Shibari & Rope Bondage",
-    "items": [
-      {
-        "id": "shibari-rope-bondage-being-tied-in-aesthetic-rope-patterns-shibari",
-        "label": "Being tied in aesthetic rope patterns (Shibari)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-rope-bondage-for-restraint-and-control",
-        "label": "Rope bondage for restraint and control",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-rope-suspension-partial-or-full",
-        "label": "Rope suspension (partial or full)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-learning-to-tie-rope-as-a-form-of-dominance",
-        "label": "Learning to tie rope as a form of dominance",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-being-tied-in-vulnerable-or-exposing-poses",
-        "label": "Being tied in vulnerable or exposing poses",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-practicing-rope-with-emotional-connection",
-        "label": "Practicing rope with emotional connection",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-enduring-discomfort-for-the-beauty-of-the-rope",
-        "label": "Enduring discomfort for the beauty of the rope",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-being-tied-in-a-mirror-and-told-to-look",
-        "label": "Being tied in a mirror and told to look",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-punishment-ties-e-g-uncomfortable-or-humiliating-positions",
-        "label": "Punishment ties (e.g., uncomfortable or humiliating positions)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-solo-rope-practice-for-mindfulness-or-masochism",
-        "label": "Solo rope practice for mindfulness or masochism",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Cosplay & Identity Play",
-    "items": [
-      {
-        "id": "cosplay-identity-play-dressing-up-in-costumes-for-scenes",
-        "label": "Dressing up in costumes for scenes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "cosplay-identity-play-playing-as-fictional-characters",
-        "label": "Playing as fictional characters",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "cosplay-identity-play-petplay-with-collars-ears-or-tails",
-        "label": "Petplay with collars, ears, or tails",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "cosplay-identity-play-pretending-to-be-a-doll-robot-or-object",
-        "label": "Pretending to be a doll, robot, or object",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "cosplay-identity-play-master-slave-cosplay-dynamic-non-24-7",
-        "label": "Master/slave cosplay dynamic (non-24/7)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "cosplay-identity-play-roleplaying-as-a-fantasy-species-or-non-human",
-        "label": "Roleplaying as a fantasy species or non-human",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "cosplay-identity-play-using-cosplay-to-deepen-power-exchange",
-        "label": "Using cosplay to deepen power exchange",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "cosplay-identity-play-scene-built-around-a-character-s-story-or-world",
-        "label": "Scene built around a character’s story or world",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "cosplay-identity-play-fantasy-uniforms-nurse-teacher-etc",
-        "label": "Fantasy uniforms (nurse, teacher, etc.)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "High-Intensity Kinks (SSC-Aware)",
-    "items": [
-      {
-        "id": "high-intensity-kinks-ssc-aware-intense-breath-play-e-g-smothering-or-pressure",
-        "label": "Intense breath play (e.g., smothering or pressure)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-knife-play-or-blade-play-without-injury",
-        "label": "Knife play or blade play (without injury)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-fear-play-using-known-or-negotiated-triggers",
-        "label": "Fear play using known or negotiated triggers",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-abduction-or-home-invasion-style-roleplay-negotiated",
-        "label": "Abduction or home-invasion style roleplay (negotiated)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-medical-themed-scenes-with-sharp-objects-not-bloodletting",
-        "label": "Medical-themed scenes with sharp objects (not bloodletting)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-sensory-deprivation-with-added-disorientation-or-helplessness",
-        "label": "Sensory deprivation with added disorientation or helplessness",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-scenes-involving-heavy-objectification-or-emotional-manipulation-with-care",
-        "label": "Scenes involving heavy objectification or emotional manipulation (with care)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-mock-interrogation-or-intense-role-pressure",
-        "label": "Mock interrogation or intense role pressure",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-consensual-threats-without-follow-through-e-g-if-you-don-t",
-        "label": "Consensual threats without follow-through (e.g. 'If you don’t...')",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-high-intensity-primal-scenes-involving-struggle-or-fear",
-        "label": "High-intensity primal scenes involving struggle or fear",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Behavioral Play",
-    "items": [
-      {
-        "id": "behavioral-play-assigning-corner-time-or-time-outs",
-        "label": "Assigning corner time or time-outs",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "behavioral-play-writing-lines-or-apology-letters-as-correction",
-        "label": "Writing lines or apology letters as correction",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "behavioral-play-removing-privileges-phone-tv-sweets",
-        "label": "Removing privileges (phone, TV, sweets)",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "behavioral-play-playful-punishments-that-still-reinforce-rules",
-        "label": "Playful punishments that still reinforce rules",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "behavioral-play-lecturing-or-scolding-to-modify-behavior",
-        "label": "Lecturing or scolding to modify behavior",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "behavioral-play-being-placed-in-the-corner-or-given-a-time-out",
-        "label": "Being placed in the corner or given a time-out",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "behavioral-play-writing-lines-or-apology-letters-when-misbehaving",
-        "label": "Writing lines or apology letters when misbehaving",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "behavioral-play-having-privileges-revoked-phone-tv",
-        "label": "Having privileges revoked (phone, TV)",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "behavioral-play-receiving-playful-funishments-for-minor-rule-breaking",
-        "label": "Receiving playful 'funishments' for minor rule-breaking",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "behavioral-play-getting-scolded-or-lectured-for-correction",
-        "label": "Getting scolded or lectured for correction",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "behavioral-play-preferred-style-of-discipline-strict-vs-lenient",
-        "label": "Preferred style of discipline (strict vs lenient)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "behavioral-play-attitude-toward-funishment-vs-serious-correction",
-        "label": "Attitude toward funishment vs serious correction",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "behavioral-play-use-of-behavior-contracts-or-rule-agreements",
-        "label": "Use of behavior contracts or rule agreements",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Appearance Play",
-    "items": [
-      {
-        "id": "appearance-play-choosing-my-partner-s-outfit-for-the-day-or-a-scene",
-        "label": "Choosing my partner’s outfit for the day or a scene",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-selecting-their-underwear-lingerie-or-base-layers",
-        "label": "Selecting their underwear, lingerie, or base layers",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-styling-their-hair-braiding-brushing-tying-etc",
-        "label": "Styling their hair (braiding, brushing, tying, etc.)",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-picking-head-coverings-bonnets-veils-hoods-hats-for-mood-or-protocol",
-        "label": "Picking head coverings (bonnets, veils, hoods, hats) for mood or protocol",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-offering-makeup-polish-or-accessories-as-part-of-ritual-or-play",
-        "label": "Offering makeup, polish, or accessories as part of ritual or play",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-creating-themed-looks-slutty-innocent-doll-like-sharp-etc",
-        "label": "Creating themed looks (slutty, innocent, doll-like, sharp, etc.)",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-dressing-them-in-role-specific-costumes-maid-bunny-doll-etc",
-        "label": "Dressing them in role-specific costumes (maid, bunny, doll, etc.)",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-curating-time-period-or-historical-outfits-e-g-victorian-50s",
-        "label": "Curating time-period or historical outfits (e.g., Victorian, 50s)",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-helping-them-present-more-femme-masc-or-androgynous-by-request",
-        "label": "Helping them present more femme, masc, or androgynous by request",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-coordinating-their-look-with-mine-for-public-or-private-scenes",
-        "label": "Coordinating their look with mine for public or private scenes",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-implementing-a-dress-ritual-or-aesthetic-preparation",
-        "label": "Implementing a “dress ritual” or aesthetic preparation",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-enforcing-a-visual-protocol-e-g-no-bra-heels-required-tied-hair",
-        "label": "Enforcing a visual protocol (e.g., no bra, heels required, tied hair)",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-having-my-outfit-selected-for-me-by-a-partner",
-        "label": "Having my outfit selected for me by a partner",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-wearing-the-underwear-or-lingerie-they-choose",
-        "label": "Wearing the underwear or lingerie they choose",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-having-my-hair-brushed-braided-tied-or-styled-for-them",
-        "label": "Having my hair brushed, braided, tied, or styled for them",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-putting-on-a-head-covering-e-g-bonnet-veil-hood-they-chose",
-        "label": "Putting on a head covering (e.g., bonnet, veil, hood) they chose",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-following-visual-appearance-rules-as-part-of-submission",
-        "label": "Following visual appearance rules as part of submission",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-wearing-makeup-polish-or-accessories-they-request",
-        "label": "Wearing makeup, polish, or accessories they request",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-dressing-to-please-their-vision-cute-filthy-classy-etc",
-        "label": "Dressing to please their vision (cute, filthy, classy, etc.)",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-wearing-roleplay-costumes-or-character-looks",
-        "label": "Wearing roleplay costumes or character looks",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-presenting-in-a-way-that-matches-their-chosen-aesthetic",
-        "label": "Presenting in a way that matches their chosen aesthetic",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-participating-in-dressing-rituals-or-undressing-ceremonies",
-        "label": "Participating in dressing rituals or undressing ceremonies",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-being-admired-for-the-way-i-look-under-their-direction",
-        "label": "Being admired for the way I look under their direction",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-receiving-praise-or-gentle-teasing-about-my-appearance",
-        "label": "Receiving praise or gentle teasing about my appearance",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-cosplay-or-fantasy-looks-anime-game-fairytale-etc",
-        "label": "Cosplay or fantasy looks (anime, game, fairytale, etc.)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-time-period-dress-up-regency-gothic-1920s-etc",
-        "label": "Time-period dress-up (regency, gothic, 1920s, etc.)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-dollification-or-polished-presented-object-aesthetics",
-        "label": "Dollification or polished/presented object aesthetics",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-uniforms-schoolgirl-military-clerical-nurse-etc",
-        "label": "Uniforms (schoolgirl, military, clerical, nurse, etc.)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-hair-based-play-forced-brushing-ribbons-or-tied-styles",
-        "label": "Hair-based play (forced brushing, ribbons, or tied styles)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-head-coverings-or-symbolic-hoods-in-ritualized-dynamics",
-        "label": "Head coverings or symbolic hoods in ritualized dynamics",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-matching-looks-or-coordinated-dress-codes",
-        "label": "Matching looks or coordinated dress codes",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-ritualized-grooming-before-scenes",
-        "label": "Ritualized grooming before scenes",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-praise-or-positive-attention-for-pleasing-visual-display",
-        "label": "Praise or positive attention for pleasing visual display",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-formal-appearance-protocols-for-scenes-or-dynamics",
-        "label": "Formal appearance protocols for scenes or dynamics",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-using-clothing-or-style-to-embody-emotional-or-power-roles",
-        "label": "Using clothing or style to embody emotional or power roles",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Psychology Play",
-    "items": [
-      {
-        "id": "psychology-play-emotional-sadism-giving-teasing-feelings-orchestrating-reactions-savoring-anticipation-without-shame-based-harm",
-        "label": "Emotional Sadism (giving): teasing feelings, orchestrating reactions, savoring anticipation without shame-based harm",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "psychology-play-psychological-control-mind-games-double-binds-deliberate-pacing-and-strategic-ambiguity",
-        "label": "Psychological Control: mind games, double binds, deliberate pacing, and strategic ambiguity",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "psychology-play-sadistic-attention-enjoying-being-the-focal-point-of-a-partner-s-fear-arousal-or-resistance",
-        "label": "Sadistic Attention: enjoying being the focal point of a partner’s fear, arousal, or resistance",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "psychology-play-teasing-humiliation-playful-status-play-without-degradation-or-shame",
-        "label": "Teasing Humiliation: playful status play without degradation or shame",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "psychology-play-emotional-sadism-receiving-enjoying-engineered-emotional-intensity-such-as-fluster-exposure-or-playful-embarrassment",
-        "label": "Emotional Sadism (receiving): enjoying engineered emotional intensity such as fluster, exposure, or playful embarrassment",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychology-play-psychological-control-receiving-arousal-from-being-studied-contained-or-outmaneuvered",
-        "label": "Psychological Control (receiving): arousal from being studied, contained, or outmaneuvered",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychology-play-being-the-focus-enjoying-being-watched-tracked-or-held-in-a-partner-s-intense-focus",
-        "label": "Being the Focus: enjoying being watched, tracked, or held in a partner’s intense focus",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychology-play-teasing-humiliation-receiving-enjoying-playful-embarrassment-or-affectionate-mockery-that-builds-intimacy",
-        "label": "Teasing Humiliation (receiving): enjoying playful embarrassment or affectionate mockery that builds intimacy",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychology-play-prey-attention-neediness-craving-focus-pursuit-or-intense-awareness-from-a-partner",
-        "label": "Prey Attention/Neediness: craving focus, pursuit, or intense awareness from a partner",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychology-play-primal-recognition-being-seen-understood-or-tracked-without-needing-words",
-        "label": "Primal Recognition: being seen, understood, or tracked without needing words",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Breeding",
-    "items": [
-      {
-        "id": "breeding-impregnation-giving-arousal-from-attempting-to-impregnate-a-partner",
-        "label": "Impregnation (giving): arousal from attempting to impregnate a partner",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "breeding-feeding-milk-giving-arousal-from-producing-and-feeding-milk-to-a-partner",
-        "label": "Feeding Milk (giving): arousal from producing and feeding milk to a partner",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "breeding-impregnation-receiving-arousal-from-being-inseminated-pregnancy-risk-or-being-bred",
-        "label": "Impregnation (receiving): arousal from being inseminated, pregnancy risk, or being bred",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "breeding-feeding-milk-receiving-arousal-from-drinking-a-partner-s-milk",
-        "label": "Feeding Milk (receiving): arousal from drinking a partner’s milk",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "breeding-pregnancy-fantasy-erotic-focus-on-pregnancy-mine-partner-s-or-fictional-scenarios",
-        "label": "Pregnancy Fantasy: erotic focus on pregnancy (mine, partner’s, or fictional scenarios)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-primal-breeding-drive-animalistic-instinctual-framing-of-sex-reproduction-territory",
-        "label": "Primal Breeding Drive: animalistic/instinctual framing of sex, reproduction, territory",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-breeding-as-control-ownership-authority-expressed-through-breeding-talk-or-pregnancy-risk",
-        "label": "Breeding as Control: ownership/authority expressed through breeding talk or pregnancy risk",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-creampie-marking-erotic-meaning-placed-on-internal-ejaculation-or-visible-claimed-markers",
-        "label": "Creampie/Marking: erotic meaning placed on internal ejaculation or visible ‘claimed’ markers",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-risk-no-contraception-talk-fantasy-dirty-talk-about-risk-or-breeding-without-actual-risk",
-        "label": "Risk/‘No Contraception’ Talk (fantasy): dirty talk about risk or breeding without actual risk",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-heat-ovulation-tracking-timing-in-heat-roleplay-or-cycle-focused-arousal",
-        "label": "Heat/Ovulation Tracking: timing, ‘in heat’ roleplay, or cycle-focused arousal",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-artificial-insemination-device-play-syringes-cups-or-medical-style-scenarios-consensual-fantasy",
-        "label": "Artificial Insemination/Device Play: syringes, cups, or medical-style scenarios (consensual fantasy)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-breeding-denial-ruined-breeding-building-toward-impregnation-talk-then-denying-or-ruining-it",
-        "label": "Breeding Denial/Ruined Breeding: building toward impregnation talk then denying or ‘ruining’ it",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-pregnancy-body-focus-belly-worship-movement-weight-changes-glow-and-attention",
-        "label": "Pregnancy Body Focus: belly worship, movement/weight changes, glow, and attention",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-pregnancy-protocol-care-protective-rules-pedestal-treatment-dedicated-aftercare",
-        "label": "Pregnancy Protocol/Care: protective rules, pedestal treatment, dedicated aftercare",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-lactation-induction-maintenance-interest-in-inducing-or-sustaining-milk-production",
-        "label": "Lactation Induction/Maintenance: interest in inducing or sustaining milk production",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-milking-scenes-manual-oral-or-pump-based-milking-as-play-or-ritual",
-        "label": "Milking Scenes: manual, oral, or pump-based ‘milking’ as play or ritual",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-contraception-boundaries-preference-to-use-protection-bc-methods-or-simulation-only",
-        "label": "Contraception Boundaries: preference to use protection, BC methods, or simulation-only",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-sti-testing-medical-boundaries-testing-cadence-disclosures-and-comfort-levels",
-        "label": "STI/Testing & Medical Boundaries: testing cadence, disclosures, and comfort levels",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  }
-]
+  "categories": [
+    {
+      "category": "Body Part Torture",
+      "items": [
+        {
+          "id": "body-part-torture-nipple-clips",
+          "label": "Nipple clips",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-nipple-weights",
+          "label": "Nipple weights",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-nipple-suction-cups",
+          "label": "Nipple suction cups",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-cock-ball-torture-cbt",
+          "label": "Cock, Ball Torture (CBT)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-clit-clips-weights-suction",
+          "label": "Clit clips/weights/suction",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-hair-pulling",
+          "label": "Hair pulling",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-face-slapping",
+          "label": "Face slapping",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-butt-slapping",
+          "label": "Butt slapping",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-breast-slapping",
+          "label": "Breast slapping",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-genital-slapping",
+          "label": "Genital slapping",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Bondage and Suspension",
+      "items": [
+        {
+          "id": "bondage-and-suspension-blindfolds",
+          "label": "Blindfolds",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-bondage-heavy",
+          "label": "Bondage (heavy)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-bondage-light",
+          "label": "Bondage (light)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-immobilisation",
+          "label": "Immobilisation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-bondage-multi-day",
+          "label": "Bondage (multi-day)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-bondage-public-under-clothing",
+          "label": "Bondage (public, under clothing)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-leather-restraints",
+          "label": "Leather restraints",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-chains",
+          "label": "Chains",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-ropes",
+          "label": "Ropes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-intricate-japanese-rope-bondage",
+          "label": "Intricate (Japanese) rope bondage",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-rope-body-harness",
+          "label": "Rope body harness",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-arm-leg-sleeves-armbinders",
+          "label": "Arm & leg sleeves (armbinders)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-harnesses-leather",
+          "label": "Harnesses (leather)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-harnesses-rope",
+          "label": "Harnesses (rope)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-cuffs-leather",
+          "label": "Cuffs (leather)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-cuffs-metal",
+          "label": "Cuffs (metal)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-manacles-irons",
+          "label": "Manacles & Irons",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-gags-cloth",
+          "label": "Gags (cloth)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-gags-rubber",
+          "label": "Gags (rubber)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-gags-tape",
+          "label": "Gags (tape)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-gags-phallic",
+          "label": "Gags (phallic)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-gags-ring",
+          "label": "Gags (ring)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-gags-ball",
+          "label": "Gags (ball)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-mouth-bits",
+          "label": "Mouth bits",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-full-head-hoods",
+          "label": "Full head hoods",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-mummification-saran-wrapping",
+          "label": "Mummification/saran wrapping",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-straight-jackets",
+          "label": "Straight jackets",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-suspension-upright",
+          "label": "Suspension (upright)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-suspension-horizontal",
+          "label": "Suspension (horizontal)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-suspension-inverted",
+          "label": "Suspension (inverted)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-breath-play",
+          "label": "Breath play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-smothering",
+          "label": "Smothering",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-forced-self-breath-control",
+          "label": "Forced self-breath-control",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-gas-mask",
+          "label": "Gas mask",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Breath Play",
+      "items": [
+        {
+          "id": "breath-play-asphyxiation",
+          "label": "Asphyxiation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "breath-play-breath-control",
+          "label": "Breath control",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "breath-play-choking",
+          "label": "Choking",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "breath-play-drowning",
+          "label": "Drowning",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "breath-play-rebreathing-into-a-bag-or-object",
+          "label": "Rebreathing into a bag or object",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "breath-play-verbal-control-of-breath-e-g-hold-it-on-command",
+          "label": "Verbal control of breath (e.g., 'hold it' on command)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Sexual Activity",
+      "items": [
+        {
+          "id": "sexual-activity-licking",
+          "label": "Licking",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-fellatio-cunnilingus",
+          "label": "Fellatio/Cunnilingus",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-swallowing-semen",
+          "label": "Swallowing semen",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-cumming-on-partner",
+          "label": "Cumming on Partner",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-hand-jobs",
+          "label": "Hand jobs",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-anal-sex",
+          "label": "Anal sex",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-anal-plugs-small",
+          "label": "Anal plugs (small)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-anal-plugs-large",
+          "label": "Anal plugs (large)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-anal-beads",
+          "label": "Anal beads",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-vibrator-on-genitals",
+          "label": "Vibrator on genitals",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-fisting",
+          "label": "Fisting",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-oral-anal-play-rimming",
+          "label": "Oral/anal play (rimming)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-double-penetration-oral-and-vaginal",
+          "label": "Double penetration (oral and vaginal)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-double-penetration-oral-and-anal",
+          "label": "Double penetration (oral and anal)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-double-penetration-anal-and-vaginal",
+          "label": "Double penetration (anal and vaginal)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-triple-oral-vaginal-and-anal",
+          "label": "Triple (Oral, Vaginal and Anal)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Sensation Play",
+      "items": [
+        {
+          "id": "sensation-play-abrasion",
+          "label": "Abrasion",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-scratching",
+          "label": "Scratching",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-biting",
+          "label": "Biting",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-tickling",
+          "label": "Tickling",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-kissing",
+          "label": "Kissing",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-zapping-e-g-electric-fly-swatter",
+          "label": "Zapping (e.g. electric fly swatter)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-ice-cubes",
+          "label": "Ice cubes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-wax-play",
+          "label": "Wax Play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-fire",
+          "label": "Fire",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-clothespins",
+          "label": "Clothespins",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-needles",
+          "label": "Needles",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-sensory-deprivation",
+          "label": "Sensory deprivation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-physical-overpowering-manhandling",
+          "label": "Physical overpowering / Manhandling",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-figging",
+          "label": "Figging",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Other",
+      "items": [
+        {
+          "id": "other-feet",
+          "label": "Feet",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-boots",
+          "label": "Boots",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-underwear",
+          "label": "Underwear",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-chastity-devices",
+          "label": "Chastity devices",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-masks",
+          "label": "Masks",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-breeding",
+          "label": "Breeding",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-leather-clothing",
+          "label": "Leather clothing",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-training-protocols-outside-scenes-e-g-etiquette-memory",
+          "label": "Training protocols outside scenes (e.g., etiquette, memory)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-long-distance-training-structure",
+          "label": "Long-distance training/structure",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-scene-journaling-and-reflection",
+          "label": "Scene journaling and reflection",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Roleplaying",
+      "items": [
+        {
+          "id": "roleplaying-fantasy-abandonment",
+          "label": "Fantasy abandonment",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-kidnapping",
+          "label": "Kidnapping",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-interrogation",
+          "label": "Interrogation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-sleep-deprivation",
+          "label": "Sleep deprivation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-cnc",
+          "label": "CNC",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-gang-bang",
+          "label": "Gang bang",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-initiation-rites",
+          "label": "Initiation rites",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-religious-scenes",
+          "label": "Religious scenes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-medical-scenes",
+          "label": "Medical scenes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-prison-scenes",
+          "label": "Prison scenes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-primal-prey",
+          "label": "Primal/Prey",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-schoolroom-scenes",
+          "label": "Schoolroom scenes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Service and Restrictive Behaviour",
+      "items": [
+        {
+          "id": "service-and-restrictive-behaviour-following-orders",
+          "label": "(Following) orders",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-forced-servitude",
+          "label": "Forced servitude",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-restrictive-rules-on-behaviour",
+          "label": "Restrictive rules on behaviour",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-eye-contact-restrictions",
+          "label": "Eye contact restrictions",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-speech-restrictions-when-what-to-whom",
+          "label": "Speech restrictions (when, what, to whom)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-washroom-restrictions",
+          "label": "Washroom restrictions",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-punishments",
+          "label": "Punishments",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-tasks",
+          "label": "Tasks",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-massage",
+          "label": "Massage",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-domestic-tasks",
+          "label": "Domestic tasks",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-serving-food-and-drink",
+          "label": "Serving food and drink",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-personal-care-rituals",
+          "label": "Personal care rituals",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-being-on-call-at-specified-times",
+          "label": "Being on-call at specified times",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-daily-task-assignments",
+          "label": "Daily task assignments",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-corrections-for-imperfection",
+          "label": "Corrections for imperfection",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-uniforms-dress-codes",
+          "label": "Uniforms / Dress codes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-kneeling-posture-presentation",
+          "label": "Kneeling / Posture presentation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-silent-service",
+          "label": "Silent service",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-public-service-at-parties-or-events",
+          "label": "Public service (at parties or events)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-erotic-service-pleasure-on-command-without-seeking-your-own",
+          "label": "Erotic service (pleasure on command, without seeking your own)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Voyeurism/Exhibitionism",
+      "items": [
+        {
+          "id": "voyeurism-exhibitionism-forced-nudity-private",
+          "label": "Forced nudity (private)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "voyeurism-exhibitionism-forced-nudity-around-others",
+          "label": "Forced nudity (around others)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "voyeurism-exhibitionism-exhibitionism-friends",
+          "label": "Exhibitionism (friends)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "voyeurism-exhibitionism-exhibitionism-strangers",
+          "label": "Exhibitionism (strangers)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "voyeurism-exhibitionism-modelling-for-erotic-photos",
+          "label": "Modelling for erotic photos",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "voyeurism-exhibitionism-toys-under-clothes-in-public",
+          "label": "Toys under clothes in public",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Virtual & Long-Distance Play",
+      "items": [
+        {
+          "id": "virtual-long-distance-play-sending-tasks-or-orders-digitally",
+          "label": "Sending tasks or orders digitally",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-recording-dominant-voice-clips-commands-edging-praise-degradation-etc",
+          "label": "Recording dominant voice clips (commands, edging, praise, degradation, etc.)",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-remote-control-of-a-sex-toy",
+          "label": "Remote control of a sex toy",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-monitoring-behavior-via-app-or-shared-doc",
+          "label": "Monitoring behavior via app or shared doc",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-giving-punishment-assignments-remotely",
+          "label": "Giving punishment assignments remotely",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-creating-countdowns-timers-or-denial-periods",
+          "label": "Creating countdowns, timers, or denial periods",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-sending-written-instructions-with-delayed-permissions",
+          "label": "Sending written instructions with delayed permissions",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-creating-custom-video-or-audio-tasks",
+          "label": "Creating custom video or audio tasks",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-voice-message-control-during-scenes",
+          "label": "Voice message control during scenes",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-being-on-call-at-specified-times",
+          "label": "Being on-call at specified times",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-receiving-tasks-or-orders-digitally",
+          "label": "Receiving tasks or orders digitally",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-listening-to-dominant-voice-clips",
+          "label": "Listening to dominant voice clips",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-using-a-remote-controlled-toy-controlled-by-another",
+          "label": "Using a remote-controlled toy controlled by another",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-completing-daily-protocol-assignments",
+          "label": "Completing daily protocol assignments",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-submitting-proof-photo-video-text",
+          "label": "Submitting proof (photo, video, text)",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-following-recorded-or-timed-commands",
+          "label": "Following recorded or timed commands",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-receiving-surprise-instructions",
+          "label": "Receiving surprise instructions",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-hearing-name-praise-spoken-in-a-custom-clip",
+          "label": "Hearing name/praise spoken in a custom clip",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-sending-submissive-voice-clips-obedience-begging-thank-you-messages-affirmations-etc",
+          "label": "Sending submissive voice clips (obedience, begging, thank-you messages, affirmations, etc.)",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-scheduling-digital-rituals-or-reminders",
+          "label": "Scheduling digital rituals or reminders",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-using-training-habit-or-behavior-tracking-apps",
+          "label": "Using training, habit, or behavior-tracking apps",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-online-rituals-digital-kneeling-posture-protocols",
+          "label": "Online rituals (digital kneeling, posture protocols)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-role-based-texting-e-g-use-honorifics-in-chat",
+          "label": "Role-based texting (e.g., \"Use honorifics in chat\")",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-shared-playlists-affirmations-or-mantras",
+          "label": "Shared playlists, affirmations, or mantras",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-countdown-timers-to-next-task-release-or-interaction",
+          "label": "Countdown timers to next task, release, or interaction",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-scheduled-good-morning-night-rituals",
+          "label": "Scheduled good morning/night rituals",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-participating-in-video-call-scenes",
+          "label": "Participating in video call scenes",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-digital-aftercare-texts-voice-images",
+          "label": "Digital aftercare (texts, voice, images)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-sexting-or-digital-roleplay-scenes",
+          "label": "Sexting or digital roleplay scenes",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-voice-notes-or-submissive-dominant-affirmations",
+          "label": "Voice notes or submissive/dominant affirmations",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Communication",
+      "items": [
+        {
+          "id": "communication-playful-and-teasing",
+          "label": "Playful and teasing",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-quiet-and-intense",
+          "label": "Quiet and intense",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-observant-and-intentional",
+          "label": "Observant and intentional",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-praise-heavy",
+          "label": "Praise-heavy",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-blunt-and-efficient",
+          "label": "Blunt and efficient",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-affirming-and-soft",
+          "label": "Affirming and soft",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-psychological-interrogation",
+          "label": "Psychological interrogation",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-verbal-coercion-teasing-traps",
+          "label": "Verbal coercion / teasing traps",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-verbal-misdirection",
+          "label": "Verbal misdirection",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-mocking-shaming",
+          "label": "Mocking / shaming",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-predatory-pacing",
+          "label": "Predatory pacing",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-reluctant-obedience",
+          "label": "Reluctant obedience",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-stammering-submission",
+          "label": "Stammering submission",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-challenging-until-caught",
+          "label": "Challenging until caught",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-quiet-surrender",
+          "label": "Quiet surrender",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-sarcastic-teasing",
+          "label": "Sarcastic teasing",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-provoking-tone",
+          "label": "Provoking tone",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-challenge-based-dialogue",
+          "label": "Challenge-based dialogue",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-double-meaning-banter",
+          "label": "Double-meaning banter",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-soft-spoken-guidance",
+          "label": "Soft-spoken guidance",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-protective-but-firm-tone",
+          "label": "Protective but firm tone",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-emotional-redirection",
+          "label": "Emotional redirection",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-steady-reassurance",
+          "label": "Steady reassurance",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-direct-and-clear",
+          "label": "Direct and clear",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-gentle-and-nurturing",
+          "label": "Gentle and nurturing",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-commanding-and-firm",
+          "label": "Commanding and firm",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-quiet-and-observant",
+          "label": "Quiet and observant",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-instructive-teacher-like",
+          "label": "Instructive / teacher-like",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-emotionally-intense",
+          "label": "Emotionally intense",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-dismissive-withholding",
+          "label": "Dismissive / withholding",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-mocking-sarcastic",
+          "label": "Mocking / sarcastic",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-blunt-tactless",
+          "label": "Blunt / tactless",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-predatory-hunting-tone",
+          "label": "Predatory / hunting tone",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-stalking-or-circling-speech",
+          "label": "Stalking or circling speech",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-you-re-mine-control-language",
+          "label": "You’re mine / control language",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-threatening-consensual",
+          "label": "Threatening (consensual)",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-verbal-cornering-coaxing",
+          "label": "Verbal cornering / coaxing",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-watching-you-unravel",
+          "label": "Watching you unravel",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-cruel-and-cutting",
+          "label": "Cruel and cutting",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-psychological-baiting",
+          "label": "Psychological baiting",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-brat-breaking-language",
+          "label": "Brat-breaking language",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-mock-affection",
+          "label": "Mock affection",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-shaming-or-emotional-edge",
+          "label": "Shaming or emotional edge",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-disappointed-dom-voice",
+          "label": "Disappointed dom voice",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-mild-scolding-mocking-affection",
+          "label": "Mild scolding / mocking affection",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-verbal-power-struggle",
+          "label": "Verbal power struggle",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-challenge-response-dynamics",
+          "label": "Challenge-response dynamics",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-warm-tone-with-expectation",
+          "label": "Warm tone with expectation",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-nurturing-dominance",
+          "label": "Nurturing dominance",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-reassuring-commands",
+          "label": "Reassuring commands",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-phrases-that-work-on-you",
+          "label": "Phrases that work on you",
+          "type": "text",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "communication-phrases-you-use-or-like-to-give",
+          "label": "Phrases you use or like to give",
+          "type": "text",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "communication-what-helps-you-feel-emotionally-safe",
+          "label": "What helps you feel emotionally safe",
+          "type": "text",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "communication-how-you-tend-to-show-affection",
+          "label": "How you tend to show affection",
+          "type": "text",
+          "options": [
+            "Words of affirmation",
+            "Acts of service",
+            "Through teasing / play",
+            "Through obedience",
+            "Through caretaking",
+            "Withholding / teasing love",
+            "Physical closeness",
+            "Quality time"
+          ],
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "communication-emotional-check-in-style",
+          "label": "Emotional check-in style",
+          "type": "text",
+          "options": [
+            "Daily texting",
+            "After-scene debriefs",
+            "Scheduled check-ins",
+            "Mix of text/video check-ins",
+            "In-person check-ins",
+            "Journaling together",
+            "Minimal / low contact",
+            "Other"
+          ],
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "communication-when-emotionally-activated-i-tend-to",
+          "label": "When emotionally activated, I tend to...",
+          "type": "text",
+          "options": [
+            "Shut down",
+            "Overexplain / fawn",
+            "Get sarcastic / prickly",
+            "Spiral internally",
+            "Ask for reassurance",
+            "Withdraw",
+            "Other"
+          ],
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Body Fluids and Functions",
+      "items": [
+        {
+          "id": "body-fluids-and-functions-watersports-golden-showers",
+          "label": "Watersports/golden showers",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-fluids-and-functions-cum",
+          "label": "Cum",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-fluids-and-functions-blood",
+          "label": "Blood",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-fluids-and-functions-scat",
+          "label": "Scat",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-fluids-and-functions-sweat",
+          "label": "Sweat",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-fluids-and-functions-vomit",
+          "label": "Vomit",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-fluids-and-functions-tears-crying",
+          "label": "Tears/crying",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Psychological Primal / Prey",
+      "items": [
+        {
+          "id": "psychological-primal-prey-primal-prey",
+          "label": "Primal/Prey",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-conditioning",
+          "label": "Conditioning",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-coc",
+          "label": "COC",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-psycholagny-hands-free-mentally-stimulated-orgasm",
+          "label": "Psycholagny (hands free, mentally stimulated orgasm)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-hypno-play",
+          "label": "Hypno Play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-praise",
+          "label": "Praise",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-degradation",
+          "label": "Degradation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-traditional-primal-prey",
+          "label": "Traditional primal/prey",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-fear-play",
+          "label": "Fear play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-objectification",
+          "label": "Objectification",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-gaslighting",
+          "label": "Gaslighting",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-role-erosion-identity-play-loss-of-self",
+          "label": "Role erosion (identity play / loss of self)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-jealousy-play",
+          "label": "Jealousy play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-manipulation",
+          "label": "Manipulation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Body Part / Fetish Play",
+      "items": [
+        {
+          "id": "body-part-fetish-play-belly-fucking",
+          "label": "Belly fucking",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-navel-play",
+          "label": "Navel play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-feet-foot-worship",
+          "label": "Feet / Foot worship",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-hands",
+          "label": "Hands",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-hair",
+          "label": "Hair",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-thighs",
+          "label": "Thighs",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-neck",
+          "label": "Neck",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-ears",
+          "label": "Ears",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-belly",
+          "label": "Belly",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-voice-fetish",
+          "label": "Voice fetish",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-nails-makeup-fetish",
+          "label": "Nails / Makeup fetish",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-cuddles",
+          "label": "Cuddles",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-food-play",
+          "label": "Food Play",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-kisses",
+          "label": "Kisses",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-masturbation",
+          "label": "Masturbation",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-romance-affection",
+          "label": "Romance / affection",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-sex-toys",
+          "label": "Sex toys",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-sexting-chat-etc",
+          "label": "Sexting /Chat etc",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-sexting-via-phone-or-video-call",
+          "label": "Sexting via phone or video call",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-strip-tease",
+          "label": "Strip tease",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-vanilla-sex",
+          "label": "Vanilla Sex",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-voice-notes",
+          "label": "Voice Notes",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-shaving-body-hair",
+          "label": "Shaving (body hair)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-sexy-clothing-private",
+          "label": "Sexy clothing (private)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-sexy-clothing-public",
+          "label": "Sexy clothing (public)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-outdoor-scenes",
+          "label": "Outdoor scenes",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-public-exposure",
+          "label": "Public exposure",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Orgasm Control & Sexual Manipulation",
+      "items": [
+        {
+          "id": "orgasm-control-sexual-manipulation-edging",
+          "label": "Edging",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-short-term-denial",
+          "label": "Short term denial",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-long-term-denial",
+          "label": "Long term denial",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-forced-orgasms-overstimulation",
+          "label": "Forced orgasms / Overstimulation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-ruined-orgasms",
+          "label": "Ruined orgasms",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-no-touch-periods",
+          "label": "No touch periods",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-milking",
+          "label": "Milking",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-chastity-devices",
+          "label": "Chastity devices",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-consensual-orgasm-control",
+          "label": "Consensual orgasm control",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-forced-masturbation",
+          "label": "Forced masturbation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Protocol and Ritual",
+      "items": [
+        {
+          "id": "protocol-and-ritual-formal-language",
+          "label": "Formal language",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-greeting-and-departure-rituals-kneeling-verbal-scripts-gestures",
+          "label": "Greeting and departure rituals (kneeling, verbal scripts, gestures)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-requiring-permission-for-things-speech-movement-attire",
+          "label": "Requiring permission for things (speech, movement, attire)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-daily-rituals-morning-check-ins-status-reports-mantra-repetitions",
+          "label": "Daily rituals (morning check-ins, status reports, mantra repetitions)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-specific-postures-for-rest-attention-punishment-waiting",
+          "label": "Specific postures for rest, attention, punishment, waiting",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-restricted-behavior-no-eye-contact-silence-no-questions",
+          "label": "Restricted behavior (no eye contact, silence, no questions)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-ritual-object-use-collar-cuffs-leash-tokens",
+          "label": "Ritual object use (collar, cuffs, leash, tokens)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-tracking-obedience-journals-apps",
+          "label": "Tracking obedience (journals, apps)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-formalized-rules-for-misbehavior-and-correction",
+          "label": "Formalized rules for misbehavior and correction",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-ritualized-aftercare-or-scene-closure",
+          "label": "Ritualized aftercare or scene closure",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-object-retrieval-on-all-fours-with-item-in-mouth",
+          "label": "Object retrieval on all fours with item in mouth",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-fetching-hairbrush-or-punishment-tool-from-dresser-while-crawling",
+          "label": "Fetching hairbrush or punishment tool from dresser while crawling",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-presenting-chosen-discipline-tool-in-kneeling-posture",
+          "label": "Presenting chosen discipline tool in kneeling posture",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-assigned-posture-or-kneeling-positions-as-ritual",
+          "label": "Assigned posture or kneeling positions as ritual",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-requesting-permission-using-specific-protocol-phrases",
+          "label": "Requesting permission using specific protocol phrases",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-carrying-items-in-mouth-as-submissive-gesture",
+          "label": "Carrying items in mouth as submissive gesture",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-crawling-back-with-object-to-dominant-after-retrieval",
+          "label": "Crawling back with object to Dominant after retrieval",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-following-via-nipple-leash-as-protocol-or-punishment",
+          "label": "Following via nipple leash as protocol or punishment",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-crawling-assigned-paths-as-ritual-or-obedience-training",
+          "label": "Crawling assigned paths as ritual or obedience training",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-crawling-rituals-e-g-object-retrieval",
+          "label": "Crawling rituals (e.g., object retrieval)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-carrying-objects-in-mouth-as-obedience",
+          "label": "Carrying objects in mouth as obedience",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-presenting-tools-or-toys-in-posture",
+          "label": "Presenting tools or toys in posture",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-using-honorifics-or-preset-protocol-language",
+          "label": "Using honorifics or preset protocol language",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-greeting-rituals-e-g-kneeling-kissing-feet",
+          "label": "Greeting rituals (e.g., kneeling, kissing feet)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-daily-check-ins-or-structured-reports",
+          "label": "Daily check-ins or structured reports",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-clothing-restrictions-or-uniforms",
+          "label": "Clothing restrictions or uniforms",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-posture-training-sitting-kneeling-standing",
+          "label": "Posture training (sitting, kneeling, standing)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-punishments-for-incorrect-behavior-or-tone",
+          "label": "Punishments for incorrect behavior or tone",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-crawling-with-items-in-mouth-e-g-hairbrush-spoon",
+          "label": "Crawling with items in mouth (e.g., hairbrush, spoon)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-earning-permission-for-meals-bathroom-use-or-rest",
+          "label": "Earning permission for meals, bathroom use, or rest",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-following-daily-rituals-or-protocol",
+          "label": "Following daily rituals or protocol",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-structured-speech-rules-e-g-titles-third-person",
+          "label": "Structured speech rules (e.g., titles, third person)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-receiving-correction-when-out-of-line",
+          "label": "Receiving correction when out of line",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-inspection-rituals-or-readiness-checks",
+          "label": "Inspection rituals or readiness checks",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Primal & Bratting",
+      "items": [
+        {
+          "id": "primal-bratting-chase-and-capture-play",
+          "label": "Chase and capture play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-bratting-for-punishment",
+          "label": "Bratting for punishment",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-playful-growling-and-biting",
+          "label": "Playful growling and biting",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-provoking-with-teasing-or-taunts",
+          "label": "Provoking with teasing or taunts",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-escaping-or-hiding-to-encourage-pursuit",
+          "label": "Escaping or hiding to encourage pursuit",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-refusing-commands-just-for-fun",
+          "label": "Refusing commands just for fun",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-provoking-your-partner-to-chase-or-discipline-you",
+          "label": "Provoking your partner to chase or discipline you",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-taunting-or-teasing-as-a-form-of-play",
+          "label": "Taunting or teasing as a form of play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-intentional-resistance-during-power-exchange",
+          "label": "Intentional resistance during power exchange",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-being-caught-and-overpowered",
+          "label": "Being caught and overpowered",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Headspace & Regression",
+      "items": [
+        {
+          "id": "headspace-regression-caregiver-little-regression-play",
+          "label": "Caregiver/little regression play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-using-pacifiers-or-sippy-cups",
+          "label": "Using pacifiers or sippy cups",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-coloring-or-childlike-crafts",
+          "label": "Coloring or childlike crafts",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-stuffed-animal-comfort",
+          "label": "Stuffed animal comfort",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-speaking-in-a-childlike-voice",
+          "label": "Speaking in a childlike voice",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-bedtime-stories-or-lullabies",
+          "label": "Bedtime stories or lullabies",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-entering-altered-headspaces-e-g-prey-pet-little",
+          "label": "Entering altered headspaces (e.g., prey, pet, little)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-regressive-behaviors-as-comfort-coloring-babytalk",
+          "label": "Regressive behaviors as comfort (coloring, babytalk)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-being-cared-for-during-emotional-vulnerability",
+          "label": "Being cared for during emotional vulnerability",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-guided-emotional-headspace-entry",
+          "label": "Guided emotional headspace entry",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Performance & Internal Struggle",
+      "items": [
+        {
+          "id": "performance-internal-struggle-obedience-under-observation",
+          "label": "Obedience under observation",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-speech-restriction-and-self-denial",
+          "label": "Speech restriction and self-denial",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-maintaining-composure-during-humiliation",
+          "label": "Maintaining composure during humiliation",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-obedience-drills-for-an-audience",
+          "label": "Obedience drills for an audience",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-struggling-against-personal-urges",
+          "label": "Struggling against personal urges",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-displaying-submission-despite-conflict",
+          "label": "Displaying submission despite conflict",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-being-told-to-act-normal-while-struggling-internally",
+          "label": "Being told to act normal while struggling internally",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-pleasing-through-high-functioning-obedience",
+          "label": "Pleasing through high-functioning obedience",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-performing-submission-while-masking-resistance",
+          "label": "Performing submission while masking resistance",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-the-pressure-of-appearing-good-while-feeling-conflicted",
+          "label": "The pressure of appearing 'good' while feeling conflicted",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-being-made-to-perform-emotions-on-command-cry-beg-moan",
+          "label": "Being made to perform emotions on command (cry, beg, moan)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-struggling-openly-while-still-obeying",
+          "label": "Struggling openly while still obeying",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-performing-exaggerated-resistance-or-denial",
+          "label": "Performing exaggerated resistance or denial",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-being-punished-for-breaking-character",
+          "label": "Being punished for 'breaking character'",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-putting-on-a-show-for-someone-else-s-pleasure",
+          "label": "Putting on a show for someone else’s pleasure",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-rehearsed-degradation-or-humiliation-scripts",
+          "label": "Rehearsed degradation or humiliation scripts",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Mindfuck & Manipulation",
+      "items": [
+        {
+          "id": "mindfuck-manipulation-confusing-commands-and-reality-shifts",
+          "label": "Confusing commands and reality shifts",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-gaslighting-or-contradictory-cues",
+          "label": "Gaslighting or contradictory cues",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-presenting-false-choices",
+          "label": "Presenting false choices",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-hidden-motives-or-secret-tasks",
+          "label": "Hidden motives or secret tasks",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-illogical-rules-meant-to-confuse",
+          "label": "Illogical rules meant to confuse",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-gaslight-style-scenes-with-consent-and-clarity",
+          "label": "Gaslight-style scenes (with consent and clarity)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-false-threats-or-staged-surprises",
+          "label": "False threats or staged surprises",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-confusing-commands-to-prompt-hesitation",
+          "label": "Confusing commands to prompt hesitation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-emotional-trickery-as-arousal",
+          "label": "Emotional trickery as arousal",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-being-misled-or-deceived-on-purpose-during-play",
+          "label": "Being misled or deceived on purpose during play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-surprise-rule-changes-or-twists-mid-scene",
+          "label": "Surprise rule changes or twists mid-scene",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-false-safeword-games-with-negotiated-limits",
+          "label": "False safeword games (with negotiated limits)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-withholding-or-delaying-aftercare-for-effect",
+          "label": "Withholding or delaying aftercare for effect",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-being-gaslit-or-doubted-in-a-controlled-roleplay",
+          "label": "Being gaslit or doubted in a controlled roleplay",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-told-you-asked-for-this-or-you-love-this-when-resisting",
+          "label": "Told 'you asked for this' or 'you love this' when resisting",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Mouth Play",
+      "items": [
+        {
+          "id": "mouth-play-holding-tools-or-restraints-in-teeth-while-crawling",
+          "label": "Holding tools or restraints in teeth while crawling",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-placing-objects-from-mouth-into-dominant-s-palm",
+          "label": "Placing objects from mouth into Dominant’s palm",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-using-mouth-instead-of-hands-for-service-rituals",
+          "label": "Using mouth instead of hands for service rituals",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-gag-presentation-and-silent-waiting-protocol",
+          "label": "Gag presentation and silent waiting protocol",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-holding-objects-in-teeth-while-crawling",
+          "label": "Holding objects in teeth while crawling",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-returning-items-using-mouth-only",
+          "label": "Returning items using mouth only",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-gag-rituals-or-waiting-silently",
+          "label": "Gag rituals or waiting silently",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-leash-held-in-mouth",
+          "label": "Leash held in mouth",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-being-gagged-or-forced-silent",
+          "label": "Being gagged or forced silent",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-having-to-hold-objects-in-your-mouth-spoon-hairbrush-leash",
+          "label": "Having to hold objects in your mouth (spoon, hairbrush, leash)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-being-used-for-oral-service-without-reciprocal-pleasure",
+          "label": "Being used for oral service without reciprocal pleasure",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-being-fed-by-hand-mouth-to-mouth-or-with-utensils",
+          "label": "Being fed by hand, mouth-to-mouth, or with utensils",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-verbal-control-e-g-only-speak-when-spoken-to",
+          "label": "Verbal control (e.g., only speak when spoken to)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-mouth-as-a-symbol-of-ownership-or-control",
+          "label": "Mouth as a symbol of ownership or control",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Impact Play",
+      "items": [
+        {
+          "id": "impact-play-hand-spanking",
+          "label": "Hand spanking",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "impact-play-paddle-strikes",
+          "label": "Paddle strikes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "impact-play-crop-snaps",
+          "label": "Crop snaps",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "impact-play-flogger-swings",
+          "label": "Flogger swings",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "impact-play-cane-strokes",
+          "label": "Cane strokes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "impact-play-belt-or-strap-hits",
+          "label": "Belt or strap hits",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "impact-play-whip-cracks",
+          "label": "Whip cracks",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "impact-play-preferred-intensity-levels",
+          "label": "Preferred intensity levels",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "impact-play-aftercare-for-bruises",
+          "label": "Aftercare for bruises",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "impact-play-target-body-areas",
+          "label": "Target body areas",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "impact-play-implement-selection",
+          "label": "Implement selection",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Medical Play",
+      "items": [
+        {
+          "id": "medical-play-needle-play",
+          "label": "Needle play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "medical-play-catheter-insertion",
+          "label": "Catheter insertion",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "medical-play-speculum-exams",
+          "label": "Speculum exams",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "medical-play-enema-administration",
+          "label": "Enema administration",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "medical-play-temperature-taking",
+          "label": "Temperature taking",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "medical-play-medical-restraints",
+          "label": "Medical restraints",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "medical-play-doctor-nurse-roleplay",
+          "label": "Doctor/nurse roleplay",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "medical-play-sterilization-procedures",
+          "label": "Sterilization procedures",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "medical-play-professional-vs-roleplay-scenes",
+          "label": "Professional vs roleplay scenes",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "medical-play-consent-for-invasive-acts",
+          "label": "Consent for invasive acts",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "medical-play-access-to-medical-equipment",
+          "label": "Access to medical equipment",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Pet Play",
+      "items": [
+        {
+          "id": "pet-play-puppy-or-kitten-play",
+          "label": "Puppy or kitten play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "pet-play-pony-play",
+          "label": "Pony play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "pet-play-wearing-collar-and-leash",
+          "label": "Wearing collar and leash",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "pet-play-eating-from-a-bowl",
+          "label": "Eating from a bowl",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "pet-play-kenneling-or-caging",
+          "label": "Kenneling or caging",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "pet-play-pet-training-commands",
+          "label": "Pet training commands",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "pet-play-animal-costumes-or-gear",
+          "label": "Animal costumes or gear",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "pet-play-preferred-animal-identities",
+          "label": "Preferred animal identities",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "pet-play-public-vs-private-play",
+          "label": "Public vs private play",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "pet-play-training-style-and-discipline",
+          "label": "Training style and discipline",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "pet-play-use-of-pet-names-and-commands",
+          "label": "Use of pet names and commands",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Body Modification",
+      "items": [
+        {
+          "id": "body-modification-piercings",
+          "label": "Piercings",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-modification-tattoos",
+          "label": "Tattoos",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-modification-branding",
+          "label": "Branding",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-modification-scarification",
+          "label": "Scarification",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-modification-permanent-chastity-devices",
+          "label": "Permanent chastity devices",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-modification-cosmetic-implants",
+          "label": "Cosmetic implants",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-modification-stretching-or-gauges",
+          "label": "Stretching or gauges",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-modification-temporary-vs-permanent-changes",
+          "label": "Temporary vs permanent changes",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-modification-professional-vs-diy-methods",
+          "label": "Professional vs DIY methods",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-modification-body-placement-considerations",
+          "label": "Body placement considerations",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-modification-healing-and-aftercare",
+          "label": "Healing and aftercare",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Relationship Preferences",
+      "items": [
+        {
+          "id": "relationship-preferences-preferred-relationship-style",
+          "label": "Preferred relationship style",
+          "type": "text",
+          "options": [
+            "Monogamous",
+            "Open relationship",
+            "Polyamorous",
+            "No preference"
+          ],
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-relationship-goals",
+          "label": "Relationship goals",
+          "type": "text",
+          "options": [
+            "One night stand",
+            "Short-term play",
+            "Long-term relationship",
+            "Platonic play partners",
+            "Romantic partners",
+            "Kink partners"
+          ],
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-monogamous",
+          "label": "Monogamous",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-polyamorous",
+          "label": "Polyamorous",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-hierarchical-dynamics",
+          "label": "Hierarchical dynamics",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-non-hierarchical-poly",
+          "label": "Non-hierarchical poly",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-solo-poly",
+          "label": "Solo-poly",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-open-with-boundaries",
+          "label": "Open with boundaries",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-closed-but-kinky-with-others",
+          "label": "Closed but kinky with others",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-switch-friendly-dynamics",
+          "label": "Switch-friendly dynamics",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Gender Play & Transformation",
+      "items": [
+        {
+          "id": "gender-play-transformation-crossdressing",
+          "label": "Crossdressing",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-forced-feminization",
+          "label": "Forced feminization",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-forced-masculinization",
+          "label": "Forced masculinization",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-gender-role-reversal",
+          "label": "Gender role reversal",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-pronoun-changes",
+          "label": "Pronoun changes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-voice-or-mannerism-training",
+          "label": "Voice or mannerism training",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-sissy-or-tomboy-persona",
+          "label": "Sissy or tomboy persona",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-preferred-pronouns-and-names",
+          "label": "Preferred pronouns and names",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-public-presentation-comfort",
+          "label": "Public presentation comfort",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-clothing-and-appearance",
+          "label": "Clothing and appearance",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-exploration-of-identity",
+          "label": "Exploration of identity",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Chastity Devices",
+      "items": [
+        {
+          "id": "chastity-devices-wearing-a-chastity-cage-short-term",
+          "label": "Wearing a chastity cage (short term)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-long-term-chastity-training",
+          "label": "Long-term chastity training",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-chastity-device-control-with-permission-to-unlock",
+          "label": "Chastity device control with permission to unlock",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-locked-remotely-by-another-person",
+          "label": "Locked remotely by another person",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-orgasm-denial-enforced-by-chastity",
+          "label": "Orgasm denial enforced by chastity",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-wearing-a-belt-style-chastity-device",
+          "label": "Wearing a belt-style chastity device",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-humiliation-while-locked-in-chastity",
+          "label": "Humiliation while locked in chastity",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-sleep-in-chastity-overnight",
+          "label": "Sleep in chastity (overnight)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-being-teased-while-unable-to-touch-yourself",
+          "label": "Being teased while unable to touch yourself",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-begging-for-release-from-chastity",
+          "label": "Begging for release from chastity",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Shibari & Rope Bondage",
+      "items": [
+        {
+          "id": "shibari-rope-bondage-being-tied-in-aesthetic-rope-patterns-shibari",
+          "label": "Being tied in aesthetic rope patterns (Shibari)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-rope-bondage-for-restraint-and-control",
+          "label": "Rope bondage for restraint and control",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-rope-suspension-partial-or-full",
+          "label": "Rope suspension (partial or full)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-learning-to-tie-rope-as-a-form-of-dominance",
+          "label": "Learning to tie rope as a form of dominance",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-being-tied-in-vulnerable-or-exposing-poses",
+          "label": "Being tied in vulnerable or exposing poses",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-practicing-rope-with-emotional-connection",
+          "label": "Practicing rope with emotional connection",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-enduring-discomfort-for-the-beauty-of-the-rope",
+          "label": "Enduring discomfort for the beauty of the rope",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-being-tied-in-a-mirror-and-told-to-look",
+          "label": "Being tied in a mirror and told to look",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-punishment-ties-e-g-uncomfortable-or-humiliating-positions",
+          "label": "Punishment ties (e.g., uncomfortable or humiliating positions)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-solo-rope-practice-for-mindfulness-or-masochism",
+          "label": "Solo rope practice for mindfulness or masochism",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Cosplay & Identity Play",
+      "items": [
+        {
+          "id": "cosplay-identity-play-dressing-up-in-costumes-for-scenes",
+          "label": "Dressing up in costumes for scenes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "cosplay-identity-play-playing-as-fictional-characters",
+          "label": "Playing as fictional characters",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "cosplay-identity-play-petplay-with-collars-ears-or-tails",
+          "label": "Petplay with collars, ears, or tails",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "cosplay-identity-play-pretending-to-be-a-doll-robot-or-object",
+          "label": "Pretending to be a doll, robot, or object",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "cosplay-identity-play-master-slave-cosplay-dynamic-non-24-7",
+          "label": "Master/slave cosplay dynamic (non-24/7)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "cosplay-identity-play-roleplaying-as-a-fantasy-species-or-non-human",
+          "label": "Roleplaying as a fantasy species or non-human",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "cosplay-identity-play-using-cosplay-to-deepen-power-exchange",
+          "label": "Using cosplay to deepen power exchange",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "cosplay-identity-play-scene-built-around-a-character-s-story-or-world",
+          "label": "Scene built around a character’s story or world",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "cosplay-identity-play-fantasy-uniforms-nurse-teacher-etc",
+          "label": "Fantasy uniforms (nurse, teacher, etc.)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "High-Intensity Kinks (SSC-Aware)",
+      "items": [
+        {
+          "id": "high-intensity-kinks-ssc-aware-intense-breath-play-e-g-smothering-or-pressure",
+          "label": "Intense breath play (e.g., smothering or pressure)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-knife-play-or-blade-play-without-injury",
+          "label": "Knife play or blade play (without injury)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-fear-play-using-known-or-negotiated-triggers",
+          "label": "Fear play using known or negotiated triggers",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-abduction-or-home-invasion-style-roleplay-negotiated",
+          "label": "Abduction or home-invasion style roleplay (negotiated)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-medical-themed-scenes-with-sharp-objects-not-bloodletting",
+          "label": "Medical-themed scenes with sharp objects (not bloodletting)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-sensory-deprivation-with-added-disorientation-or-helplessness",
+          "label": "Sensory deprivation with added disorientation or helplessness",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-scenes-involving-heavy-objectification-or-emotional-manipulation-with-care",
+          "label": "Scenes involving heavy objectification or emotional manipulation (with care)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-mock-interrogation-or-intense-role-pressure",
+          "label": "Mock interrogation or intense role pressure",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-consensual-threats-without-follow-through-e-g-if-you-don-t",
+          "label": "Consensual threats without follow-through (e.g. 'If you don’t...')",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-high-intensity-primal-scenes-involving-struggle-or-fear",
+          "label": "High-intensity primal scenes involving struggle or fear",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Behavioral Play",
+      "items": [
+        {
+          "id": "behavioral-play-assigning-corner-time-or-time-outs",
+          "label": "Assigning corner time or time-outs",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "behavioral-play-writing-lines-or-apology-letters-as-correction",
+          "label": "Writing lines or apology letters as correction",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "behavioral-play-removing-privileges-phone-tv-sweets",
+          "label": "Removing privileges (phone, TV, sweets)",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "behavioral-play-playful-punishments-that-still-reinforce-rules",
+          "label": "Playful punishments that still reinforce rules",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "behavioral-play-lecturing-or-scolding-to-modify-behavior",
+          "label": "Lecturing or scolding to modify behavior",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "behavioral-play-being-placed-in-the-corner-or-given-a-time-out",
+          "label": "Being placed in the corner or given a time-out",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "behavioral-play-writing-lines-or-apology-letters-when-misbehaving",
+          "label": "Writing lines or apology letters when misbehaving",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "behavioral-play-having-privileges-revoked-phone-tv",
+          "label": "Having privileges revoked (phone, TV)",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "behavioral-play-receiving-playful-funishments-for-minor-rule-breaking",
+          "label": "Receiving playful 'funishments' for minor rule-breaking",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "behavioral-play-getting-scolded-or-lectured-for-correction",
+          "label": "Getting scolded or lectured for correction",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "behavioral-play-preferred-style-of-discipline-strict-vs-lenient",
+          "label": "Preferred style of discipline (strict vs lenient)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "behavioral-play-attitude-toward-funishment-vs-serious-correction",
+          "label": "Attitude toward funishment vs serious correction",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "behavioral-play-use-of-behavior-contracts-or-rule-agreements",
+          "label": "Use of behavior contracts or rule agreements",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Appearance Play",
+      "items": [
+        {
+          "id": "appearance-play-choosing-my-partner-s-outfit-for-the-day-or-a-scene",
+          "label": "Choosing my partner’s outfit for the day or a scene",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-selecting-their-underwear-lingerie-or-base-layers",
+          "label": "Selecting their underwear, lingerie, or base layers",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-styling-their-hair-braiding-brushing-tying-etc",
+          "label": "Styling their hair (braiding, brushing, tying, etc.)",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-picking-head-coverings-bonnets-veils-hoods-hats-for-mood-or-protocol",
+          "label": "Picking head coverings (bonnets, veils, hoods, hats) for mood or protocol",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-offering-makeup-polish-or-accessories-as-part-of-ritual-or-play",
+          "label": "Offering makeup, polish, or accessories as part of ritual or play",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-creating-themed-looks-slutty-innocent-doll-like-sharp-etc",
+          "label": "Creating themed looks (slutty, innocent, doll-like, sharp, etc.)",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-dressing-them-in-role-specific-costumes-maid-bunny-doll-etc",
+          "label": "Dressing them in role-specific costumes (maid, bunny, doll, etc.)",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-curating-time-period-or-historical-outfits-e-g-victorian-50s",
+          "label": "Curating time-period or historical outfits (e.g., Victorian, 50s)",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-helping-them-present-more-femme-masc-or-androgynous-by-request",
+          "label": "Helping them present more femme, masc, or androgynous by request",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-coordinating-their-look-with-mine-for-public-or-private-scenes",
+          "label": "Coordinating their look with mine for public or private scenes",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-implementing-a-dress-ritual-or-aesthetic-preparation",
+          "label": "Implementing a “dress ritual” or aesthetic preparation",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-enforcing-a-visual-protocol-e-g-no-bra-heels-required-tied-hair",
+          "label": "Enforcing a visual protocol (e.g., no bra, heels required, tied hair)",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-having-my-outfit-selected-for-me-by-a-partner",
+          "label": "Having my outfit selected for me by a partner",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-wearing-the-underwear-or-lingerie-they-choose",
+          "label": "Wearing the underwear or lingerie they choose",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-having-my-hair-brushed-braided-tied-or-styled-for-them",
+          "label": "Having my hair brushed, braided, tied, or styled for them",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-putting-on-a-head-covering-e-g-bonnet-veil-hood-they-chose",
+          "label": "Putting on a head covering (e.g., bonnet, veil, hood) they chose",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-following-visual-appearance-rules-as-part-of-submission",
+          "label": "Following visual appearance rules as part of submission",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-wearing-makeup-polish-or-accessories-they-request",
+          "label": "Wearing makeup, polish, or accessories they request",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-dressing-to-please-their-vision-cute-filthy-classy-etc",
+          "label": "Dressing to please their vision (cute, filthy, classy, etc.)",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-wearing-roleplay-costumes-or-character-looks",
+          "label": "Wearing roleplay costumes or character looks",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-presenting-in-a-way-that-matches-their-chosen-aesthetic",
+          "label": "Presenting in a way that matches their chosen aesthetic",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-participating-in-dressing-rituals-or-undressing-ceremonies",
+          "label": "Participating in dressing rituals or undressing ceremonies",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-being-admired-for-the-way-i-look-under-their-direction",
+          "label": "Being admired for the way I look under their direction",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-receiving-praise-or-gentle-teasing-about-my-appearance",
+          "label": "Receiving praise or gentle teasing about my appearance",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-cosplay-or-fantasy-looks-anime-game-fairytale-etc",
+          "label": "Cosplay or fantasy looks (anime, game, fairytale, etc.)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-time-period-dress-up-regency-gothic-1920s-etc",
+          "label": "Time-period dress-up (regency, gothic, 1920s, etc.)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-dollification-or-polished-presented-object-aesthetics",
+          "label": "Dollification or polished/presented object aesthetics",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-uniforms-schoolgirl-military-clerical-nurse-etc",
+          "label": "Uniforms (schoolgirl, military, clerical, nurse, etc.)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-hair-based-play-forced-brushing-ribbons-or-tied-styles",
+          "label": "Hair-based play (forced brushing, ribbons, or tied styles)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-head-coverings-or-symbolic-hoods-in-ritualized-dynamics",
+          "label": "Head coverings or symbolic hoods in ritualized dynamics",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-matching-looks-or-coordinated-dress-codes",
+          "label": "Matching looks or coordinated dress codes",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-ritualized-grooming-before-scenes",
+          "label": "Ritualized grooming before scenes",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-praise-or-positive-attention-for-pleasing-visual-display",
+          "label": "Praise or positive attention for pleasing visual display",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-formal-appearance-protocols-for-scenes-or-dynamics",
+          "label": "Formal appearance protocols for scenes or dynamics",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-using-clothing-or-style-to-embody-emotional-or-power-roles",
+          "label": "Using clothing or style to embody emotional or power roles",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Psychology Play",
+      "items": [
+        {
+          "id": "psychology-play-emotional-sadism-giving-teasing-feelings-orchestrating-reactions-savoring-anticipation-without-shame-based-harm",
+          "label": "Emotional Sadism (giving): teasing feelings, orchestrating reactions, savoring anticipation without shame-based harm",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "psychology-play-psychological-control-mind-games-double-binds-deliberate-pacing-and-strategic-ambiguity",
+          "label": "Psychological Control: mind games, double binds, deliberate pacing, and strategic ambiguity",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "psychology-play-sadistic-attention-enjoying-being-the-focal-point-of-a-partner-s-fear-arousal-or-resistance",
+          "label": "Sadistic Attention: enjoying being the focal point of a partner’s fear, arousal, or resistance",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "psychology-play-teasing-humiliation-playful-status-play-without-degradation-or-shame",
+          "label": "Teasing Humiliation: playful status play without degradation or shame",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "psychology-play-emotional-sadism-receiving-enjoying-engineered-emotional-intensity-such-as-fluster-exposure-or-playful-embarrassment",
+          "label": "Emotional Sadism (receiving): enjoying engineered emotional intensity such as fluster, exposure, or playful embarrassment",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychology-play-psychological-control-receiving-arousal-from-being-studied-contained-or-outmaneuvered",
+          "label": "Psychological Control (receiving): arousal from being studied, contained, or outmaneuvered",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychology-play-being-the-focus-enjoying-being-watched-tracked-or-held-in-a-partner-s-intense-focus",
+          "label": "Being the Focus: enjoying being watched, tracked, or held in a partner’s intense focus",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychology-play-teasing-humiliation-receiving-enjoying-playful-embarrassment-or-affectionate-mockery-that-builds-intimacy",
+          "label": "Teasing Humiliation (receiving): enjoying playful embarrassment or affectionate mockery that builds intimacy",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychology-play-prey-attention-neediness-craving-focus-pursuit-or-intense-awareness-from-a-partner",
+          "label": "Prey Attention/Neediness: craving focus, pursuit, or intense awareness from a partner",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychology-play-primal-recognition-being-seen-understood-or-tracked-without-needing-words",
+          "label": "Primal Recognition: being seen, understood, or tracked without needing words",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Breeding",
+      "items": [
+        {
+          "id": "breeding-impregnation-giving-arousal-from-attempting-to-impregnate-a-partner",
+          "label": "Impregnation (giving): arousal from attempting to impregnate a partner",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "breeding-feeding-milk-giving-arousal-from-producing-and-feeding-milk-to-a-partner",
+          "label": "Feeding Milk (giving): arousal from producing and feeding milk to a partner",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "breeding-impregnation-receiving-arousal-from-being-inseminated-pregnancy-risk-or-being-bred",
+          "label": "Impregnation (receiving): arousal from being inseminated, pregnancy risk, or being bred",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "breeding-feeding-milk-receiving-arousal-from-drinking-a-partner-s-milk",
+          "label": "Feeding Milk (receiving): arousal from drinking a partner’s milk",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "breeding-pregnancy-fantasy-erotic-focus-on-pregnancy-mine-partner-s-or-fictional-scenarios",
+          "label": "Pregnancy Fantasy: erotic focus on pregnancy (mine, partner’s, or fictional scenarios)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-primal-breeding-drive-animalistic-instinctual-framing-of-sex-reproduction-territory",
+          "label": "Primal Breeding Drive: animalistic/instinctual framing of sex, reproduction, territory",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-breeding-as-control-ownership-authority-expressed-through-breeding-talk-or-pregnancy-risk",
+          "label": "Breeding as Control: ownership/authority expressed through breeding talk or pregnancy risk",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-creampie-marking-erotic-meaning-placed-on-internal-ejaculation-or-visible-claimed-markers",
+          "label": "Creampie/Marking: erotic meaning placed on internal ejaculation or visible ‘claimed’ markers",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-risk-no-contraception-talk-fantasy-dirty-talk-about-risk-or-breeding-without-actual-risk",
+          "label": "Risk/‘No Contraception’ Talk (fantasy): dirty talk about risk or breeding without actual risk",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-heat-ovulation-tracking-timing-in-heat-roleplay-or-cycle-focused-arousal",
+          "label": "Heat/Ovulation Tracking: timing, ‘in heat’ roleplay, or cycle-focused arousal",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-artificial-insemination-device-play-syringes-cups-or-medical-style-scenarios-consensual-fantasy",
+          "label": "Artificial Insemination/Device Play: syringes, cups, or medical-style scenarios (consensual fantasy)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-breeding-denial-ruined-breeding-building-toward-impregnation-talk-then-denying-or-ruining-it",
+          "label": "Breeding Denial/Ruined Breeding: building toward impregnation talk then denying or ‘ruining’ it",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-pregnancy-body-focus-belly-worship-movement-weight-changes-glow-and-attention",
+          "label": "Pregnancy Body Focus: belly worship, movement/weight changes, glow, and attention",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-pregnancy-protocol-care-protective-rules-pedestal-treatment-dedicated-aftercare",
+          "label": "Pregnancy Protocol/Care: protective rules, pedestal treatment, dedicated aftercare",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-lactation-induction-maintenance-interest-in-inducing-or-sustaining-milk-production",
+          "label": "Lactation Induction/Maintenance: interest in inducing or sustaining milk production",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-milking-scenes-manual-oral-or-pump-based-milking-as-play-or-ritual",
+          "label": "Milking Scenes: manual, oral, or pump-based ‘milking’ as play or ritual",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-contraception-boundaries-preference-to-use-protection-bc-methods-or-simulation-only",
+          "label": "Contraception Boundaries: preference to use protection, BC methods, or simulation-only",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-sti-testing-medical-boundaries-testing-cadence-disclosures-and-comfort-levels",
+          "label": "STI/Testing & Medical Boundaries: testing cadence, disclosures, and comfort levels",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    }
+  ],
+  "kinks": [
+    {
+      "id": "body-part-torture-nipple-clips",
+      "label": "Nipple clips",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-nipple-weights",
+      "label": "Nipple weights",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-nipple-suction-cups",
+      "label": "Nipple suction cups",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-cock-ball-torture-cbt",
+      "label": "Cock, Ball Torture (CBT)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-clit-clips-weights-suction",
+      "label": "Clit clips/weights/suction",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-hair-pulling",
+      "label": "Hair pulling",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-face-slapping",
+      "label": "Face slapping",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-butt-slapping",
+      "label": "Butt slapping",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-breast-slapping",
+      "label": "Breast slapping",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-genital-slapping",
+      "label": "Genital slapping",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "bondage-and-suspension-blindfolds",
+      "label": "Blindfolds",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-bondage-heavy",
+      "label": "Bondage (heavy)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-bondage-light",
+      "label": "Bondage (light)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-immobilisation",
+      "label": "Immobilisation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-bondage-multi-day",
+      "label": "Bondage (multi-day)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-bondage-public-under-clothing",
+      "label": "Bondage (public, under clothing)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-leather-restraints",
+      "label": "Leather restraints",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-chains",
+      "label": "Chains",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-ropes",
+      "label": "Ropes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-intricate-japanese-rope-bondage",
+      "label": "Intricate (Japanese) rope bondage",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-rope-body-harness",
+      "label": "Rope body harness",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-arm-leg-sleeves-armbinders",
+      "label": "Arm & leg sleeves (armbinders)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-harnesses-leather",
+      "label": "Harnesses (leather)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-harnesses-rope",
+      "label": "Harnesses (rope)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-cuffs-leather",
+      "label": "Cuffs (leather)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-cuffs-metal",
+      "label": "Cuffs (metal)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-manacles-irons",
+      "label": "Manacles & Irons",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-gags-cloth",
+      "label": "Gags (cloth)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-gags-rubber",
+      "label": "Gags (rubber)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-gags-tape",
+      "label": "Gags (tape)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-gags-phallic",
+      "label": "Gags (phallic)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-gags-ring",
+      "label": "Gags (ring)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-gags-ball",
+      "label": "Gags (ball)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-mouth-bits",
+      "label": "Mouth bits",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-full-head-hoods",
+      "label": "Full head hoods",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-mummification-saran-wrapping",
+      "label": "Mummification/saran wrapping",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-straight-jackets",
+      "label": "Straight jackets",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-suspension-upright",
+      "label": "Suspension (upright)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-suspension-horizontal",
+      "label": "Suspension (horizontal)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-suspension-inverted",
+      "label": "Suspension (inverted)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-breath-play",
+      "label": "Breath play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-smothering",
+      "label": "Smothering",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-forced-self-breath-control",
+      "label": "Forced self-breath-control",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-gas-mask",
+      "label": "Gas mask",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "breath-play-asphyxiation",
+      "label": "Asphyxiation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Breath Play"
+    },
+    {
+      "id": "breath-play-breath-control",
+      "label": "Breath control",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Breath Play"
+    },
+    {
+      "id": "breath-play-choking",
+      "label": "Choking",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Breath Play"
+    },
+    {
+      "id": "breath-play-drowning",
+      "label": "Drowning",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Breath Play"
+    },
+    {
+      "id": "breath-play-rebreathing-into-a-bag-or-object",
+      "label": "Rebreathing into a bag or object",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Breath Play"
+    },
+    {
+      "id": "breath-play-verbal-control-of-breath-e-g-hold-it-on-command",
+      "label": "Verbal control of breath (e.g., 'hold it' on command)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Breath Play"
+    },
+    {
+      "id": "sexual-activity-licking",
+      "label": "Licking",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-fellatio-cunnilingus",
+      "label": "Fellatio/Cunnilingus",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-swallowing-semen",
+      "label": "Swallowing semen",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-cumming-on-partner",
+      "label": "Cumming on Partner",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-hand-jobs",
+      "label": "Hand jobs",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-anal-sex",
+      "label": "Anal sex",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-anal-plugs-small",
+      "label": "Anal plugs (small)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-anal-plugs-large",
+      "label": "Anal plugs (large)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-anal-beads",
+      "label": "Anal beads",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-vibrator-on-genitals",
+      "label": "Vibrator on genitals",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-fisting",
+      "label": "Fisting",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-oral-anal-play-rimming",
+      "label": "Oral/anal play (rimming)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-double-penetration-oral-and-vaginal",
+      "label": "Double penetration (oral and vaginal)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-double-penetration-oral-and-anal",
+      "label": "Double penetration (oral and anal)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-double-penetration-anal-and-vaginal",
+      "label": "Double penetration (anal and vaginal)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-triple-oral-vaginal-and-anal",
+      "label": "Triple (Oral, Vaginal and Anal)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sensation-play-abrasion",
+      "label": "Abrasion",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-scratching",
+      "label": "Scratching",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-biting",
+      "label": "Biting",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-tickling",
+      "label": "Tickling",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-kissing",
+      "label": "Kissing",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-zapping-e-g-electric-fly-swatter",
+      "label": "Zapping (e.g. electric fly swatter)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-ice-cubes",
+      "label": "Ice cubes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-wax-play",
+      "label": "Wax Play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-fire",
+      "label": "Fire",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-clothespins",
+      "label": "Clothespins",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-needles",
+      "label": "Needles",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-sensory-deprivation",
+      "label": "Sensory deprivation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-physical-overpowering-manhandling",
+      "label": "Physical overpowering / Manhandling",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-figging",
+      "label": "Figging",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "other-feet",
+      "label": "Feet",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-boots",
+      "label": "Boots",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-underwear",
+      "label": "Underwear",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-chastity-devices",
+      "label": "Chastity devices",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-masks",
+      "label": "Masks",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-breeding",
+      "label": "Breeding",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-leather-clothing",
+      "label": "Leather clothing",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-training-protocols-outside-scenes-e-g-etiquette-memory",
+      "label": "Training protocols outside scenes (e.g., etiquette, memory)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-long-distance-training-structure",
+      "label": "Long-distance training/structure",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-scene-journaling-and-reflection",
+      "label": "Scene journaling and reflection",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "roleplaying-fantasy-abandonment",
+      "label": "Fantasy abandonment",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-kidnapping",
+      "label": "Kidnapping",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-interrogation",
+      "label": "Interrogation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-sleep-deprivation",
+      "label": "Sleep deprivation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-cnc",
+      "label": "CNC",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-gang-bang",
+      "label": "Gang bang",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-initiation-rites",
+      "label": "Initiation rites",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-religious-scenes",
+      "label": "Religious scenes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-medical-scenes",
+      "label": "Medical scenes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-prison-scenes",
+      "label": "Prison scenes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-primal-prey",
+      "label": "Primal/Prey",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-schoolroom-scenes",
+      "label": "Schoolroom scenes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-following-orders",
+      "label": "(Following) orders",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-forced-servitude",
+      "label": "Forced servitude",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-restrictive-rules-on-behaviour",
+      "label": "Restrictive rules on behaviour",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-eye-contact-restrictions",
+      "label": "Eye contact restrictions",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-speech-restrictions-when-what-to-whom",
+      "label": "Speech restrictions (when, what, to whom)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-washroom-restrictions",
+      "label": "Washroom restrictions",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-punishments",
+      "label": "Punishments",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-tasks",
+      "label": "Tasks",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-massage",
+      "label": "Massage",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-domestic-tasks",
+      "label": "Domestic tasks",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-serving-food-and-drink",
+      "label": "Serving food and drink",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-personal-care-rituals",
+      "label": "Personal care rituals",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-being-on-call-at-specified-times",
+      "label": "Being on-call at specified times",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-daily-task-assignments",
+      "label": "Daily task assignments",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-corrections-for-imperfection",
+      "label": "Corrections for imperfection",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-uniforms-dress-codes",
+      "label": "Uniforms / Dress codes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-kneeling-posture-presentation",
+      "label": "Kneeling / Posture presentation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-silent-service",
+      "label": "Silent service",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-public-service-at-parties-or-events",
+      "label": "Public service (at parties or events)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-erotic-service-pleasure-on-command-without-seeking-your-own",
+      "label": "Erotic service (pleasure on command, without seeking your own)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "voyeurism-exhibitionism-forced-nudity-private",
+      "label": "Forced nudity (private)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Voyeurism/Exhibitionism"
+    },
+    {
+      "id": "voyeurism-exhibitionism-forced-nudity-around-others",
+      "label": "Forced nudity (around others)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Voyeurism/Exhibitionism"
+    },
+    {
+      "id": "voyeurism-exhibitionism-exhibitionism-friends",
+      "label": "Exhibitionism (friends)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Voyeurism/Exhibitionism"
+    },
+    {
+      "id": "voyeurism-exhibitionism-exhibitionism-strangers",
+      "label": "Exhibitionism (strangers)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Voyeurism/Exhibitionism"
+    },
+    {
+      "id": "voyeurism-exhibitionism-modelling-for-erotic-photos",
+      "label": "Modelling for erotic photos",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Voyeurism/Exhibitionism"
+    },
+    {
+      "id": "voyeurism-exhibitionism-toys-under-clothes-in-public",
+      "label": "Toys under clothes in public",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Voyeurism/Exhibitionism"
+    },
+    {
+      "id": "virtual-long-distance-play-sending-tasks-or-orders-digitally",
+      "label": "Sending tasks or orders digitally",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-recording-dominant-voice-clips-commands-edging-praise-degradation-etc",
+      "label": "Recording dominant voice clips (commands, edging, praise, degradation, etc.)",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-remote-control-of-a-sex-toy",
+      "label": "Remote control of a sex toy",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-monitoring-behavior-via-app-or-shared-doc",
+      "label": "Monitoring behavior via app or shared doc",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-giving-punishment-assignments-remotely",
+      "label": "Giving punishment assignments remotely",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-creating-countdowns-timers-or-denial-periods",
+      "label": "Creating countdowns, timers, or denial periods",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-sending-written-instructions-with-delayed-permissions",
+      "label": "Sending written instructions with delayed permissions",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-creating-custom-video-or-audio-tasks",
+      "label": "Creating custom video or audio tasks",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-voice-message-control-during-scenes",
+      "label": "Voice message control during scenes",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-being-on-call-at-specified-times",
+      "label": "Being on-call at specified times",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-receiving-tasks-or-orders-digitally",
+      "label": "Receiving tasks or orders digitally",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-listening-to-dominant-voice-clips",
+      "label": "Listening to dominant voice clips",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-using-a-remote-controlled-toy-controlled-by-another",
+      "label": "Using a remote-controlled toy controlled by another",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-completing-daily-protocol-assignments",
+      "label": "Completing daily protocol assignments",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-submitting-proof-photo-video-text",
+      "label": "Submitting proof (photo, video, text)",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-following-recorded-or-timed-commands",
+      "label": "Following recorded or timed commands",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-receiving-surprise-instructions",
+      "label": "Receiving surprise instructions",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-hearing-name-praise-spoken-in-a-custom-clip",
+      "label": "Hearing name/praise spoken in a custom clip",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-sending-submissive-voice-clips-obedience-begging-thank-you-messages-affirmations-etc",
+      "label": "Sending submissive voice clips (obedience, begging, thank-you messages, affirmations, etc.)",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-scheduling-digital-rituals-or-reminders",
+      "label": "Scheduling digital rituals or reminders",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-using-training-habit-or-behavior-tracking-apps",
+      "label": "Using training, habit, or behavior-tracking apps",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-online-rituals-digital-kneeling-posture-protocols",
+      "label": "Online rituals (digital kneeling, posture protocols)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-role-based-texting-e-g-use-honorifics-in-chat",
+      "label": "Role-based texting (e.g., \"Use honorifics in chat\")",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-shared-playlists-affirmations-or-mantras",
+      "label": "Shared playlists, affirmations, or mantras",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-countdown-timers-to-next-task-release-or-interaction",
+      "label": "Countdown timers to next task, release, or interaction",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-scheduled-good-morning-night-rituals",
+      "label": "Scheduled good morning/night rituals",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-participating-in-video-call-scenes",
+      "label": "Participating in video call scenes",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-digital-aftercare-texts-voice-images",
+      "label": "Digital aftercare (texts, voice, images)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-sexting-or-digital-roleplay-scenes",
+      "label": "Sexting or digital roleplay scenes",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-voice-notes-or-submissive-dominant-affirmations",
+      "label": "Voice notes or submissive/dominant affirmations",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "communication-playful-and-teasing",
+      "label": "Playful and teasing",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-quiet-and-intense",
+      "label": "Quiet and intense",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-observant-and-intentional",
+      "label": "Observant and intentional",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-praise-heavy",
+      "label": "Praise-heavy",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-blunt-and-efficient",
+      "label": "Blunt and efficient",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-affirming-and-soft",
+      "label": "Affirming and soft",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-psychological-interrogation",
+      "label": "Psychological interrogation",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-verbal-coercion-teasing-traps",
+      "label": "Verbal coercion / teasing traps",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-verbal-misdirection",
+      "label": "Verbal misdirection",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-mocking-shaming",
+      "label": "Mocking / shaming",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-predatory-pacing",
+      "label": "Predatory pacing",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-reluctant-obedience",
+      "label": "Reluctant obedience",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-stammering-submission",
+      "label": "Stammering submission",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-challenging-until-caught",
+      "label": "Challenging until caught",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-quiet-surrender",
+      "label": "Quiet surrender",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-sarcastic-teasing",
+      "label": "Sarcastic teasing",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-provoking-tone",
+      "label": "Provoking tone",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-challenge-based-dialogue",
+      "label": "Challenge-based dialogue",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-double-meaning-banter",
+      "label": "Double-meaning banter",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-soft-spoken-guidance",
+      "label": "Soft-spoken guidance",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-protective-but-firm-tone",
+      "label": "Protective but firm tone",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-emotional-redirection",
+      "label": "Emotional redirection",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-steady-reassurance",
+      "label": "Steady reassurance",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-direct-and-clear",
+      "label": "Direct and clear",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-gentle-and-nurturing",
+      "label": "Gentle and nurturing",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-commanding-and-firm",
+      "label": "Commanding and firm",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-quiet-and-observant",
+      "label": "Quiet and observant",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-instructive-teacher-like",
+      "label": "Instructive / teacher-like",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-emotionally-intense",
+      "label": "Emotionally intense",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-dismissive-withholding",
+      "label": "Dismissive / withholding",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-mocking-sarcastic",
+      "label": "Mocking / sarcastic",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-blunt-tactless",
+      "label": "Blunt / tactless",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-predatory-hunting-tone",
+      "label": "Predatory / hunting tone",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-stalking-or-circling-speech",
+      "label": "Stalking or circling speech",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-you-re-mine-control-language",
+      "label": "You’re mine / control language",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-threatening-consensual",
+      "label": "Threatening (consensual)",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-verbal-cornering-coaxing",
+      "label": "Verbal cornering / coaxing",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-watching-you-unravel",
+      "label": "Watching you unravel",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-cruel-and-cutting",
+      "label": "Cruel and cutting",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-psychological-baiting",
+      "label": "Psychological baiting",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-brat-breaking-language",
+      "label": "Brat-breaking language",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-mock-affection",
+      "label": "Mock affection",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-shaming-or-emotional-edge",
+      "label": "Shaming or emotional edge",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-disappointed-dom-voice",
+      "label": "Disappointed dom voice",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-mild-scolding-mocking-affection",
+      "label": "Mild scolding / mocking affection",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-verbal-power-struggle",
+      "label": "Verbal power struggle",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-challenge-response-dynamics",
+      "label": "Challenge-response dynamics",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-warm-tone-with-expectation",
+      "label": "Warm tone with expectation",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-nurturing-dominance",
+      "label": "Nurturing dominance",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-reassuring-commands",
+      "label": "Reassuring commands",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-phrases-that-work-on-you",
+      "label": "Phrases that work on you",
+      "type": "text",
+      "roles": [
+        "General"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-phrases-you-use-or-like-to-give",
+      "label": "Phrases you use or like to give",
+      "type": "text",
+      "roles": [
+        "General"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-what-helps-you-feel-emotionally-safe",
+      "label": "What helps you feel emotionally safe",
+      "type": "text",
+      "roles": [
+        "General"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-how-you-tend-to-show-affection",
+      "label": "How you tend to show affection",
+      "type": "text",
+      "roles": [
+        "General"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-emotional-check-in-style",
+      "label": "Emotional check-in style",
+      "type": "text",
+      "roles": [
+        "General"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-when-emotionally-activated-i-tend-to",
+      "label": "When emotionally activated, I tend to...",
+      "type": "text",
+      "roles": [
+        "General"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "body-fluids-and-functions-watersports-golden-showers",
+      "label": "Watersports/golden showers",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Fluids and Functions"
+    },
+    {
+      "id": "body-fluids-and-functions-cum",
+      "label": "Cum",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Fluids and Functions"
+    },
+    {
+      "id": "body-fluids-and-functions-blood",
+      "label": "Blood",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Fluids and Functions"
+    },
+    {
+      "id": "body-fluids-and-functions-scat",
+      "label": "Scat",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Fluids and Functions"
+    },
+    {
+      "id": "body-fluids-and-functions-sweat",
+      "label": "Sweat",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Fluids and Functions"
+    },
+    {
+      "id": "body-fluids-and-functions-vomit",
+      "label": "Vomit",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Fluids and Functions"
+    },
+    {
+      "id": "body-fluids-and-functions-tears-crying",
+      "label": "Tears/crying",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Fluids and Functions"
+    },
+    {
+      "id": "psychological-primal-prey-primal-prey",
+      "label": "Primal/Prey",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-conditioning",
+      "label": "Conditioning",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-coc",
+      "label": "COC",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-psycholagny-hands-free-mentally-stimulated-orgasm",
+      "label": "Psycholagny (hands free, mentally stimulated orgasm)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-hypno-play",
+      "label": "Hypno Play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-praise",
+      "label": "Praise",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-degradation",
+      "label": "Degradation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-traditional-primal-prey",
+      "label": "Traditional primal/prey",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-fear-play",
+      "label": "Fear play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-objectification",
+      "label": "Objectification",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-gaslighting",
+      "label": "Gaslighting",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-role-erosion-identity-play-loss-of-self",
+      "label": "Role erosion (identity play / loss of self)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-jealousy-play",
+      "label": "Jealousy play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-manipulation",
+      "label": "Manipulation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "body-part-fetish-play-belly-fucking",
+      "label": "Belly fucking",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-navel-play",
+      "label": "Navel play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-feet-foot-worship",
+      "label": "Feet / Foot worship",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-hands",
+      "label": "Hands",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-hair",
+      "label": "Hair",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-thighs",
+      "label": "Thighs",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-neck",
+      "label": "Neck",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-ears",
+      "label": "Ears",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-belly",
+      "label": "Belly",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-voice-fetish",
+      "label": "Voice fetish",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-nails-makeup-fetish",
+      "label": "Nails / Makeup fetish",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-cuddles",
+      "label": "Cuddles",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-food-play",
+      "label": "Food Play",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-kisses",
+      "label": "Kisses",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-masturbation",
+      "label": "Masturbation",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-romance-affection",
+      "label": "Romance / affection",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-sex-toys",
+      "label": "Sex toys",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-sexting-chat-etc",
+      "label": "Sexting /Chat etc",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-sexting-via-phone-or-video-call",
+      "label": "Sexting via phone or video call",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-strip-tease",
+      "label": "Strip tease",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-vanilla-sex",
+      "label": "Vanilla Sex",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-voice-notes",
+      "label": "Voice Notes",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-shaving-body-hair",
+      "label": "Shaving (body hair)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-sexy-clothing-private",
+      "label": "Sexy clothing (private)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-sexy-clothing-public",
+      "label": "Sexy clothing (public)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-outdoor-scenes",
+      "label": "Outdoor scenes",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-public-exposure",
+      "label": "Public exposure",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-edging",
+      "label": "Edging",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-short-term-denial",
+      "label": "Short term denial",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-long-term-denial",
+      "label": "Long term denial",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-forced-orgasms-overstimulation",
+      "label": "Forced orgasms / Overstimulation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-ruined-orgasms",
+      "label": "Ruined orgasms",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-no-touch-periods",
+      "label": "No touch periods",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-milking",
+      "label": "Milking",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-chastity-devices",
+      "label": "Chastity devices",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-consensual-orgasm-control",
+      "label": "Consensual orgasm control",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-forced-masturbation",
+      "label": "Forced masturbation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "protocol-and-ritual-formal-language",
+      "label": "Formal language",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-greeting-and-departure-rituals-kneeling-verbal-scripts-gestures",
+      "label": "Greeting and departure rituals (kneeling, verbal scripts, gestures)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-requiring-permission-for-things-speech-movement-attire",
+      "label": "Requiring permission for things (speech, movement, attire)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-daily-rituals-morning-check-ins-status-reports-mantra-repetitions",
+      "label": "Daily rituals (morning check-ins, status reports, mantra repetitions)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-specific-postures-for-rest-attention-punishment-waiting",
+      "label": "Specific postures for rest, attention, punishment, waiting",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-restricted-behavior-no-eye-contact-silence-no-questions",
+      "label": "Restricted behavior (no eye contact, silence, no questions)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-ritual-object-use-collar-cuffs-leash-tokens",
+      "label": "Ritual object use (collar, cuffs, leash, tokens)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-tracking-obedience-journals-apps",
+      "label": "Tracking obedience (journals, apps)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-formalized-rules-for-misbehavior-and-correction",
+      "label": "Formalized rules for misbehavior and correction",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-ritualized-aftercare-or-scene-closure",
+      "label": "Ritualized aftercare or scene closure",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-object-retrieval-on-all-fours-with-item-in-mouth",
+      "label": "Object retrieval on all fours with item in mouth",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-fetching-hairbrush-or-punishment-tool-from-dresser-while-crawling",
+      "label": "Fetching hairbrush or punishment tool from dresser while crawling",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-presenting-chosen-discipline-tool-in-kneeling-posture",
+      "label": "Presenting chosen discipline tool in kneeling posture",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-assigned-posture-or-kneeling-positions-as-ritual",
+      "label": "Assigned posture or kneeling positions as ritual",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-requesting-permission-using-specific-protocol-phrases",
+      "label": "Requesting permission using specific protocol phrases",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-carrying-items-in-mouth-as-submissive-gesture",
+      "label": "Carrying items in mouth as submissive gesture",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-crawling-back-with-object-to-dominant-after-retrieval",
+      "label": "Crawling back with object to Dominant after retrieval",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-following-via-nipple-leash-as-protocol-or-punishment",
+      "label": "Following via nipple leash as protocol or punishment",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-crawling-assigned-paths-as-ritual-or-obedience-training",
+      "label": "Crawling assigned paths as ritual or obedience training",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-crawling-rituals-e-g-object-retrieval",
+      "label": "Crawling rituals (e.g., object retrieval)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-carrying-objects-in-mouth-as-obedience",
+      "label": "Carrying objects in mouth as obedience",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-presenting-tools-or-toys-in-posture",
+      "label": "Presenting tools or toys in posture",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-using-honorifics-or-preset-protocol-language",
+      "label": "Using honorifics or preset protocol language",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-greeting-rituals-e-g-kneeling-kissing-feet",
+      "label": "Greeting rituals (e.g., kneeling, kissing feet)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-daily-check-ins-or-structured-reports",
+      "label": "Daily check-ins or structured reports",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-clothing-restrictions-or-uniforms",
+      "label": "Clothing restrictions or uniforms",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-posture-training-sitting-kneeling-standing",
+      "label": "Posture training (sitting, kneeling, standing)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-punishments-for-incorrect-behavior-or-tone",
+      "label": "Punishments for incorrect behavior or tone",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-crawling-with-items-in-mouth-e-g-hairbrush-spoon",
+      "label": "Crawling with items in mouth (e.g., hairbrush, spoon)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-earning-permission-for-meals-bathroom-use-or-rest",
+      "label": "Earning permission for meals, bathroom use, or rest",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-following-daily-rituals-or-protocol",
+      "label": "Following daily rituals or protocol",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-structured-speech-rules-e-g-titles-third-person",
+      "label": "Structured speech rules (e.g., titles, third person)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-receiving-correction-when-out-of-line",
+      "label": "Receiving correction when out of line",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-inspection-rituals-or-readiness-checks",
+      "label": "Inspection rituals or readiness checks",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "primal-bratting-chase-and-capture-play",
+      "label": "Chase and capture play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-bratting-for-punishment",
+      "label": "Bratting for punishment",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-playful-growling-and-biting",
+      "label": "Playful growling and biting",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-provoking-with-teasing-or-taunts",
+      "label": "Provoking with teasing or taunts",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-escaping-or-hiding-to-encourage-pursuit",
+      "label": "Escaping or hiding to encourage pursuit",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-refusing-commands-just-for-fun",
+      "label": "Refusing commands just for fun",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-provoking-your-partner-to-chase-or-discipline-you",
+      "label": "Provoking your partner to chase or discipline you",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-taunting-or-teasing-as-a-form-of-play",
+      "label": "Taunting or teasing as a form of play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-intentional-resistance-during-power-exchange",
+      "label": "Intentional resistance during power exchange",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-being-caught-and-overpowered",
+      "label": "Being caught and overpowered",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "headspace-regression-caregiver-little-regression-play",
+      "label": "Caregiver/little regression play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-using-pacifiers-or-sippy-cups",
+      "label": "Using pacifiers or sippy cups",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-coloring-or-childlike-crafts",
+      "label": "Coloring or childlike crafts",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-stuffed-animal-comfort",
+      "label": "Stuffed animal comfort",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-speaking-in-a-childlike-voice",
+      "label": "Speaking in a childlike voice",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-bedtime-stories-or-lullabies",
+      "label": "Bedtime stories or lullabies",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-entering-altered-headspaces-e-g-prey-pet-little",
+      "label": "Entering altered headspaces (e.g., prey, pet, little)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-regressive-behaviors-as-comfort-coloring-babytalk",
+      "label": "Regressive behaviors as comfort (coloring, babytalk)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-being-cared-for-during-emotional-vulnerability",
+      "label": "Being cared for during emotional vulnerability",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-guided-emotional-headspace-entry",
+      "label": "Guided emotional headspace entry",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "performance-internal-struggle-obedience-under-observation",
+      "label": "Obedience under observation",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-speech-restriction-and-self-denial",
+      "label": "Speech restriction and self-denial",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-maintaining-composure-during-humiliation",
+      "label": "Maintaining composure during humiliation",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-obedience-drills-for-an-audience",
+      "label": "Obedience drills for an audience",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-struggling-against-personal-urges",
+      "label": "Struggling against personal urges",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-displaying-submission-despite-conflict",
+      "label": "Displaying submission despite conflict",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-being-told-to-act-normal-while-struggling-internally",
+      "label": "Being told to act normal while struggling internally",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-pleasing-through-high-functioning-obedience",
+      "label": "Pleasing through high-functioning obedience",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-performing-submission-while-masking-resistance",
+      "label": "Performing submission while masking resistance",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-the-pressure-of-appearing-good-while-feeling-conflicted",
+      "label": "The pressure of appearing 'good' while feeling conflicted",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-being-made-to-perform-emotions-on-command-cry-beg-moan",
+      "label": "Being made to perform emotions on command (cry, beg, moan)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-struggling-openly-while-still-obeying",
+      "label": "Struggling openly while still obeying",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-performing-exaggerated-resistance-or-denial",
+      "label": "Performing exaggerated resistance or denial",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-being-punished-for-breaking-character",
+      "label": "Being punished for 'breaking character'",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-putting-on-a-show-for-someone-else-s-pleasure",
+      "label": "Putting on a show for someone else’s pleasure",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-rehearsed-degradation-or-humiliation-scripts",
+      "label": "Rehearsed degradation or humiliation scripts",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "mindfuck-manipulation-confusing-commands-and-reality-shifts",
+      "label": "Confusing commands and reality shifts",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-gaslighting-or-contradictory-cues",
+      "label": "Gaslighting or contradictory cues",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-presenting-false-choices",
+      "label": "Presenting false choices",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-hidden-motives-or-secret-tasks",
+      "label": "Hidden motives or secret tasks",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-illogical-rules-meant-to-confuse",
+      "label": "Illogical rules meant to confuse",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-gaslight-style-scenes-with-consent-and-clarity",
+      "label": "Gaslight-style scenes (with consent and clarity)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-false-threats-or-staged-surprises",
+      "label": "False threats or staged surprises",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-confusing-commands-to-prompt-hesitation",
+      "label": "Confusing commands to prompt hesitation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-emotional-trickery-as-arousal",
+      "label": "Emotional trickery as arousal",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-being-misled-or-deceived-on-purpose-during-play",
+      "label": "Being misled or deceived on purpose during play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-surprise-rule-changes-or-twists-mid-scene",
+      "label": "Surprise rule changes or twists mid-scene",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-false-safeword-games-with-negotiated-limits",
+      "label": "False safeword games (with negotiated limits)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-withholding-or-delaying-aftercare-for-effect",
+      "label": "Withholding or delaying aftercare for effect",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-being-gaslit-or-doubted-in-a-controlled-roleplay",
+      "label": "Being gaslit or doubted in a controlled roleplay",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-told-you-asked-for-this-or-you-love-this-when-resisting",
+      "label": "Told 'you asked for this' or 'you love this' when resisting",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mouth-play-holding-tools-or-restraints-in-teeth-while-crawling",
+      "label": "Holding tools or restraints in teeth while crawling",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-placing-objects-from-mouth-into-dominant-s-palm",
+      "label": "Placing objects from mouth into Dominant’s palm",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-using-mouth-instead-of-hands-for-service-rituals",
+      "label": "Using mouth instead of hands for service rituals",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-gag-presentation-and-silent-waiting-protocol",
+      "label": "Gag presentation and silent waiting protocol",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-holding-objects-in-teeth-while-crawling",
+      "label": "Holding objects in teeth while crawling",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-returning-items-using-mouth-only",
+      "label": "Returning items using mouth only",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-gag-rituals-or-waiting-silently",
+      "label": "Gag rituals or waiting silently",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-leash-held-in-mouth",
+      "label": "Leash held in mouth",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-being-gagged-or-forced-silent",
+      "label": "Being gagged or forced silent",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-having-to-hold-objects-in-your-mouth-spoon-hairbrush-leash",
+      "label": "Having to hold objects in your mouth (spoon, hairbrush, leash)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-being-used-for-oral-service-without-reciprocal-pleasure",
+      "label": "Being used for oral service without reciprocal pleasure",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-being-fed-by-hand-mouth-to-mouth-or-with-utensils",
+      "label": "Being fed by hand, mouth-to-mouth, or with utensils",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-verbal-control-e-g-only-speak-when-spoken-to",
+      "label": "Verbal control (e.g., only speak when spoken to)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-mouth-as-a-symbol-of-ownership-or-control",
+      "label": "Mouth as a symbol of ownership or control",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "impact-play-hand-spanking",
+      "label": "Hand spanking",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-paddle-strikes",
+      "label": "Paddle strikes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-crop-snaps",
+      "label": "Crop snaps",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-flogger-swings",
+      "label": "Flogger swings",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-cane-strokes",
+      "label": "Cane strokes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-belt-or-strap-hits",
+      "label": "Belt or strap hits",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-whip-cracks",
+      "label": "Whip cracks",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-preferred-intensity-levels",
+      "label": "Preferred intensity levels",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-aftercare-for-bruises",
+      "label": "Aftercare for bruises",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-target-body-areas",
+      "label": "Target body areas",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-implement-selection",
+      "label": "Implement selection",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "medical-play-needle-play",
+      "label": "Needle play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-catheter-insertion",
+      "label": "Catheter insertion",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-speculum-exams",
+      "label": "Speculum exams",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-enema-administration",
+      "label": "Enema administration",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-temperature-taking",
+      "label": "Temperature taking",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-medical-restraints",
+      "label": "Medical restraints",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-doctor-nurse-roleplay",
+      "label": "Doctor/nurse roleplay",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-sterilization-procedures",
+      "label": "Sterilization procedures",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-professional-vs-roleplay-scenes",
+      "label": "Professional vs roleplay scenes",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-consent-for-invasive-acts",
+      "label": "Consent for invasive acts",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-access-to-medical-equipment",
+      "label": "Access to medical equipment",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "pet-play-puppy-or-kitten-play",
+      "label": "Puppy or kitten play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-pony-play",
+      "label": "Pony play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-wearing-collar-and-leash",
+      "label": "Wearing collar and leash",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-eating-from-a-bowl",
+      "label": "Eating from a bowl",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-kenneling-or-caging",
+      "label": "Kenneling or caging",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-pet-training-commands",
+      "label": "Pet training commands",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-animal-costumes-or-gear",
+      "label": "Animal costumes or gear",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-preferred-animal-identities",
+      "label": "Preferred animal identities",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-public-vs-private-play",
+      "label": "Public vs private play",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-training-style-and-discipline",
+      "label": "Training style and discipline",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-use-of-pet-names-and-commands",
+      "label": "Use of pet names and commands",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "body-modification-piercings",
+      "label": "Piercings",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-tattoos",
+      "label": "Tattoos",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-branding",
+      "label": "Branding",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-scarification",
+      "label": "Scarification",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-permanent-chastity-devices",
+      "label": "Permanent chastity devices",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-cosmetic-implants",
+      "label": "Cosmetic implants",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-stretching-or-gauges",
+      "label": "Stretching or gauges",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-temporary-vs-permanent-changes",
+      "label": "Temporary vs permanent changes",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-professional-vs-diy-methods",
+      "label": "Professional vs DIY methods",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-body-placement-considerations",
+      "label": "Body placement considerations",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-healing-and-aftercare",
+      "label": "Healing and aftercare",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "relationship-preferences-preferred-relationship-style",
+      "label": "Preferred relationship style",
+      "type": "text",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-relationship-goals",
+      "label": "Relationship goals",
+      "type": "text",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-monogamous",
+      "label": "Monogamous",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-polyamorous",
+      "label": "Polyamorous",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-hierarchical-dynamics",
+      "label": "Hierarchical dynamics",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-non-hierarchical-poly",
+      "label": "Non-hierarchical poly",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-solo-poly",
+      "label": "Solo-poly",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-open-with-boundaries",
+      "label": "Open with boundaries",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-closed-but-kinky-with-others",
+      "label": "Closed but kinky with others",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-switch-friendly-dynamics",
+      "label": "Switch-friendly dynamics",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "gender-play-transformation-crossdressing",
+      "label": "Crossdressing",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-forced-feminization",
+      "label": "Forced feminization",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-forced-masculinization",
+      "label": "Forced masculinization",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-gender-role-reversal",
+      "label": "Gender role reversal",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-pronoun-changes",
+      "label": "Pronoun changes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-voice-or-mannerism-training",
+      "label": "Voice or mannerism training",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-sissy-or-tomboy-persona",
+      "label": "Sissy or tomboy persona",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-preferred-pronouns-and-names",
+      "label": "Preferred pronouns and names",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-public-presentation-comfort",
+      "label": "Public presentation comfort",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-clothing-and-appearance",
+      "label": "Clothing and appearance",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-exploration-of-identity",
+      "label": "Exploration of identity",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "chastity-devices-wearing-a-chastity-cage-short-term",
+      "label": "Wearing a chastity cage (short term)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-long-term-chastity-training",
+      "label": "Long-term chastity training",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-chastity-device-control-with-permission-to-unlock",
+      "label": "Chastity device control with permission to unlock",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-locked-remotely-by-another-person",
+      "label": "Locked remotely by another person",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-orgasm-denial-enforced-by-chastity",
+      "label": "Orgasm denial enforced by chastity",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-wearing-a-belt-style-chastity-device",
+      "label": "Wearing a belt-style chastity device",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-humiliation-while-locked-in-chastity",
+      "label": "Humiliation while locked in chastity",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-sleep-in-chastity-overnight",
+      "label": "Sleep in chastity (overnight)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-being-teased-while-unable-to-touch-yourself",
+      "label": "Being teased while unable to touch yourself",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-begging-for-release-from-chastity",
+      "label": "Begging for release from chastity",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "shibari-rope-bondage-being-tied-in-aesthetic-rope-patterns-shibari",
+      "label": "Being tied in aesthetic rope patterns (Shibari)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-rope-bondage-for-restraint-and-control",
+      "label": "Rope bondage for restraint and control",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-rope-suspension-partial-or-full",
+      "label": "Rope suspension (partial or full)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-learning-to-tie-rope-as-a-form-of-dominance",
+      "label": "Learning to tie rope as a form of dominance",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-being-tied-in-vulnerable-or-exposing-poses",
+      "label": "Being tied in vulnerable or exposing poses",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-practicing-rope-with-emotional-connection",
+      "label": "Practicing rope with emotional connection",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-enduring-discomfort-for-the-beauty-of-the-rope",
+      "label": "Enduring discomfort for the beauty of the rope",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-being-tied-in-a-mirror-and-told-to-look",
+      "label": "Being tied in a mirror and told to look",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-punishment-ties-e-g-uncomfortable-or-humiliating-positions",
+      "label": "Punishment ties (e.g., uncomfortable or humiliating positions)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-solo-rope-practice-for-mindfulness-or-masochism",
+      "label": "Solo rope practice for mindfulness or masochism",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "cosplay-identity-play-dressing-up-in-costumes-for-scenes",
+      "label": "Dressing up in costumes for scenes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "cosplay-identity-play-playing-as-fictional-characters",
+      "label": "Playing as fictional characters",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "cosplay-identity-play-petplay-with-collars-ears-or-tails",
+      "label": "Petplay with collars, ears, or tails",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "cosplay-identity-play-pretending-to-be-a-doll-robot-or-object",
+      "label": "Pretending to be a doll, robot, or object",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "cosplay-identity-play-master-slave-cosplay-dynamic-non-24-7",
+      "label": "Master/slave cosplay dynamic (non-24/7)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "cosplay-identity-play-roleplaying-as-a-fantasy-species-or-non-human",
+      "label": "Roleplaying as a fantasy species or non-human",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "cosplay-identity-play-using-cosplay-to-deepen-power-exchange",
+      "label": "Using cosplay to deepen power exchange",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "cosplay-identity-play-scene-built-around-a-character-s-story-or-world",
+      "label": "Scene built around a character’s story or world",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "cosplay-identity-play-fantasy-uniforms-nurse-teacher-etc",
+      "label": "Fantasy uniforms (nurse, teacher, etc.)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-intense-breath-play-e-g-smothering-or-pressure",
+      "label": "Intense breath play (e.g., smothering or pressure)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-knife-play-or-blade-play-without-injury",
+      "label": "Knife play or blade play (without injury)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-fear-play-using-known-or-negotiated-triggers",
+      "label": "Fear play using known or negotiated triggers",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-abduction-or-home-invasion-style-roleplay-negotiated",
+      "label": "Abduction or home-invasion style roleplay (negotiated)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-medical-themed-scenes-with-sharp-objects-not-bloodletting",
+      "label": "Medical-themed scenes with sharp objects (not bloodletting)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-sensory-deprivation-with-added-disorientation-or-helplessness",
+      "label": "Sensory deprivation with added disorientation or helplessness",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-scenes-involving-heavy-objectification-or-emotional-manipulation-with-care",
+      "label": "Scenes involving heavy objectification or emotional manipulation (with care)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-mock-interrogation-or-intense-role-pressure",
+      "label": "Mock interrogation or intense role pressure",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-consensual-threats-without-follow-through-e-g-if-you-don-t",
+      "label": "Consensual threats without follow-through (e.g. 'If you don’t...')",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-high-intensity-primal-scenes-involving-struggle-or-fear",
+      "label": "High-intensity primal scenes involving struggle or fear",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "behavioral-play-assigning-corner-time-or-time-outs",
+      "label": "Assigning corner time or time-outs",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-writing-lines-or-apology-letters-as-correction",
+      "label": "Writing lines or apology letters as correction",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-removing-privileges-phone-tv-sweets",
+      "label": "Removing privileges (phone, TV, sweets)",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-playful-punishments-that-still-reinforce-rules",
+      "label": "Playful punishments that still reinforce rules",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-lecturing-or-scolding-to-modify-behavior",
+      "label": "Lecturing or scolding to modify behavior",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-being-placed-in-the-corner-or-given-a-time-out",
+      "label": "Being placed in the corner or given a time-out",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-writing-lines-or-apology-letters-when-misbehaving",
+      "label": "Writing lines or apology letters when misbehaving",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-having-privileges-revoked-phone-tv",
+      "label": "Having privileges revoked (phone, TV)",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-receiving-playful-funishments-for-minor-rule-breaking",
+      "label": "Receiving playful 'funishments' for minor rule-breaking",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-getting-scolded-or-lectured-for-correction",
+      "label": "Getting scolded or lectured for correction",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-preferred-style-of-discipline-strict-vs-lenient",
+      "label": "Preferred style of discipline (strict vs lenient)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-attitude-toward-funishment-vs-serious-correction",
+      "label": "Attitude toward funishment vs serious correction",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-use-of-behavior-contracts-or-rule-agreements",
+      "label": "Use of behavior contracts or rule agreements",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "appearance-play-choosing-my-partner-s-outfit-for-the-day-or-a-scene",
+      "label": "Choosing my partner’s outfit for the day or a scene",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-selecting-their-underwear-lingerie-or-base-layers",
+      "label": "Selecting their underwear, lingerie, or base layers",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-styling-their-hair-braiding-brushing-tying-etc",
+      "label": "Styling their hair (braiding, brushing, tying, etc.)",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-picking-head-coverings-bonnets-veils-hoods-hats-for-mood-or-protocol",
+      "label": "Picking head coverings (bonnets, veils, hoods, hats) for mood or protocol",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-offering-makeup-polish-or-accessories-as-part-of-ritual-or-play",
+      "label": "Offering makeup, polish, or accessories as part of ritual or play",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-creating-themed-looks-slutty-innocent-doll-like-sharp-etc",
+      "label": "Creating themed looks (slutty, innocent, doll-like, sharp, etc.)",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-dressing-them-in-role-specific-costumes-maid-bunny-doll-etc",
+      "label": "Dressing them in role-specific costumes (maid, bunny, doll, etc.)",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-curating-time-period-or-historical-outfits-e-g-victorian-50s",
+      "label": "Curating time-period or historical outfits (e.g., Victorian, 50s)",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-helping-them-present-more-femme-masc-or-androgynous-by-request",
+      "label": "Helping them present more femme, masc, or androgynous by request",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-coordinating-their-look-with-mine-for-public-or-private-scenes",
+      "label": "Coordinating their look with mine for public or private scenes",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-implementing-a-dress-ritual-or-aesthetic-preparation",
+      "label": "Implementing a “dress ritual” or aesthetic preparation",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-enforcing-a-visual-protocol-e-g-no-bra-heels-required-tied-hair",
+      "label": "Enforcing a visual protocol (e.g., no bra, heels required, tied hair)",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-having-my-outfit-selected-for-me-by-a-partner",
+      "label": "Having my outfit selected for me by a partner",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-wearing-the-underwear-or-lingerie-they-choose",
+      "label": "Wearing the underwear or lingerie they choose",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-having-my-hair-brushed-braided-tied-or-styled-for-them",
+      "label": "Having my hair brushed, braided, tied, or styled for them",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-putting-on-a-head-covering-e-g-bonnet-veil-hood-they-chose",
+      "label": "Putting on a head covering (e.g., bonnet, veil, hood) they chose",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-following-visual-appearance-rules-as-part-of-submission",
+      "label": "Following visual appearance rules as part of submission",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-wearing-makeup-polish-or-accessories-they-request",
+      "label": "Wearing makeup, polish, or accessories they request",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-dressing-to-please-their-vision-cute-filthy-classy-etc",
+      "label": "Dressing to please their vision (cute, filthy, classy, etc.)",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-wearing-roleplay-costumes-or-character-looks",
+      "label": "Wearing roleplay costumes or character looks",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-presenting-in-a-way-that-matches-their-chosen-aesthetic",
+      "label": "Presenting in a way that matches their chosen aesthetic",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-participating-in-dressing-rituals-or-undressing-ceremonies",
+      "label": "Participating in dressing rituals or undressing ceremonies",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-being-admired-for-the-way-i-look-under-their-direction",
+      "label": "Being admired for the way I look under their direction",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-receiving-praise-or-gentle-teasing-about-my-appearance",
+      "label": "Receiving praise or gentle teasing about my appearance",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-cosplay-or-fantasy-looks-anime-game-fairytale-etc",
+      "label": "Cosplay or fantasy looks (anime, game, fairytale, etc.)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-time-period-dress-up-regency-gothic-1920s-etc",
+      "label": "Time-period dress-up (regency, gothic, 1920s, etc.)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-dollification-or-polished-presented-object-aesthetics",
+      "label": "Dollification or polished/presented object aesthetics",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-uniforms-schoolgirl-military-clerical-nurse-etc",
+      "label": "Uniforms (schoolgirl, military, clerical, nurse, etc.)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-hair-based-play-forced-brushing-ribbons-or-tied-styles",
+      "label": "Hair-based play (forced brushing, ribbons, or tied styles)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-head-coverings-or-symbolic-hoods-in-ritualized-dynamics",
+      "label": "Head coverings or symbolic hoods in ritualized dynamics",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-matching-looks-or-coordinated-dress-codes",
+      "label": "Matching looks or coordinated dress codes",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-ritualized-grooming-before-scenes",
+      "label": "Ritualized grooming before scenes",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-praise-or-positive-attention-for-pleasing-visual-display",
+      "label": "Praise or positive attention for pleasing visual display",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-formal-appearance-protocols-for-scenes-or-dynamics",
+      "label": "Formal appearance protocols for scenes or dynamics",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-using-clothing-or-style-to-embody-emotional-or-power-roles",
+      "label": "Using clothing or style to embody emotional or power roles",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "psychology-play-emotional-sadism-giving-teasing-feelings-orchestrating-reactions-savoring-anticipation-without-shame-based-harm",
+      "label": "Emotional Sadism (giving): teasing feelings, orchestrating reactions, savoring anticipation without shame-based harm",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-psychological-control-mind-games-double-binds-deliberate-pacing-and-strategic-ambiguity",
+      "label": "Psychological Control: mind games, double binds, deliberate pacing, and strategic ambiguity",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-sadistic-attention-enjoying-being-the-focal-point-of-a-partner-s-fear-arousal-or-resistance",
+      "label": "Sadistic Attention: enjoying being the focal point of a partner’s fear, arousal, or resistance",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-teasing-humiliation-playful-status-play-without-degradation-or-shame",
+      "label": "Teasing Humiliation: playful status play without degradation or shame",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-emotional-sadism-receiving-enjoying-engineered-emotional-intensity-such-as-fluster-exposure-or-playful-embarrassment",
+      "label": "Emotional Sadism (receiving): enjoying engineered emotional intensity such as fluster, exposure, or playful embarrassment",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-psychological-control-receiving-arousal-from-being-studied-contained-or-outmaneuvered",
+      "label": "Psychological Control (receiving): arousal from being studied, contained, or outmaneuvered",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-being-the-focus-enjoying-being-watched-tracked-or-held-in-a-partner-s-intense-focus",
+      "label": "Being the Focus: enjoying being watched, tracked, or held in a partner’s intense focus",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-teasing-humiliation-receiving-enjoying-playful-embarrassment-or-affectionate-mockery-that-builds-intimacy",
+      "label": "Teasing Humiliation (receiving): enjoying playful embarrassment or affectionate mockery that builds intimacy",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-prey-attention-neediness-craving-focus-pursuit-or-intense-awareness-from-a-partner",
+      "label": "Prey Attention/Neediness: craving focus, pursuit, or intense awareness from a partner",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-primal-recognition-being-seen-understood-or-tracked-without-needing-words",
+      "label": "Primal Recognition: being seen, understood, or tracked without needing words",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "breeding-impregnation-giving-arousal-from-attempting-to-impregnate-a-partner",
+      "label": "Impregnation (giving): arousal from attempting to impregnate a partner",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-feeding-milk-giving-arousal-from-producing-and-feeding-milk-to-a-partner",
+      "label": "Feeding Milk (giving): arousal from producing and feeding milk to a partner",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-impregnation-receiving-arousal-from-being-inseminated-pregnancy-risk-or-being-bred",
+      "label": "Impregnation (receiving): arousal from being inseminated, pregnancy risk, or being bred",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-feeding-milk-receiving-arousal-from-drinking-a-partner-s-milk",
+      "label": "Feeding Milk (receiving): arousal from drinking a partner’s milk",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-pregnancy-fantasy-erotic-focus-on-pregnancy-mine-partner-s-or-fictional-scenarios",
+      "label": "Pregnancy Fantasy: erotic focus on pregnancy (mine, partner’s, or fictional scenarios)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-primal-breeding-drive-animalistic-instinctual-framing-of-sex-reproduction-territory",
+      "label": "Primal Breeding Drive: animalistic/instinctual framing of sex, reproduction, territory",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-breeding-as-control-ownership-authority-expressed-through-breeding-talk-or-pregnancy-risk",
+      "label": "Breeding as Control: ownership/authority expressed through breeding talk or pregnancy risk",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-creampie-marking-erotic-meaning-placed-on-internal-ejaculation-or-visible-claimed-markers",
+      "label": "Creampie/Marking: erotic meaning placed on internal ejaculation or visible ‘claimed’ markers",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-risk-no-contraception-talk-fantasy-dirty-talk-about-risk-or-breeding-without-actual-risk",
+      "label": "Risk/‘No Contraception’ Talk (fantasy): dirty talk about risk or breeding without actual risk",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-heat-ovulation-tracking-timing-in-heat-roleplay-or-cycle-focused-arousal",
+      "label": "Heat/Ovulation Tracking: timing, ‘in heat’ roleplay, or cycle-focused arousal",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-artificial-insemination-device-play-syringes-cups-or-medical-style-scenarios-consensual-fantasy",
+      "label": "Artificial Insemination/Device Play: syringes, cups, or medical-style scenarios (consensual fantasy)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-breeding-denial-ruined-breeding-building-toward-impregnation-talk-then-denying-or-ruining-it",
+      "label": "Breeding Denial/Ruined Breeding: building toward impregnation talk then denying or ‘ruining’ it",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-pregnancy-body-focus-belly-worship-movement-weight-changes-glow-and-attention",
+      "label": "Pregnancy Body Focus: belly worship, movement/weight changes, glow, and attention",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-pregnancy-protocol-care-protective-rules-pedestal-treatment-dedicated-aftercare",
+      "label": "Pregnancy Protocol/Care: protective rules, pedestal treatment, dedicated aftercare",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-lactation-induction-maintenance-interest-in-inducing-or-sustaining-milk-production",
+      "label": "Lactation Induction/Maintenance: interest in inducing or sustaining milk production",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-milking-scenes-manual-oral-or-pump-based-milking-as-play-or-ritual",
+      "label": "Milking Scenes: manual, oral, or pump-based ‘milking’ as play or ritual",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-contraception-boundaries-preference-to-use-protection-bc-methods-or-simulation-only",
+      "label": "Contraception Boundaries: preference to use protection, BC methods, or simulation-only",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-sti-testing-medical-boundaries-testing-cadence-disclosures-and-comfort-levels",
+      "label": "STI/Testing & Medical Boundaries: testing cadence, disclosures, and comfort levels",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    }
+  ]
+}

--- a/docs/kinks.json
+++ b/docs/kinks.json
@@ -1,4943 +1,10247 @@
-[
-  {
-    "category": "Body Part Torture",
-    "items": [
-      {
-        "id": "body-part-torture-nipple-clips",
-        "label": "Nipple clips",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-nipple-weights",
-        "label": "Nipple weights",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-nipple-suction-cups",
-        "label": "Nipple suction cups",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-cock-ball-torture-cbt",
-        "label": "Cock, Ball Torture (CBT)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-clit-clips-weights-suction",
-        "label": "Clit clips/weights/suction",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-hair-pulling",
-        "label": "Hair pulling",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-face-slapping",
-        "label": "Face slapping",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-butt-slapping",
-        "label": "Butt slapping",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-breast-slapping",
-        "label": "Breast slapping",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-genital-slapping",
-        "label": "Genital slapping",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
+{
+  "labels": {
+    "cb_169ma": "Time-period dress-up",
+    "cb_2c0f9": "Hair-based play (brushing, ribbons, tying)",
+    "cb_2gxmo": "Uniforms (school, military, nurse, etc.)",
+    "cb_3ozhq": "Praise for pleasing visual display",
+    "cb_4yyxa": "Dollification / polished object aesthetics",
+    "cb_065gv": "Formal appearance protocols",
+    "cb_6jd2f": "Pick lingerie / base layers",
+    "cb_fsnmj": "Praise for pleasing visual display",
+    "cb_gkzbu": "Hair-based play (brushing, ribbons, tying)",
+    "cb_hqakm": "Formal appearance protocols",
+    "cb_ifkmg": "Clothing as power-role signal",
+    "cb_kaku7": "Time-period dress-up",
+    "cb_kgrnn": "Uniforms (school, military, nurse, etc.)",
+    "cb_kua8l": "Dress partner’s outfit",
+    "cb_qflrp": "Dollification / polished object aesthetics",
+    "cb_qw9jg": "Ritualized grooming",
+    "cb_qwnhi": "Head coverings / symbolic hoods",
+    "cb_r7cwr": "Head coverings / symbolic hoods",
+    "cb_rn136": "Clothing as power-role signal",
+    "cb_ss4gf": "Ritualized grooming",
+    "cb_w2dc1": "Coordinated looks / dress codes",
+    "cb_yzegd": "Pick lingerie / base layers",
+    "cb_zsnrb": "Dress partner’s outfit",
+    "cb_zvchg": "Coordinated looks / dress codes"
   },
-  {
-    "category": "Bondage and Suspension",
-    "items": [
-      {
-        "id": "bondage-and-suspension-blindfolds",
-        "label": "Blindfolds",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-bondage-heavy",
-        "label": "Bondage (heavy)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-bondage-light",
-        "label": "Bondage (light)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-immobilisation",
-        "label": "Immobilisation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-bondage-multi-day",
-        "label": "Bondage (multi-day)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-bondage-public-under-clothing",
-        "label": "Bondage (public, under clothing)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-leather-restraints",
-        "label": "Leather restraints",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-chains",
-        "label": "Chains",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-ropes",
-        "label": "Ropes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-intricate-japanese-rope-bondage",
-        "label": "Intricate (Japanese) rope bondage",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-rope-body-harness",
-        "label": "Rope body harness",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-arm-leg-sleeves-armbinders",
-        "label": "Arm & leg sleeves (armbinders)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-harnesses-leather",
-        "label": "Harnesses (leather)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-harnesses-rope",
-        "label": "Harnesses (rope)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-cuffs-leather",
-        "label": "Cuffs (leather)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-cuffs-metal",
-        "label": "Cuffs (metal)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-manacles-irons",
-        "label": "Manacles & Irons",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-gags-cloth",
-        "label": "Gags (cloth)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-gags-rubber",
-        "label": "Gags (rubber)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-gags-tape",
-        "label": "Gags (tape)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-gags-phallic",
-        "label": "Gags (phallic)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-gags-ring",
-        "label": "Gags (ring)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-gags-ball",
-        "label": "Gags (ball)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-mouth-bits",
-        "label": "Mouth bits",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-full-head-hoods",
-        "label": "Full head hoods",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-mummification-saran-wrapping",
-        "label": "Mummification/saran wrapping",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-straight-jackets",
-        "label": "Straight jackets",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-suspension-upright",
-        "label": "Suspension (upright)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-suspension-horizontal",
-        "label": "Suspension (horizontal)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-suspension-inverted",
-        "label": "Suspension (inverted)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-breath-play",
-        "label": "Breath play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-smothering",
-        "label": "Smothering",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-forced-self-breath-control",
-        "label": "Forced self-breath-control",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-gas-mask",
-        "label": "Gas mask",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Breath Play",
-    "items": [
-      {
-        "id": "breath-play-asphyxiation",
-        "label": "Asphyxiation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "breath-play-breath-control",
-        "label": "Breath control",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "breath-play-choking",
-        "label": "Choking",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "breath-play-drowning",
-        "label": "Drowning",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "breath-play-rebreathing-into-a-bag-or-object",
-        "label": "Rebreathing into a bag or object",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "breath-play-verbal-control-of-breath-e-g-hold-it-on-command",
-        "label": "Verbal control of breath (e.g., 'hold it' on command)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Sexual Activity",
-    "items": [
-      {
-        "id": "sexual-activity-licking",
-        "label": "Licking",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-fellatio-cunnilingus",
-        "label": "Fellatio/Cunnilingus",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-swallowing-semen",
-        "label": "Swallowing semen",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-cumming-on-partner",
-        "label": "Cumming on Partner",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-hand-jobs",
-        "label": "Hand jobs",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-anal-sex",
-        "label": "Anal sex",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-anal-plugs-small",
-        "label": "Anal plugs (small)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-anal-plugs-large",
-        "label": "Anal plugs (large)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-anal-beads",
-        "label": "Anal beads",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-vibrator-on-genitals",
-        "label": "Vibrator on genitals",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-fisting",
-        "label": "Fisting",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-oral-anal-play-rimming",
-        "label": "Oral/anal play (rimming)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-double-penetration-oral-and-vaginal",
-        "label": "Double penetration (oral and vaginal)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-double-penetration-oral-and-anal",
-        "label": "Double penetration (oral and anal)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-double-penetration-anal-and-vaginal",
-        "label": "Double penetration (anal and vaginal)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-triple-oral-vaginal-and-anal",
-        "label": "Triple (Oral, Vaginal and Anal)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Sensation Play",
-    "items": [
-      {
-        "id": "sensation-play-abrasion",
-        "label": "Abrasion",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-scratching",
-        "label": "Scratching",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-biting",
-        "label": "Biting",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-tickling",
-        "label": "Tickling",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-kissing",
-        "label": "Kissing",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-zapping-e-g-electric-fly-swatter",
-        "label": "Zapping (e.g. electric fly swatter)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-ice-cubes",
-        "label": "Ice cubes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-wax-play",
-        "label": "Wax Play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-fire",
-        "label": "Fire",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-clothespins",
-        "label": "Clothespins",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-needles",
-        "label": "Needles",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-sensory-deprivation",
-        "label": "Sensory deprivation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-physical-overpowering-manhandling",
-        "label": "Physical overpowering / Manhandling",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-figging",
-        "label": "Figging",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Other",
-    "items": [
-      {
-        "id": "other-feet",
-        "label": "Feet",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-boots",
-        "label": "Boots",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-underwear",
-        "label": "Underwear",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-chastity-devices",
-        "label": "Chastity devices",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-masks",
-        "label": "Masks",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-breeding",
-        "label": "Breeding",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-leather-clothing",
-        "label": "Leather clothing",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-training-protocols-outside-scenes-e-g-etiquette-memory",
-        "label": "Training protocols outside scenes (e.g., etiquette, memory)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-long-distance-training-structure",
-        "label": "Long-distance training/structure",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-scene-journaling-and-reflection",
-        "label": "Scene journaling and reflection",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Roleplaying",
-    "items": [
-      {
-        "id": "roleplaying-fantasy-abandonment",
-        "label": "Fantasy abandonment",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-kidnapping",
-        "label": "Kidnapping",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-interrogation",
-        "label": "Interrogation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-sleep-deprivation",
-        "label": "Sleep deprivation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-cnc",
-        "label": "CNC",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-gang-bang",
-        "label": "Gang bang",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-initiation-rites",
-        "label": "Initiation rites",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-religious-scenes",
-        "label": "Religious scenes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-medical-scenes",
-        "label": "Medical scenes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-prison-scenes",
-        "label": "Prison scenes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-primal-prey",
-        "label": "Primal/Prey",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-schoolroom-scenes",
-        "label": "Schoolroom scenes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Service and Restrictive Behaviour",
-    "items": [
-      {
-        "id": "service-and-restrictive-behaviour-following-orders",
-        "label": "(Following) orders",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-forced-servitude",
-        "label": "Forced servitude",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-restrictive-rules-on-behaviour",
-        "label": "Restrictive rules on behaviour",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-eye-contact-restrictions",
-        "label": "Eye contact restrictions",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-speech-restrictions-when-what-to-whom",
-        "label": "Speech restrictions (when, what, to whom)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-washroom-restrictions",
-        "label": "Washroom restrictions",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-punishments",
-        "label": "Punishments",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-tasks",
-        "label": "Tasks",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-massage",
-        "label": "Massage",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-domestic-tasks",
-        "label": "Domestic tasks",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-serving-food-and-drink",
-        "label": "Serving food and drink",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-personal-care-rituals",
-        "label": "Personal care rituals",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-being-on-call-at-specified-times",
-        "label": "Being on-call at specified times",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-daily-task-assignments",
-        "label": "Daily task assignments",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-corrections-for-imperfection",
-        "label": "Corrections for imperfection",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-uniforms-dress-codes",
-        "label": "Uniforms / Dress codes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-kneeling-posture-presentation",
-        "label": "Kneeling / Posture presentation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-silent-service",
-        "label": "Silent service",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-public-service-at-parties-or-events",
-        "label": "Public service (at parties or events)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-erotic-service-pleasure-on-command-without-seeking-your-own",
-        "label": "Erotic service (pleasure on command, without seeking your own)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Voyeurism/Exhibitionism",
-    "items": [
-      {
-        "id": "voyeurism-exhibitionism-forced-nudity-private",
-        "label": "Forced nudity (private)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "voyeurism-exhibitionism-forced-nudity-around-others",
-        "label": "Forced nudity (around others)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "voyeurism-exhibitionism-exhibitionism-friends",
-        "label": "Exhibitionism (friends)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "voyeurism-exhibitionism-exhibitionism-strangers",
-        "label": "Exhibitionism (strangers)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "voyeurism-exhibitionism-modelling-for-erotic-photos",
-        "label": "Modelling for erotic photos",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "voyeurism-exhibitionism-toys-under-clothes-in-public",
-        "label": "Toys under clothes in public",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Virtual & Long-Distance Play",
-    "items": [
-      {
-        "id": "virtual-long-distance-play-sending-tasks-or-orders-digitally",
-        "label": "Sending tasks or orders digitally",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-recording-dominant-voice-clips-commands-edging-praise-degradation-etc",
-        "label": "Recording dominant voice clips (commands, edging, praise, degradation, etc.)",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-remote-control-of-a-sex-toy",
-        "label": "Remote control of a sex toy",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-monitoring-behavior-via-app-or-shared-doc",
-        "label": "Monitoring behavior via app or shared doc",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-giving-punishment-assignments-remotely",
-        "label": "Giving punishment assignments remotely",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-creating-countdowns-timers-or-denial-periods",
-        "label": "Creating countdowns, timers, or denial periods",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-sending-written-instructions-with-delayed-permissions",
-        "label": "Sending written instructions with delayed permissions",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-creating-custom-video-or-audio-tasks",
-        "label": "Creating custom video or audio tasks",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-voice-message-control-during-scenes",
-        "label": "Voice message control during scenes",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-being-on-call-at-specified-times",
-        "label": "Being on-call at specified times",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-receiving-tasks-or-orders-digitally",
-        "label": "Receiving tasks or orders digitally",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-listening-to-dominant-voice-clips",
-        "label": "Listening to dominant voice clips",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-using-a-remote-controlled-toy-controlled-by-another",
-        "label": "Using a remote-controlled toy controlled by another",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-completing-daily-protocol-assignments",
-        "label": "Completing daily protocol assignments",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-submitting-proof-photo-video-text",
-        "label": "Submitting proof (photo, video, text)",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-following-recorded-or-timed-commands",
-        "label": "Following recorded or timed commands",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-receiving-surprise-instructions",
-        "label": "Receiving surprise instructions",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-hearing-name-praise-spoken-in-a-custom-clip",
-        "label": "Hearing name/praise spoken in a custom clip",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-sending-submissive-voice-clips-obedience-begging-thank-you-messages-affirmations-etc",
-        "label": "Sending submissive voice clips (obedience, begging, thank-you messages, affirmations, etc.)",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-scheduling-digital-rituals-or-reminders",
-        "label": "Scheduling digital rituals or reminders",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-using-training-habit-or-behavior-tracking-apps",
-        "label": "Using training, habit, or behavior-tracking apps",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-online-rituals-digital-kneeling-posture-protocols",
-        "label": "Online rituals (digital kneeling, posture protocols)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-role-based-texting-e-g-use-honorifics-in-chat",
-        "label": "Role-based texting (e.g., \"Use honorifics in chat\")",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-shared-playlists-affirmations-or-mantras",
-        "label": "Shared playlists, affirmations, or mantras",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-countdown-timers-to-next-task-release-or-interaction",
-        "label": "Countdown timers to next task, release, or interaction",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-scheduled-good-morning-night-rituals",
-        "label": "Scheduled good morning/night rituals",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-participating-in-video-call-scenes",
-        "label": "Participating in video call scenes",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-digital-aftercare-texts-voice-images",
-        "label": "Digital aftercare (texts, voice, images)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-sexting-or-digital-roleplay-scenes",
-        "label": "Sexting or digital roleplay scenes",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-voice-notes-or-submissive-dominant-affirmations",
-        "label": "Voice notes or submissive/dominant affirmations",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Communication",
-    "items": [
-      {
-        "id": "communication-playful-and-teasing",
-        "label": "Playful and teasing",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-quiet-and-intense",
-        "label": "Quiet and intense",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-observant-and-intentional",
-        "label": "Observant and intentional",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-praise-heavy",
-        "label": "Praise-heavy",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-blunt-and-efficient",
-        "label": "Blunt and efficient",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-affirming-and-soft",
-        "label": "Affirming and soft",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-psychological-interrogation",
-        "label": "Psychological interrogation",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-verbal-coercion-teasing-traps",
-        "label": "Verbal coercion / teasing traps",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-verbal-misdirection",
-        "label": "Verbal misdirection",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-mocking-shaming",
-        "label": "Mocking / shaming",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-predatory-pacing",
-        "label": "Predatory pacing",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-reluctant-obedience",
-        "label": "Reluctant obedience",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-stammering-submission",
-        "label": "Stammering submission",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-challenging-until-caught",
-        "label": "Challenging until caught",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-quiet-surrender",
-        "label": "Quiet surrender",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-sarcastic-teasing",
-        "label": "Sarcastic teasing",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-provoking-tone",
-        "label": "Provoking tone",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-challenge-based-dialogue",
-        "label": "Challenge-based dialogue",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-double-meaning-banter",
-        "label": "Double-meaning banter",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-soft-spoken-guidance",
-        "label": "Soft-spoken guidance",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-protective-but-firm-tone",
-        "label": "Protective but firm tone",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-emotional-redirection",
-        "label": "Emotional redirection",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-steady-reassurance",
-        "label": "Steady reassurance",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-direct-and-clear",
-        "label": "Direct and clear",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-gentle-and-nurturing",
-        "label": "Gentle and nurturing",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-commanding-and-firm",
-        "label": "Commanding and firm",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-quiet-and-observant",
-        "label": "Quiet and observant",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-instructive-teacher-like",
-        "label": "Instructive / teacher-like",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-emotionally-intense",
-        "label": "Emotionally intense",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-dismissive-withholding",
-        "label": "Dismissive / withholding",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-mocking-sarcastic",
-        "label": "Mocking / sarcastic",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-blunt-tactless",
-        "label": "Blunt / tactless",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-predatory-hunting-tone",
-        "label": "Predatory / hunting tone",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-stalking-or-circling-speech",
-        "label": "Stalking or circling speech",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-you-re-mine-control-language",
-        "label": "You’re mine / control language",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-threatening-consensual",
-        "label": "Threatening (consensual)",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-verbal-cornering-coaxing",
-        "label": "Verbal cornering / coaxing",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-watching-you-unravel",
-        "label": "Watching you unravel",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-cruel-and-cutting",
-        "label": "Cruel and cutting",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-psychological-baiting",
-        "label": "Psychological baiting",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-brat-breaking-language",
-        "label": "Brat-breaking language",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-mock-affection",
-        "label": "Mock affection",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-shaming-or-emotional-edge",
-        "label": "Shaming or emotional edge",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-disappointed-dom-voice",
-        "label": "Disappointed dom voice",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-mild-scolding-mocking-affection",
-        "label": "Mild scolding / mocking affection",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-verbal-power-struggle",
-        "label": "Verbal power struggle",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-challenge-response-dynamics",
-        "label": "Challenge-response dynamics",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-warm-tone-with-expectation",
-        "label": "Warm tone with expectation",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-nurturing-dominance",
-        "label": "Nurturing dominance",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-reassuring-commands",
-        "label": "Reassuring commands",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-phrases-that-work-on-you",
-        "label": "Phrases that work on you",
-        "type": "text",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "communication-phrases-you-use-or-like-to-give",
-        "label": "Phrases you use or like to give",
-        "type": "text",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "communication-what-helps-you-feel-emotionally-safe",
-        "label": "What helps you feel emotionally safe",
-        "type": "text",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "communication-how-you-tend-to-show-affection",
-        "label": "How you tend to show affection",
-        "type": "text",
-        "options": [
-          "Words of affirmation",
-          "Acts of service",
-          "Through teasing / play",
-          "Through obedience",
-          "Through caretaking",
-          "Withholding / teasing love",
-          "Physical closeness",
-          "Quality time"
-        ],
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "communication-emotional-check-in-style",
-        "label": "Emotional check-in style",
-        "type": "text",
-        "options": [
-          "Daily texting",
-          "After-scene debriefs",
-          "Scheduled check-ins",
-          "Mix of text/video check-ins",
-          "In-person check-ins",
-          "Journaling together",
-          "Minimal / low contact",
-          "Other"
-        ],
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "communication-when-emotionally-activated-i-tend-to",
-        "label": "When emotionally activated, I tend to...",
-        "type": "text",
-        "options": [
-          "Shut down",
-          "Overexplain / fawn",
-          "Get sarcastic / prickly",
-          "Spiral internally",
-          "Ask for reassurance",
-          "Withdraw",
-          "Other"
-        ],
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Body Fluids and Functions",
-    "items": [
-      {
-        "id": "body-fluids-and-functions-watersports-golden-showers",
-        "label": "Watersports/golden showers",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-fluids-and-functions-cum",
-        "label": "Cum",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-fluids-and-functions-blood",
-        "label": "Blood",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-fluids-and-functions-scat",
-        "label": "Scat",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-fluids-and-functions-sweat",
-        "label": "Sweat",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-fluids-and-functions-vomit",
-        "label": "Vomit",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-fluids-and-functions-tears-crying",
-        "label": "Tears/crying",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Psychological Primal / Prey",
-    "items": [
-      {
-        "id": "psychological-primal-prey-primal-prey",
-        "label": "Primal/Prey",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-conditioning",
-        "label": "Conditioning",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-coc",
-        "label": "COC",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-psycholagny-hands-free-mentally-stimulated-orgasm",
-        "label": "Psycholagny (hands free, mentally stimulated orgasm)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-hypno-play",
-        "label": "Hypno Play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-praise",
-        "label": "Praise",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-degradation",
-        "label": "Degradation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-traditional-primal-prey",
-        "label": "Traditional primal/prey",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-fear-play",
-        "label": "Fear play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-objectification",
-        "label": "Objectification",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-gaslighting",
-        "label": "Gaslighting",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-role-erosion-identity-play-loss-of-self",
-        "label": "Role erosion (identity play / loss of self)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-jealousy-play",
-        "label": "Jealousy play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-manipulation",
-        "label": "Manipulation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Body Part / Fetish Play",
-    "items": [
-      {
-        "id": "body-part-fetish-play-belly-fucking",
-        "label": "Belly fucking",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-navel-play",
-        "label": "Navel play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-feet-foot-worship",
-        "label": "Feet / Foot worship",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-hands",
-        "label": "Hands",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-hair",
-        "label": "Hair",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-thighs",
-        "label": "Thighs",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-neck",
-        "label": "Neck",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-ears",
-        "label": "Ears",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-belly",
-        "label": "Belly",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-voice-fetish",
-        "label": "Voice fetish",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-nails-makeup-fetish",
-        "label": "Nails / Makeup fetish",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-cuddles",
-        "label": "Cuddles",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-food-play",
-        "label": "Food Play",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-kisses",
-        "label": "Kisses",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-masturbation",
-        "label": "Masturbation",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-romance-affection",
-        "label": "Romance / affection",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-sex-toys",
-        "label": "Sex toys",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-sexting-chat-etc",
-        "label": "Sexting /Chat etc",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-sexting-via-phone-or-video-call",
-        "label": "Sexting via phone or video call",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-strip-tease",
-        "label": "Strip tease",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-vanilla-sex",
-        "label": "Vanilla Sex",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-voice-notes",
-        "label": "Voice Notes",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-shaving-body-hair",
-        "label": "Shaving (body hair)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-sexy-clothing-private",
-        "label": "Sexy clothing (private)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-sexy-clothing-public",
-        "label": "Sexy clothing (public)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-outdoor-scenes",
-        "label": "Outdoor scenes",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-public-exposure",
-        "label": "Public exposure",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Orgasm Control & Sexual Manipulation",
-    "items": [
-      {
-        "id": "orgasm-control-sexual-manipulation-edging",
-        "label": "Edging",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-short-term-denial",
-        "label": "Short term denial",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-long-term-denial",
-        "label": "Long term denial",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-forced-orgasms-overstimulation",
-        "label": "Forced orgasms / Overstimulation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-ruined-orgasms",
-        "label": "Ruined orgasms",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-no-touch-periods",
-        "label": "No touch periods",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-milking",
-        "label": "Milking",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-chastity-devices",
-        "label": "Chastity devices",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-consensual-orgasm-control",
-        "label": "Consensual orgasm control",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-forced-masturbation",
-        "label": "Forced masturbation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Protocol and Ritual",
-    "items": [
-      {
-        "id": "protocol-and-ritual-formal-language",
-        "label": "Formal language",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-greeting-and-departure-rituals-kneeling-verbal-scripts-gestures",
-        "label": "Greeting and departure rituals (kneeling, verbal scripts, gestures)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-requiring-permission-for-things-speech-movement-attire",
-        "label": "Requiring permission for things (speech, movement, attire)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-daily-rituals-morning-check-ins-status-reports-mantra-repetitions",
-        "label": "Daily rituals (morning check-ins, status reports, mantra repetitions)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-specific-postures-for-rest-attention-punishment-waiting",
-        "label": "Specific postures for rest, attention, punishment, waiting",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-restricted-behavior-no-eye-contact-silence-no-questions",
-        "label": "Restricted behavior (no eye contact, silence, no questions)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-ritual-object-use-collar-cuffs-leash-tokens",
-        "label": "Ritual object use (collar, cuffs, leash, tokens)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-tracking-obedience-journals-apps",
-        "label": "Tracking obedience (journals, apps)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-formalized-rules-for-misbehavior-and-correction",
-        "label": "Formalized rules for misbehavior and correction",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-ritualized-aftercare-or-scene-closure",
-        "label": "Ritualized aftercare or scene closure",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-object-retrieval-on-all-fours-with-item-in-mouth",
-        "label": "Object retrieval on all fours with item in mouth",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-fetching-hairbrush-or-punishment-tool-from-dresser-while-crawling",
-        "label": "Fetching hairbrush or punishment tool from dresser while crawling",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-presenting-chosen-discipline-tool-in-kneeling-posture",
-        "label": "Presenting chosen discipline tool in kneeling posture",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-assigned-posture-or-kneeling-positions-as-ritual",
-        "label": "Assigned posture or kneeling positions as ritual",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-requesting-permission-using-specific-protocol-phrases",
-        "label": "Requesting permission using specific protocol phrases",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-carrying-items-in-mouth-as-submissive-gesture",
-        "label": "Carrying items in mouth as submissive gesture",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-crawling-back-with-object-to-dominant-after-retrieval",
-        "label": "Crawling back with object to Dominant after retrieval",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-following-via-nipple-leash-as-protocol-or-punishment",
-        "label": "Following via nipple leash as protocol or punishment",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-crawling-assigned-paths-as-ritual-or-obedience-training",
-        "label": "Crawling assigned paths as ritual or obedience training",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-crawling-rituals-e-g-object-retrieval",
-        "label": "Crawling rituals (e.g., object retrieval)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-carrying-objects-in-mouth-as-obedience",
-        "label": "Carrying objects in mouth as obedience",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-presenting-tools-or-toys-in-posture",
-        "label": "Presenting tools or toys in posture",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-using-honorifics-or-preset-protocol-language",
-        "label": "Using honorifics or preset protocol language",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-greeting-rituals-e-g-kneeling-kissing-feet",
-        "label": "Greeting rituals (e.g., kneeling, kissing feet)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-daily-check-ins-or-structured-reports",
-        "label": "Daily check-ins or structured reports",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-clothing-restrictions-or-uniforms",
-        "label": "Clothing restrictions or uniforms",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-posture-training-sitting-kneeling-standing",
-        "label": "Posture training (sitting, kneeling, standing)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-punishments-for-incorrect-behavior-or-tone",
-        "label": "Punishments for incorrect behavior or tone",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-crawling-with-items-in-mouth-e-g-hairbrush-spoon",
-        "label": "Crawling with items in mouth (e.g., hairbrush, spoon)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-earning-permission-for-meals-bathroom-use-or-rest",
-        "label": "Earning permission for meals, bathroom use, or rest",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-following-daily-rituals-or-protocol",
-        "label": "Following daily rituals or protocol",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-structured-speech-rules-e-g-titles-third-person",
-        "label": "Structured speech rules (e.g., titles, third person)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-receiving-correction-when-out-of-line",
-        "label": "Receiving correction when out of line",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-inspection-rituals-or-readiness-checks",
-        "label": "Inspection rituals or readiness checks",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Primal & Bratting",
-    "items": [
-      {
-        "id": "primal-bratting-chase-and-capture-play",
-        "label": "Chase and capture play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-bratting-for-punishment",
-        "label": "Bratting for punishment",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-playful-growling-and-biting",
-        "label": "Playful growling and biting",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-provoking-with-teasing-or-taunts",
-        "label": "Provoking with teasing or taunts",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-escaping-or-hiding-to-encourage-pursuit",
-        "label": "Escaping or hiding to encourage pursuit",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-refusing-commands-just-for-fun",
-        "label": "Refusing commands just for fun",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-provoking-your-partner-to-chase-or-discipline-you",
-        "label": "Provoking your partner to chase or discipline you",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-taunting-or-teasing-as-a-form-of-play",
-        "label": "Taunting or teasing as a form of play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-intentional-resistance-during-power-exchange",
-        "label": "Intentional resistance during power exchange",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-being-caught-and-overpowered",
-        "label": "Being caught and overpowered",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Headspace & Regression",
-    "items": [
-      {
-        "id": "headspace-regression-caregiver-little-regression-play",
-        "label": "Caregiver/little regression play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-using-pacifiers-or-sippy-cups",
-        "label": "Using pacifiers or sippy cups",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-coloring-or-childlike-crafts",
-        "label": "Coloring or childlike crafts",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-stuffed-animal-comfort",
-        "label": "Stuffed animal comfort",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-speaking-in-a-childlike-voice",
-        "label": "Speaking in a childlike voice",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-bedtime-stories-or-lullabies",
-        "label": "Bedtime stories or lullabies",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-entering-altered-headspaces-e-g-prey-pet-little",
-        "label": "Entering altered headspaces (e.g., prey, pet, little)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-regressive-behaviors-as-comfort-coloring-babytalk",
-        "label": "Regressive behaviors as comfort (coloring, babytalk)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-being-cared-for-during-emotional-vulnerability",
-        "label": "Being cared for during emotional vulnerability",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-guided-emotional-headspace-entry",
-        "label": "Guided emotional headspace entry",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Performance & Internal Struggle",
-    "items": [
-      {
-        "id": "performance-internal-struggle-obedience-under-observation",
-        "label": "Obedience under observation",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-speech-restriction-and-self-denial",
-        "label": "Speech restriction and self-denial",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-maintaining-composure-during-humiliation",
-        "label": "Maintaining composure during humiliation",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-obedience-drills-for-an-audience",
-        "label": "Obedience drills for an audience",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-struggling-against-personal-urges",
-        "label": "Struggling against personal urges",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-displaying-submission-despite-conflict",
-        "label": "Displaying submission despite conflict",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-being-told-to-act-normal-while-struggling-internally",
-        "label": "Being told to act normal while struggling internally",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-pleasing-through-high-functioning-obedience",
-        "label": "Pleasing through high-functioning obedience",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-performing-submission-while-masking-resistance",
-        "label": "Performing submission while masking resistance",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-the-pressure-of-appearing-good-while-feeling-conflicted",
-        "label": "The pressure of appearing 'good' while feeling conflicted",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-being-made-to-perform-emotions-on-command-cry-beg-moan",
-        "label": "Being made to perform emotions on command (cry, beg, moan)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-struggling-openly-while-still-obeying",
-        "label": "Struggling openly while still obeying",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-performing-exaggerated-resistance-or-denial",
-        "label": "Performing exaggerated resistance or denial",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-being-punished-for-breaking-character",
-        "label": "Being punished for 'breaking character'",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-putting-on-a-show-for-someone-else-s-pleasure",
-        "label": "Putting on a show for someone else’s pleasure",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-rehearsed-degradation-or-humiliation-scripts",
-        "label": "Rehearsed degradation or humiliation scripts",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Mindfuck & Manipulation",
-    "items": [
-      {
-        "id": "mindfuck-manipulation-confusing-commands-and-reality-shifts",
-        "label": "Confusing commands and reality shifts",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-gaslighting-or-contradictory-cues",
-        "label": "Gaslighting or contradictory cues",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-presenting-false-choices",
-        "label": "Presenting false choices",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-hidden-motives-or-secret-tasks",
-        "label": "Hidden motives or secret tasks",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-illogical-rules-meant-to-confuse",
-        "label": "Illogical rules meant to confuse",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-gaslight-style-scenes-with-consent-and-clarity",
-        "label": "Gaslight-style scenes (with consent and clarity)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-false-threats-or-staged-surprises",
-        "label": "False threats or staged surprises",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-confusing-commands-to-prompt-hesitation",
-        "label": "Confusing commands to prompt hesitation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-emotional-trickery-as-arousal",
-        "label": "Emotional trickery as arousal",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-being-misled-or-deceived-on-purpose-during-play",
-        "label": "Being misled or deceived on purpose during play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-surprise-rule-changes-or-twists-mid-scene",
-        "label": "Surprise rule changes or twists mid-scene",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-false-safeword-games-with-negotiated-limits",
-        "label": "False safeword games (with negotiated limits)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-withholding-or-delaying-aftercare-for-effect",
-        "label": "Withholding or delaying aftercare for effect",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-being-gaslit-or-doubted-in-a-controlled-roleplay",
-        "label": "Being gaslit or doubted in a controlled roleplay",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-told-you-asked-for-this-or-you-love-this-when-resisting",
-        "label": "Told 'you asked for this' or 'you love this' when resisting",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Mouth Play",
-    "items": [
-      {
-        "id": "mouth-play-holding-tools-or-restraints-in-teeth-while-crawling",
-        "label": "Holding tools or restraints in teeth while crawling",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-placing-objects-from-mouth-into-dominant-s-palm",
-        "label": "Placing objects from mouth into Dominant’s palm",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-using-mouth-instead-of-hands-for-service-rituals",
-        "label": "Using mouth instead of hands for service rituals",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-gag-presentation-and-silent-waiting-protocol",
-        "label": "Gag presentation and silent waiting protocol",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-holding-objects-in-teeth-while-crawling",
-        "label": "Holding objects in teeth while crawling",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-returning-items-using-mouth-only",
-        "label": "Returning items using mouth only",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-gag-rituals-or-waiting-silently",
-        "label": "Gag rituals or waiting silently",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-leash-held-in-mouth",
-        "label": "Leash held in mouth",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-being-gagged-or-forced-silent",
-        "label": "Being gagged or forced silent",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-having-to-hold-objects-in-your-mouth-spoon-hairbrush-leash",
-        "label": "Having to hold objects in your mouth (spoon, hairbrush, leash)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-being-used-for-oral-service-without-reciprocal-pleasure",
-        "label": "Being used for oral service without reciprocal pleasure",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-being-fed-by-hand-mouth-to-mouth-or-with-utensils",
-        "label": "Being fed by hand, mouth-to-mouth, or with utensils",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-verbal-control-e-g-only-speak-when-spoken-to",
-        "label": "Verbal control (e.g., only speak when spoken to)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-mouth-as-a-symbol-of-ownership-or-control",
-        "label": "Mouth as a symbol of ownership or control",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Impact Play",
-    "items": [
-      {
-        "id": "impact-play-hand-spanking",
-        "label": "Hand spanking",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "impact-play-paddle-strikes",
-        "label": "Paddle strikes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "impact-play-crop-snaps",
-        "label": "Crop snaps",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "impact-play-flogger-swings",
-        "label": "Flogger swings",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "impact-play-cane-strokes",
-        "label": "Cane strokes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "impact-play-belt-or-strap-hits",
-        "label": "Belt or strap hits",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "impact-play-whip-cracks",
-        "label": "Whip cracks",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "impact-play-preferred-intensity-levels",
-        "label": "Preferred intensity levels",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "impact-play-aftercare-for-bruises",
-        "label": "Aftercare for bruises",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "impact-play-target-body-areas",
-        "label": "Target body areas",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "impact-play-implement-selection",
-        "label": "Implement selection",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Medical Play",
-    "items": [
-      {
-        "id": "medical-play-needle-play",
-        "label": "Needle play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "medical-play-catheter-insertion",
-        "label": "Catheter insertion",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "medical-play-speculum-exams",
-        "label": "Speculum exams",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "medical-play-enema-administration",
-        "label": "Enema administration",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "medical-play-temperature-taking",
-        "label": "Temperature taking",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "medical-play-medical-restraints",
-        "label": "Medical restraints",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "medical-play-doctor-nurse-roleplay",
-        "label": "Doctor/nurse roleplay",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "medical-play-sterilization-procedures",
-        "label": "Sterilization procedures",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "medical-play-professional-vs-roleplay-scenes",
-        "label": "Professional vs roleplay scenes",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "medical-play-consent-for-invasive-acts",
-        "label": "Consent for invasive acts",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "medical-play-access-to-medical-equipment",
-        "label": "Access to medical equipment",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Pet Play",
-    "items": [
-      {
-        "id": "pet-play-puppy-or-kitten-play",
-        "label": "Puppy or kitten play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "pet-play-pony-play",
-        "label": "Pony play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "pet-play-wearing-collar-and-leash",
-        "label": "Wearing collar and leash",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "pet-play-eating-from-a-bowl",
-        "label": "Eating from a bowl",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "pet-play-kenneling-or-caging",
-        "label": "Kenneling or caging",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "pet-play-pet-training-commands",
-        "label": "Pet training commands",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "pet-play-animal-costumes-or-gear",
-        "label": "Animal costumes or gear",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "pet-play-preferred-animal-identities",
-        "label": "Preferred animal identities",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "pet-play-public-vs-private-play",
-        "label": "Public vs private play",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "pet-play-training-style-and-discipline",
-        "label": "Training style and discipline",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "pet-play-use-of-pet-names-and-commands",
-        "label": "Use of pet names and commands",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Body Modification",
-    "items": [
-      {
-        "id": "body-modification-piercings",
-        "label": "Piercings",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-modification-tattoos",
-        "label": "Tattoos",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-modification-branding",
-        "label": "Branding",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-modification-scarification",
-        "label": "Scarification",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-modification-permanent-chastity-devices",
-        "label": "Permanent chastity devices",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-modification-cosmetic-implants",
-        "label": "Cosmetic implants",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-modification-stretching-or-gauges",
-        "label": "Stretching or gauges",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-modification-temporary-vs-permanent-changes",
-        "label": "Temporary vs permanent changes",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-modification-professional-vs-diy-methods",
-        "label": "Professional vs DIY methods",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-modification-body-placement-considerations",
-        "label": "Body placement considerations",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-modification-healing-and-aftercare",
-        "label": "Healing and aftercare",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Relationship Preferences",
-    "items": [
-      {
-        "id": "relationship-preferences-preferred-relationship-style",
-        "label": "Preferred relationship style",
-        "type": "text",
-        "options": [
-          "Monogamous",
-          "Open relationship",
-          "Polyamorous",
-          "No preference"
-        ],
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-relationship-goals",
-        "label": "Relationship goals",
-        "type": "text",
-        "options": [
-          "One night stand",
-          "Short-term play",
-          "Long-term relationship",
-          "Platonic play partners",
-          "Romantic partners",
-          "Kink partners"
-        ],
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-monogamous",
-        "label": "Monogamous",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-polyamorous",
-        "label": "Polyamorous",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-hierarchical-dynamics",
-        "label": "Hierarchical dynamics",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-non-hierarchical-poly",
-        "label": "Non-hierarchical poly",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-solo-poly",
-        "label": "Solo-poly",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-open-with-boundaries",
-        "label": "Open with boundaries",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-closed-but-kinky-with-others",
-        "label": "Closed but kinky with others",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-switch-friendly-dynamics",
-        "label": "Switch-friendly dynamics",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Gender Play & Transformation",
-    "items": [
-      {
-        "id": "gender-play-transformation-crossdressing",
-        "label": "Crossdressing",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-forced-feminization",
-        "label": "Forced feminization",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-forced-masculinization",
-        "label": "Forced masculinization",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-gender-role-reversal",
-        "label": "Gender role reversal",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-pronoun-changes",
-        "label": "Pronoun changes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-voice-or-mannerism-training",
-        "label": "Voice or mannerism training",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-sissy-or-tomboy-persona",
-        "label": "Sissy or tomboy persona",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-preferred-pronouns-and-names",
-        "label": "Preferred pronouns and names",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-public-presentation-comfort",
-        "label": "Public presentation comfort",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-clothing-and-appearance",
-        "label": "Clothing and appearance",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-exploration-of-identity",
-        "label": "Exploration of identity",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Chastity Devices",
-    "items": [
-      {
-        "id": "chastity-devices-wearing-a-chastity-cage-short-term",
-        "label": "Wearing a chastity cage (short term)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-long-term-chastity-training",
-        "label": "Long-term chastity training",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-chastity-device-control-with-permission-to-unlock",
-        "label": "Chastity device control with permission to unlock",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-locked-remotely-by-another-person",
-        "label": "Locked remotely by another person",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-orgasm-denial-enforced-by-chastity",
-        "label": "Orgasm denial enforced by chastity",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-wearing-a-belt-style-chastity-device",
-        "label": "Wearing a belt-style chastity device",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-humiliation-while-locked-in-chastity",
-        "label": "Humiliation while locked in chastity",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-sleep-in-chastity-overnight",
-        "label": "Sleep in chastity (overnight)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-being-teased-while-unable-to-touch-yourself",
-        "label": "Being teased while unable to touch yourself",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-begging-for-release-from-chastity",
-        "label": "Begging for release from chastity",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Shibari & Rope Bondage",
-    "items": [
-      {
-        "id": "shibari-rope-bondage-being-tied-in-aesthetic-rope-patterns-shibari",
-        "label": "Being tied in aesthetic rope patterns (Shibari)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-rope-bondage-for-restraint-and-control",
-        "label": "Rope bondage for restraint and control",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-rope-suspension-partial-or-full",
-        "label": "Rope suspension (partial or full)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-learning-to-tie-rope-as-a-form-of-dominance",
-        "label": "Learning to tie rope as a form of dominance",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-being-tied-in-vulnerable-or-exposing-poses",
-        "label": "Being tied in vulnerable or exposing poses",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-practicing-rope-with-emotional-connection",
-        "label": "Practicing rope with emotional connection",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-enduring-discomfort-for-the-beauty-of-the-rope",
-        "label": "Enduring discomfort for the beauty of the rope",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-being-tied-in-a-mirror-and-told-to-look",
-        "label": "Being tied in a mirror and told to look",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-punishment-ties-e-g-uncomfortable-or-humiliating-positions",
-        "label": "Punishment ties (e.g., uncomfortable or humiliating positions)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-solo-rope-practice-for-mindfulness-or-masochism",
-        "label": "Solo rope practice for mindfulness or masochism",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Cosplay & Identity Play",
-    "items": [
-      {
-        "id": "cosplay-identity-play-dressing-up-in-costumes-for-scenes",
-        "label": "Dressing up in costumes for scenes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "cosplay-identity-play-playing-as-fictional-characters",
-        "label": "Playing as fictional characters",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "cosplay-identity-play-petplay-with-collars-ears-or-tails",
-        "label": "Petplay with collars, ears, or tails",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "cosplay-identity-play-pretending-to-be-a-doll-robot-or-object",
-        "label": "Pretending to be a doll, robot, or object",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "cosplay-identity-play-master-slave-cosplay-dynamic-non-24-7",
-        "label": "Master/slave cosplay dynamic (non-24/7)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "cosplay-identity-play-roleplaying-as-a-fantasy-species-or-non-human",
-        "label": "Roleplaying as a fantasy species or non-human",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "cosplay-identity-play-using-cosplay-to-deepen-power-exchange",
-        "label": "Using cosplay to deepen power exchange",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "cosplay-identity-play-scene-built-around-a-character-s-story-or-world",
-        "label": "Scene built around a character’s story or world",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "cosplay-identity-play-fantasy-uniforms-nurse-teacher-etc",
-        "label": "Fantasy uniforms (nurse, teacher, etc.)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "High-Intensity Kinks (SSC-Aware)",
-    "items": [
-      {
-        "id": "high-intensity-kinks-ssc-aware-intense-breath-play-e-g-smothering-or-pressure",
-        "label": "Intense breath play (e.g., smothering or pressure)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-knife-play-or-blade-play-without-injury",
-        "label": "Knife play or blade play (without injury)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-fear-play-using-known-or-negotiated-triggers",
-        "label": "Fear play using known or negotiated triggers",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-abduction-or-home-invasion-style-roleplay-negotiated",
-        "label": "Abduction or home-invasion style roleplay (negotiated)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-medical-themed-scenes-with-sharp-objects-not-bloodletting",
-        "label": "Medical-themed scenes with sharp objects (not bloodletting)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-sensory-deprivation-with-added-disorientation-or-helplessness",
-        "label": "Sensory deprivation with added disorientation or helplessness",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-scenes-involving-heavy-objectification-or-emotional-manipulation-with-care",
-        "label": "Scenes involving heavy objectification or emotional manipulation (with care)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-mock-interrogation-or-intense-role-pressure",
-        "label": "Mock interrogation or intense role pressure",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-consensual-threats-without-follow-through-e-g-if-you-don-t",
-        "label": "Consensual threats without follow-through (e.g. 'If you don’t...')",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-high-intensity-primal-scenes-involving-struggle-or-fear",
-        "label": "High-intensity primal scenes involving struggle or fear",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Behavioral Play",
-    "items": [
-      {
-        "id": "behavioral-play-assigning-corner-time-or-time-outs",
-        "label": "Assigning corner time or time-outs",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "behavioral-play-writing-lines-or-apology-letters-as-correction",
-        "label": "Writing lines or apology letters as correction",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "behavioral-play-removing-privileges-phone-tv-sweets",
-        "label": "Removing privileges (phone, TV, sweets)",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "behavioral-play-playful-punishments-that-still-reinforce-rules",
-        "label": "Playful punishments that still reinforce rules",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "behavioral-play-lecturing-or-scolding-to-modify-behavior",
-        "label": "Lecturing or scolding to modify behavior",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "behavioral-play-being-placed-in-the-corner-or-given-a-time-out",
-        "label": "Being placed in the corner or given a time-out",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "behavioral-play-writing-lines-or-apology-letters-when-misbehaving",
-        "label": "Writing lines or apology letters when misbehaving",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "behavioral-play-having-privileges-revoked-phone-tv",
-        "label": "Having privileges revoked (phone, TV)",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "behavioral-play-receiving-playful-funishments-for-minor-rule-breaking",
-        "label": "Receiving playful 'funishments' for minor rule-breaking",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "behavioral-play-getting-scolded-or-lectured-for-correction",
-        "label": "Getting scolded or lectured for correction",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "behavioral-play-preferred-style-of-discipline-strict-vs-lenient",
-        "label": "Preferred style of discipline (strict vs lenient)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "behavioral-play-attitude-toward-funishment-vs-serious-correction",
-        "label": "Attitude toward funishment vs serious correction",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "behavioral-play-use-of-behavior-contracts-or-rule-agreements",
-        "label": "Use of behavior contracts or rule agreements",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Appearance Play",
-    "items": [
-      {
-        "id": "appearance-play-choosing-my-partner-s-outfit-for-the-day-or-a-scene",
-        "label": "Choosing my partner’s outfit for the day or a scene",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-selecting-their-underwear-lingerie-or-base-layers",
-        "label": "Selecting their underwear, lingerie, or base layers",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-styling-their-hair-braiding-brushing-tying-etc",
-        "label": "Styling their hair (braiding, brushing, tying, etc.)",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-picking-head-coverings-bonnets-veils-hoods-hats-for-mood-or-protocol",
-        "label": "Picking head coverings (bonnets, veils, hoods, hats) for mood or protocol",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-offering-makeup-polish-or-accessories-as-part-of-ritual-or-play",
-        "label": "Offering makeup, polish, or accessories as part of ritual or play",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-creating-themed-looks-slutty-innocent-doll-like-sharp-etc",
-        "label": "Creating themed looks (slutty, innocent, doll-like, sharp, etc.)",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-dressing-them-in-role-specific-costumes-maid-bunny-doll-etc",
-        "label": "Dressing them in role-specific costumes (maid, bunny, doll, etc.)",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-curating-time-period-or-historical-outfits-e-g-victorian-50s",
-        "label": "Curating time-period or historical outfits (e.g., Victorian, 50s)",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-helping-them-present-more-femme-masc-or-androgynous-by-request",
-        "label": "Helping them present more femme, masc, or androgynous by request",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-coordinating-their-look-with-mine-for-public-or-private-scenes",
-        "label": "Coordinating their look with mine for public or private scenes",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-implementing-a-dress-ritual-or-aesthetic-preparation",
-        "label": "Implementing a “dress ritual” or aesthetic preparation",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-enforcing-a-visual-protocol-e-g-no-bra-heels-required-tied-hair",
-        "label": "Enforcing a visual protocol (e.g., no bra, heels required, tied hair)",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-having-my-outfit-selected-for-me-by-a-partner",
-        "label": "Having my outfit selected for me by a partner",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-wearing-the-underwear-or-lingerie-they-choose",
-        "label": "Wearing the underwear or lingerie they choose",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-having-my-hair-brushed-braided-tied-or-styled-for-them",
-        "label": "Having my hair brushed, braided, tied, or styled for them",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-putting-on-a-head-covering-e-g-bonnet-veil-hood-they-chose",
-        "label": "Putting on a head covering (e.g., bonnet, veil, hood) they chose",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-following-visual-appearance-rules-as-part-of-submission",
-        "label": "Following visual appearance rules as part of submission",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-wearing-makeup-polish-or-accessories-they-request",
-        "label": "Wearing makeup, polish, or accessories they request",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-dressing-to-please-their-vision-cute-filthy-classy-etc",
-        "label": "Dressing to please their vision (cute, filthy, classy, etc.)",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-wearing-roleplay-costumes-or-character-looks",
-        "label": "Wearing roleplay costumes or character looks",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-presenting-in-a-way-that-matches-their-chosen-aesthetic",
-        "label": "Presenting in a way that matches their chosen aesthetic",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-participating-in-dressing-rituals-or-undressing-ceremonies",
-        "label": "Participating in dressing rituals or undressing ceremonies",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-being-admired-for-the-way-i-look-under-their-direction",
-        "label": "Being admired for the way I look under their direction",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-receiving-praise-or-gentle-teasing-about-my-appearance",
-        "label": "Receiving praise or gentle teasing about my appearance",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-cosplay-or-fantasy-looks-anime-game-fairytale-etc",
-        "label": "Cosplay or fantasy looks (anime, game, fairytale, etc.)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-time-period-dress-up-regency-gothic-1920s-etc",
-        "label": "Time-period dress-up (regency, gothic, 1920s, etc.)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-dollification-or-polished-presented-object-aesthetics",
-        "label": "Dollification or polished/presented object aesthetics",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-uniforms-schoolgirl-military-clerical-nurse-etc",
-        "label": "Uniforms (schoolgirl, military, clerical, nurse, etc.)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-hair-based-play-forced-brushing-ribbons-or-tied-styles",
-        "label": "Hair-based play (forced brushing, ribbons, or tied styles)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-head-coverings-or-symbolic-hoods-in-ritualized-dynamics",
-        "label": "Head coverings or symbolic hoods in ritualized dynamics",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-matching-looks-or-coordinated-dress-codes",
-        "label": "Matching looks or coordinated dress codes",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-ritualized-grooming-before-scenes",
-        "label": "Ritualized grooming before scenes",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-praise-or-positive-attention-for-pleasing-visual-display",
-        "label": "Praise or positive attention for pleasing visual display",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-formal-appearance-protocols-for-scenes-or-dynamics",
-        "label": "Formal appearance protocols for scenes or dynamics",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-using-clothing-or-style-to-embody-emotional-or-power-roles",
-        "label": "Using clothing or style to embody emotional or power roles",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Psychology Play",
-    "items": [
-      {
-        "id": "psychology-play-emotional-sadism-giving-teasing-feelings-orchestrating-reactions-savoring-anticipation-without-shame-based-harm",
-        "label": "Emotional Sadism (giving): teasing feelings, orchestrating reactions, savoring anticipation without shame-based harm",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "psychology-play-psychological-control-mind-games-double-binds-deliberate-pacing-and-strategic-ambiguity",
-        "label": "Psychological Control: mind games, double binds, deliberate pacing, and strategic ambiguity",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "psychology-play-sadistic-attention-enjoying-being-the-focal-point-of-a-partner-s-fear-arousal-or-resistance",
-        "label": "Sadistic Attention: enjoying being the focal point of a partner’s fear, arousal, or resistance",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "psychology-play-teasing-humiliation-playful-status-play-without-degradation-or-shame",
-        "label": "Teasing Humiliation: playful status play without degradation or shame",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "psychology-play-emotional-sadism-receiving-enjoying-engineered-emotional-intensity-such-as-fluster-exposure-or-playful-embarrassment",
-        "label": "Emotional Sadism (receiving): enjoying engineered emotional intensity such as fluster, exposure, or playful embarrassment",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychology-play-psychological-control-receiving-arousal-from-being-studied-contained-or-outmaneuvered",
-        "label": "Psychological Control (receiving): arousal from being studied, contained, or outmaneuvered",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychology-play-being-the-focus-enjoying-being-watched-tracked-or-held-in-a-partner-s-intense-focus",
-        "label": "Being the Focus: enjoying being watched, tracked, or held in a partner’s intense focus",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychology-play-teasing-humiliation-receiving-enjoying-playful-embarrassment-or-affectionate-mockery-that-builds-intimacy",
-        "label": "Teasing Humiliation (receiving): enjoying playful embarrassment or affectionate mockery that builds intimacy",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychology-play-prey-attention-neediness-craving-focus-pursuit-or-intense-awareness-from-a-partner",
-        "label": "Prey Attention/Neediness: craving focus, pursuit, or intense awareness from a partner",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychology-play-primal-recognition-being-seen-understood-or-tracked-without-needing-words",
-        "label": "Primal Recognition: being seen, understood, or tracked without needing words",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Breeding",
-    "items": [
-      {
-        "id": "breeding-impregnation-giving-arousal-from-attempting-to-impregnate-a-partner",
-        "label": "Impregnation (giving): arousal from attempting to impregnate a partner",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "breeding-feeding-milk-giving-arousal-from-producing-and-feeding-milk-to-a-partner",
-        "label": "Feeding Milk (giving): arousal from producing and feeding milk to a partner",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "breeding-impregnation-receiving-arousal-from-being-inseminated-pregnancy-risk-or-being-bred",
-        "label": "Impregnation (receiving): arousal from being inseminated, pregnancy risk, or being bred",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "breeding-feeding-milk-receiving-arousal-from-drinking-a-partner-s-milk",
-        "label": "Feeding Milk (receiving): arousal from drinking a partner’s milk",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "breeding-pregnancy-fantasy-erotic-focus-on-pregnancy-mine-partner-s-or-fictional-scenarios",
-        "label": "Pregnancy Fantasy: erotic focus on pregnancy (mine, partner’s, or fictional scenarios)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-primal-breeding-drive-animalistic-instinctual-framing-of-sex-reproduction-territory",
-        "label": "Primal Breeding Drive: animalistic/instinctual framing of sex, reproduction, territory",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-breeding-as-control-ownership-authority-expressed-through-breeding-talk-or-pregnancy-risk",
-        "label": "Breeding as Control: ownership/authority expressed through breeding talk or pregnancy risk",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-creampie-marking-erotic-meaning-placed-on-internal-ejaculation-or-visible-claimed-markers",
-        "label": "Creampie/Marking: erotic meaning placed on internal ejaculation or visible ‘claimed’ markers",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-risk-no-contraception-talk-fantasy-dirty-talk-about-risk-or-breeding-without-actual-risk",
-        "label": "Risk/‘No Contraception’ Talk (fantasy): dirty talk about risk or breeding without actual risk",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-heat-ovulation-tracking-timing-in-heat-roleplay-or-cycle-focused-arousal",
-        "label": "Heat/Ovulation Tracking: timing, ‘in heat’ roleplay, or cycle-focused arousal",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-artificial-insemination-device-play-syringes-cups-or-medical-style-scenarios-consensual-fantasy",
-        "label": "Artificial Insemination/Device Play: syringes, cups, or medical-style scenarios (consensual fantasy)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-breeding-denial-ruined-breeding-building-toward-impregnation-talk-then-denying-or-ruining-it",
-        "label": "Breeding Denial/Ruined Breeding: building toward impregnation talk then denying or ‘ruining’ it",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-pregnancy-body-focus-belly-worship-movement-weight-changes-glow-and-attention",
-        "label": "Pregnancy Body Focus: belly worship, movement/weight changes, glow, and attention",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-pregnancy-protocol-care-protective-rules-pedestal-treatment-dedicated-aftercare",
-        "label": "Pregnancy Protocol/Care: protective rules, pedestal treatment, dedicated aftercare",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-lactation-induction-maintenance-interest-in-inducing-or-sustaining-milk-production",
-        "label": "Lactation Induction/Maintenance: interest in inducing or sustaining milk production",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-milking-scenes-manual-oral-or-pump-based-milking-as-play-or-ritual",
-        "label": "Milking Scenes: manual, oral, or pump-based ‘milking’ as play or ritual",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-contraception-boundaries-preference-to-use-protection-bc-methods-or-simulation-only",
-        "label": "Contraception Boundaries: preference to use protection, BC methods, or simulation-only",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-sti-testing-medical-boundaries-testing-cadence-disclosures-and-comfort-levels",
-        "label": "STI/Testing & Medical Boundaries: testing cadence, disclosures, and comfort levels",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  }
-]
+  "categories": [
+    {
+      "category": "Body Part Torture",
+      "items": [
+        {
+          "id": "body-part-torture-nipple-clips",
+          "label": "Nipple clips",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-nipple-weights",
+          "label": "Nipple weights",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-nipple-suction-cups",
+          "label": "Nipple suction cups",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-cock-ball-torture-cbt",
+          "label": "Cock, Ball Torture (CBT)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-clit-clips-weights-suction",
+          "label": "Clit clips/weights/suction",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-hair-pulling",
+          "label": "Hair pulling",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-face-slapping",
+          "label": "Face slapping",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-butt-slapping",
+          "label": "Butt slapping",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-breast-slapping",
+          "label": "Breast slapping",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-genital-slapping",
+          "label": "Genital slapping",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Bondage and Suspension",
+      "items": [
+        {
+          "id": "bondage-and-suspension-blindfolds",
+          "label": "Blindfolds",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-bondage-heavy",
+          "label": "Bondage (heavy)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-bondage-light",
+          "label": "Bondage (light)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-immobilisation",
+          "label": "Immobilisation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-bondage-multi-day",
+          "label": "Bondage (multi-day)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-bondage-public-under-clothing",
+          "label": "Bondage (public, under clothing)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-leather-restraints",
+          "label": "Leather restraints",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-chains",
+          "label": "Chains",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-ropes",
+          "label": "Ropes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-intricate-japanese-rope-bondage",
+          "label": "Intricate (Japanese) rope bondage",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-rope-body-harness",
+          "label": "Rope body harness",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-arm-leg-sleeves-armbinders",
+          "label": "Arm & leg sleeves (armbinders)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-harnesses-leather",
+          "label": "Harnesses (leather)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-harnesses-rope",
+          "label": "Harnesses (rope)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-cuffs-leather",
+          "label": "Cuffs (leather)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-cuffs-metal",
+          "label": "Cuffs (metal)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-manacles-irons",
+          "label": "Manacles & Irons",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-gags-cloth",
+          "label": "Gags (cloth)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-gags-rubber",
+          "label": "Gags (rubber)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-gags-tape",
+          "label": "Gags (tape)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-gags-phallic",
+          "label": "Gags (phallic)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-gags-ring",
+          "label": "Gags (ring)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-gags-ball",
+          "label": "Gags (ball)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-mouth-bits",
+          "label": "Mouth bits",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-full-head-hoods",
+          "label": "Full head hoods",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-mummification-saran-wrapping",
+          "label": "Mummification/saran wrapping",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-straight-jackets",
+          "label": "Straight jackets",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-suspension-upright",
+          "label": "Suspension (upright)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-suspension-horizontal",
+          "label": "Suspension (horizontal)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-suspension-inverted",
+          "label": "Suspension (inverted)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-breath-play",
+          "label": "Breath play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-smothering",
+          "label": "Smothering",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-forced-self-breath-control",
+          "label": "Forced self-breath-control",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-gas-mask",
+          "label": "Gas mask",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Breath Play",
+      "items": [
+        {
+          "id": "breath-play-asphyxiation",
+          "label": "Asphyxiation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "breath-play-breath-control",
+          "label": "Breath control",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "breath-play-choking",
+          "label": "Choking",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "breath-play-drowning",
+          "label": "Drowning",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "breath-play-rebreathing-into-a-bag-or-object",
+          "label": "Rebreathing into a bag or object",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "breath-play-verbal-control-of-breath-e-g-hold-it-on-command",
+          "label": "Verbal control of breath (e.g., 'hold it' on command)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Sexual Activity",
+      "items": [
+        {
+          "id": "sexual-activity-licking",
+          "label": "Licking",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-fellatio-cunnilingus",
+          "label": "Fellatio/Cunnilingus",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-swallowing-semen",
+          "label": "Swallowing semen",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-cumming-on-partner",
+          "label": "Cumming on Partner",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-hand-jobs",
+          "label": "Hand jobs",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-anal-sex",
+          "label": "Anal sex",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-anal-plugs-small",
+          "label": "Anal plugs (small)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-anal-plugs-large",
+          "label": "Anal plugs (large)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-anal-beads",
+          "label": "Anal beads",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-vibrator-on-genitals",
+          "label": "Vibrator on genitals",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-fisting",
+          "label": "Fisting",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-oral-anal-play-rimming",
+          "label": "Oral/anal play (rimming)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-double-penetration-oral-and-vaginal",
+          "label": "Double penetration (oral and vaginal)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-double-penetration-oral-and-anal",
+          "label": "Double penetration (oral and anal)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-double-penetration-anal-and-vaginal",
+          "label": "Double penetration (anal and vaginal)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-triple-oral-vaginal-and-anal",
+          "label": "Triple (Oral, Vaginal and Anal)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Sensation Play",
+      "items": [
+        {
+          "id": "sensation-play-abrasion",
+          "label": "Abrasion",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-scratching",
+          "label": "Scratching",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-biting",
+          "label": "Biting",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-tickling",
+          "label": "Tickling",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-kissing",
+          "label": "Kissing",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-zapping-e-g-electric-fly-swatter",
+          "label": "Zapping (e.g. electric fly swatter)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-ice-cubes",
+          "label": "Ice cubes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-wax-play",
+          "label": "Wax Play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-fire",
+          "label": "Fire",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-clothespins",
+          "label": "Clothespins",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-needles",
+          "label": "Needles",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-sensory-deprivation",
+          "label": "Sensory deprivation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-physical-overpowering-manhandling",
+          "label": "Physical overpowering / Manhandling",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-figging",
+          "label": "Figging",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Other",
+      "items": [
+        {
+          "id": "other-feet",
+          "label": "Feet",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-boots",
+          "label": "Boots",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-underwear",
+          "label": "Underwear",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-chastity-devices",
+          "label": "Chastity devices",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-masks",
+          "label": "Masks",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-breeding",
+          "label": "Breeding",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-leather-clothing",
+          "label": "Leather clothing",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-training-protocols-outside-scenes-e-g-etiquette-memory",
+          "label": "Training protocols outside scenes (e.g., etiquette, memory)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-long-distance-training-structure",
+          "label": "Long-distance training/structure",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-scene-journaling-and-reflection",
+          "label": "Scene journaling and reflection",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Roleplaying",
+      "items": [
+        {
+          "id": "roleplaying-fantasy-abandonment",
+          "label": "Fantasy abandonment",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-kidnapping",
+          "label": "Kidnapping",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-interrogation",
+          "label": "Interrogation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-sleep-deprivation",
+          "label": "Sleep deprivation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-cnc",
+          "label": "CNC",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-gang-bang",
+          "label": "Gang bang",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-initiation-rites",
+          "label": "Initiation rites",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-religious-scenes",
+          "label": "Religious scenes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-medical-scenes",
+          "label": "Medical scenes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-prison-scenes",
+          "label": "Prison scenes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-primal-prey",
+          "label": "Primal/Prey",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-schoolroom-scenes",
+          "label": "Schoolroom scenes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Service and Restrictive Behaviour",
+      "items": [
+        {
+          "id": "service-and-restrictive-behaviour-following-orders",
+          "label": "(Following) orders",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-forced-servitude",
+          "label": "Forced servitude",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-restrictive-rules-on-behaviour",
+          "label": "Restrictive rules on behaviour",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-eye-contact-restrictions",
+          "label": "Eye contact restrictions",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-speech-restrictions-when-what-to-whom",
+          "label": "Speech restrictions (when, what, to whom)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-washroom-restrictions",
+          "label": "Washroom restrictions",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-punishments",
+          "label": "Punishments",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-tasks",
+          "label": "Tasks",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-massage",
+          "label": "Massage",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-domestic-tasks",
+          "label": "Domestic tasks",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-serving-food-and-drink",
+          "label": "Serving food and drink",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-personal-care-rituals",
+          "label": "Personal care rituals",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-being-on-call-at-specified-times",
+          "label": "Being on-call at specified times",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-daily-task-assignments",
+          "label": "Daily task assignments",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-corrections-for-imperfection",
+          "label": "Corrections for imperfection",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-uniforms-dress-codes",
+          "label": "Uniforms / Dress codes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-kneeling-posture-presentation",
+          "label": "Kneeling / Posture presentation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-silent-service",
+          "label": "Silent service",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-public-service-at-parties-or-events",
+          "label": "Public service (at parties or events)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-erotic-service-pleasure-on-command-without-seeking-your-own",
+          "label": "Erotic service (pleasure on command, without seeking your own)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Voyeurism/Exhibitionism",
+      "items": [
+        {
+          "id": "voyeurism-exhibitionism-forced-nudity-private",
+          "label": "Forced nudity (private)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "voyeurism-exhibitionism-forced-nudity-around-others",
+          "label": "Forced nudity (around others)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "voyeurism-exhibitionism-exhibitionism-friends",
+          "label": "Exhibitionism (friends)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "voyeurism-exhibitionism-exhibitionism-strangers",
+          "label": "Exhibitionism (strangers)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "voyeurism-exhibitionism-modelling-for-erotic-photos",
+          "label": "Modelling for erotic photos",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "voyeurism-exhibitionism-toys-under-clothes-in-public",
+          "label": "Toys under clothes in public",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Virtual & Long-Distance Play",
+      "items": [
+        {
+          "id": "virtual-long-distance-play-sending-tasks-or-orders-digitally",
+          "label": "Sending tasks or orders digitally",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-recording-dominant-voice-clips-commands-edging-praise-degradation-etc",
+          "label": "Recording dominant voice clips (commands, edging, praise, degradation, etc.)",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-remote-control-of-a-sex-toy",
+          "label": "Remote control of a sex toy",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-monitoring-behavior-via-app-or-shared-doc",
+          "label": "Monitoring behavior via app or shared doc",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-giving-punishment-assignments-remotely",
+          "label": "Giving punishment assignments remotely",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-creating-countdowns-timers-or-denial-periods",
+          "label": "Creating countdowns, timers, or denial periods",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-sending-written-instructions-with-delayed-permissions",
+          "label": "Sending written instructions with delayed permissions",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-creating-custom-video-or-audio-tasks",
+          "label": "Creating custom video or audio tasks",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-voice-message-control-during-scenes",
+          "label": "Voice message control during scenes",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-being-on-call-at-specified-times",
+          "label": "Being on-call at specified times",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-receiving-tasks-or-orders-digitally",
+          "label": "Receiving tasks or orders digitally",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-listening-to-dominant-voice-clips",
+          "label": "Listening to dominant voice clips",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-using-a-remote-controlled-toy-controlled-by-another",
+          "label": "Using a remote-controlled toy controlled by another",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-completing-daily-protocol-assignments",
+          "label": "Completing daily protocol assignments",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-submitting-proof-photo-video-text",
+          "label": "Submitting proof (photo, video, text)",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-following-recorded-or-timed-commands",
+          "label": "Following recorded or timed commands",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-receiving-surprise-instructions",
+          "label": "Receiving surprise instructions",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-hearing-name-praise-spoken-in-a-custom-clip",
+          "label": "Hearing name/praise spoken in a custom clip",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-sending-submissive-voice-clips-obedience-begging-thank-you-messages-affirmations-etc",
+          "label": "Sending submissive voice clips (obedience, begging, thank-you messages, affirmations, etc.)",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-scheduling-digital-rituals-or-reminders",
+          "label": "Scheduling digital rituals or reminders",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-using-training-habit-or-behavior-tracking-apps",
+          "label": "Using training, habit, or behavior-tracking apps",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-online-rituals-digital-kneeling-posture-protocols",
+          "label": "Online rituals (digital kneeling, posture protocols)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-role-based-texting-e-g-use-honorifics-in-chat",
+          "label": "Role-based texting (e.g., \"Use honorifics in chat\")",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-shared-playlists-affirmations-or-mantras",
+          "label": "Shared playlists, affirmations, or mantras",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-countdown-timers-to-next-task-release-or-interaction",
+          "label": "Countdown timers to next task, release, or interaction",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-scheduled-good-morning-night-rituals",
+          "label": "Scheduled good morning/night rituals",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-participating-in-video-call-scenes",
+          "label": "Participating in video call scenes",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-digital-aftercare-texts-voice-images",
+          "label": "Digital aftercare (texts, voice, images)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-sexting-or-digital-roleplay-scenes",
+          "label": "Sexting or digital roleplay scenes",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-voice-notes-or-submissive-dominant-affirmations",
+          "label": "Voice notes or submissive/dominant affirmations",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Communication",
+      "items": [
+        {
+          "id": "communication-playful-and-teasing",
+          "label": "Playful and teasing",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-quiet-and-intense",
+          "label": "Quiet and intense",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-observant-and-intentional",
+          "label": "Observant and intentional",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-praise-heavy",
+          "label": "Praise-heavy",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-blunt-and-efficient",
+          "label": "Blunt and efficient",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-affirming-and-soft",
+          "label": "Affirming and soft",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-psychological-interrogation",
+          "label": "Psychological interrogation",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-verbal-coercion-teasing-traps",
+          "label": "Verbal coercion / teasing traps",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-verbal-misdirection",
+          "label": "Verbal misdirection",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-mocking-shaming",
+          "label": "Mocking / shaming",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-predatory-pacing",
+          "label": "Predatory pacing",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-reluctant-obedience",
+          "label": "Reluctant obedience",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-stammering-submission",
+          "label": "Stammering submission",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-challenging-until-caught",
+          "label": "Challenging until caught",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-quiet-surrender",
+          "label": "Quiet surrender",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-sarcastic-teasing",
+          "label": "Sarcastic teasing",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-provoking-tone",
+          "label": "Provoking tone",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-challenge-based-dialogue",
+          "label": "Challenge-based dialogue",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-double-meaning-banter",
+          "label": "Double-meaning banter",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-soft-spoken-guidance",
+          "label": "Soft-spoken guidance",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-protective-but-firm-tone",
+          "label": "Protective but firm tone",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-emotional-redirection",
+          "label": "Emotional redirection",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-steady-reassurance",
+          "label": "Steady reassurance",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-direct-and-clear",
+          "label": "Direct and clear",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-gentle-and-nurturing",
+          "label": "Gentle and nurturing",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-commanding-and-firm",
+          "label": "Commanding and firm",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-quiet-and-observant",
+          "label": "Quiet and observant",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-instructive-teacher-like",
+          "label": "Instructive / teacher-like",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-emotionally-intense",
+          "label": "Emotionally intense",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-dismissive-withholding",
+          "label": "Dismissive / withholding",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-mocking-sarcastic",
+          "label": "Mocking / sarcastic",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-blunt-tactless",
+          "label": "Blunt / tactless",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-predatory-hunting-tone",
+          "label": "Predatory / hunting tone",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-stalking-or-circling-speech",
+          "label": "Stalking or circling speech",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-you-re-mine-control-language",
+          "label": "You’re mine / control language",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-threatening-consensual",
+          "label": "Threatening (consensual)",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-verbal-cornering-coaxing",
+          "label": "Verbal cornering / coaxing",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-watching-you-unravel",
+          "label": "Watching you unravel",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-cruel-and-cutting",
+          "label": "Cruel and cutting",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-psychological-baiting",
+          "label": "Psychological baiting",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-brat-breaking-language",
+          "label": "Brat-breaking language",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-mock-affection",
+          "label": "Mock affection",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-shaming-or-emotional-edge",
+          "label": "Shaming or emotional edge",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-disappointed-dom-voice",
+          "label": "Disappointed dom voice",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-mild-scolding-mocking-affection",
+          "label": "Mild scolding / mocking affection",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-verbal-power-struggle",
+          "label": "Verbal power struggle",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-challenge-response-dynamics",
+          "label": "Challenge-response dynamics",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-warm-tone-with-expectation",
+          "label": "Warm tone with expectation",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-nurturing-dominance",
+          "label": "Nurturing dominance",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-reassuring-commands",
+          "label": "Reassuring commands",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-phrases-that-work-on-you",
+          "label": "Phrases that work on you",
+          "type": "text",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "communication-phrases-you-use-or-like-to-give",
+          "label": "Phrases you use or like to give",
+          "type": "text",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "communication-what-helps-you-feel-emotionally-safe",
+          "label": "What helps you feel emotionally safe",
+          "type": "text",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "communication-how-you-tend-to-show-affection",
+          "label": "How you tend to show affection",
+          "type": "text",
+          "options": [
+            "Words of affirmation",
+            "Acts of service",
+            "Through teasing / play",
+            "Through obedience",
+            "Through caretaking",
+            "Withholding / teasing love",
+            "Physical closeness",
+            "Quality time"
+          ],
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "communication-emotional-check-in-style",
+          "label": "Emotional check-in style",
+          "type": "text",
+          "options": [
+            "Daily texting",
+            "After-scene debriefs",
+            "Scheduled check-ins",
+            "Mix of text/video check-ins",
+            "In-person check-ins",
+            "Journaling together",
+            "Minimal / low contact",
+            "Other"
+          ],
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "communication-when-emotionally-activated-i-tend-to",
+          "label": "When emotionally activated, I tend to...",
+          "type": "text",
+          "options": [
+            "Shut down",
+            "Overexplain / fawn",
+            "Get sarcastic / prickly",
+            "Spiral internally",
+            "Ask for reassurance",
+            "Withdraw",
+            "Other"
+          ],
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Body Fluids and Functions",
+      "items": [
+        {
+          "id": "body-fluids-and-functions-watersports-golden-showers",
+          "label": "Watersports/golden showers",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-fluids-and-functions-cum",
+          "label": "Cum",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-fluids-and-functions-blood",
+          "label": "Blood",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-fluids-and-functions-scat",
+          "label": "Scat",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-fluids-and-functions-sweat",
+          "label": "Sweat",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-fluids-and-functions-vomit",
+          "label": "Vomit",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-fluids-and-functions-tears-crying",
+          "label": "Tears/crying",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Psychological Primal / Prey",
+      "items": [
+        {
+          "id": "psychological-primal-prey-primal-prey",
+          "label": "Primal/Prey",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-conditioning",
+          "label": "Conditioning",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-coc",
+          "label": "COC",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-psycholagny-hands-free-mentally-stimulated-orgasm",
+          "label": "Psycholagny (hands free, mentally stimulated orgasm)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-hypno-play",
+          "label": "Hypno Play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-praise",
+          "label": "Praise",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-degradation",
+          "label": "Degradation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-traditional-primal-prey",
+          "label": "Traditional primal/prey",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-fear-play",
+          "label": "Fear play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-objectification",
+          "label": "Objectification",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-gaslighting",
+          "label": "Gaslighting",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-role-erosion-identity-play-loss-of-self",
+          "label": "Role erosion (identity play / loss of self)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-jealousy-play",
+          "label": "Jealousy play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-manipulation",
+          "label": "Manipulation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Body Part / Fetish Play",
+      "items": [
+        {
+          "id": "body-part-fetish-play-belly-fucking",
+          "label": "Belly fucking",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-navel-play",
+          "label": "Navel play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-feet-foot-worship",
+          "label": "Feet / Foot worship",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-hands",
+          "label": "Hands",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-hair",
+          "label": "Hair",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-thighs",
+          "label": "Thighs",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-neck",
+          "label": "Neck",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-ears",
+          "label": "Ears",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-belly",
+          "label": "Belly",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-voice-fetish",
+          "label": "Voice fetish",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-nails-makeup-fetish",
+          "label": "Nails / Makeup fetish",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-cuddles",
+          "label": "Cuddles",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-food-play",
+          "label": "Food Play",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-kisses",
+          "label": "Kisses",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-masturbation",
+          "label": "Masturbation",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-romance-affection",
+          "label": "Romance / affection",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-sex-toys",
+          "label": "Sex toys",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-sexting-chat-etc",
+          "label": "Sexting /Chat etc",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-sexting-via-phone-or-video-call",
+          "label": "Sexting via phone or video call",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-strip-tease",
+          "label": "Strip tease",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-vanilla-sex",
+          "label": "Vanilla Sex",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-voice-notes",
+          "label": "Voice Notes",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-shaving-body-hair",
+          "label": "Shaving (body hair)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-sexy-clothing-private",
+          "label": "Sexy clothing (private)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-sexy-clothing-public",
+          "label": "Sexy clothing (public)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-outdoor-scenes",
+          "label": "Outdoor scenes",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-public-exposure",
+          "label": "Public exposure",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Orgasm Control & Sexual Manipulation",
+      "items": [
+        {
+          "id": "orgasm-control-sexual-manipulation-edging",
+          "label": "Edging",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-short-term-denial",
+          "label": "Short term denial",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-long-term-denial",
+          "label": "Long term denial",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-forced-orgasms-overstimulation",
+          "label": "Forced orgasms / Overstimulation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-ruined-orgasms",
+          "label": "Ruined orgasms",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-no-touch-periods",
+          "label": "No touch periods",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-milking",
+          "label": "Milking",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-chastity-devices",
+          "label": "Chastity devices",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-consensual-orgasm-control",
+          "label": "Consensual orgasm control",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-forced-masturbation",
+          "label": "Forced masturbation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Protocol and Ritual",
+      "items": [
+        {
+          "id": "protocol-and-ritual-formal-language",
+          "label": "Formal language",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-greeting-and-departure-rituals-kneeling-verbal-scripts-gestures",
+          "label": "Greeting and departure rituals (kneeling, verbal scripts, gestures)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-requiring-permission-for-things-speech-movement-attire",
+          "label": "Requiring permission for things (speech, movement, attire)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-daily-rituals-morning-check-ins-status-reports-mantra-repetitions",
+          "label": "Daily rituals (morning check-ins, status reports, mantra repetitions)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-specific-postures-for-rest-attention-punishment-waiting",
+          "label": "Specific postures for rest, attention, punishment, waiting",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-restricted-behavior-no-eye-contact-silence-no-questions",
+          "label": "Restricted behavior (no eye contact, silence, no questions)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-ritual-object-use-collar-cuffs-leash-tokens",
+          "label": "Ritual object use (collar, cuffs, leash, tokens)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-tracking-obedience-journals-apps",
+          "label": "Tracking obedience (journals, apps)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-formalized-rules-for-misbehavior-and-correction",
+          "label": "Formalized rules for misbehavior and correction",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-ritualized-aftercare-or-scene-closure",
+          "label": "Ritualized aftercare or scene closure",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-object-retrieval-on-all-fours-with-item-in-mouth",
+          "label": "Object retrieval on all fours with item in mouth",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-fetching-hairbrush-or-punishment-tool-from-dresser-while-crawling",
+          "label": "Fetching hairbrush or punishment tool from dresser while crawling",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-presenting-chosen-discipline-tool-in-kneeling-posture",
+          "label": "Presenting chosen discipline tool in kneeling posture",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-assigned-posture-or-kneeling-positions-as-ritual",
+          "label": "Assigned posture or kneeling positions as ritual",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-requesting-permission-using-specific-protocol-phrases",
+          "label": "Requesting permission using specific protocol phrases",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-carrying-items-in-mouth-as-submissive-gesture",
+          "label": "Carrying items in mouth as submissive gesture",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-crawling-back-with-object-to-dominant-after-retrieval",
+          "label": "Crawling back with object to Dominant after retrieval",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-following-via-nipple-leash-as-protocol-or-punishment",
+          "label": "Following via nipple leash as protocol or punishment",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-crawling-assigned-paths-as-ritual-or-obedience-training",
+          "label": "Crawling assigned paths as ritual or obedience training",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-crawling-rituals-e-g-object-retrieval",
+          "label": "Crawling rituals (e.g., object retrieval)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-carrying-objects-in-mouth-as-obedience",
+          "label": "Carrying objects in mouth as obedience",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-presenting-tools-or-toys-in-posture",
+          "label": "Presenting tools or toys in posture",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-using-honorifics-or-preset-protocol-language",
+          "label": "Using honorifics or preset protocol language",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-greeting-rituals-e-g-kneeling-kissing-feet",
+          "label": "Greeting rituals (e.g., kneeling, kissing feet)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-daily-check-ins-or-structured-reports",
+          "label": "Daily check-ins or structured reports",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-clothing-restrictions-or-uniforms",
+          "label": "Clothing restrictions or uniforms",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-posture-training-sitting-kneeling-standing",
+          "label": "Posture training (sitting, kneeling, standing)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-punishments-for-incorrect-behavior-or-tone",
+          "label": "Punishments for incorrect behavior or tone",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-crawling-with-items-in-mouth-e-g-hairbrush-spoon",
+          "label": "Crawling with items in mouth (e.g., hairbrush, spoon)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-earning-permission-for-meals-bathroom-use-or-rest",
+          "label": "Earning permission for meals, bathroom use, or rest",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-following-daily-rituals-or-protocol",
+          "label": "Following daily rituals or protocol",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-structured-speech-rules-e-g-titles-third-person",
+          "label": "Structured speech rules (e.g., titles, third person)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-receiving-correction-when-out-of-line",
+          "label": "Receiving correction when out of line",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-inspection-rituals-or-readiness-checks",
+          "label": "Inspection rituals or readiness checks",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Primal & Bratting",
+      "items": [
+        {
+          "id": "primal-bratting-chase-and-capture-play",
+          "label": "Chase and capture play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-bratting-for-punishment",
+          "label": "Bratting for punishment",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-playful-growling-and-biting",
+          "label": "Playful growling and biting",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-provoking-with-teasing-or-taunts",
+          "label": "Provoking with teasing or taunts",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-escaping-or-hiding-to-encourage-pursuit",
+          "label": "Escaping or hiding to encourage pursuit",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-refusing-commands-just-for-fun",
+          "label": "Refusing commands just for fun",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-provoking-your-partner-to-chase-or-discipline-you",
+          "label": "Provoking your partner to chase or discipline you",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-taunting-or-teasing-as-a-form-of-play",
+          "label": "Taunting or teasing as a form of play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-intentional-resistance-during-power-exchange",
+          "label": "Intentional resistance during power exchange",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-being-caught-and-overpowered",
+          "label": "Being caught and overpowered",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Headspace & Regression",
+      "items": [
+        {
+          "id": "headspace-regression-caregiver-little-regression-play",
+          "label": "Caregiver/little regression play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-using-pacifiers-or-sippy-cups",
+          "label": "Using pacifiers or sippy cups",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-coloring-or-childlike-crafts",
+          "label": "Coloring or childlike crafts",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-stuffed-animal-comfort",
+          "label": "Stuffed animal comfort",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-speaking-in-a-childlike-voice",
+          "label": "Speaking in a childlike voice",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-bedtime-stories-or-lullabies",
+          "label": "Bedtime stories or lullabies",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-entering-altered-headspaces-e-g-prey-pet-little",
+          "label": "Entering altered headspaces (e.g., prey, pet, little)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-regressive-behaviors-as-comfort-coloring-babytalk",
+          "label": "Regressive behaviors as comfort (coloring, babytalk)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-being-cared-for-during-emotional-vulnerability",
+          "label": "Being cared for during emotional vulnerability",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-guided-emotional-headspace-entry",
+          "label": "Guided emotional headspace entry",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Performance & Internal Struggle",
+      "items": [
+        {
+          "id": "performance-internal-struggle-obedience-under-observation",
+          "label": "Obedience under observation",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-speech-restriction-and-self-denial",
+          "label": "Speech restriction and self-denial",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-maintaining-composure-during-humiliation",
+          "label": "Maintaining composure during humiliation",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-obedience-drills-for-an-audience",
+          "label": "Obedience drills for an audience",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-struggling-against-personal-urges",
+          "label": "Struggling against personal urges",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-displaying-submission-despite-conflict",
+          "label": "Displaying submission despite conflict",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-being-told-to-act-normal-while-struggling-internally",
+          "label": "Being told to act normal while struggling internally",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-pleasing-through-high-functioning-obedience",
+          "label": "Pleasing through high-functioning obedience",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-performing-submission-while-masking-resistance",
+          "label": "Performing submission while masking resistance",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-the-pressure-of-appearing-good-while-feeling-conflicted",
+          "label": "The pressure of appearing 'good' while feeling conflicted",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-being-made-to-perform-emotions-on-command-cry-beg-moan",
+          "label": "Being made to perform emotions on command (cry, beg, moan)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-struggling-openly-while-still-obeying",
+          "label": "Struggling openly while still obeying",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-performing-exaggerated-resistance-or-denial",
+          "label": "Performing exaggerated resistance or denial",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-being-punished-for-breaking-character",
+          "label": "Being punished for 'breaking character'",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-putting-on-a-show-for-someone-else-s-pleasure",
+          "label": "Putting on a show for someone else’s pleasure",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-rehearsed-degradation-or-humiliation-scripts",
+          "label": "Rehearsed degradation or humiliation scripts",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Mindfuck & Manipulation",
+      "items": [
+        {
+          "id": "mindfuck-manipulation-confusing-commands-and-reality-shifts",
+          "label": "Confusing commands and reality shifts",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-gaslighting-or-contradictory-cues",
+          "label": "Gaslighting or contradictory cues",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-presenting-false-choices",
+          "label": "Presenting false choices",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-hidden-motives-or-secret-tasks",
+          "label": "Hidden motives or secret tasks",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-illogical-rules-meant-to-confuse",
+          "label": "Illogical rules meant to confuse",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-gaslight-style-scenes-with-consent-and-clarity",
+          "label": "Gaslight-style scenes (with consent and clarity)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-false-threats-or-staged-surprises",
+          "label": "False threats or staged surprises",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-confusing-commands-to-prompt-hesitation",
+          "label": "Confusing commands to prompt hesitation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-emotional-trickery-as-arousal",
+          "label": "Emotional trickery as arousal",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-being-misled-or-deceived-on-purpose-during-play",
+          "label": "Being misled or deceived on purpose during play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-surprise-rule-changes-or-twists-mid-scene",
+          "label": "Surprise rule changes or twists mid-scene",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-false-safeword-games-with-negotiated-limits",
+          "label": "False safeword games (with negotiated limits)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-withholding-or-delaying-aftercare-for-effect",
+          "label": "Withholding or delaying aftercare for effect",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-being-gaslit-or-doubted-in-a-controlled-roleplay",
+          "label": "Being gaslit or doubted in a controlled roleplay",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-told-you-asked-for-this-or-you-love-this-when-resisting",
+          "label": "Told 'you asked for this' or 'you love this' when resisting",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Mouth Play",
+      "items": [
+        {
+          "id": "mouth-play-holding-tools-or-restraints-in-teeth-while-crawling",
+          "label": "Holding tools or restraints in teeth while crawling",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-placing-objects-from-mouth-into-dominant-s-palm",
+          "label": "Placing objects from mouth into Dominant’s palm",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-using-mouth-instead-of-hands-for-service-rituals",
+          "label": "Using mouth instead of hands for service rituals",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-gag-presentation-and-silent-waiting-protocol",
+          "label": "Gag presentation and silent waiting protocol",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-holding-objects-in-teeth-while-crawling",
+          "label": "Holding objects in teeth while crawling",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-returning-items-using-mouth-only",
+          "label": "Returning items using mouth only",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-gag-rituals-or-waiting-silently",
+          "label": "Gag rituals or waiting silently",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-leash-held-in-mouth",
+          "label": "Leash held in mouth",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-being-gagged-or-forced-silent",
+          "label": "Being gagged or forced silent",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-having-to-hold-objects-in-your-mouth-spoon-hairbrush-leash",
+          "label": "Having to hold objects in your mouth (spoon, hairbrush, leash)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-being-used-for-oral-service-without-reciprocal-pleasure",
+          "label": "Being used for oral service without reciprocal pleasure",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-being-fed-by-hand-mouth-to-mouth-or-with-utensils",
+          "label": "Being fed by hand, mouth-to-mouth, or with utensils",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-verbal-control-e-g-only-speak-when-spoken-to",
+          "label": "Verbal control (e.g., only speak when spoken to)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-mouth-as-a-symbol-of-ownership-or-control",
+          "label": "Mouth as a symbol of ownership or control",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Impact Play",
+      "items": [
+        {
+          "id": "impact-play-hand-spanking",
+          "label": "Hand spanking",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "impact-play-paddle-strikes",
+          "label": "Paddle strikes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "impact-play-crop-snaps",
+          "label": "Crop snaps",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "impact-play-flogger-swings",
+          "label": "Flogger swings",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "impact-play-cane-strokes",
+          "label": "Cane strokes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "impact-play-belt-or-strap-hits",
+          "label": "Belt or strap hits",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "impact-play-whip-cracks",
+          "label": "Whip cracks",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "impact-play-preferred-intensity-levels",
+          "label": "Preferred intensity levels",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "impact-play-aftercare-for-bruises",
+          "label": "Aftercare for bruises",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "impact-play-target-body-areas",
+          "label": "Target body areas",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "impact-play-implement-selection",
+          "label": "Implement selection",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Medical Play",
+      "items": [
+        {
+          "id": "medical-play-needle-play",
+          "label": "Needle play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "medical-play-catheter-insertion",
+          "label": "Catheter insertion",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "medical-play-speculum-exams",
+          "label": "Speculum exams",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "medical-play-enema-administration",
+          "label": "Enema administration",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "medical-play-temperature-taking",
+          "label": "Temperature taking",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "medical-play-medical-restraints",
+          "label": "Medical restraints",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "medical-play-doctor-nurse-roleplay",
+          "label": "Doctor/nurse roleplay",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "medical-play-sterilization-procedures",
+          "label": "Sterilization procedures",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "medical-play-professional-vs-roleplay-scenes",
+          "label": "Professional vs roleplay scenes",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "medical-play-consent-for-invasive-acts",
+          "label": "Consent for invasive acts",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "medical-play-access-to-medical-equipment",
+          "label": "Access to medical equipment",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Pet Play",
+      "items": [
+        {
+          "id": "pet-play-puppy-or-kitten-play",
+          "label": "Puppy or kitten play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "pet-play-pony-play",
+          "label": "Pony play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "pet-play-wearing-collar-and-leash",
+          "label": "Wearing collar and leash",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "pet-play-eating-from-a-bowl",
+          "label": "Eating from a bowl",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "pet-play-kenneling-or-caging",
+          "label": "Kenneling or caging",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "pet-play-pet-training-commands",
+          "label": "Pet training commands",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "pet-play-animal-costumes-or-gear",
+          "label": "Animal costumes or gear",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "pet-play-preferred-animal-identities",
+          "label": "Preferred animal identities",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "pet-play-public-vs-private-play",
+          "label": "Public vs private play",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "pet-play-training-style-and-discipline",
+          "label": "Training style and discipline",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "pet-play-use-of-pet-names-and-commands",
+          "label": "Use of pet names and commands",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Body Modification",
+      "items": [
+        {
+          "id": "body-modification-piercings",
+          "label": "Piercings",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-modification-tattoos",
+          "label": "Tattoos",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-modification-branding",
+          "label": "Branding",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-modification-scarification",
+          "label": "Scarification",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-modification-permanent-chastity-devices",
+          "label": "Permanent chastity devices",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-modification-cosmetic-implants",
+          "label": "Cosmetic implants",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-modification-stretching-or-gauges",
+          "label": "Stretching or gauges",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-modification-temporary-vs-permanent-changes",
+          "label": "Temporary vs permanent changes",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-modification-professional-vs-diy-methods",
+          "label": "Professional vs DIY methods",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-modification-body-placement-considerations",
+          "label": "Body placement considerations",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-modification-healing-and-aftercare",
+          "label": "Healing and aftercare",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Relationship Preferences",
+      "items": [
+        {
+          "id": "relationship-preferences-preferred-relationship-style",
+          "label": "Preferred relationship style",
+          "type": "text",
+          "options": [
+            "Monogamous",
+            "Open relationship",
+            "Polyamorous",
+            "No preference"
+          ],
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-relationship-goals",
+          "label": "Relationship goals",
+          "type": "text",
+          "options": [
+            "One night stand",
+            "Short-term play",
+            "Long-term relationship",
+            "Platonic play partners",
+            "Romantic partners",
+            "Kink partners"
+          ],
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-monogamous",
+          "label": "Monogamous",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-polyamorous",
+          "label": "Polyamorous",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-hierarchical-dynamics",
+          "label": "Hierarchical dynamics",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-non-hierarchical-poly",
+          "label": "Non-hierarchical poly",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-solo-poly",
+          "label": "Solo-poly",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-open-with-boundaries",
+          "label": "Open with boundaries",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-closed-but-kinky-with-others",
+          "label": "Closed but kinky with others",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-switch-friendly-dynamics",
+          "label": "Switch-friendly dynamics",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Gender Play & Transformation",
+      "items": [
+        {
+          "id": "gender-play-transformation-crossdressing",
+          "label": "Crossdressing",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-forced-feminization",
+          "label": "Forced feminization",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-forced-masculinization",
+          "label": "Forced masculinization",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-gender-role-reversal",
+          "label": "Gender role reversal",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-pronoun-changes",
+          "label": "Pronoun changes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-voice-or-mannerism-training",
+          "label": "Voice or mannerism training",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-sissy-or-tomboy-persona",
+          "label": "Sissy or tomboy persona",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-preferred-pronouns-and-names",
+          "label": "Preferred pronouns and names",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-public-presentation-comfort",
+          "label": "Public presentation comfort",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-clothing-and-appearance",
+          "label": "Clothing and appearance",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-exploration-of-identity",
+          "label": "Exploration of identity",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Chastity Devices",
+      "items": [
+        {
+          "id": "chastity-devices-wearing-a-chastity-cage-short-term",
+          "label": "Wearing a chastity cage (short term)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-long-term-chastity-training",
+          "label": "Long-term chastity training",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-chastity-device-control-with-permission-to-unlock",
+          "label": "Chastity device control with permission to unlock",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-locked-remotely-by-another-person",
+          "label": "Locked remotely by another person",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-orgasm-denial-enforced-by-chastity",
+          "label": "Orgasm denial enforced by chastity",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-wearing-a-belt-style-chastity-device",
+          "label": "Wearing a belt-style chastity device",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-humiliation-while-locked-in-chastity",
+          "label": "Humiliation while locked in chastity",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-sleep-in-chastity-overnight",
+          "label": "Sleep in chastity (overnight)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-being-teased-while-unable-to-touch-yourself",
+          "label": "Being teased while unable to touch yourself",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-begging-for-release-from-chastity",
+          "label": "Begging for release from chastity",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Shibari & Rope Bondage",
+      "items": [
+        {
+          "id": "shibari-rope-bondage-being-tied-in-aesthetic-rope-patterns-shibari",
+          "label": "Being tied in aesthetic rope patterns (Shibari)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-rope-bondage-for-restraint-and-control",
+          "label": "Rope bondage for restraint and control",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-rope-suspension-partial-or-full",
+          "label": "Rope suspension (partial or full)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-learning-to-tie-rope-as-a-form-of-dominance",
+          "label": "Learning to tie rope as a form of dominance",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-being-tied-in-vulnerable-or-exposing-poses",
+          "label": "Being tied in vulnerable or exposing poses",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-practicing-rope-with-emotional-connection",
+          "label": "Practicing rope with emotional connection",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-enduring-discomfort-for-the-beauty-of-the-rope",
+          "label": "Enduring discomfort for the beauty of the rope",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-being-tied-in-a-mirror-and-told-to-look",
+          "label": "Being tied in a mirror and told to look",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-punishment-ties-e-g-uncomfortable-or-humiliating-positions",
+          "label": "Punishment ties (e.g., uncomfortable or humiliating positions)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-solo-rope-practice-for-mindfulness-or-masochism",
+          "label": "Solo rope practice for mindfulness or masochism",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Cosplay & Identity Play",
+      "items": [
+        {
+          "id": "cosplay-identity-play-dressing-up-in-costumes-for-scenes",
+          "label": "Dressing up in costumes for scenes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "cosplay-identity-play-playing-as-fictional-characters",
+          "label": "Playing as fictional characters",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "cosplay-identity-play-petplay-with-collars-ears-or-tails",
+          "label": "Petplay with collars, ears, or tails",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "cosplay-identity-play-pretending-to-be-a-doll-robot-or-object",
+          "label": "Pretending to be a doll, robot, or object",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "cosplay-identity-play-master-slave-cosplay-dynamic-non-24-7",
+          "label": "Master/slave cosplay dynamic (non-24/7)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "cosplay-identity-play-roleplaying-as-a-fantasy-species-or-non-human",
+          "label": "Roleplaying as a fantasy species or non-human",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "cosplay-identity-play-using-cosplay-to-deepen-power-exchange",
+          "label": "Using cosplay to deepen power exchange",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "cosplay-identity-play-scene-built-around-a-character-s-story-or-world",
+          "label": "Scene built around a character’s story or world",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "cosplay-identity-play-fantasy-uniforms-nurse-teacher-etc",
+          "label": "Fantasy uniforms (nurse, teacher, etc.)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "High-Intensity Kinks (SSC-Aware)",
+      "items": [
+        {
+          "id": "high-intensity-kinks-ssc-aware-intense-breath-play-e-g-smothering-or-pressure",
+          "label": "Intense breath play (e.g., smothering or pressure)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-knife-play-or-blade-play-without-injury",
+          "label": "Knife play or blade play (without injury)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-fear-play-using-known-or-negotiated-triggers",
+          "label": "Fear play using known or negotiated triggers",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-abduction-or-home-invasion-style-roleplay-negotiated",
+          "label": "Abduction or home-invasion style roleplay (negotiated)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-medical-themed-scenes-with-sharp-objects-not-bloodletting",
+          "label": "Medical-themed scenes with sharp objects (not bloodletting)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-sensory-deprivation-with-added-disorientation-or-helplessness",
+          "label": "Sensory deprivation with added disorientation or helplessness",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-scenes-involving-heavy-objectification-or-emotional-manipulation-with-care",
+          "label": "Scenes involving heavy objectification or emotional manipulation (with care)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-mock-interrogation-or-intense-role-pressure",
+          "label": "Mock interrogation or intense role pressure",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-consensual-threats-without-follow-through-e-g-if-you-don-t",
+          "label": "Consensual threats without follow-through (e.g. 'If you don’t...')",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-high-intensity-primal-scenes-involving-struggle-or-fear",
+          "label": "High-intensity primal scenes involving struggle or fear",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Behavioral Play",
+      "items": [
+        {
+          "id": "behavioral-play-assigning-corner-time-or-time-outs",
+          "label": "Assigning corner time or time-outs",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "behavioral-play-writing-lines-or-apology-letters-as-correction",
+          "label": "Writing lines or apology letters as correction",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "behavioral-play-removing-privileges-phone-tv-sweets",
+          "label": "Removing privileges (phone, TV, sweets)",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "behavioral-play-playful-punishments-that-still-reinforce-rules",
+          "label": "Playful punishments that still reinforce rules",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "behavioral-play-lecturing-or-scolding-to-modify-behavior",
+          "label": "Lecturing or scolding to modify behavior",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "behavioral-play-being-placed-in-the-corner-or-given-a-time-out",
+          "label": "Being placed in the corner or given a time-out",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "behavioral-play-writing-lines-or-apology-letters-when-misbehaving",
+          "label": "Writing lines or apology letters when misbehaving",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "behavioral-play-having-privileges-revoked-phone-tv",
+          "label": "Having privileges revoked (phone, TV)",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "behavioral-play-receiving-playful-funishments-for-minor-rule-breaking",
+          "label": "Receiving playful 'funishments' for minor rule-breaking",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "behavioral-play-getting-scolded-or-lectured-for-correction",
+          "label": "Getting scolded or lectured for correction",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "behavioral-play-preferred-style-of-discipline-strict-vs-lenient",
+          "label": "Preferred style of discipline (strict vs lenient)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "behavioral-play-attitude-toward-funishment-vs-serious-correction",
+          "label": "Attitude toward funishment vs serious correction",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "behavioral-play-use-of-behavior-contracts-or-rule-agreements",
+          "label": "Use of behavior contracts or rule agreements",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Appearance Play",
+      "items": [
+        {
+          "id": "appearance-play-choosing-my-partner-s-outfit-for-the-day-or-a-scene",
+          "label": "Choosing my partner’s outfit for the day or a scene",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-selecting-their-underwear-lingerie-or-base-layers",
+          "label": "Selecting their underwear, lingerie, or base layers",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-styling-their-hair-braiding-brushing-tying-etc",
+          "label": "Styling their hair (braiding, brushing, tying, etc.)",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-picking-head-coverings-bonnets-veils-hoods-hats-for-mood-or-protocol",
+          "label": "Picking head coverings (bonnets, veils, hoods, hats) for mood or protocol",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-offering-makeup-polish-or-accessories-as-part-of-ritual-or-play",
+          "label": "Offering makeup, polish, or accessories as part of ritual or play",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-creating-themed-looks-slutty-innocent-doll-like-sharp-etc",
+          "label": "Creating themed looks (slutty, innocent, doll-like, sharp, etc.)",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-dressing-them-in-role-specific-costumes-maid-bunny-doll-etc",
+          "label": "Dressing them in role-specific costumes (maid, bunny, doll, etc.)",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-curating-time-period-or-historical-outfits-e-g-victorian-50s",
+          "label": "Curating time-period or historical outfits (e.g., Victorian, 50s)",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-helping-them-present-more-femme-masc-or-androgynous-by-request",
+          "label": "Helping them present more femme, masc, or androgynous by request",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-coordinating-their-look-with-mine-for-public-or-private-scenes",
+          "label": "Coordinating their look with mine for public or private scenes",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-implementing-a-dress-ritual-or-aesthetic-preparation",
+          "label": "Implementing a “dress ritual” or aesthetic preparation",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-enforcing-a-visual-protocol-e-g-no-bra-heels-required-tied-hair",
+          "label": "Enforcing a visual protocol (e.g., no bra, heels required, tied hair)",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-having-my-outfit-selected-for-me-by-a-partner",
+          "label": "Having my outfit selected for me by a partner",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-wearing-the-underwear-or-lingerie-they-choose",
+          "label": "Wearing the underwear or lingerie they choose",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-having-my-hair-brushed-braided-tied-or-styled-for-them",
+          "label": "Having my hair brushed, braided, tied, or styled for them",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-putting-on-a-head-covering-e-g-bonnet-veil-hood-they-chose",
+          "label": "Putting on a head covering (e.g., bonnet, veil, hood) they chose",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-following-visual-appearance-rules-as-part-of-submission",
+          "label": "Following visual appearance rules as part of submission",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-wearing-makeup-polish-or-accessories-they-request",
+          "label": "Wearing makeup, polish, or accessories they request",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-dressing-to-please-their-vision-cute-filthy-classy-etc",
+          "label": "Dressing to please their vision (cute, filthy, classy, etc.)",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-wearing-roleplay-costumes-or-character-looks",
+          "label": "Wearing roleplay costumes or character looks",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-presenting-in-a-way-that-matches-their-chosen-aesthetic",
+          "label": "Presenting in a way that matches their chosen aesthetic",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-participating-in-dressing-rituals-or-undressing-ceremonies",
+          "label": "Participating in dressing rituals or undressing ceremonies",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-being-admired-for-the-way-i-look-under-their-direction",
+          "label": "Being admired for the way I look under their direction",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-receiving-praise-or-gentle-teasing-about-my-appearance",
+          "label": "Receiving praise or gentle teasing about my appearance",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-cosplay-or-fantasy-looks-anime-game-fairytale-etc",
+          "label": "Cosplay or fantasy looks (anime, game, fairytale, etc.)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-time-period-dress-up-regency-gothic-1920s-etc",
+          "label": "Time-period dress-up (regency, gothic, 1920s, etc.)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-dollification-or-polished-presented-object-aesthetics",
+          "label": "Dollification or polished/presented object aesthetics",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-uniforms-schoolgirl-military-clerical-nurse-etc",
+          "label": "Uniforms (schoolgirl, military, clerical, nurse, etc.)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-hair-based-play-forced-brushing-ribbons-or-tied-styles",
+          "label": "Hair-based play (forced brushing, ribbons, or tied styles)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-head-coverings-or-symbolic-hoods-in-ritualized-dynamics",
+          "label": "Head coverings or symbolic hoods in ritualized dynamics",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-matching-looks-or-coordinated-dress-codes",
+          "label": "Matching looks or coordinated dress codes",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-ritualized-grooming-before-scenes",
+          "label": "Ritualized grooming before scenes",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-praise-or-positive-attention-for-pleasing-visual-display",
+          "label": "Praise or positive attention for pleasing visual display",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-formal-appearance-protocols-for-scenes-or-dynamics",
+          "label": "Formal appearance protocols for scenes or dynamics",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-using-clothing-or-style-to-embody-emotional-or-power-roles",
+          "label": "Using clothing or style to embody emotional or power roles",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Psychology Play",
+      "items": [
+        {
+          "id": "psychology-play-emotional-sadism-giving-teasing-feelings-orchestrating-reactions-savoring-anticipation-without-shame-based-harm",
+          "label": "Emotional Sadism (giving): teasing feelings, orchestrating reactions, savoring anticipation without shame-based harm",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "psychology-play-psychological-control-mind-games-double-binds-deliberate-pacing-and-strategic-ambiguity",
+          "label": "Psychological Control: mind games, double binds, deliberate pacing, and strategic ambiguity",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "psychology-play-sadistic-attention-enjoying-being-the-focal-point-of-a-partner-s-fear-arousal-or-resistance",
+          "label": "Sadistic Attention: enjoying being the focal point of a partner’s fear, arousal, or resistance",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "psychology-play-teasing-humiliation-playful-status-play-without-degradation-or-shame",
+          "label": "Teasing Humiliation: playful status play without degradation or shame",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "psychology-play-emotional-sadism-receiving-enjoying-engineered-emotional-intensity-such-as-fluster-exposure-or-playful-embarrassment",
+          "label": "Emotional Sadism (receiving): enjoying engineered emotional intensity such as fluster, exposure, or playful embarrassment",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychology-play-psychological-control-receiving-arousal-from-being-studied-contained-or-outmaneuvered",
+          "label": "Psychological Control (receiving): arousal from being studied, contained, or outmaneuvered",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychology-play-being-the-focus-enjoying-being-watched-tracked-or-held-in-a-partner-s-intense-focus",
+          "label": "Being the Focus: enjoying being watched, tracked, or held in a partner’s intense focus",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychology-play-teasing-humiliation-receiving-enjoying-playful-embarrassment-or-affectionate-mockery-that-builds-intimacy",
+          "label": "Teasing Humiliation (receiving): enjoying playful embarrassment or affectionate mockery that builds intimacy",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychology-play-prey-attention-neediness-craving-focus-pursuit-or-intense-awareness-from-a-partner",
+          "label": "Prey Attention/Neediness: craving focus, pursuit, or intense awareness from a partner",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychology-play-primal-recognition-being-seen-understood-or-tracked-without-needing-words",
+          "label": "Primal Recognition: being seen, understood, or tracked without needing words",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Breeding",
+      "items": [
+        {
+          "id": "breeding-impregnation-giving-arousal-from-attempting-to-impregnate-a-partner",
+          "label": "Impregnation (giving): arousal from attempting to impregnate a partner",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "breeding-feeding-milk-giving-arousal-from-producing-and-feeding-milk-to-a-partner",
+          "label": "Feeding Milk (giving): arousal from producing and feeding milk to a partner",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "breeding-impregnation-receiving-arousal-from-being-inseminated-pregnancy-risk-or-being-bred",
+          "label": "Impregnation (receiving): arousal from being inseminated, pregnancy risk, or being bred",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "breeding-feeding-milk-receiving-arousal-from-drinking-a-partner-s-milk",
+          "label": "Feeding Milk (receiving): arousal from drinking a partner’s milk",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "breeding-pregnancy-fantasy-erotic-focus-on-pregnancy-mine-partner-s-or-fictional-scenarios",
+          "label": "Pregnancy Fantasy: erotic focus on pregnancy (mine, partner’s, or fictional scenarios)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-primal-breeding-drive-animalistic-instinctual-framing-of-sex-reproduction-territory",
+          "label": "Primal Breeding Drive: animalistic/instinctual framing of sex, reproduction, territory",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-breeding-as-control-ownership-authority-expressed-through-breeding-talk-or-pregnancy-risk",
+          "label": "Breeding as Control: ownership/authority expressed through breeding talk or pregnancy risk",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-creampie-marking-erotic-meaning-placed-on-internal-ejaculation-or-visible-claimed-markers",
+          "label": "Creampie/Marking: erotic meaning placed on internal ejaculation or visible ‘claimed’ markers",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-risk-no-contraception-talk-fantasy-dirty-talk-about-risk-or-breeding-without-actual-risk",
+          "label": "Risk/‘No Contraception’ Talk (fantasy): dirty talk about risk or breeding without actual risk",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-heat-ovulation-tracking-timing-in-heat-roleplay-or-cycle-focused-arousal",
+          "label": "Heat/Ovulation Tracking: timing, ‘in heat’ roleplay, or cycle-focused arousal",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-artificial-insemination-device-play-syringes-cups-or-medical-style-scenarios-consensual-fantasy",
+          "label": "Artificial Insemination/Device Play: syringes, cups, or medical-style scenarios (consensual fantasy)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-breeding-denial-ruined-breeding-building-toward-impregnation-talk-then-denying-or-ruining-it",
+          "label": "Breeding Denial/Ruined Breeding: building toward impregnation talk then denying or ‘ruining’ it",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-pregnancy-body-focus-belly-worship-movement-weight-changes-glow-and-attention",
+          "label": "Pregnancy Body Focus: belly worship, movement/weight changes, glow, and attention",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-pregnancy-protocol-care-protective-rules-pedestal-treatment-dedicated-aftercare",
+          "label": "Pregnancy Protocol/Care: protective rules, pedestal treatment, dedicated aftercare",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-lactation-induction-maintenance-interest-in-inducing-or-sustaining-milk-production",
+          "label": "Lactation Induction/Maintenance: interest in inducing or sustaining milk production",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-milking-scenes-manual-oral-or-pump-based-milking-as-play-or-ritual",
+          "label": "Milking Scenes: manual, oral, or pump-based ‘milking’ as play or ritual",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-contraception-boundaries-preference-to-use-protection-bc-methods-or-simulation-only",
+          "label": "Contraception Boundaries: preference to use protection, BC methods, or simulation-only",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-sti-testing-medical-boundaries-testing-cadence-disclosures-and-comfort-levels",
+          "label": "STI/Testing & Medical Boundaries: testing cadence, disclosures, and comfort levels",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    }
+  ],
+  "kinks": [
+    {
+      "id": "body-part-torture-nipple-clips",
+      "label": "Nipple clips",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-nipple-weights",
+      "label": "Nipple weights",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-nipple-suction-cups",
+      "label": "Nipple suction cups",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-cock-ball-torture-cbt",
+      "label": "Cock, Ball Torture (CBT)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-clit-clips-weights-suction",
+      "label": "Clit clips/weights/suction",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-hair-pulling",
+      "label": "Hair pulling",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-face-slapping",
+      "label": "Face slapping",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-butt-slapping",
+      "label": "Butt slapping",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-breast-slapping",
+      "label": "Breast slapping",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-genital-slapping",
+      "label": "Genital slapping",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "bondage-and-suspension-blindfolds",
+      "label": "Blindfolds",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-bondage-heavy",
+      "label": "Bondage (heavy)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-bondage-light",
+      "label": "Bondage (light)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-immobilisation",
+      "label": "Immobilisation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-bondage-multi-day",
+      "label": "Bondage (multi-day)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-bondage-public-under-clothing",
+      "label": "Bondage (public, under clothing)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-leather-restraints",
+      "label": "Leather restraints",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-chains",
+      "label": "Chains",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-ropes",
+      "label": "Ropes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-intricate-japanese-rope-bondage",
+      "label": "Intricate (Japanese) rope bondage",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-rope-body-harness",
+      "label": "Rope body harness",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-arm-leg-sleeves-armbinders",
+      "label": "Arm & leg sleeves (armbinders)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-harnesses-leather",
+      "label": "Harnesses (leather)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-harnesses-rope",
+      "label": "Harnesses (rope)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-cuffs-leather",
+      "label": "Cuffs (leather)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-cuffs-metal",
+      "label": "Cuffs (metal)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-manacles-irons",
+      "label": "Manacles & Irons",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-gags-cloth",
+      "label": "Gags (cloth)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-gags-rubber",
+      "label": "Gags (rubber)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-gags-tape",
+      "label": "Gags (tape)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-gags-phallic",
+      "label": "Gags (phallic)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-gags-ring",
+      "label": "Gags (ring)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-gags-ball",
+      "label": "Gags (ball)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-mouth-bits",
+      "label": "Mouth bits",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-full-head-hoods",
+      "label": "Full head hoods",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-mummification-saran-wrapping",
+      "label": "Mummification/saran wrapping",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-straight-jackets",
+      "label": "Straight jackets",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-suspension-upright",
+      "label": "Suspension (upright)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-suspension-horizontal",
+      "label": "Suspension (horizontal)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-suspension-inverted",
+      "label": "Suspension (inverted)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-breath-play",
+      "label": "Breath play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-smothering",
+      "label": "Smothering",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-forced-self-breath-control",
+      "label": "Forced self-breath-control",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-gas-mask",
+      "label": "Gas mask",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "breath-play-asphyxiation",
+      "label": "Asphyxiation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Breath Play"
+    },
+    {
+      "id": "breath-play-breath-control",
+      "label": "Breath control",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Breath Play"
+    },
+    {
+      "id": "breath-play-choking",
+      "label": "Choking",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Breath Play"
+    },
+    {
+      "id": "breath-play-drowning",
+      "label": "Drowning",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Breath Play"
+    },
+    {
+      "id": "breath-play-rebreathing-into-a-bag-or-object",
+      "label": "Rebreathing into a bag or object",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Breath Play"
+    },
+    {
+      "id": "breath-play-verbal-control-of-breath-e-g-hold-it-on-command",
+      "label": "Verbal control of breath (e.g., 'hold it' on command)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Breath Play"
+    },
+    {
+      "id": "sexual-activity-licking",
+      "label": "Licking",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-fellatio-cunnilingus",
+      "label": "Fellatio/Cunnilingus",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-swallowing-semen",
+      "label": "Swallowing semen",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-cumming-on-partner",
+      "label": "Cumming on Partner",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-hand-jobs",
+      "label": "Hand jobs",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-anal-sex",
+      "label": "Anal sex",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-anal-plugs-small",
+      "label": "Anal plugs (small)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-anal-plugs-large",
+      "label": "Anal plugs (large)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-anal-beads",
+      "label": "Anal beads",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-vibrator-on-genitals",
+      "label": "Vibrator on genitals",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-fisting",
+      "label": "Fisting",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-oral-anal-play-rimming",
+      "label": "Oral/anal play (rimming)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-double-penetration-oral-and-vaginal",
+      "label": "Double penetration (oral and vaginal)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-double-penetration-oral-and-anal",
+      "label": "Double penetration (oral and anal)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-double-penetration-anal-and-vaginal",
+      "label": "Double penetration (anal and vaginal)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-triple-oral-vaginal-and-anal",
+      "label": "Triple (Oral, Vaginal and Anal)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sensation-play-abrasion",
+      "label": "Abrasion",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-scratching",
+      "label": "Scratching",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-biting",
+      "label": "Biting",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-tickling",
+      "label": "Tickling",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-kissing",
+      "label": "Kissing",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-zapping-e-g-electric-fly-swatter",
+      "label": "Zapping (e.g. electric fly swatter)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-ice-cubes",
+      "label": "Ice cubes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-wax-play",
+      "label": "Wax Play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-fire",
+      "label": "Fire",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-clothespins",
+      "label": "Clothespins",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-needles",
+      "label": "Needles",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-sensory-deprivation",
+      "label": "Sensory deprivation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-physical-overpowering-manhandling",
+      "label": "Physical overpowering / Manhandling",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-figging",
+      "label": "Figging",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "other-feet",
+      "label": "Feet",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-boots",
+      "label": "Boots",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-underwear",
+      "label": "Underwear",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-chastity-devices",
+      "label": "Chastity devices",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-masks",
+      "label": "Masks",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-breeding",
+      "label": "Breeding",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-leather-clothing",
+      "label": "Leather clothing",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-training-protocols-outside-scenes-e-g-etiquette-memory",
+      "label": "Training protocols outside scenes (e.g., etiquette, memory)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-long-distance-training-structure",
+      "label": "Long-distance training/structure",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-scene-journaling-and-reflection",
+      "label": "Scene journaling and reflection",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "roleplaying-fantasy-abandonment",
+      "label": "Fantasy abandonment",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-kidnapping",
+      "label": "Kidnapping",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-interrogation",
+      "label": "Interrogation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-sleep-deprivation",
+      "label": "Sleep deprivation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-cnc",
+      "label": "CNC",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-gang-bang",
+      "label": "Gang bang",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-initiation-rites",
+      "label": "Initiation rites",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-religious-scenes",
+      "label": "Religious scenes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-medical-scenes",
+      "label": "Medical scenes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-prison-scenes",
+      "label": "Prison scenes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-primal-prey",
+      "label": "Primal/Prey",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-schoolroom-scenes",
+      "label": "Schoolroom scenes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-following-orders",
+      "label": "(Following) orders",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-forced-servitude",
+      "label": "Forced servitude",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-restrictive-rules-on-behaviour",
+      "label": "Restrictive rules on behaviour",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-eye-contact-restrictions",
+      "label": "Eye contact restrictions",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-speech-restrictions-when-what-to-whom",
+      "label": "Speech restrictions (when, what, to whom)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-washroom-restrictions",
+      "label": "Washroom restrictions",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-punishments",
+      "label": "Punishments",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-tasks",
+      "label": "Tasks",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-massage",
+      "label": "Massage",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-domestic-tasks",
+      "label": "Domestic tasks",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-serving-food-and-drink",
+      "label": "Serving food and drink",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-personal-care-rituals",
+      "label": "Personal care rituals",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-being-on-call-at-specified-times",
+      "label": "Being on-call at specified times",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-daily-task-assignments",
+      "label": "Daily task assignments",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-corrections-for-imperfection",
+      "label": "Corrections for imperfection",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-uniforms-dress-codes",
+      "label": "Uniforms / Dress codes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-kneeling-posture-presentation",
+      "label": "Kneeling / Posture presentation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-silent-service",
+      "label": "Silent service",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-public-service-at-parties-or-events",
+      "label": "Public service (at parties or events)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-erotic-service-pleasure-on-command-without-seeking-your-own",
+      "label": "Erotic service (pleasure on command, without seeking your own)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "voyeurism-exhibitionism-forced-nudity-private",
+      "label": "Forced nudity (private)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Voyeurism/Exhibitionism"
+    },
+    {
+      "id": "voyeurism-exhibitionism-forced-nudity-around-others",
+      "label": "Forced nudity (around others)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Voyeurism/Exhibitionism"
+    },
+    {
+      "id": "voyeurism-exhibitionism-exhibitionism-friends",
+      "label": "Exhibitionism (friends)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Voyeurism/Exhibitionism"
+    },
+    {
+      "id": "voyeurism-exhibitionism-exhibitionism-strangers",
+      "label": "Exhibitionism (strangers)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Voyeurism/Exhibitionism"
+    },
+    {
+      "id": "voyeurism-exhibitionism-modelling-for-erotic-photos",
+      "label": "Modelling for erotic photos",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Voyeurism/Exhibitionism"
+    },
+    {
+      "id": "voyeurism-exhibitionism-toys-under-clothes-in-public",
+      "label": "Toys under clothes in public",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Voyeurism/Exhibitionism"
+    },
+    {
+      "id": "virtual-long-distance-play-sending-tasks-or-orders-digitally",
+      "label": "Sending tasks or orders digitally",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-recording-dominant-voice-clips-commands-edging-praise-degradation-etc",
+      "label": "Recording dominant voice clips (commands, edging, praise, degradation, etc.)",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-remote-control-of-a-sex-toy",
+      "label": "Remote control of a sex toy",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-monitoring-behavior-via-app-or-shared-doc",
+      "label": "Monitoring behavior via app or shared doc",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-giving-punishment-assignments-remotely",
+      "label": "Giving punishment assignments remotely",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-creating-countdowns-timers-or-denial-periods",
+      "label": "Creating countdowns, timers, or denial periods",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-sending-written-instructions-with-delayed-permissions",
+      "label": "Sending written instructions with delayed permissions",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-creating-custom-video-or-audio-tasks",
+      "label": "Creating custom video or audio tasks",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-voice-message-control-during-scenes",
+      "label": "Voice message control during scenes",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-being-on-call-at-specified-times",
+      "label": "Being on-call at specified times",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-receiving-tasks-or-orders-digitally",
+      "label": "Receiving tasks or orders digitally",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-listening-to-dominant-voice-clips",
+      "label": "Listening to dominant voice clips",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-using-a-remote-controlled-toy-controlled-by-another",
+      "label": "Using a remote-controlled toy controlled by another",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-completing-daily-protocol-assignments",
+      "label": "Completing daily protocol assignments",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-submitting-proof-photo-video-text",
+      "label": "Submitting proof (photo, video, text)",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-following-recorded-or-timed-commands",
+      "label": "Following recorded or timed commands",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-receiving-surprise-instructions",
+      "label": "Receiving surprise instructions",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-hearing-name-praise-spoken-in-a-custom-clip",
+      "label": "Hearing name/praise spoken in a custom clip",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-sending-submissive-voice-clips-obedience-begging-thank-you-messages-affirmations-etc",
+      "label": "Sending submissive voice clips (obedience, begging, thank-you messages, affirmations, etc.)",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-scheduling-digital-rituals-or-reminders",
+      "label": "Scheduling digital rituals or reminders",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-using-training-habit-or-behavior-tracking-apps",
+      "label": "Using training, habit, or behavior-tracking apps",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-online-rituals-digital-kneeling-posture-protocols",
+      "label": "Online rituals (digital kneeling, posture protocols)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-role-based-texting-e-g-use-honorifics-in-chat",
+      "label": "Role-based texting (e.g., \"Use honorifics in chat\")",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-shared-playlists-affirmations-or-mantras",
+      "label": "Shared playlists, affirmations, or mantras",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-countdown-timers-to-next-task-release-or-interaction",
+      "label": "Countdown timers to next task, release, or interaction",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-scheduled-good-morning-night-rituals",
+      "label": "Scheduled good morning/night rituals",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-participating-in-video-call-scenes",
+      "label": "Participating in video call scenes",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-digital-aftercare-texts-voice-images",
+      "label": "Digital aftercare (texts, voice, images)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-sexting-or-digital-roleplay-scenes",
+      "label": "Sexting or digital roleplay scenes",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-voice-notes-or-submissive-dominant-affirmations",
+      "label": "Voice notes or submissive/dominant affirmations",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "communication-playful-and-teasing",
+      "label": "Playful and teasing",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-quiet-and-intense",
+      "label": "Quiet and intense",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-observant-and-intentional",
+      "label": "Observant and intentional",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-praise-heavy",
+      "label": "Praise-heavy",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-blunt-and-efficient",
+      "label": "Blunt and efficient",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-affirming-and-soft",
+      "label": "Affirming and soft",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-psychological-interrogation",
+      "label": "Psychological interrogation",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-verbal-coercion-teasing-traps",
+      "label": "Verbal coercion / teasing traps",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-verbal-misdirection",
+      "label": "Verbal misdirection",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-mocking-shaming",
+      "label": "Mocking / shaming",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-predatory-pacing",
+      "label": "Predatory pacing",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-reluctant-obedience",
+      "label": "Reluctant obedience",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-stammering-submission",
+      "label": "Stammering submission",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-challenging-until-caught",
+      "label": "Challenging until caught",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-quiet-surrender",
+      "label": "Quiet surrender",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-sarcastic-teasing",
+      "label": "Sarcastic teasing",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-provoking-tone",
+      "label": "Provoking tone",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-challenge-based-dialogue",
+      "label": "Challenge-based dialogue",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-double-meaning-banter",
+      "label": "Double-meaning banter",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-soft-spoken-guidance",
+      "label": "Soft-spoken guidance",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-protective-but-firm-tone",
+      "label": "Protective but firm tone",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-emotional-redirection",
+      "label": "Emotional redirection",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-steady-reassurance",
+      "label": "Steady reassurance",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-direct-and-clear",
+      "label": "Direct and clear",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-gentle-and-nurturing",
+      "label": "Gentle and nurturing",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-commanding-and-firm",
+      "label": "Commanding and firm",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-quiet-and-observant",
+      "label": "Quiet and observant",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-instructive-teacher-like",
+      "label": "Instructive / teacher-like",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-emotionally-intense",
+      "label": "Emotionally intense",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-dismissive-withholding",
+      "label": "Dismissive / withholding",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-mocking-sarcastic",
+      "label": "Mocking / sarcastic",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-blunt-tactless",
+      "label": "Blunt / tactless",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-predatory-hunting-tone",
+      "label": "Predatory / hunting tone",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-stalking-or-circling-speech",
+      "label": "Stalking or circling speech",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-you-re-mine-control-language",
+      "label": "You’re mine / control language",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-threatening-consensual",
+      "label": "Threatening (consensual)",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-verbal-cornering-coaxing",
+      "label": "Verbal cornering / coaxing",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-watching-you-unravel",
+      "label": "Watching you unravel",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-cruel-and-cutting",
+      "label": "Cruel and cutting",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-psychological-baiting",
+      "label": "Psychological baiting",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-brat-breaking-language",
+      "label": "Brat-breaking language",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-mock-affection",
+      "label": "Mock affection",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-shaming-or-emotional-edge",
+      "label": "Shaming or emotional edge",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-disappointed-dom-voice",
+      "label": "Disappointed dom voice",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-mild-scolding-mocking-affection",
+      "label": "Mild scolding / mocking affection",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-verbal-power-struggle",
+      "label": "Verbal power struggle",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-challenge-response-dynamics",
+      "label": "Challenge-response dynamics",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-warm-tone-with-expectation",
+      "label": "Warm tone with expectation",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-nurturing-dominance",
+      "label": "Nurturing dominance",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-reassuring-commands",
+      "label": "Reassuring commands",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-phrases-that-work-on-you",
+      "label": "Phrases that work on you",
+      "type": "text",
+      "roles": [
+        "General"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-phrases-you-use-or-like-to-give",
+      "label": "Phrases you use or like to give",
+      "type": "text",
+      "roles": [
+        "General"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-what-helps-you-feel-emotionally-safe",
+      "label": "What helps you feel emotionally safe",
+      "type": "text",
+      "roles": [
+        "General"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-how-you-tend-to-show-affection",
+      "label": "How you tend to show affection",
+      "type": "text",
+      "roles": [
+        "General"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-emotional-check-in-style",
+      "label": "Emotional check-in style",
+      "type": "text",
+      "roles": [
+        "General"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-when-emotionally-activated-i-tend-to",
+      "label": "When emotionally activated, I tend to...",
+      "type": "text",
+      "roles": [
+        "General"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "body-fluids-and-functions-watersports-golden-showers",
+      "label": "Watersports/golden showers",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Fluids and Functions"
+    },
+    {
+      "id": "body-fluids-and-functions-cum",
+      "label": "Cum",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Fluids and Functions"
+    },
+    {
+      "id": "body-fluids-and-functions-blood",
+      "label": "Blood",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Fluids and Functions"
+    },
+    {
+      "id": "body-fluids-and-functions-scat",
+      "label": "Scat",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Fluids and Functions"
+    },
+    {
+      "id": "body-fluids-and-functions-sweat",
+      "label": "Sweat",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Fluids and Functions"
+    },
+    {
+      "id": "body-fluids-and-functions-vomit",
+      "label": "Vomit",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Fluids and Functions"
+    },
+    {
+      "id": "body-fluids-and-functions-tears-crying",
+      "label": "Tears/crying",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Fluids and Functions"
+    },
+    {
+      "id": "psychological-primal-prey-primal-prey",
+      "label": "Primal/Prey",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-conditioning",
+      "label": "Conditioning",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-coc",
+      "label": "COC",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-psycholagny-hands-free-mentally-stimulated-orgasm",
+      "label": "Psycholagny (hands free, mentally stimulated orgasm)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-hypno-play",
+      "label": "Hypno Play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-praise",
+      "label": "Praise",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-degradation",
+      "label": "Degradation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-traditional-primal-prey",
+      "label": "Traditional primal/prey",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-fear-play",
+      "label": "Fear play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-objectification",
+      "label": "Objectification",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-gaslighting",
+      "label": "Gaslighting",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-role-erosion-identity-play-loss-of-self",
+      "label": "Role erosion (identity play / loss of self)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-jealousy-play",
+      "label": "Jealousy play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-manipulation",
+      "label": "Manipulation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "body-part-fetish-play-belly-fucking",
+      "label": "Belly fucking",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-navel-play",
+      "label": "Navel play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-feet-foot-worship",
+      "label": "Feet / Foot worship",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-hands",
+      "label": "Hands",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-hair",
+      "label": "Hair",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-thighs",
+      "label": "Thighs",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-neck",
+      "label": "Neck",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-ears",
+      "label": "Ears",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-belly",
+      "label": "Belly",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-voice-fetish",
+      "label": "Voice fetish",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-nails-makeup-fetish",
+      "label": "Nails / Makeup fetish",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-cuddles",
+      "label": "Cuddles",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-food-play",
+      "label": "Food Play",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-kisses",
+      "label": "Kisses",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-masturbation",
+      "label": "Masturbation",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-romance-affection",
+      "label": "Romance / affection",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-sex-toys",
+      "label": "Sex toys",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-sexting-chat-etc",
+      "label": "Sexting /Chat etc",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-sexting-via-phone-or-video-call",
+      "label": "Sexting via phone or video call",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-strip-tease",
+      "label": "Strip tease",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-vanilla-sex",
+      "label": "Vanilla Sex",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-voice-notes",
+      "label": "Voice Notes",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-shaving-body-hair",
+      "label": "Shaving (body hair)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-sexy-clothing-private",
+      "label": "Sexy clothing (private)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-sexy-clothing-public",
+      "label": "Sexy clothing (public)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-outdoor-scenes",
+      "label": "Outdoor scenes",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-public-exposure",
+      "label": "Public exposure",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-edging",
+      "label": "Edging",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-short-term-denial",
+      "label": "Short term denial",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-long-term-denial",
+      "label": "Long term denial",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-forced-orgasms-overstimulation",
+      "label": "Forced orgasms / Overstimulation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-ruined-orgasms",
+      "label": "Ruined orgasms",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-no-touch-periods",
+      "label": "No touch periods",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-milking",
+      "label": "Milking",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-chastity-devices",
+      "label": "Chastity devices",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-consensual-orgasm-control",
+      "label": "Consensual orgasm control",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-forced-masturbation",
+      "label": "Forced masturbation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "protocol-and-ritual-formal-language",
+      "label": "Formal language",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-greeting-and-departure-rituals-kneeling-verbal-scripts-gestures",
+      "label": "Greeting and departure rituals (kneeling, verbal scripts, gestures)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-requiring-permission-for-things-speech-movement-attire",
+      "label": "Requiring permission for things (speech, movement, attire)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-daily-rituals-morning-check-ins-status-reports-mantra-repetitions",
+      "label": "Daily rituals (morning check-ins, status reports, mantra repetitions)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-specific-postures-for-rest-attention-punishment-waiting",
+      "label": "Specific postures for rest, attention, punishment, waiting",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-restricted-behavior-no-eye-contact-silence-no-questions",
+      "label": "Restricted behavior (no eye contact, silence, no questions)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-ritual-object-use-collar-cuffs-leash-tokens",
+      "label": "Ritual object use (collar, cuffs, leash, tokens)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-tracking-obedience-journals-apps",
+      "label": "Tracking obedience (journals, apps)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-formalized-rules-for-misbehavior-and-correction",
+      "label": "Formalized rules for misbehavior and correction",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-ritualized-aftercare-or-scene-closure",
+      "label": "Ritualized aftercare or scene closure",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-object-retrieval-on-all-fours-with-item-in-mouth",
+      "label": "Object retrieval on all fours with item in mouth",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-fetching-hairbrush-or-punishment-tool-from-dresser-while-crawling",
+      "label": "Fetching hairbrush or punishment tool from dresser while crawling",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-presenting-chosen-discipline-tool-in-kneeling-posture",
+      "label": "Presenting chosen discipline tool in kneeling posture",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-assigned-posture-or-kneeling-positions-as-ritual",
+      "label": "Assigned posture or kneeling positions as ritual",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-requesting-permission-using-specific-protocol-phrases",
+      "label": "Requesting permission using specific protocol phrases",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-carrying-items-in-mouth-as-submissive-gesture",
+      "label": "Carrying items in mouth as submissive gesture",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-crawling-back-with-object-to-dominant-after-retrieval",
+      "label": "Crawling back with object to Dominant after retrieval",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-following-via-nipple-leash-as-protocol-or-punishment",
+      "label": "Following via nipple leash as protocol or punishment",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-crawling-assigned-paths-as-ritual-or-obedience-training",
+      "label": "Crawling assigned paths as ritual or obedience training",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-crawling-rituals-e-g-object-retrieval",
+      "label": "Crawling rituals (e.g., object retrieval)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-carrying-objects-in-mouth-as-obedience",
+      "label": "Carrying objects in mouth as obedience",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-presenting-tools-or-toys-in-posture",
+      "label": "Presenting tools or toys in posture",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-using-honorifics-or-preset-protocol-language",
+      "label": "Using honorifics or preset protocol language",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-greeting-rituals-e-g-kneeling-kissing-feet",
+      "label": "Greeting rituals (e.g., kneeling, kissing feet)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-daily-check-ins-or-structured-reports",
+      "label": "Daily check-ins or structured reports",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-clothing-restrictions-or-uniforms",
+      "label": "Clothing restrictions or uniforms",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-posture-training-sitting-kneeling-standing",
+      "label": "Posture training (sitting, kneeling, standing)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-punishments-for-incorrect-behavior-or-tone",
+      "label": "Punishments for incorrect behavior or tone",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-crawling-with-items-in-mouth-e-g-hairbrush-spoon",
+      "label": "Crawling with items in mouth (e.g., hairbrush, spoon)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-earning-permission-for-meals-bathroom-use-or-rest",
+      "label": "Earning permission for meals, bathroom use, or rest",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-following-daily-rituals-or-protocol",
+      "label": "Following daily rituals or protocol",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-structured-speech-rules-e-g-titles-third-person",
+      "label": "Structured speech rules (e.g., titles, third person)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-receiving-correction-when-out-of-line",
+      "label": "Receiving correction when out of line",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-inspection-rituals-or-readiness-checks",
+      "label": "Inspection rituals or readiness checks",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "primal-bratting-chase-and-capture-play",
+      "label": "Chase and capture play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-bratting-for-punishment",
+      "label": "Bratting for punishment",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-playful-growling-and-biting",
+      "label": "Playful growling and biting",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-provoking-with-teasing-or-taunts",
+      "label": "Provoking with teasing or taunts",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-escaping-or-hiding-to-encourage-pursuit",
+      "label": "Escaping or hiding to encourage pursuit",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-refusing-commands-just-for-fun",
+      "label": "Refusing commands just for fun",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-provoking-your-partner-to-chase-or-discipline-you",
+      "label": "Provoking your partner to chase or discipline you",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-taunting-or-teasing-as-a-form-of-play",
+      "label": "Taunting or teasing as a form of play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-intentional-resistance-during-power-exchange",
+      "label": "Intentional resistance during power exchange",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-being-caught-and-overpowered",
+      "label": "Being caught and overpowered",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "headspace-regression-caregiver-little-regression-play",
+      "label": "Caregiver/little regression play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-using-pacifiers-or-sippy-cups",
+      "label": "Using pacifiers or sippy cups",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-coloring-or-childlike-crafts",
+      "label": "Coloring or childlike crafts",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-stuffed-animal-comfort",
+      "label": "Stuffed animal comfort",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-speaking-in-a-childlike-voice",
+      "label": "Speaking in a childlike voice",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-bedtime-stories-or-lullabies",
+      "label": "Bedtime stories or lullabies",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-entering-altered-headspaces-e-g-prey-pet-little",
+      "label": "Entering altered headspaces (e.g., prey, pet, little)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-regressive-behaviors-as-comfort-coloring-babytalk",
+      "label": "Regressive behaviors as comfort (coloring, babytalk)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-being-cared-for-during-emotional-vulnerability",
+      "label": "Being cared for during emotional vulnerability",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-guided-emotional-headspace-entry",
+      "label": "Guided emotional headspace entry",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "performance-internal-struggle-obedience-under-observation",
+      "label": "Obedience under observation",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-speech-restriction-and-self-denial",
+      "label": "Speech restriction and self-denial",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-maintaining-composure-during-humiliation",
+      "label": "Maintaining composure during humiliation",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-obedience-drills-for-an-audience",
+      "label": "Obedience drills for an audience",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-struggling-against-personal-urges",
+      "label": "Struggling against personal urges",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-displaying-submission-despite-conflict",
+      "label": "Displaying submission despite conflict",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-being-told-to-act-normal-while-struggling-internally",
+      "label": "Being told to act normal while struggling internally",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-pleasing-through-high-functioning-obedience",
+      "label": "Pleasing through high-functioning obedience",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-performing-submission-while-masking-resistance",
+      "label": "Performing submission while masking resistance",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-the-pressure-of-appearing-good-while-feeling-conflicted",
+      "label": "The pressure of appearing 'good' while feeling conflicted",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-being-made-to-perform-emotions-on-command-cry-beg-moan",
+      "label": "Being made to perform emotions on command (cry, beg, moan)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-struggling-openly-while-still-obeying",
+      "label": "Struggling openly while still obeying",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-performing-exaggerated-resistance-or-denial",
+      "label": "Performing exaggerated resistance or denial",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-being-punished-for-breaking-character",
+      "label": "Being punished for 'breaking character'",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-putting-on-a-show-for-someone-else-s-pleasure",
+      "label": "Putting on a show for someone else’s pleasure",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-rehearsed-degradation-or-humiliation-scripts",
+      "label": "Rehearsed degradation or humiliation scripts",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "mindfuck-manipulation-confusing-commands-and-reality-shifts",
+      "label": "Confusing commands and reality shifts",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-gaslighting-or-contradictory-cues",
+      "label": "Gaslighting or contradictory cues",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-presenting-false-choices",
+      "label": "Presenting false choices",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-hidden-motives-or-secret-tasks",
+      "label": "Hidden motives or secret tasks",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-illogical-rules-meant-to-confuse",
+      "label": "Illogical rules meant to confuse",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-gaslight-style-scenes-with-consent-and-clarity",
+      "label": "Gaslight-style scenes (with consent and clarity)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-false-threats-or-staged-surprises",
+      "label": "False threats or staged surprises",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-confusing-commands-to-prompt-hesitation",
+      "label": "Confusing commands to prompt hesitation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-emotional-trickery-as-arousal",
+      "label": "Emotional trickery as arousal",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-being-misled-or-deceived-on-purpose-during-play",
+      "label": "Being misled or deceived on purpose during play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-surprise-rule-changes-or-twists-mid-scene",
+      "label": "Surprise rule changes or twists mid-scene",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-false-safeword-games-with-negotiated-limits",
+      "label": "False safeword games (with negotiated limits)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-withholding-or-delaying-aftercare-for-effect",
+      "label": "Withholding or delaying aftercare for effect",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-being-gaslit-or-doubted-in-a-controlled-roleplay",
+      "label": "Being gaslit or doubted in a controlled roleplay",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-told-you-asked-for-this-or-you-love-this-when-resisting",
+      "label": "Told 'you asked for this' or 'you love this' when resisting",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mouth-play-holding-tools-or-restraints-in-teeth-while-crawling",
+      "label": "Holding tools or restraints in teeth while crawling",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-placing-objects-from-mouth-into-dominant-s-palm",
+      "label": "Placing objects from mouth into Dominant’s palm",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-using-mouth-instead-of-hands-for-service-rituals",
+      "label": "Using mouth instead of hands for service rituals",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-gag-presentation-and-silent-waiting-protocol",
+      "label": "Gag presentation and silent waiting protocol",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-holding-objects-in-teeth-while-crawling",
+      "label": "Holding objects in teeth while crawling",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-returning-items-using-mouth-only",
+      "label": "Returning items using mouth only",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-gag-rituals-or-waiting-silently",
+      "label": "Gag rituals or waiting silently",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-leash-held-in-mouth",
+      "label": "Leash held in mouth",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-being-gagged-or-forced-silent",
+      "label": "Being gagged or forced silent",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-having-to-hold-objects-in-your-mouth-spoon-hairbrush-leash",
+      "label": "Having to hold objects in your mouth (spoon, hairbrush, leash)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-being-used-for-oral-service-without-reciprocal-pleasure",
+      "label": "Being used for oral service without reciprocal pleasure",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-being-fed-by-hand-mouth-to-mouth-or-with-utensils",
+      "label": "Being fed by hand, mouth-to-mouth, or with utensils",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-verbal-control-e-g-only-speak-when-spoken-to",
+      "label": "Verbal control (e.g., only speak when spoken to)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-mouth-as-a-symbol-of-ownership-or-control",
+      "label": "Mouth as a symbol of ownership or control",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "impact-play-hand-spanking",
+      "label": "Hand spanking",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-paddle-strikes",
+      "label": "Paddle strikes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-crop-snaps",
+      "label": "Crop snaps",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-flogger-swings",
+      "label": "Flogger swings",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-cane-strokes",
+      "label": "Cane strokes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-belt-or-strap-hits",
+      "label": "Belt or strap hits",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-whip-cracks",
+      "label": "Whip cracks",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-preferred-intensity-levels",
+      "label": "Preferred intensity levels",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-aftercare-for-bruises",
+      "label": "Aftercare for bruises",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-target-body-areas",
+      "label": "Target body areas",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-implement-selection",
+      "label": "Implement selection",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "medical-play-needle-play",
+      "label": "Needle play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-catheter-insertion",
+      "label": "Catheter insertion",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-speculum-exams",
+      "label": "Speculum exams",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-enema-administration",
+      "label": "Enema administration",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-temperature-taking",
+      "label": "Temperature taking",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-medical-restraints",
+      "label": "Medical restraints",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-doctor-nurse-roleplay",
+      "label": "Doctor/nurse roleplay",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-sterilization-procedures",
+      "label": "Sterilization procedures",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-professional-vs-roleplay-scenes",
+      "label": "Professional vs roleplay scenes",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-consent-for-invasive-acts",
+      "label": "Consent for invasive acts",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-access-to-medical-equipment",
+      "label": "Access to medical equipment",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "pet-play-puppy-or-kitten-play",
+      "label": "Puppy or kitten play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-pony-play",
+      "label": "Pony play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-wearing-collar-and-leash",
+      "label": "Wearing collar and leash",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-eating-from-a-bowl",
+      "label": "Eating from a bowl",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-kenneling-or-caging",
+      "label": "Kenneling or caging",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-pet-training-commands",
+      "label": "Pet training commands",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-animal-costumes-or-gear",
+      "label": "Animal costumes or gear",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-preferred-animal-identities",
+      "label": "Preferred animal identities",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-public-vs-private-play",
+      "label": "Public vs private play",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-training-style-and-discipline",
+      "label": "Training style and discipline",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-use-of-pet-names-and-commands",
+      "label": "Use of pet names and commands",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "body-modification-piercings",
+      "label": "Piercings",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-tattoos",
+      "label": "Tattoos",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-branding",
+      "label": "Branding",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-scarification",
+      "label": "Scarification",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-permanent-chastity-devices",
+      "label": "Permanent chastity devices",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-cosmetic-implants",
+      "label": "Cosmetic implants",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-stretching-or-gauges",
+      "label": "Stretching or gauges",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-temporary-vs-permanent-changes",
+      "label": "Temporary vs permanent changes",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-professional-vs-diy-methods",
+      "label": "Professional vs DIY methods",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-body-placement-considerations",
+      "label": "Body placement considerations",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-healing-and-aftercare",
+      "label": "Healing and aftercare",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "relationship-preferences-preferred-relationship-style",
+      "label": "Preferred relationship style",
+      "type": "text",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-relationship-goals",
+      "label": "Relationship goals",
+      "type": "text",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-monogamous",
+      "label": "Monogamous",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-polyamorous",
+      "label": "Polyamorous",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-hierarchical-dynamics",
+      "label": "Hierarchical dynamics",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-non-hierarchical-poly",
+      "label": "Non-hierarchical poly",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-solo-poly",
+      "label": "Solo-poly",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-open-with-boundaries",
+      "label": "Open with boundaries",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-closed-but-kinky-with-others",
+      "label": "Closed but kinky with others",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-switch-friendly-dynamics",
+      "label": "Switch-friendly dynamics",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "gender-play-transformation-crossdressing",
+      "label": "Crossdressing",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-forced-feminization",
+      "label": "Forced feminization",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-forced-masculinization",
+      "label": "Forced masculinization",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-gender-role-reversal",
+      "label": "Gender role reversal",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-pronoun-changes",
+      "label": "Pronoun changes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-voice-or-mannerism-training",
+      "label": "Voice or mannerism training",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-sissy-or-tomboy-persona",
+      "label": "Sissy or tomboy persona",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-preferred-pronouns-and-names",
+      "label": "Preferred pronouns and names",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-public-presentation-comfort",
+      "label": "Public presentation comfort",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-clothing-and-appearance",
+      "label": "Clothing and appearance",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-exploration-of-identity",
+      "label": "Exploration of identity",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "chastity-devices-wearing-a-chastity-cage-short-term",
+      "label": "Wearing a chastity cage (short term)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-long-term-chastity-training",
+      "label": "Long-term chastity training",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-chastity-device-control-with-permission-to-unlock",
+      "label": "Chastity device control with permission to unlock",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-locked-remotely-by-another-person",
+      "label": "Locked remotely by another person",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-orgasm-denial-enforced-by-chastity",
+      "label": "Orgasm denial enforced by chastity",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-wearing-a-belt-style-chastity-device",
+      "label": "Wearing a belt-style chastity device",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-humiliation-while-locked-in-chastity",
+      "label": "Humiliation while locked in chastity",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-sleep-in-chastity-overnight",
+      "label": "Sleep in chastity (overnight)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-being-teased-while-unable-to-touch-yourself",
+      "label": "Being teased while unable to touch yourself",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-begging-for-release-from-chastity",
+      "label": "Begging for release from chastity",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "shibari-rope-bondage-being-tied-in-aesthetic-rope-patterns-shibari",
+      "label": "Being tied in aesthetic rope patterns (Shibari)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-rope-bondage-for-restraint-and-control",
+      "label": "Rope bondage for restraint and control",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-rope-suspension-partial-or-full",
+      "label": "Rope suspension (partial or full)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-learning-to-tie-rope-as-a-form-of-dominance",
+      "label": "Learning to tie rope as a form of dominance",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-being-tied-in-vulnerable-or-exposing-poses",
+      "label": "Being tied in vulnerable or exposing poses",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-practicing-rope-with-emotional-connection",
+      "label": "Practicing rope with emotional connection",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-enduring-discomfort-for-the-beauty-of-the-rope",
+      "label": "Enduring discomfort for the beauty of the rope",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-being-tied-in-a-mirror-and-told-to-look",
+      "label": "Being tied in a mirror and told to look",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-punishment-ties-e-g-uncomfortable-or-humiliating-positions",
+      "label": "Punishment ties (e.g., uncomfortable or humiliating positions)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-solo-rope-practice-for-mindfulness-or-masochism",
+      "label": "Solo rope practice for mindfulness or masochism",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "cosplay-identity-play-dressing-up-in-costumes-for-scenes",
+      "label": "Dressing up in costumes for scenes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "cosplay-identity-play-playing-as-fictional-characters",
+      "label": "Playing as fictional characters",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "cosplay-identity-play-petplay-with-collars-ears-or-tails",
+      "label": "Petplay with collars, ears, or tails",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "cosplay-identity-play-pretending-to-be-a-doll-robot-or-object",
+      "label": "Pretending to be a doll, robot, or object",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "cosplay-identity-play-master-slave-cosplay-dynamic-non-24-7",
+      "label": "Master/slave cosplay dynamic (non-24/7)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "cosplay-identity-play-roleplaying-as-a-fantasy-species-or-non-human",
+      "label": "Roleplaying as a fantasy species or non-human",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "cosplay-identity-play-using-cosplay-to-deepen-power-exchange",
+      "label": "Using cosplay to deepen power exchange",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "cosplay-identity-play-scene-built-around-a-character-s-story-or-world",
+      "label": "Scene built around a character’s story or world",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "cosplay-identity-play-fantasy-uniforms-nurse-teacher-etc",
+      "label": "Fantasy uniforms (nurse, teacher, etc.)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-intense-breath-play-e-g-smothering-or-pressure",
+      "label": "Intense breath play (e.g., smothering or pressure)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-knife-play-or-blade-play-without-injury",
+      "label": "Knife play or blade play (without injury)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-fear-play-using-known-or-negotiated-triggers",
+      "label": "Fear play using known or negotiated triggers",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-abduction-or-home-invasion-style-roleplay-negotiated",
+      "label": "Abduction or home-invasion style roleplay (negotiated)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-medical-themed-scenes-with-sharp-objects-not-bloodletting",
+      "label": "Medical-themed scenes with sharp objects (not bloodletting)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-sensory-deprivation-with-added-disorientation-or-helplessness",
+      "label": "Sensory deprivation with added disorientation or helplessness",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-scenes-involving-heavy-objectification-or-emotional-manipulation-with-care",
+      "label": "Scenes involving heavy objectification or emotional manipulation (with care)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-mock-interrogation-or-intense-role-pressure",
+      "label": "Mock interrogation or intense role pressure",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-consensual-threats-without-follow-through-e-g-if-you-don-t",
+      "label": "Consensual threats without follow-through (e.g. 'If you don’t...')",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-high-intensity-primal-scenes-involving-struggle-or-fear",
+      "label": "High-intensity primal scenes involving struggle or fear",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "behavioral-play-assigning-corner-time-or-time-outs",
+      "label": "Assigning corner time or time-outs",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-writing-lines-or-apology-letters-as-correction",
+      "label": "Writing lines or apology letters as correction",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-removing-privileges-phone-tv-sweets",
+      "label": "Removing privileges (phone, TV, sweets)",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-playful-punishments-that-still-reinforce-rules",
+      "label": "Playful punishments that still reinforce rules",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-lecturing-or-scolding-to-modify-behavior",
+      "label": "Lecturing or scolding to modify behavior",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-being-placed-in-the-corner-or-given-a-time-out",
+      "label": "Being placed in the corner or given a time-out",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-writing-lines-or-apology-letters-when-misbehaving",
+      "label": "Writing lines or apology letters when misbehaving",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-having-privileges-revoked-phone-tv",
+      "label": "Having privileges revoked (phone, TV)",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-receiving-playful-funishments-for-minor-rule-breaking",
+      "label": "Receiving playful 'funishments' for minor rule-breaking",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-getting-scolded-or-lectured-for-correction",
+      "label": "Getting scolded or lectured for correction",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-preferred-style-of-discipline-strict-vs-lenient",
+      "label": "Preferred style of discipline (strict vs lenient)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-attitude-toward-funishment-vs-serious-correction",
+      "label": "Attitude toward funishment vs serious correction",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-use-of-behavior-contracts-or-rule-agreements",
+      "label": "Use of behavior contracts or rule agreements",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "appearance-play-choosing-my-partner-s-outfit-for-the-day-or-a-scene",
+      "label": "Choosing my partner’s outfit for the day or a scene",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-selecting-their-underwear-lingerie-or-base-layers",
+      "label": "Selecting their underwear, lingerie, or base layers",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-styling-their-hair-braiding-brushing-tying-etc",
+      "label": "Styling their hair (braiding, brushing, tying, etc.)",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-picking-head-coverings-bonnets-veils-hoods-hats-for-mood-or-protocol",
+      "label": "Picking head coverings (bonnets, veils, hoods, hats) for mood or protocol",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-offering-makeup-polish-or-accessories-as-part-of-ritual-or-play",
+      "label": "Offering makeup, polish, or accessories as part of ritual or play",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-creating-themed-looks-slutty-innocent-doll-like-sharp-etc",
+      "label": "Creating themed looks (slutty, innocent, doll-like, sharp, etc.)",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-dressing-them-in-role-specific-costumes-maid-bunny-doll-etc",
+      "label": "Dressing them in role-specific costumes (maid, bunny, doll, etc.)",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-curating-time-period-or-historical-outfits-e-g-victorian-50s",
+      "label": "Curating time-period or historical outfits (e.g., Victorian, 50s)",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-helping-them-present-more-femme-masc-or-androgynous-by-request",
+      "label": "Helping them present more femme, masc, or androgynous by request",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-coordinating-their-look-with-mine-for-public-or-private-scenes",
+      "label": "Coordinating their look with mine for public or private scenes",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-implementing-a-dress-ritual-or-aesthetic-preparation",
+      "label": "Implementing a “dress ritual” or aesthetic preparation",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-enforcing-a-visual-protocol-e-g-no-bra-heels-required-tied-hair",
+      "label": "Enforcing a visual protocol (e.g., no bra, heels required, tied hair)",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-having-my-outfit-selected-for-me-by-a-partner",
+      "label": "Having my outfit selected for me by a partner",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-wearing-the-underwear-or-lingerie-they-choose",
+      "label": "Wearing the underwear or lingerie they choose",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-having-my-hair-brushed-braided-tied-or-styled-for-them",
+      "label": "Having my hair brushed, braided, tied, or styled for them",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-putting-on-a-head-covering-e-g-bonnet-veil-hood-they-chose",
+      "label": "Putting on a head covering (e.g., bonnet, veil, hood) they chose",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-following-visual-appearance-rules-as-part-of-submission",
+      "label": "Following visual appearance rules as part of submission",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-wearing-makeup-polish-or-accessories-they-request",
+      "label": "Wearing makeup, polish, or accessories they request",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-dressing-to-please-their-vision-cute-filthy-classy-etc",
+      "label": "Dressing to please their vision (cute, filthy, classy, etc.)",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-wearing-roleplay-costumes-or-character-looks",
+      "label": "Wearing roleplay costumes or character looks",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-presenting-in-a-way-that-matches-their-chosen-aesthetic",
+      "label": "Presenting in a way that matches their chosen aesthetic",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-participating-in-dressing-rituals-or-undressing-ceremonies",
+      "label": "Participating in dressing rituals or undressing ceremonies",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-being-admired-for-the-way-i-look-under-their-direction",
+      "label": "Being admired for the way I look under their direction",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-receiving-praise-or-gentle-teasing-about-my-appearance",
+      "label": "Receiving praise or gentle teasing about my appearance",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-cosplay-or-fantasy-looks-anime-game-fairytale-etc",
+      "label": "Cosplay or fantasy looks (anime, game, fairytale, etc.)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-time-period-dress-up-regency-gothic-1920s-etc",
+      "label": "Time-period dress-up (regency, gothic, 1920s, etc.)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-dollification-or-polished-presented-object-aesthetics",
+      "label": "Dollification or polished/presented object aesthetics",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-uniforms-schoolgirl-military-clerical-nurse-etc",
+      "label": "Uniforms (schoolgirl, military, clerical, nurse, etc.)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-hair-based-play-forced-brushing-ribbons-or-tied-styles",
+      "label": "Hair-based play (forced brushing, ribbons, or tied styles)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-head-coverings-or-symbolic-hoods-in-ritualized-dynamics",
+      "label": "Head coverings or symbolic hoods in ritualized dynamics",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-matching-looks-or-coordinated-dress-codes",
+      "label": "Matching looks or coordinated dress codes",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-ritualized-grooming-before-scenes",
+      "label": "Ritualized grooming before scenes",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-praise-or-positive-attention-for-pleasing-visual-display",
+      "label": "Praise or positive attention for pleasing visual display",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-formal-appearance-protocols-for-scenes-or-dynamics",
+      "label": "Formal appearance protocols for scenes or dynamics",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-using-clothing-or-style-to-embody-emotional-or-power-roles",
+      "label": "Using clothing or style to embody emotional or power roles",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "psychology-play-emotional-sadism-giving-teasing-feelings-orchestrating-reactions-savoring-anticipation-without-shame-based-harm",
+      "label": "Emotional Sadism (giving): teasing feelings, orchestrating reactions, savoring anticipation without shame-based harm",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-psychological-control-mind-games-double-binds-deliberate-pacing-and-strategic-ambiguity",
+      "label": "Psychological Control: mind games, double binds, deliberate pacing, and strategic ambiguity",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-sadistic-attention-enjoying-being-the-focal-point-of-a-partner-s-fear-arousal-or-resistance",
+      "label": "Sadistic Attention: enjoying being the focal point of a partner’s fear, arousal, or resistance",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-teasing-humiliation-playful-status-play-without-degradation-or-shame",
+      "label": "Teasing Humiliation: playful status play without degradation or shame",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-emotional-sadism-receiving-enjoying-engineered-emotional-intensity-such-as-fluster-exposure-or-playful-embarrassment",
+      "label": "Emotional Sadism (receiving): enjoying engineered emotional intensity such as fluster, exposure, or playful embarrassment",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-psychological-control-receiving-arousal-from-being-studied-contained-or-outmaneuvered",
+      "label": "Psychological Control (receiving): arousal from being studied, contained, or outmaneuvered",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-being-the-focus-enjoying-being-watched-tracked-or-held-in-a-partner-s-intense-focus",
+      "label": "Being the Focus: enjoying being watched, tracked, or held in a partner’s intense focus",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-teasing-humiliation-receiving-enjoying-playful-embarrassment-or-affectionate-mockery-that-builds-intimacy",
+      "label": "Teasing Humiliation (receiving): enjoying playful embarrassment or affectionate mockery that builds intimacy",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-prey-attention-neediness-craving-focus-pursuit-or-intense-awareness-from-a-partner",
+      "label": "Prey Attention/Neediness: craving focus, pursuit, or intense awareness from a partner",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-primal-recognition-being-seen-understood-or-tracked-without-needing-words",
+      "label": "Primal Recognition: being seen, understood, or tracked without needing words",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "breeding-impregnation-giving-arousal-from-attempting-to-impregnate-a-partner",
+      "label": "Impregnation (giving): arousal from attempting to impregnate a partner",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-feeding-milk-giving-arousal-from-producing-and-feeding-milk-to-a-partner",
+      "label": "Feeding Milk (giving): arousal from producing and feeding milk to a partner",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-impregnation-receiving-arousal-from-being-inseminated-pregnancy-risk-or-being-bred",
+      "label": "Impregnation (receiving): arousal from being inseminated, pregnancy risk, or being bred",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-feeding-milk-receiving-arousal-from-drinking-a-partner-s-milk",
+      "label": "Feeding Milk (receiving): arousal from drinking a partner’s milk",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-pregnancy-fantasy-erotic-focus-on-pregnancy-mine-partner-s-or-fictional-scenarios",
+      "label": "Pregnancy Fantasy: erotic focus on pregnancy (mine, partner’s, or fictional scenarios)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-primal-breeding-drive-animalistic-instinctual-framing-of-sex-reproduction-territory",
+      "label": "Primal Breeding Drive: animalistic/instinctual framing of sex, reproduction, territory",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-breeding-as-control-ownership-authority-expressed-through-breeding-talk-or-pregnancy-risk",
+      "label": "Breeding as Control: ownership/authority expressed through breeding talk or pregnancy risk",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-creampie-marking-erotic-meaning-placed-on-internal-ejaculation-or-visible-claimed-markers",
+      "label": "Creampie/Marking: erotic meaning placed on internal ejaculation or visible ‘claimed’ markers",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-risk-no-contraception-talk-fantasy-dirty-talk-about-risk-or-breeding-without-actual-risk",
+      "label": "Risk/‘No Contraception’ Talk (fantasy): dirty talk about risk or breeding without actual risk",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-heat-ovulation-tracking-timing-in-heat-roleplay-or-cycle-focused-arousal",
+      "label": "Heat/Ovulation Tracking: timing, ‘in heat’ roleplay, or cycle-focused arousal",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-artificial-insemination-device-play-syringes-cups-or-medical-style-scenarios-consensual-fantasy",
+      "label": "Artificial Insemination/Device Play: syringes, cups, or medical-style scenarios (consensual fantasy)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-breeding-denial-ruined-breeding-building-toward-impregnation-talk-then-denying-or-ruining-it",
+      "label": "Breeding Denial/Ruined Breeding: building toward impregnation talk then denying or ‘ruining’ it",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-pregnancy-body-focus-belly-worship-movement-weight-changes-glow-and-attention",
+      "label": "Pregnancy Body Focus: belly worship, movement/weight changes, glow, and attention",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-pregnancy-protocol-care-protective-rules-pedestal-treatment-dedicated-aftercare",
+      "label": "Pregnancy Protocol/Care: protective rules, pedestal treatment, dedicated aftercare",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-lactation-induction-maintenance-interest-in-inducing-or-sustaining-milk-production",
+      "label": "Lactation Induction/Maintenance: interest in inducing or sustaining milk production",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-milking-scenes-manual-oral-or-pump-based-milking-as-play-or-ritual",
+      "label": "Milking Scenes: manual, oral, or pump-based ‘milking’ as play or ritual",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-contraception-boundaries-preference-to-use-protection-bc-methods-or-simulation-only",
+      "label": "Contraception Boundaries: preference to use protection, BC methods, or simulation-only",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-sti-testing-medical-boundaries-testing-cadence-disclosures-and-comfort-levels",
+      "label": "STI/Testing & Medical Boundaries: testing cadence, disclosures, and comfort levels",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    }
+  ]
+}

--- a/docs/kinks/data/kinks.json
+++ b/docs/kinks/data/kinks.json
@@ -1,4943 +1,10247 @@
-[
-  {
-    "category": "Body Part Torture",
-    "items": [
-      {
-        "id": "body-part-torture-nipple-clips",
-        "label": "Nipple clips",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-nipple-weights",
-        "label": "Nipple weights",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-nipple-suction-cups",
-        "label": "Nipple suction cups",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-cock-ball-torture-cbt",
-        "label": "Cock, Ball Torture (CBT)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-clit-clips-weights-suction",
-        "label": "Clit clips/weights/suction",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-hair-pulling",
-        "label": "Hair pulling",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-face-slapping",
-        "label": "Face slapping",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-butt-slapping",
-        "label": "Butt slapping",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-breast-slapping",
-        "label": "Breast slapping",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-genital-slapping",
-        "label": "Genital slapping",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
+{
+  "labels": {
+    "cb_169ma": "Time-period dress-up",
+    "cb_2c0f9": "Hair-based play (brushing, ribbons, tying)",
+    "cb_2gxmo": "Uniforms (school, military, nurse, etc.)",
+    "cb_3ozhq": "Praise for pleasing visual display",
+    "cb_4yyxa": "Dollification / polished object aesthetics",
+    "cb_065gv": "Formal appearance protocols",
+    "cb_6jd2f": "Pick lingerie / base layers",
+    "cb_fsnmj": "Praise for pleasing visual display",
+    "cb_gkzbu": "Hair-based play (brushing, ribbons, tying)",
+    "cb_hqakm": "Formal appearance protocols",
+    "cb_ifkmg": "Clothing as power-role signal",
+    "cb_kaku7": "Time-period dress-up",
+    "cb_kgrnn": "Uniforms (school, military, nurse, etc.)",
+    "cb_kua8l": "Dress partner’s outfit",
+    "cb_qflrp": "Dollification / polished object aesthetics",
+    "cb_qw9jg": "Ritualized grooming",
+    "cb_qwnhi": "Head coverings / symbolic hoods",
+    "cb_r7cwr": "Head coverings / symbolic hoods",
+    "cb_rn136": "Clothing as power-role signal",
+    "cb_ss4gf": "Ritualized grooming",
+    "cb_w2dc1": "Coordinated looks / dress codes",
+    "cb_yzegd": "Pick lingerie / base layers",
+    "cb_zsnrb": "Dress partner’s outfit",
+    "cb_zvchg": "Coordinated looks / dress codes"
   },
-  {
-    "category": "Bondage and Suspension",
-    "items": [
-      {
-        "id": "bondage-and-suspension-blindfolds",
-        "label": "Blindfolds",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-bondage-heavy",
-        "label": "Bondage (heavy)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-bondage-light",
-        "label": "Bondage (light)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-immobilisation",
-        "label": "Immobilisation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-bondage-multi-day",
-        "label": "Bondage (multi-day)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-bondage-public-under-clothing",
-        "label": "Bondage (public, under clothing)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-leather-restraints",
-        "label": "Leather restraints",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-chains",
-        "label": "Chains",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-ropes",
-        "label": "Ropes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-intricate-japanese-rope-bondage",
-        "label": "Intricate (Japanese) rope bondage",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-rope-body-harness",
-        "label": "Rope body harness",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-arm-leg-sleeves-armbinders",
-        "label": "Arm & leg sleeves (armbinders)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-harnesses-leather",
-        "label": "Harnesses (leather)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-harnesses-rope",
-        "label": "Harnesses (rope)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-cuffs-leather",
-        "label": "Cuffs (leather)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-cuffs-metal",
-        "label": "Cuffs (metal)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-manacles-irons",
-        "label": "Manacles & Irons",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-gags-cloth",
-        "label": "Gags (cloth)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-gags-rubber",
-        "label": "Gags (rubber)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-gags-tape",
-        "label": "Gags (tape)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-gags-phallic",
-        "label": "Gags (phallic)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-gags-ring",
-        "label": "Gags (ring)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-gags-ball",
-        "label": "Gags (ball)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-mouth-bits",
-        "label": "Mouth bits",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-full-head-hoods",
-        "label": "Full head hoods",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-mummification-saran-wrapping",
-        "label": "Mummification/saran wrapping",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-straight-jackets",
-        "label": "Straight jackets",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-suspension-upright",
-        "label": "Suspension (upright)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-suspension-horizontal",
-        "label": "Suspension (horizontal)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-suspension-inverted",
-        "label": "Suspension (inverted)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-breath-play",
-        "label": "Breath play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-smothering",
-        "label": "Smothering",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-forced-self-breath-control",
-        "label": "Forced self-breath-control",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-gas-mask",
-        "label": "Gas mask",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Breath Play",
-    "items": [
-      {
-        "id": "breath-play-asphyxiation",
-        "label": "Asphyxiation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "breath-play-breath-control",
-        "label": "Breath control",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "breath-play-choking",
-        "label": "Choking",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "breath-play-drowning",
-        "label": "Drowning",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "breath-play-rebreathing-into-a-bag-or-object",
-        "label": "Rebreathing into a bag or object",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "breath-play-verbal-control-of-breath-e-g-hold-it-on-command",
-        "label": "Verbal control of breath (e.g., 'hold it' on command)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Sexual Activity",
-    "items": [
-      {
-        "id": "sexual-activity-licking",
-        "label": "Licking",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-fellatio-cunnilingus",
-        "label": "Fellatio/Cunnilingus",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-swallowing-semen",
-        "label": "Swallowing semen",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-cumming-on-partner",
-        "label": "Cumming on Partner",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-hand-jobs",
-        "label": "Hand jobs",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-anal-sex",
-        "label": "Anal sex",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-anal-plugs-small",
-        "label": "Anal plugs (small)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-anal-plugs-large",
-        "label": "Anal plugs (large)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-anal-beads",
-        "label": "Anal beads",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-vibrator-on-genitals",
-        "label": "Vibrator on genitals",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-fisting",
-        "label": "Fisting",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-oral-anal-play-rimming",
-        "label": "Oral/anal play (rimming)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-double-penetration-oral-and-vaginal",
-        "label": "Double penetration (oral and vaginal)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-double-penetration-oral-and-anal",
-        "label": "Double penetration (oral and anal)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-double-penetration-anal-and-vaginal",
-        "label": "Double penetration (anal and vaginal)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-triple-oral-vaginal-and-anal",
-        "label": "Triple (Oral, Vaginal and Anal)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Sensation Play",
-    "items": [
-      {
-        "id": "sensation-play-abrasion",
-        "label": "Abrasion",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-scratching",
-        "label": "Scratching",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-biting",
-        "label": "Biting",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-tickling",
-        "label": "Tickling",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-kissing",
-        "label": "Kissing",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-zapping-e-g-electric-fly-swatter",
-        "label": "Zapping (e.g. electric fly swatter)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-ice-cubes",
-        "label": "Ice cubes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-wax-play",
-        "label": "Wax Play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-fire",
-        "label": "Fire",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-clothespins",
-        "label": "Clothespins",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-needles",
-        "label": "Needles",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-sensory-deprivation",
-        "label": "Sensory deprivation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-physical-overpowering-manhandling",
-        "label": "Physical overpowering / Manhandling",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-figging",
-        "label": "Figging",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Other",
-    "items": [
-      {
-        "id": "other-feet",
-        "label": "Feet",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-boots",
-        "label": "Boots",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-underwear",
-        "label": "Underwear",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-chastity-devices",
-        "label": "Chastity devices",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-masks",
-        "label": "Masks",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-breeding",
-        "label": "Breeding",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-leather-clothing",
-        "label": "Leather clothing",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-training-protocols-outside-scenes-e-g-etiquette-memory",
-        "label": "Training protocols outside scenes (e.g., etiquette, memory)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-long-distance-training-structure",
-        "label": "Long-distance training/structure",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-scene-journaling-and-reflection",
-        "label": "Scene journaling and reflection",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Roleplaying",
-    "items": [
-      {
-        "id": "roleplaying-fantasy-abandonment",
-        "label": "Fantasy abandonment",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-kidnapping",
-        "label": "Kidnapping",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-interrogation",
-        "label": "Interrogation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-sleep-deprivation",
-        "label": "Sleep deprivation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-cnc",
-        "label": "CNC",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-gang-bang",
-        "label": "Gang bang",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-initiation-rites",
-        "label": "Initiation rites",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-religious-scenes",
-        "label": "Religious scenes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-medical-scenes",
-        "label": "Medical scenes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-prison-scenes",
-        "label": "Prison scenes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-primal-prey",
-        "label": "Primal/Prey",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-schoolroom-scenes",
-        "label": "Schoolroom scenes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Service and Restrictive Behaviour",
-    "items": [
-      {
-        "id": "service-and-restrictive-behaviour-following-orders",
-        "label": "(Following) orders",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-forced-servitude",
-        "label": "Forced servitude",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-restrictive-rules-on-behaviour",
-        "label": "Restrictive rules on behaviour",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-eye-contact-restrictions",
-        "label": "Eye contact restrictions",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-speech-restrictions-when-what-to-whom",
-        "label": "Speech restrictions (when, what, to whom)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-washroom-restrictions",
-        "label": "Washroom restrictions",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-punishments",
-        "label": "Punishments",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-tasks",
-        "label": "Tasks",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-massage",
-        "label": "Massage",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-domestic-tasks",
-        "label": "Domestic tasks",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-serving-food-and-drink",
-        "label": "Serving food and drink",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-personal-care-rituals",
-        "label": "Personal care rituals",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-being-on-call-at-specified-times",
-        "label": "Being on-call at specified times",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-daily-task-assignments",
-        "label": "Daily task assignments",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-corrections-for-imperfection",
-        "label": "Corrections for imperfection",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-uniforms-dress-codes",
-        "label": "Uniforms / Dress codes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-kneeling-posture-presentation",
-        "label": "Kneeling / Posture presentation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-silent-service",
-        "label": "Silent service",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-public-service-at-parties-or-events",
-        "label": "Public service (at parties or events)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-erotic-service-pleasure-on-command-without-seeking-your-own",
-        "label": "Erotic service (pleasure on command, without seeking your own)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Voyeurism/Exhibitionism",
-    "items": [
-      {
-        "id": "voyeurism-exhibitionism-forced-nudity-private",
-        "label": "Forced nudity (private)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "voyeurism-exhibitionism-forced-nudity-around-others",
-        "label": "Forced nudity (around others)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "voyeurism-exhibitionism-exhibitionism-friends",
-        "label": "Exhibitionism (friends)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "voyeurism-exhibitionism-exhibitionism-strangers",
-        "label": "Exhibitionism (strangers)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "voyeurism-exhibitionism-modelling-for-erotic-photos",
-        "label": "Modelling for erotic photos",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "voyeurism-exhibitionism-toys-under-clothes-in-public",
-        "label": "Toys under clothes in public",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Virtual & Long-Distance Play",
-    "items": [
-      {
-        "id": "virtual-long-distance-play-sending-tasks-or-orders-digitally",
-        "label": "Sending tasks or orders digitally",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-recording-dominant-voice-clips-commands-edging-praise-degradation-etc",
-        "label": "Recording dominant voice clips (commands, edging, praise, degradation, etc.)",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-remote-control-of-a-sex-toy",
-        "label": "Remote control of a sex toy",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-monitoring-behavior-via-app-or-shared-doc",
-        "label": "Monitoring behavior via app or shared doc",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-giving-punishment-assignments-remotely",
-        "label": "Giving punishment assignments remotely",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-creating-countdowns-timers-or-denial-periods",
-        "label": "Creating countdowns, timers, or denial periods",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-sending-written-instructions-with-delayed-permissions",
-        "label": "Sending written instructions with delayed permissions",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-creating-custom-video-or-audio-tasks",
-        "label": "Creating custom video or audio tasks",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-voice-message-control-during-scenes",
-        "label": "Voice message control during scenes",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-being-on-call-at-specified-times",
-        "label": "Being on-call at specified times",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-receiving-tasks-or-orders-digitally",
-        "label": "Receiving tasks or orders digitally",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-listening-to-dominant-voice-clips",
-        "label": "Listening to dominant voice clips",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-using-a-remote-controlled-toy-controlled-by-another",
-        "label": "Using a remote-controlled toy controlled by another",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-completing-daily-protocol-assignments",
-        "label": "Completing daily protocol assignments",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-submitting-proof-photo-video-text",
-        "label": "Submitting proof (photo, video, text)",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-following-recorded-or-timed-commands",
-        "label": "Following recorded or timed commands",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-receiving-surprise-instructions",
-        "label": "Receiving surprise instructions",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-hearing-name-praise-spoken-in-a-custom-clip",
-        "label": "Hearing name/praise spoken in a custom clip",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-sending-submissive-voice-clips-obedience-begging-thank-you-messages-affirmations-etc",
-        "label": "Sending submissive voice clips (obedience, begging, thank-you messages, affirmations, etc.)",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-scheduling-digital-rituals-or-reminders",
-        "label": "Scheduling digital rituals or reminders",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-using-training-habit-or-behavior-tracking-apps",
-        "label": "Using training, habit, or behavior-tracking apps",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-online-rituals-digital-kneeling-posture-protocols",
-        "label": "Online rituals (digital kneeling, posture protocols)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-role-based-texting-e-g-use-honorifics-in-chat",
-        "label": "Role-based texting (e.g., \"Use honorifics in chat\")",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-shared-playlists-affirmations-or-mantras",
-        "label": "Shared playlists, affirmations, or mantras",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-countdown-timers-to-next-task-release-or-interaction",
-        "label": "Countdown timers to next task, release, or interaction",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-scheduled-good-morning-night-rituals",
-        "label": "Scheduled good morning/night rituals",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-participating-in-video-call-scenes",
-        "label": "Participating in video call scenes",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-digital-aftercare-texts-voice-images",
-        "label": "Digital aftercare (texts, voice, images)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-sexting-or-digital-roleplay-scenes",
-        "label": "Sexting or digital roleplay scenes",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-voice-notes-or-submissive-dominant-affirmations",
-        "label": "Voice notes or submissive/dominant affirmations",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Communication",
-    "items": [
-      {
-        "id": "communication-playful-and-teasing",
-        "label": "Playful and teasing",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-quiet-and-intense",
-        "label": "Quiet and intense",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-observant-and-intentional",
-        "label": "Observant and intentional",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-praise-heavy",
-        "label": "Praise-heavy",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-blunt-and-efficient",
-        "label": "Blunt and efficient",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-affirming-and-soft",
-        "label": "Affirming and soft",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-psychological-interrogation",
-        "label": "Psychological interrogation",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-verbal-coercion-teasing-traps",
-        "label": "Verbal coercion / teasing traps",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-verbal-misdirection",
-        "label": "Verbal misdirection",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-mocking-shaming",
-        "label": "Mocking / shaming",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-predatory-pacing",
-        "label": "Predatory pacing",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-reluctant-obedience",
-        "label": "Reluctant obedience",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-stammering-submission",
-        "label": "Stammering submission",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-challenging-until-caught",
-        "label": "Challenging until caught",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-quiet-surrender",
-        "label": "Quiet surrender",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-sarcastic-teasing",
-        "label": "Sarcastic teasing",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-provoking-tone",
-        "label": "Provoking tone",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-challenge-based-dialogue",
-        "label": "Challenge-based dialogue",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-double-meaning-banter",
-        "label": "Double-meaning banter",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-soft-spoken-guidance",
-        "label": "Soft-spoken guidance",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-protective-but-firm-tone",
-        "label": "Protective but firm tone",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-emotional-redirection",
-        "label": "Emotional redirection",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-steady-reassurance",
-        "label": "Steady reassurance",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-direct-and-clear",
-        "label": "Direct and clear",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-gentle-and-nurturing",
-        "label": "Gentle and nurturing",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-commanding-and-firm",
-        "label": "Commanding and firm",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-quiet-and-observant",
-        "label": "Quiet and observant",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-instructive-teacher-like",
-        "label": "Instructive / teacher-like",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-emotionally-intense",
-        "label": "Emotionally intense",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-dismissive-withholding",
-        "label": "Dismissive / withholding",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-mocking-sarcastic",
-        "label": "Mocking / sarcastic",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-blunt-tactless",
-        "label": "Blunt / tactless",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-predatory-hunting-tone",
-        "label": "Predatory / hunting tone",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-stalking-or-circling-speech",
-        "label": "Stalking or circling speech",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-you-re-mine-control-language",
-        "label": "You’re mine / control language",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-threatening-consensual",
-        "label": "Threatening (consensual)",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-verbal-cornering-coaxing",
-        "label": "Verbal cornering / coaxing",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-watching-you-unravel",
-        "label": "Watching you unravel",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-cruel-and-cutting",
-        "label": "Cruel and cutting",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-psychological-baiting",
-        "label": "Psychological baiting",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-brat-breaking-language",
-        "label": "Brat-breaking language",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-mock-affection",
-        "label": "Mock affection",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-shaming-or-emotional-edge",
-        "label": "Shaming or emotional edge",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-disappointed-dom-voice",
-        "label": "Disappointed dom voice",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-mild-scolding-mocking-affection",
-        "label": "Mild scolding / mocking affection",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-verbal-power-struggle",
-        "label": "Verbal power struggle",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-challenge-response-dynamics",
-        "label": "Challenge-response dynamics",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-warm-tone-with-expectation",
-        "label": "Warm tone with expectation",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-nurturing-dominance",
-        "label": "Nurturing dominance",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-reassuring-commands",
-        "label": "Reassuring commands",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-phrases-that-work-on-you",
-        "label": "Phrases that work on you",
-        "type": "text",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "communication-phrases-you-use-or-like-to-give",
-        "label": "Phrases you use or like to give",
-        "type": "text",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "communication-what-helps-you-feel-emotionally-safe",
-        "label": "What helps you feel emotionally safe",
-        "type": "text",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "communication-how-you-tend-to-show-affection",
-        "label": "How you tend to show affection",
-        "type": "text",
-        "options": [
-          "Words of affirmation",
-          "Acts of service",
-          "Through teasing / play",
-          "Through obedience",
-          "Through caretaking",
-          "Withholding / teasing love",
-          "Physical closeness",
-          "Quality time"
-        ],
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "communication-emotional-check-in-style",
-        "label": "Emotional check-in style",
-        "type": "text",
-        "options": [
-          "Daily texting",
-          "After-scene debriefs",
-          "Scheduled check-ins",
-          "Mix of text/video check-ins",
-          "In-person check-ins",
-          "Journaling together",
-          "Minimal / low contact",
-          "Other"
-        ],
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "communication-when-emotionally-activated-i-tend-to",
-        "label": "When emotionally activated, I tend to...",
-        "type": "text",
-        "options": [
-          "Shut down",
-          "Overexplain / fawn",
-          "Get sarcastic / prickly",
-          "Spiral internally",
-          "Ask for reassurance",
-          "Withdraw",
-          "Other"
-        ],
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Body Fluids and Functions",
-    "items": [
-      {
-        "id": "body-fluids-and-functions-watersports-golden-showers",
-        "label": "Watersports/golden showers",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-fluids-and-functions-cum",
-        "label": "Cum",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-fluids-and-functions-blood",
-        "label": "Blood",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-fluids-and-functions-scat",
-        "label": "Scat",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-fluids-and-functions-sweat",
-        "label": "Sweat",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-fluids-and-functions-vomit",
-        "label": "Vomit",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-fluids-and-functions-tears-crying",
-        "label": "Tears/crying",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Psychological Primal / Prey",
-    "items": [
-      {
-        "id": "psychological-primal-prey-primal-prey",
-        "label": "Primal/Prey",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-conditioning",
-        "label": "Conditioning",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-coc",
-        "label": "COC",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-psycholagny-hands-free-mentally-stimulated-orgasm",
-        "label": "Psycholagny (hands free, mentally stimulated orgasm)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-hypno-play",
-        "label": "Hypno Play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-praise",
-        "label": "Praise",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-degradation",
-        "label": "Degradation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-traditional-primal-prey",
-        "label": "Traditional primal/prey",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-fear-play",
-        "label": "Fear play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-objectification",
-        "label": "Objectification",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-gaslighting",
-        "label": "Gaslighting",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-role-erosion-identity-play-loss-of-self",
-        "label": "Role erosion (identity play / loss of self)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-jealousy-play",
-        "label": "Jealousy play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-manipulation",
-        "label": "Manipulation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Body Part / Fetish Play",
-    "items": [
-      {
-        "id": "body-part-fetish-play-belly-fucking",
-        "label": "Belly fucking",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-navel-play",
-        "label": "Navel play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-feet-foot-worship",
-        "label": "Feet / Foot worship",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-hands",
-        "label": "Hands",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-hair",
-        "label": "Hair",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-thighs",
-        "label": "Thighs",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-neck",
-        "label": "Neck",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-ears",
-        "label": "Ears",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-belly",
-        "label": "Belly",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-voice-fetish",
-        "label": "Voice fetish",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-nails-makeup-fetish",
-        "label": "Nails / Makeup fetish",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-cuddles",
-        "label": "Cuddles",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-food-play",
-        "label": "Food Play",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-kisses",
-        "label": "Kisses",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-masturbation",
-        "label": "Masturbation",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-romance-affection",
-        "label": "Romance / affection",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-sex-toys",
-        "label": "Sex toys",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-sexting-chat-etc",
-        "label": "Sexting /Chat etc",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-sexting-via-phone-or-video-call",
-        "label": "Sexting via phone or video call",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-strip-tease",
-        "label": "Strip tease",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-vanilla-sex",
-        "label": "Vanilla Sex",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-voice-notes",
-        "label": "Voice Notes",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-shaving-body-hair",
-        "label": "Shaving (body hair)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-sexy-clothing-private",
-        "label": "Sexy clothing (private)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-sexy-clothing-public",
-        "label": "Sexy clothing (public)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-outdoor-scenes",
-        "label": "Outdoor scenes",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-public-exposure",
-        "label": "Public exposure",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Orgasm Control & Sexual Manipulation",
-    "items": [
-      {
-        "id": "orgasm-control-sexual-manipulation-edging",
-        "label": "Edging",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-short-term-denial",
-        "label": "Short term denial",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-long-term-denial",
-        "label": "Long term denial",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-forced-orgasms-overstimulation",
-        "label": "Forced orgasms / Overstimulation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-ruined-orgasms",
-        "label": "Ruined orgasms",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-no-touch-periods",
-        "label": "No touch periods",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-milking",
-        "label": "Milking",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-chastity-devices",
-        "label": "Chastity devices",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-consensual-orgasm-control",
-        "label": "Consensual orgasm control",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-forced-masturbation",
-        "label": "Forced masturbation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Protocol and Ritual",
-    "items": [
-      {
-        "id": "protocol-and-ritual-formal-language",
-        "label": "Formal language",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-greeting-and-departure-rituals-kneeling-verbal-scripts-gestures",
-        "label": "Greeting and departure rituals (kneeling, verbal scripts, gestures)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-requiring-permission-for-things-speech-movement-attire",
-        "label": "Requiring permission for things (speech, movement, attire)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-daily-rituals-morning-check-ins-status-reports-mantra-repetitions",
-        "label": "Daily rituals (morning check-ins, status reports, mantra repetitions)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-specific-postures-for-rest-attention-punishment-waiting",
-        "label": "Specific postures for rest, attention, punishment, waiting",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-restricted-behavior-no-eye-contact-silence-no-questions",
-        "label": "Restricted behavior (no eye contact, silence, no questions)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-ritual-object-use-collar-cuffs-leash-tokens",
-        "label": "Ritual object use (collar, cuffs, leash, tokens)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-tracking-obedience-journals-apps",
-        "label": "Tracking obedience (journals, apps)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-formalized-rules-for-misbehavior-and-correction",
-        "label": "Formalized rules for misbehavior and correction",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-ritualized-aftercare-or-scene-closure",
-        "label": "Ritualized aftercare or scene closure",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-object-retrieval-on-all-fours-with-item-in-mouth",
-        "label": "Object retrieval on all fours with item in mouth",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-fetching-hairbrush-or-punishment-tool-from-dresser-while-crawling",
-        "label": "Fetching hairbrush or punishment tool from dresser while crawling",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-presenting-chosen-discipline-tool-in-kneeling-posture",
-        "label": "Presenting chosen discipline tool in kneeling posture",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-assigned-posture-or-kneeling-positions-as-ritual",
-        "label": "Assigned posture or kneeling positions as ritual",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-requesting-permission-using-specific-protocol-phrases",
-        "label": "Requesting permission using specific protocol phrases",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-carrying-items-in-mouth-as-submissive-gesture",
-        "label": "Carrying items in mouth as submissive gesture",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-crawling-back-with-object-to-dominant-after-retrieval",
-        "label": "Crawling back with object to Dominant after retrieval",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-following-via-nipple-leash-as-protocol-or-punishment",
-        "label": "Following via nipple leash as protocol or punishment",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-crawling-assigned-paths-as-ritual-or-obedience-training",
-        "label": "Crawling assigned paths as ritual or obedience training",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-crawling-rituals-e-g-object-retrieval",
-        "label": "Crawling rituals (e.g., object retrieval)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-carrying-objects-in-mouth-as-obedience",
-        "label": "Carrying objects in mouth as obedience",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-presenting-tools-or-toys-in-posture",
-        "label": "Presenting tools or toys in posture",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-using-honorifics-or-preset-protocol-language",
-        "label": "Using honorifics or preset protocol language",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-greeting-rituals-e-g-kneeling-kissing-feet",
-        "label": "Greeting rituals (e.g., kneeling, kissing feet)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-daily-check-ins-or-structured-reports",
-        "label": "Daily check-ins or structured reports",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-clothing-restrictions-or-uniforms",
-        "label": "Clothing restrictions or uniforms",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-posture-training-sitting-kneeling-standing",
-        "label": "Posture training (sitting, kneeling, standing)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-punishments-for-incorrect-behavior-or-tone",
-        "label": "Punishments for incorrect behavior or tone",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-crawling-with-items-in-mouth-e-g-hairbrush-spoon",
-        "label": "Crawling with items in mouth (e.g., hairbrush, spoon)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-earning-permission-for-meals-bathroom-use-or-rest",
-        "label": "Earning permission for meals, bathroom use, or rest",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-following-daily-rituals-or-protocol",
-        "label": "Following daily rituals or protocol",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-structured-speech-rules-e-g-titles-third-person",
-        "label": "Structured speech rules (e.g., titles, third person)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-receiving-correction-when-out-of-line",
-        "label": "Receiving correction when out of line",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-inspection-rituals-or-readiness-checks",
-        "label": "Inspection rituals or readiness checks",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Primal & Bratting",
-    "items": [
-      {
-        "id": "primal-bratting-chase-and-capture-play",
-        "label": "Chase and capture play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-bratting-for-punishment",
-        "label": "Bratting for punishment",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-playful-growling-and-biting",
-        "label": "Playful growling and biting",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-provoking-with-teasing-or-taunts",
-        "label": "Provoking with teasing or taunts",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-escaping-or-hiding-to-encourage-pursuit",
-        "label": "Escaping or hiding to encourage pursuit",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-refusing-commands-just-for-fun",
-        "label": "Refusing commands just for fun",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-provoking-your-partner-to-chase-or-discipline-you",
-        "label": "Provoking your partner to chase or discipline you",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-taunting-or-teasing-as-a-form-of-play",
-        "label": "Taunting or teasing as a form of play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-intentional-resistance-during-power-exchange",
-        "label": "Intentional resistance during power exchange",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-being-caught-and-overpowered",
-        "label": "Being caught and overpowered",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Headspace & Regression",
-    "items": [
-      {
-        "id": "headspace-regression-caregiver-little-regression-play",
-        "label": "Caregiver/little regression play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-using-pacifiers-or-sippy-cups",
-        "label": "Using pacifiers or sippy cups",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-coloring-or-childlike-crafts",
-        "label": "Coloring or childlike crafts",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-stuffed-animal-comfort",
-        "label": "Stuffed animal comfort",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-speaking-in-a-childlike-voice",
-        "label": "Speaking in a childlike voice",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-bedtime-stories-or-lullabies",
-        "label": "Bedtime stories or lullabies",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-entering-altered-headspaces-e-g-prey-pet-little",
-        "label": "Entering altered headspaces (e.g., prey, pet, little)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-regressive-behaviors-as-comfort-coloring-babytalk",
-        "label": "Regressive behaviors as comfort (coloring, babytalk)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-being-cared-for-during-emotional-vulnerability",
-        "label": "Being cared for during emotional vulnerability",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-guided-emotional-headspace-entry",
-        "label": "Guided emotional headspace entry",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Performance & Internal Struggle",
-    "items": [
-      {
-        "id": "performance-internal-struggle-obedience-under-observation",
-        "label": "Obedience under observation",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-speech-restriction-and-self-denial",
-        "label": "Speech restriction and self-denial",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-maintaining-composure-during-humiliation",
-        "label": "Maintaining composure during humiliation",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-obedience-drills-for-an-audience",
-        "label": "Obedience drills for an audience",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-struggling-against-personal-urges",
-        "label": "Struggling against personal urges",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-displaying-submission-despite-conflict",
-        "label": "Displaying submission despite conflict",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-being-told-to-act-normal-while-struggling-internally",
-        "label": "Being told to act normal while struggling internally",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-pleasing-through-high-functioning-obedience",
-        "label": "Pleasing through high-functioning obedience",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-performing-submission-while-masking-resistance",
-        "label": "Performing submission while masking resistance",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-the-pressure-of-appearing-good-while-feeling-conflicted",
-        "label": "The pressure of appearing 'good' while feeling conflicted",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-being-made-to-perform-emotions-on-command-cry-beg-moan",
-        "label": "Being made to perform emotions on command (cry, beg, moan)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-struggling-openly-while-still-obeying",
-        "label": "Struggling openly while still obeying",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-performing-exaggerated-resistance-or-denial",
-        "label": "Performing exaggerated resistance or denial",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-being-punished-for-breaking-character",
-        "label": "Being punished for 'breaking character'",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-putting-on-a-show-for-someone-else-s-pleasure",
-        "label": "Putting on a show for someone else’s pleasure",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-rehearsed-degradation-or-humiliation-scripts",
-        "label": "Rehearsed degradation or humiliation scripts",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Mindfuck & Manipulation",
-    "items": [
-      {
-        "id": "mindfuck-manipulation-confusing-commands-and-reality-shifts",
-        "label": "Confusing commands and reality shifts",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-gaslighting-or-contradictory-cues",
-        "label": "Gaslighting or contradictory cues",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-presenting-false-choices",
-        "label": "Presenting false choices",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-hidden-motives-or-secret-tasks",
-        "label": "Hidden motives or secret tasks",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-illogical-rules-meant-to-confuse",
-        "label": "Illogical rules meant to confuse",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-gaslight-style-scenes-with-consent-and-clarity",
-        "label": "Gaslight-style scenes (with consent and clarity)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-false-threats-or-staged-surprises",
-        "label": "False threats or staged surprises",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-confusing-commands-to-prompt-hesitation",
-        "label": "Confusing commands to prompt hesitation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-emotional-trickery-as-arousal",
-        "label": "Emotional trickery as arousal",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-being-misled-or-deceived-on-purpose-during-play",
-        "label": "Being misled or deceived on purpose during play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-surprise-rule-changes-or-twists-mid-scene",
-        "label": "Surprise rule changes or twists mid-scene",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-false-safeword-games-with-negotiated-limits",
-        "label": "False safeword games (with negotiated limits)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-withholding-or-delaying-aftercare-for-effect",
-        "label": "Withholding or delaying aftercare for effect",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-being-gaslit-or-doubted-in-a-controlled-roleplay",
-        "label": "Being gaslit or doubted in a controlled roleplay",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-told-you-asked-for-this-or-you-love-this-when-resisting",
-        "label": "Told 'you asked for this' or 'you love this' when resisting",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Mouth Play",
-    "items": [
-      {
-        "id": "mouth-play-holding-tools-or-restraints-in-teeth-while-crawling",
-        "label": "Holding tools or restraints in teeth while crawling",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-placing-objects-from-mouth-into-dominant-s-palm",
-        "label": "Placing objects from mouth into Dominant’s palm",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-using-mouth-instead-of-hands-for-service-rituals",
-        "label": "Using mouth instead of hands for service rituals",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-gag-presentation-and-silent-waiting-protocol",
-        "label": "Gag presentation and silent waiting protocol",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-holding-objects-in-teeth-while-crawling",
-        "label": "Holding objects in teeth while crawling",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-returning-items-using-mouth-only",
-        "label": "Returning items using mouth only",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-gag-rituals-or-waiting-silently",
-        "label": "Gag rituals or waiting silently",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-leash-held-in-mouth",
-        "label": "Leash held in mouth",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-being-gagged-or-forced-silent",
-        "label": "Being gagged or forced silent",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-having-to-hold-objects-in-your-mouth-spoon-hairbrush-leash",
-        "label": "Having to hold objects in your mouth (spoon, hairbrush, leash)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-being-used-for-oral-service-without-reciprocal-pleasure",
-        "label": "Being used for oral service without reciprocal pleasure",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-being-fed-by-hand-mouth-to-mouth-or-with-utensils",
-        "label": "Being fed by hand, mouth-to-mouth, or with utensils",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-verbal-control-e-g-only-speak-when-spoken-to",
-        "label": "Verbal control (e.g., only speak when spoken to)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-mouth-as-a-symbol-of-ownership-or-control",
-        "label": "Mouth as a symbol of ownership or control",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Impact Play",
-    "items": [
-      {
-        "id": "impact-play-hand-spanking",
-        "label": "Hand spanking",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "impact-play-paddle-strikes",
-        "label": "Paddle strikes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "impact-play-crop-snaps",
-        "label": "Crop snaps",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "impact-play-flogger-swings",
-        "label": "Flogger swings",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "impact-play-cane-strokes",
-        "label": "Cane strokes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "impact-play-belt-or-strap-hits",
-        "label": "Belt or strap hits",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "impact-play-whip-cracks",
-        "label": "Whip cracks",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "impact-play-preferred-intensity-levels",
-        "label": "Preferred intensity levels",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "impact-play-aftercare-for-bruises",
-        "label": "Aftercare for bruises",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "impact-play-target-body-areas",
-        "label": "Target body areas",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "impact-play-implement-selection",
-        "label": "Implement selection",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Medical Play",
-    "items": [
-      {
-        "id": "medical-play-needle-play",
-        "label": "Needle play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "medical-play-catheter-insertion",
-        "label": "Catheter insertion",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "medical-play-speculum-exams",
-        "label": "Speculum exams",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "medical-play-enema-administration",
-        "label": "Enema administration",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "medical-play-temperature-taking",
-        "label": "Temperature taking",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "medical-play-medical-restraints",
-        "label": "Medical restraints",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "medical-play-doctor-nurse-roleplay",
-        "label": "Doctor/nurse roleplay",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "medical-play-sterilization-procedures",
-        "label": "Sterilization procedures",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "medical-play-professional-vs-roleplay-scenes",
-        "label": "Professional vs roleplay scenes",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "medical-play-consent-for-invasive-acts",
-        "label": "Consent for invasive acts",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "medical-play-access-to-medical-equipment",
-        "label": "Access to medical equipment",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Pet Play",
-    "items": [
-      {
-        "id": "pet-play-puppy-or-kitten-play",
-        "label": "Puppy or kitten play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "pet-play-pony-play",
-        "label": "Pony play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "pet-play-wearing-collar-and-leash",
-        "label": "Wearing collar and leash",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "pet-play-eating-from-a-bowl",
-        "label": "Eating from a bowl",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "pet-play-kenneling-or-caging",
-        "label": "Kenneling or caging",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "pet-play-pet-training-commands",
-        "label": "Pet training commands",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "pet-play-animal-costumes-or-gear",
-        "label": "Animal costumes or gear",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "pet-play-preferred-animal-identities",
-        "label": "Preferred animal identities",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "pet-play-public-vs-private-play",
-        "label": "Public vs private play",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "pet-play-training-style-and-discipline",
-        "label": "Training style and discipline",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "pet-play-use-of-pet-names-and-commands",
-        "label": "Use of pet names and commands",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Body Modification",
-    "items": [
-      {
-        "id": "body-modification-piercings",
-        "label": "Piercings",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-modification-tattoos",
-        "label": "Tattoos",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-modification-branding",
-        "label": "Branding",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-modification-scarification",
-        "label": "Scarification",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-modification-permanent-chastity-devices",
-        "label": "Permanent chastity devices",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-modification-cosmetic-implants",
-        "label": "Cosmetic implants",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-modification-stretching-or-gauges",
-        "label": "Stretching or gauges",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-modification-temporary-vs-permanent-changes",
-        "label": "Temporary vs permanent changes",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-modification-professional-vs-diy-methods",
-        "label": "Professional vs DIY methods",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-modification-body-placement-considerations",
-        "label": "Body placement considerations",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-modification-healing-and-aftercare",
-        "label": "Healing and aftercare",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Relationship Preferences",
-    "items": [
-      {
-        "id": "relationship-preferences-preferred-relationship-style",
-        "label": "Preferred relationship style",
-        "type": "text",
-        "options": [
-          "Monogamous",
-          "Open relationship",
-          "Polyamorous",
-          "No preference"
-        ],
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-relationship-goals",
-        "label": "Relationship goals",
-        "type": "text",
-        "options": [
-          "One night stand",
-          "Short-term play",
-          "Long-term relationship",
-          "Platonic play partners",
-          "Romantic partners",
-          "Kink partners"
-        ],
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-monogamous",
-        "label": "Monogamous",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-polyamorous",
-        "label": "Polyamorous",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-hierarchical-dynamics",
-        "label": "Hierarchical dynamics",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-non-hierarchical-poly",
-        "label": "Non-hierarchical poly",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-solo-poly",
-        "label": "Solo-poly",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-open-with-boundaries",
-        "label": "Open with boundaries",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-closed-but-kinky-with-others",
-        "label": "Closed but kinky with others",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-switch-friendly-dynamics",
-        "label": "Switch-friendly dynamics",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Gender Play & Transformation",
-    "items": [
-      {
-        "id": "gender-play-transformation-crossdressing",
-        "label": "Crossdressing",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-forced-feminization",
-        "label": "Forced feminization",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-forced-masculinization",
-        "label": "Forced masculinization",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-gender-role-reversal",
-        "label": "Gender role reversal",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-pronoun-changes",
-        "label": "Pronoun changes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-voice-or-mannerism-training",
-        "label": "Voice or mannerism training",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-sissy-or-tomboy-persona",
-        "label": "Sissy or tomboy persona",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-preferred-pronouns-and-names",
-        "label": "Preferred pronouns and names",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-public-presentation-comfort",
-        "label": "Public presentation comfort",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-clothing-and-appearance",
-        "label": "Clothing and appearance",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-exploration-of-identity",
-        "label": "Exploration of identity",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Chastity Devices",
-    "items": [
-      {
-        "id": "chastity-devices-wearing-a-chastity-cage-short-term",
-        "label": "Wearing a chastity cage (short term)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-long-term-chastity-training",
-        "label": "Long-term chastity training",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-chastity-device-control-with-permission-to-unlock",
-        "label": "Chastity device control with permission to unlock",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-locked-remotely-by-another-person",
-        "label": "Locked remotely by another person",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-orgasm-denial-enforced-by-chastity",
-        "label": "Orgasm denial enforced by chastity",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-wearing-a-belt-style-chastity-device",
-        "label": "Wearing a belt-style chastity device",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-humiliation-while-locked-in-chastity",
-        "label": "Humiliation while locked in chastity",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-sleep-in-chastity-overnight",
-        "label": "Sleep in chastity (overnight)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-being-teased-while-unable-to-touch-yourself",
-        "label": "Being teased while unable to touch yourself",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-begging-for-release-from-chastity",
-        "label": "Begging for release from chastity",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Shibari & Rope Bondage",
-    "items": [
-      {
-        "id": "shibari-rope-bondage-being-tied-in-aesthetic-rope-patterns-shibari",
-        "label": "Being tied in aesthetic rope patterns (Shibari)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-rope-bondage-for-restraint-and-control",
-        "label": "Rope bondage for restraint and control",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-rope-suspension-partial-or-full",
-        "label": "Rope suspension (partial or full)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-learning-to-tie-rope-as-a-form-of-dominance",
-        "label": "Learning to tie rope as a form of dominance",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-being-tied-in-vulnerable-or-exposing-poses",
-        "label": "Being tied in vulnerable or exposing poses",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-practicing-rope-with-emotional-connection",
-        "label": "Practicing rope with emotional connection",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-enduring-discomfort-for-the-beauty-of-the-rope",
-        "label": "Enduring discomfort for the beauty of the rope",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-being-tied-in-a-mirror-and-told-to-look",
-        "label": "Being tied in a mirror and told to look",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-punishment-ties-e-g-uncomfortable-or-humiliating-positions",
-        "label": "Punishment ties (e.g., uncomfortable or humiliating positions)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-solo-rope-practice-for-mindfulness-or-masochism",
-        "label": "Solo rope practice for mindfulness or masochism",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Cosplay & Identity Play",
-    "items": [
-      {
-        "id": "cosplay-identity-play-dressing-up-in-costumes-for-scenes",
-        "label": "Dressing up in costumes for scenes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "cosplay-identity-play-playing-as-fictional-characters",
-        "label": "Playing as fictional characters",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "cosplay-identity-play-petplay-with-collars-ears-or-tails",
-        "label": "Petplay with collars, ears, or tails",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "cosplay-identity-play-pretending-to-be-a-doll-robot-or-object",
-        "label": "Pretending to be a doll, robot, or object",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "cosplay-identity-play-master-slave-cosplay-dynamic-non-24-7",
-        "label": "Master/slave cosplay dynamic (non-24/7)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "cosplay-identity-play-roleplaying-as-a-fantasy-species-or-non-human",
-        "label": "Roleplaying as a fantasy species or non-human",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "cosplay-identity-play-using-cosplay-to-deepen-power-exchange",
-        "label": "Using cosplay to deepen power exchange",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "cosplay-identity-play-scene-built-around-a-character-s-story-or-world",
-        "label": "Scene built around a character’s story or world",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "cosplay-identity-play-fantasy-uniforms-nurse-teacher-etc",
-        "label": "Fantasy uniforms (nurse, teacher, etc.)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "High-Intensity Kinks (SSC-Aware)",
-    "items": [
-      {
-        "id": "high-intensity-kinks-ssc-aware-intense-breath-play-e-g-smothering-or-pressure",
-        "label": "Intense breath play (e.g., smothering or pressure)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-knife-play-or-blade-play-without-injury",
-        "label": "Knife play or blade play (without injury)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-fear-play-using-known-or-negotiated-triggers",
-        "label": "Fear play using known or negotiated triggers",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-abduction-or-home-invasion-style-roleplay-negotiated",
-        "label": "Abduction or home-invasion style roleplay (negotiated)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-medical-themed-scenes-with-sharp-objects-not-bloodletting",
-        "label": "Medical-themed scenes with sharp objects (not bloodletting)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-sensory-deprivation-with-added-disorientation-or-helplessness",
-        "label": "Sensory deprivation with added disorientation or helplessness",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-scenes-involving-heavy-objectification-or-emotional-manipulation-with-care",
-        "label": "Scenes involving heavy objectification or emotional manipulation (with care)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-mock-interrogation-or-intense-role-pressure",
-        "label": "Mock interrogation or intense role pressure",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-consensual-threats-without-follow-through-e-g-if-you-don-t",
-        "label": "Consensual threats without follow-through (e.g. 'If you don’t...')",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-high-intensity-primal-scenes-involving-struggle-or-fear",
-        "label": "High-intensity primal scenes involving struggle or fear",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Behavioral Play",
-    "items": [
-      {
-        "id": "behavioral-play-assigning-corner-time-or-time-outs",
-        "label": "Assigning corner time or time-outs",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "behavioral-play-writing-lines-or-apology-letters-as-correction",
-        "label": "Writing lines or apology letters as correction",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "behavioral-play-removing-privileges-phone-tv-sweets",
-        "label": "Removing privileges (phone, TV, sweets)",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "behavioral-play-playful-punishments-that-still-reinforce-rules",
-        "label": "Playful punishments that still reinforce rules",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "behavioral-play-lecturing-or-scolding-to-modify-behavior",
-        "label": "Lecturing or scolding to modify behavior",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "behavioral-play-being-placed-in-the-corner-or-given-a-time-out",
-        "label": "Being placed in the corner or given a time-out",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "behavioral-play-writing-lines-or-apology-letters-when-misbehaving",
-        "label": "Writing lines or apology letters when misbehaving",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "behavioral-play-having-privileges-revoked-phone-tv",
-        "label": "Having privileges revoked (phone, TV)",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "behavioral-play-receiving-playful-funishments-for-minor-rule-breaking",
-        "label": "Receiving playful 'funishments' for minor rule-breaking",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "behavioral-play-getting-scolded-or-lectured-for-correction",
-        "label": "Getting scolded or lectured for correction",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "behavioral-play-preferred-style-of-discipline-strict-vs-lenient",
-        "label": "Preferred style of discipline (strict vs lenient)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "behavioral-play-attitude-toward-funishment-vs-serious-correction",
-        "label": "Attitude toward funishment vs serious correction",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "behavioral-play-use-of-behavior-contracts-or-rule-agreements",
-        "label": "Use of behavior contracts or rule agreements",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Appearance Play",
-    "items": [
-      {
-        "id": "appearance-play-choosing-my-partner-s-outfit-for-the-day-or-a-scene",
-        "label": "Choosing my partner’s outfit for the day or a scene",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-selecting-their-underwear-lingerie-or-base-layers",
-        "label": "Selecting their underwear, lingerie, or base layers",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-styling-their-hair-braiding-brushing-tying-etc",
-        "label": "Styling their hair (braiding, brushing, tying, etc.)",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-picking-head-coverings-bonnets-veils-hoods-hats-for-mood-or-protocol",
-        "label": "Picking head coverings (bonnets, veils, hoods, hats) for mood or protocol",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-offering-makeup-polish-or-accessories-as-part-of-ritual-or-play",
-        "label": "Offering makeup, polish, or accessories as part of ritual or play",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-creating-themed-looks-slutty-innocent-doll-like-sharp-etc",
-        "label": "Creating themed looks (slutty, innocent, doll-like, sharp, etc.)",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-dressing-them-in-role-specific-costumes-maid-bunny-doll-etc",
-        "label": "Dressing them in role-specific costumes (maid, bunny, doll, etc.)",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-curating-time-period-or-historical-outfits-e-g-victorian-50s",
-        "label": "Curating time-period or historical outfits (e.g., Victorian, 50s)",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-helping-them-present-more-femme-masc-or-androgynous-by-request",
-        "label": "Helping them present more femme, masc, or androgynous by request",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-coordinating-their-look-with-mine-for-public-or-private-scenes",
-        "label": "Coordinating their look with mine for public or private scenes",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-implementing-a-dress-ritual-or-aesthetic-preparation",
-        "label": "Implementing a “dress ritual” or aesthetic preparation",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-enforcing-a-visual-protocol-e-g-no-bra-heels-required-tied-hair",
-        "label": "Enforcing a visual protocol (e.g., no bra, heels required, tied hair)",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-having-my-outfit-selected-for-me-by-a-partner",
-        "label": "Having my outfit selected for me by a partner",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-wearing-the-underwear-or-lingerie-they-choose",
-        "label": "Wearing the underwear or lingerie they choose",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-having-my-hair-brushed-braided-tied-or-styled-for-them",
-        "label": "Having my hair brushed, braided, tied, or styled for them",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-putting-on-a-head-covering-e-g-bonnet-veil-hood-they-chose",
-        "label": "Putting on a head covering (e.g., bonnet, veil, hood) they chose",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-following-visual-appearance-rules-as-part-of-submission",
-        "label": "Following visual appearance rules as part of submission",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-wearing-makeup-polish-or-accessories-they-request",
-        "label": "Wearing makeup, polish, or accessories they request",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-dressing-to-please-their-vision-cute-filthy-classy-etc",
-        "label": "Dressing to please their vision (cute, filthy, classy, etc.)",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-wearing-roleplay-costumes-or-character-looks",
-        "label": "Wearing roleplay costumes or character looks",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-presenting-in-a-way-that-matches-their-chosen-aesthetic",
-        "label": "Presenting in a way that matches their chosen aesthetic",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-participating-in-dressing-rituals-or-undressing-ceremonies",
-        "label": "Participating in dressing rituals or undressing ceremonies",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-being-admired-for-the-way-i-look-under-their-direction",
-        "label": "Being admired for the way I look under their direction",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-receiving-praise-or-gentle-teasing-about-my-appearance",
-        "label": "Receiving praise or gentle teasing about my appearance",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-cosplay-or-fantasy-looks-anime-game-fairytale-etc",
-        "label": "Cosplay or fantasy looks (anime, game, fairytale, etc.)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-time-period-dress-up-regency-gothic-1920s-etc",
-        "label": "Time-period dress-up (regency, gothic, 1920s, etc.)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-dollification-or-polished-presented-object-aesthetics",
-        "label": "Dollification or polished/presented object aesthetics",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-uniforms-schoolgirl-military-clerical-nurse-etc",
-        "label": "Uniforms (schoolgirl, military, clerical, nurse, etc.)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-hair-based-play-forced-brushing-ribbons-or-tied-styles",
-        "label": "Hair-based play (forced brushing, ribbons, or tied styles)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-head-coverings-or-symbolic-hoods-in-ritualized-dynamics",
-        "label": "Head coverings or symbolic hoods in ritualized dynamics",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-matching-looks-or-coordinated-dress-codes",
-        "label": "Matching looks or coordinated dress codes",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-ritualized-grooming-before-scenes",
-        "label": "Ritualized grooming before scenes",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-praise-or-positive-attention-for-pleasing-visual-display",
-        "label": "Praise or positive attention for pleasing visual display",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-formal-appearance-protocols-for-scenes-or-dynamics",
-        "label": "Formal appearance protocols for scenes or dynamics",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-using-clothing-or-style-to-embody-emotional-or-power-roles",
-        "label": "Using clothing or style to embody emotional or power roles",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Psychology Play",
-    "items": [
-      {
-        "id": "psychology-play-emotional-sadism-giving-teasing-feelings-orchestrating-reactions-savoring-anticipation-without-shame-based-harm",
-        "label": "Emotional Sadism (giving): teasing feelings, orchestrating reactions, savoring anticipation without shame-based harm",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "psychology-play-psychological-control-mind-games-double-binds-deliberate-pacing-and-strategic-ambiguity",
-        "label": "Psychological Control: mind games, double binds, deliberate pacing, and strategic ambiguity",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "psychology-play-sadistic-attention-enjoying-being-the-focal-point-of-a-partner-s-fear-arousal-or-resistance",
-        "label": "Sadistic Attention: enjoying being the focal point of a partner’s fear, arousal, or resistance",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "psychology-play-teasing-humiliation-playful-status-play-without-degradation-or-shame",
-        "label": "Teasing Humiliation: playful status play without degradation or shame",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "psychology-play-emotional-sadism-receiving-enjoying-engineered-emotional-intensity-such-as-fluster-exposure-or-playful-embarrassment",
-        "label": "Emotional Sadism (receiving): enjoying engineered emotional intensity such as fluster, exposure, or playful embarrassment",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychology-play-psychological-control-receiving-arousal-from-being-studied-contained-or-outmaneuvered",
-        "label": "Psychological Control (receiving): arousal from being studied, contained, or outmaneuvered",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychology-play-being-the-focus-enjoying-being-watched-tracked-or-held-in-a-partner-s-intense-focus",
-        "label": "Being the Focus: enjoying being watched, tracked, or held in a partner’s intense focus",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychology-play-teasing-humiliation-receiving-enjoying-playful-embarrassment-or-affectionate-mockery-that-builds-intimacy",
-        "label": "Teasing Humiliation (receiving): enjoying playful embarrassment or affectionate mockery that builds intimacy",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychology-play-prey-attention-neediness-craving-focus-pursuit-or-intense-awareness-from-a-partner",
-        "label": "Prey Attention/Neediness: craving focus, pursuit, or intense awareness from a partner",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychology-play-primal-recognition-being-seen-understood-or-tracked-without-needing-words",
-        "label": "Primal Recognition: being seen, understood, or tracked without needing words",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Breeding",
-    "items": [
-      {
-        "id": "breeding-impregnation-giving-arousal-from-attempting-to-impregnate-a-partner",
-        "label": "Impregnation (giving): arousal from attempting to impregnate a partner",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "breeding-feeding-milk-giving-arousal-from-producing-and-feeding-milk-to-a-partner",
-        "label": "Feeding Milk (giving): arousal from producing and feeding milk to a partner",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "breeding-impregnation-receiving-arousal-from-being-inseminated-pregnancy-risk-or-being-bred",
-        "label": "Impregnation (receiving): arousal from being inseminated, pregnancy risk, or being bred",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "breeding-feeding-milk-receiving-arousal-from-drinking-a-partner-s-milk",
-        "label": "Feeding Milk (receiving): arousal from drinking a partner’s milk",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "breeding-pregnancy-fantasy-erotic-focus-on-pregnancy-mine-partner-s-or-fictional-scenarios",
-        "label": "Pregnancy Fantasy: erotic focus on pregnancy (mine, partner’s, or fictional scenarios)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-primal-breeding-drive-animalistic-instinctual-framing-of-sex-reproduction-territory",
-        "label": "Primal Breeding Drive: animalistic/instinctual framing of sex, reproduction, territory",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-breeding-as-control-ownership-authority-expressed-through-breeding-talk-or-pregnancy-risk",
-        "label": "Breeding as Control: ownership/authority expressed through breeding talk or pregnancy risk",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-creampie-marking-erotic-meaning-placed-on-internal-ejaculation-or-visible-claimed-markers",
-        "label": "Creampie/Marking: erotic meaning placed on internal ejaculation or visible ‘claimed’ markers",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-risk-no-contraception-talk-fantasy-dirty-talk-about-risk-or-breeding-without-actual-risk",
-        "label": "Risk/‘No Contraception’ Talk (fantasy): dirty talk about risk or breeding without actual risk",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-heat-ovulation-tracking-timing-in-heat-roleplay-or-cycle-focused-arousal",
-        "label": "Heat/Ovulation Tracking: timing, ‘in heat’ roleplay, or cycle-focused arousal",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-artificial-insemination-device-play-syringes-cups-or-medical-style-scenarios-consensual-fantasy",
-        "label": "Artificial Insemination/Device Play: syringes, cups, or medical-style scenarios (consensual fantasy)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-breeding-denial-ruined-breeding-building-toward-impregnation-talk-then-denying-or-ruining-it",
-        "label": "Breeding Denial/Ruined Breeding: building toward impregnation talk then denying or ‘ruining’ it",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-pregnancy-body-focus-belly-worship-movement-weight-changes-glow-and-attention",
-        "label": "Pregnancy Body Focus: belly worship, movement/weight changes, glow, and attention",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-pregnancy-protocol-care-protective-rules-pedestal-treatment-dedicated-aftercare",
-        "label": "Pregnancy Protocol/Care: protective rules, pedestal treatment, dedicated aftercare",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-lactation-induction-maintenance-interest-in-inducing-or-sustaining-milk-production",
-        "label": "Lactation Induction/Maintenance: interest in inducing or sustaining milk production",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-milking-scenes-manual-oral-or-pump-based-milking-as-play-or-ritual",
-        "label": "Milking Scenes: manual, oral, or pump-based ‘milking’ as play or ritual",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-contraception-boundaries-preference-to-use-protection-bc-methods-or-simulation-only",
-        "label": "Contraception Boundaries: preference to use protection, BC methods, or simulation-only",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-sti-testing-medical-boundaries-testing-cadence-disclosures-and-comfort-levels",
-        "label": "STI/Testing & Medical Boundaries: testing cadence, disclosures, and comfort levels",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  }
-]
+  "categories": [
+    {
+      "category": "Body Part Torture",
+      "items": [
+        {
+          "id": "body-part-torture-nipple-clips",
+          "label": "Nipple clips",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-nipple-weights",
+          "label": "Nipple weights",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-nipple-suction-cups",
+          "label": "Nipple suction cups",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-cock-ball-torture-cbt",
+          "label": "Cock, Ball Torture (CBT)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-clit-clips-weights-suction",
+          "label": "Clit clips/weights/suction",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-hair-pulling",
+          "label": "Hair pulling",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-face-slapping",
+          "label": "Face slapping",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-butt-slapping",
+          "label": "Butt slapping",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-breast-slapping",
+          "label": "Breast slapping",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-genital-slapping",
+          "label": "Genital slapping",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Bondage and Suspension",
+      "items": [
+        {
+          "id": "bondage-and-suspension-blindfolds",
+          "label": "Blindfolds",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-bondage-heavy",
+          "label": "Bondage (heavy)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-bondage-light",
+          "label": "Bondage (light)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-immobilisation",
+          "label": "Immobilisation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-bondage-multi-day",
+          "label": "Bondage (multi-day)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-bondage-public-under-clothing",
+          "label": "Bondage (public, under clothing)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-leather-restraints",
+          "label": "Leather restraints",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-chains",
+          "label": "Chains",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-ropes",
+          "label": "Ropes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-intricate-japanese-rope-bondage",
+          "label": "Intricate (Japanese) rope bondage",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-rope-body-harness",
+          "label": "Rope body harness",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-arm-leg-sleeves-armbinders",
+          "label": "Arm & leg sleeves (armbinders)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-harnesses-leather",
+          "label": "Harnesses (leather)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-harnesses-rope",
+          "label": "Harnesses (rope)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-cuffs-leather",
+          "label": "Cuffs (leather)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-cuffs-metal",
+          "label": "Cuffs (metal)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-manacles-irons",
+          "label": "Manacles & Irons",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-gags-cloth",
+          "label": "Gags (cloth)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-gags-rubber",
+          "label": "Gags (rubber)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-gags-tape",
+          "label": "Gags (tape)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-gags-phallic",
+          "label": "Gags (phallic)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-gags-ring",
+          "label": "Gags (ring)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-gags-ball",
+          "label": "Gags (ball)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-mouth-bits",
+          "label": "Mouth bits",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-full-head-hoods",
+          "label": "Full head hoods",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-mummification-saran-wrapping",
+          "label": "Mummification/saran wrapping",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-straight-jackets",
+          "label": "Straight jackets",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-suspension-upright",
+          "label": "Suspension (upright)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-suspension-horizontal",
+          "label": "Suspension (horizontal)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-suspension-inverted",
+          "label": "Suspension (inverted)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-breath-play",
+          "label": "Breath play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-smothering",
+          "label": "Smothering",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-forced-self-breath-control",
+          "label": "Forced self-breath-control",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-gas-mask",
+          "label": "Gas mask",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Breath Play",
+      "items": [
+        {
+          "id": "breath-play-asphyxiation",
+          "label": "Asphyxiation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "breath-play-breath-control",
+          "label": "Breath control",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "breath-play-choking",
+          "label": "Choking",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "breath-play-drowning",
+          "label": "Drowning",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "breath-play-rebreathing-into-a-bag-or-object",
+          "label": "Rebreathing into a bag or object",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "breath-play-verbal-control-of-breath-e-g-hold-it-on-command",
+          "label": "Verbal control of breath (e.g., 'hold it' on command)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Sexual Activity",
+      "items": [
+        {
+          "id": "sexual-activity-licking",
+          "label": "Licking",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-fellatio-cunnilingus",
+          "label": "Fellatio/Cunnilingus",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-swallowing-semen",
+          "label": "Swallowing semen",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-cumming-on-partner",
+          "label": "Cumming on Partner",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-hand-jobs",
+          "label": "Hand jobs",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-anal-sex",
+          "label": "Anal sex",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-anal-plugs-small",
+          "label": "Anal plugs (small)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-anal-plugs-large",
+          "label": "Anal plugs (large)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-anal-beads",
+          "label": "Anal beads",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-vibrator-on-genitals",
+          "label": "Vibrator on genitals",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-fisting",
+          "label": "Fisting",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-oral-anal-play-rimming",
+          "label": "Oral/anal play (rimming)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-double-penetration-oral-and-vaginal",
+          "label": "Double penetration (oral and vaginal)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-double-penetration-oral-and-anal",
+          "label": "Double penetration (oral and anal)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-double-penetration-anal-and-vaginal",
+          "label": "Double penetration (anal and vaginal)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-triple-oral-vaginal-and-anal",
+          "label": "Triple (Oral, Vaginal and Anal)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Sensation Play",
+      "items": [
+        {
+          "id": "sensation-play-abrasion",
+          "label": "Abrasion",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-scratching",
+          "label": "Scratching",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-biting",
+          "label": "Biting",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-tickling",
+          "label": "Tickling",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-kissing",
+          "label": "Kissing",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-zapping-e-g-electric-fly-swatter",
+          "label": "Zapping (e.g. electric fly swatter)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-ice-cubes",
+          "label": "Ice cubes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-wax-play",
+          "label": "Wax Play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-fire",
+          "label": "Fire",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-clothespins",
+          "label": "Clothespins",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-needles",
+          "label": "Needles",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-sensory-deprivation",
+          "label": "Sensory deprivation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-physical-overpowering-manhandling",
+          "label": "Physical overpowering / Manhandling",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-figging",
+          "label": "Figging",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Other",
+      "items": [
+        {
+          "id": "other-feet",
+          "label": "Feet",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-boots",
+          "label": "Boots",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-underwear",
+          "label": "Underwear",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-chastity-devices",
+          "label": "Chastity devices",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-masks",
+          "label": "Masks",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-breeding",
+          "label": "Breeding",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-leather-clothing",
+          "label": "Leather clothing",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-training-protocols-outside-scenes-e-g-etiquette-memory",
+          "label": "Training protocols outside scenes (e.g., etiquette, memory)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-long-distance-training-structure",
+          "label": "Long-distance training/structure",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-scene-journaling-and-reflection",
+          "label": "Scene journaling and reflection",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Roleplaying",
+      "items": [
+        {
+          "id": "roleplaying-fantasy-abandonment",
+          "label": "Fantasy abandonment",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-kidnapping",
+          "label": "Kidnapping",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-interrogation",
+          "label": "Interrogation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-sleep-deprivation",
+          "label": "Sleep deprivation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-cnc",
+          "label": "CNC",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-gang-bang",
+          "label": "Gang bang",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-initiation-rites",
+          "label": "Initiation rites",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-religious-scenes",
+          "label": "Religious scenes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-medical-scenes",
+          "label": "Medical scenes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-prison-scenes",
+          "label": "Prison scenes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-primal-prey",
+          "label": "Primal/Prey",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-schoolroom-scenes",
+          "label": "Schoolroom scenes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Service and Restrictive Behaviour",
+      "items": [
+        {
+          "id": "service-and-restrictive-behaviour-following-orders",
+          "label": "(Following) orders",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-forced-servitude",
+          "label": "Forced servitude",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-restrictive-rules-on-behaviour",
+          "label": "Restrictive rules on behaviour",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-eye-contact-restrictions",
+          "label": "Eye contact restrictions",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-speech-restrictions-when-what-to-whom",
+          "label": "Speech restrictions (when, what, to whom)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-washroom-restrictions",
+          "label": "Washroom restrictions",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-punishments",
+          "label": "Punishments",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-tasks",
+          "label": "Tasks",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-massage",
+          "label": "Massage",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-domestic-tasks",
+          "label": "Domestic tasks",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-serving-food-and-drink",
+          "label": "Serving food and drink",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-personal-care-rituals",
+          "label": "Personal care rituals",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-being-on-call-at-specified-times",
+          "label": "Being on-call at specified times",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-daily-task-assignments",
+          "label": "Daily task assignments",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-corrections-for-imperfection",
+          "label": "Corrections for imperfection",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-uniforms-dress-codes",
+          "label": "Uniforms / Dress codes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-kneeling-posture-presentation",
+          "label": "Kneeling / Posture presentation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-silent-service",
+          "label": "Silent service",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-public-service-at-parties-or-events",
+          "label": "Public service (at parties or events)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-erotic-service-pleasure-on-command-without-seeking-your-own",
+          "label": "Erotic service (pleasure on command, without seeking your own)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Voyeurism/Exhibitionism",
+      "items": [
+        {
+          "id": "voyeurism-exhibitionism-forced-nudity-private",
+          "label": "Forced nudity (private)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "voyeurism-exhibitionism-forced-nudity-around-others",
+          "label": "Forced nudity (around others)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "voyeurism-exhibitionism-exhibitionism-friends",
+          "label": "Exhibitionism (friends)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "voyeurism-exhibitionism-exhibitionism-strangers",
+          "label": "Exhibitionism (strangers)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "voyeurism-exhibitionism-modelling-for-erotic-photos",
+          "label": "Modelling for erotic photos",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "voyeurism-exhibitionism-toys-under-clothes-in-public",
+          "label": "Toys under clothes in public",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Virtual & Long-Distance Play",
+      "items": [
+        {
+          "id": "virtual-long-distance-play-sending-tasks-or-orders-digitally",
+          "label": "Sending tasks or orders digitally",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-recording-dominant-voice-clips-commands-edging-praise-degradation-etc",
+          "label": "Recording dominant voice clips (commands, edging, praise, degradation, etc.)",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-remote-control-of-a-sex-toy",
+          "label": "Remote control of a sex toy",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-monitoring-behavior-via-app-or-shared-doc",
+          "label": "Monitoring behavior via app or shared doc",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-giving-punishment-assignments-remotely",
+          "label": "Giving punishment assignments remotely",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-creating-countdowns-timers-or-denial-periods",
+          "label": "Creating countdowns, timers, or denial periods",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-sending-written-instructions-with-delayed-permissions",
+          "label": "Sending written instructions with delayed permissions",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-creating-custom-video-or-audio-tasks",
+          "label": "Creating custom video or audio tasks",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-voice-message-control-during-scenes",
+          "label": "Voice message control during scenes",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-being-on-call-at-specified-times",
+          "label": "Being on-call at specified times",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-receiving-tasks-or-orders-digitally",
+          "label": "Receiving tasks or orders digitally",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-listening-to-dominant-voice-clips",
+          "label": "Listening to dominant voice clips",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-using-a-remote-controlled-toy-controlled-by-another",
+          "label": "Using a remote-controlled toy controlled by another",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-completing-daily-protocol-assignments",
+          "label": "Completing daily protocol assignments",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-submitting-proof-photo-video-text",
+          "label": "Submitting proof (photo, video, text)",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-following-recorded-or-timed-commands",
+          "label": "Following recorded or timed commands",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-receiving-surprise-instructions",
+          "label": "Receiving surprise instructions",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-hearing-name-praise-spoken-in-a-custom-clip",
+          "label": "Hearing name/praise spoken in a custom clip",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-sending-submissive-voice-clips-obedience-begging-thank-you-messages-affirmations-etc",
+          "label": "Sending submissive voice clips (obedience, begging, thank-you messages, affirmations, etc.)",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-scheduling-digital-rituals-or-reminders",
+          "label": "Scheduling digital rituals or reminders",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-using-training-habit-or-behavior-tracking-apps",
+          "label": "Using training, habit, or behavior-tracking apps",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-online-rituals-digital-kneeling-posture-protocols",
+          "label": "Online rituals (digital kneeling, posture protocols)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-role-based-texting-e-g-use-honorifics-in-chat",
+          "label": "Role-based texting (e.g., \"Use honorifics in chat\")",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-shared-playlists-affirmations-or-mantras",
+          "label": "Shared playlists, affirmations, or mantras",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-countdown-timers-to-next-task-release-or-interaction",
+          "label": "Countdown timers to next task, release, or interaction",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-scheduled-good-morning-night-rituals",
+          "label": "Scheduled good morning/night rituals",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-participating-in-video-call-scenes",
+          "label": "Participating in video call scenes",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-digital-aftercare-texts-voice-images",
+          "label": "Digital aftercare (texts, voice, images)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-sexting-or-digital-roleplay-scenes",
+          "label": "Sexting or digital roleplay scenes",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-voice-notes-or-submissive-dominant-affirmations",
+          "label": "Voice notes or submissive/dominant affirmations",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Communication",
+      "items": [
+        {
+          "id": "communication-playful-and-teasing",
+          "label": "Playful and teasing",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-quiet-and-intense",
+          "label": "Quiet and intense",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-observant-and-intentional",
+          "label": "Observant and intentional",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-praise-heavy",
+          "label": "Praise-heavy",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-blunt-and-efficient",
+          "label": "Blunt and efficient",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-affirming-and-soft",
+          "label": "Affirming and soft",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-psychological-interrogation",
+          "label": "Psychological interrogation",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-verbal-coercion-teasing-traps",
+          "label": "Verbal coercion / teasing traps",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-verbal-misdirection",
+          "label": "Verbal misdirection",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-mocking-shaming",
+          "label": "Mocking / shaming",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-predatory-pacing",
+          "label": "Predatory pacing",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-reluctant-obedience",
+          "label": "Reluctant obedience",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-stammering-submission",
+          "label": "Stammering submission",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-challenging-until-caught",
+          "label": "Challenging until caught",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-quiet-surrender",
+          "label": "Quiet surrender",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-sarcastic-teasing",
+          "label": "Sarcastic teasing",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-provoking-tone",
+          "label": "Provoking tone",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-challenge-based-dialogue",
+          "label": "Challenge-based dialogue",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-double-meaning-banter",
+          "label": "Double-meaning banter",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-soft-spoken-guidance",
+          "label": "Soft-spoken guidance",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-protective-but-firm-tone",
+          "label": "Protective but firm tone",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-emotional-redirection",
+          "label": "Emotional redirection",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-steady-reassurance",
+          "label": "Steady reassurance",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-direct-and-clear",
+          "label": "Direct and clear",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-gentle-and-nurturing",
+          "label": "Gentle and nurturing",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-commanding-and-firm",
+          "label": "Commanding and firm",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-quiet-and-observant",
+          "label": "Quiet and observant",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-instructive-teacher-like",
+          "label": "Instructive / teacher-like",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-emotionally-intense",
+          "label": "Emotionally intense",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-dismissive-withholding",
+          "label": "Dismissive / withholding",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-mocking-sarcastic",
+          "label": "Mocking / sarcastic",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-blunt-tactless",
+          "label": "Blunt / tactless",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-predatory-hunting-tone",
+          "label": "Predatory / hunting tone",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-stalking-or-circling-speech",
+          "label": "Stalking or circling speech",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-you-re-mine-control-language",
+          "label": "You’re mine / control language",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-threatening-consensual",
+          "label": "Threatening (consensual)",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-verbal-cornering-coaxing",
+          "label": "Verbal cornering / coaxing",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-watching-you-unravel",
+          "label": "Watching you unravel",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-cruel-and-cutting",
+          "label": "Cruel and cutting",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-psychological-baiting",
+          "label": "Psychological baiting",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-brat-breaking-language",
+          "label": "Brat-breaking language",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-mock-affection",
+          "label": "Mock affection",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-shaming-or-emotional-edge",
+          "label": "Shaming or emotional edge",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-disappointed-dom-voice",
+          "label": "Disappointed dom voice",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-mild-scolding-mocking-affection",
+          "label": "Mild scolding / mocking affection",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-verbal-power-struggle",
+          "label": "Verbal power struggle",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-challenge-response-dynamics",
+          "label": "Challenge-response dynamics",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-warm-tone-with-expectation",
+          "label": "Warm tone with expectation",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-nurturing-dominance",
+          "label": "Nurturing dominance",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-reassuring-commands",
+          "label": "Reassuring commands",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-phrases-that-work-on-you",
+          "label": "Phrases that work on you",
+          "type": "text",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "communication-phrases-you-use-or-like-to-give",
+          "label": "Phrases you use or like to give",
+          "type": "text",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "communication-what-helps-you-feel-emotionally-safe",
+          "label": "What helps you feel emotionally safe",
+          "type": "text",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "communication-how-you-tend-to-show-affection",
+          "label": "How you tend to show affection",
+          "type": "text",
+          "options": [
+            "Words of affirmation",
+            "Acts of service",
+            "Through teasing / play",
+            "Through obedience",
+            "Through caretaking",
+            "Withholding / teasing love",
+            "Physical closeness",
+            "Quality time"
+          ],
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "communication-emotional-check-in-style",
+          "label": "Emotional check-in style",
+          "type": "text",
+          "options": [
+            "Daily texting",
+            "After-scene debriefs",
+            "Scheduled check-ins",
+            "Mix of text/video check-ins",
+            "In-person check-ins",
+            "Journaling together",
+            "Minimal / low contact",
+            "Other"
+          ],
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "communication-when-emotionally-activated-i-tend-to",
+          "label": "When emotionally activated, I tend to...",
+          "type": "text",
+          "options": [
+            "Shut down",
+            "Overexplain / fawn",
+            "Get sarcastic / prickly",
+            "Spiral internally",
+            "Ask for reassurance",
+            "Withdraw",
+            "Other"
+          ],
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Body Fluids and Functions",
+      "items": [
+        {
+          "id": "body-fluids-and-functions-watersports-golden-showers",
+          "label": "Watersports/golden showers",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-fluids-and-functions-cum",
+          "label": "Cum",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-fluids-and-functions-blood",
+          "label": "Blood",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-fluids-and-functions-scat",
+          "label": "Scat",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-fluids-and-functions-sweat",
+          "label": "Sweat",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-fluids-and-functions-vomit",
+          "label": "Vomit",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-fluids-and-functions-tears-crying",
+          "label": "Tears/crying",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Psychological Primal / Prey",
+      "items": [
+        {
+          "id": "psychological-primal-prey-primal-prey",
+          "label": "Primal/Prey",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-conditioning",
+          "label": "Conditioning",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-coc",
+          "label": "COC",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-psycholagny-hands-free-mentally-stimulated-orgasm",
+          "label": "Psycholagny (hands free, mentally stimulated orgasm)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-hypno-play",
+          "label": "Hypno Play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-praise",
+          "label": "Praise",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-degradation",
+          "label": "Degradation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-traditional-primal-prey",
+          "label": "Traditional primal/prey",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-fear-play",
+          "label": "Fear play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-objectification",
+          "label": "Objectification",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-gaslighting",
+          "label": "Gaslighting",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-role-erosion-identity-play-loss-of-self",
+          "label": "Role erosion (identity play / loss of self)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-jealousy-play",
+          "label": "Jealousy play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-manipulation",
+          "label": "Manipulation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Body Part / Fetish Play",
+      "items": [
+        {
+          "id": "body-part-fetish-play-belly-fucking",
+          "label": "Belly fucking",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-navel-play",
+          "label": "Navel play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-feet-foot-worship",
+          "label": "Feet / Foot worship",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-hands",
+          "label": "Hands",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-hair",
+          "label": "Hair",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-thighs",
+          "label": "Thighs",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-neck",
+          "label": "Neck",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-ears",
+          "label": "Ears",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-belly",
+          "label": "Belly",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-voice-fetish",
+          "label": "Voice fetish",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-nails-makeup-fetish",
+          "label": "Nails / Makeup fetish",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-cuddles",
+          "label": "Cuddles",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-food-play",
+          "label": "Food Play",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-kisses",
+          "label": "Kisses",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-masturbation",
+          "label": "Masturbation",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-romance-affection",
+          "label": "Romance / affection",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-sex-toys",
+          "label": "Sex toys",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-sexting-chat-etc",
+          "label": "Sexting /Chat etc",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-sexting-via-phone-or-video-call",
+          "label": "Sexting via phone or video call",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-strip-tease",
+          "label": "Strip tease",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-vanilla-sex",
+          "label": "Vanilla Sex",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-voice-notes",
+          "label": "Voice Notes",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-shaving-body-hair",
+          "label": "Shaving (body hair)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-sexy-clothing-private",
+          "label": "Sexy clothing (private)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-sexy-clothing-public",
+          "label": "Sexy clothing (public)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-outdoor-scenes",
+          "label": "Outdoor scenes",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-public-exposure",
+          "label": "Public exposure",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Orgasm Control & Sexual Manipulation",
+      "items": [
+        {
+          "id": "orgasm-control-sexual-manipulation-edging",
+          "label": "Edging",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-short-term-denial",
+          "label": "Short term denial",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-long-term-denial",
+          "label": "Long term denial",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-forced-orgasms-overstimulation",
+          "label": "Forced orgasms / Overstimulation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-ruined-orgasms",
+          "label": "Ruined orgasms",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-no-touch-periods",
+          "label": "No touch periods",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-milking",
+          "label": "Milking",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-chastity-devices",
+          "label": "Chastity devices",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-consensual-orgasm-control",
+          "label": "Consensual orgasm control",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-forced-masturbation",
+          "label": "Forced masturbation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Protocol and Ritual",
+      "items": [
+        {
+          "id": "protocol-and-ritual-formal-language",
+          "label": "Formal language",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-greeting-and-departure-rituals-kneeling-verbal-scripts-gestures",
+          "label": "Greeting and departure rituals (kneeling, verbal scripts, gestures)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-requiring-permission-for-things-speech-movement-attire",
+          "label": "Requiring permission for things (speech, movement, attire)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-daily-rituals-morning-check-ins-status-reports-mantra-repetitions",
+          "label": "Daily rituals (morning check-ins, status reports, mantra repetitions)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-specific-postures-for-rest-attention-punishment-waiting",
+          "label": "Specific postures for rest, attention, punishment, waiting",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-restricted-behavior-no-eye-contact-silence-no-questions",
+          "label": "Restricted behavior (no eye contact, silence, no questions)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-ritual-object-use-collar-cuffs-leash-tokens",
+          "label": "Ritual object use (collar, cuffs, leash, tokens)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-tracking-obedience-journals-apps",
+          "label": "Tracking obedience (journals, apps)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-formalized-rules-for-misbehavior-and-correction",
+          "label": "Formalized rules for misbehavior and correction",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-ritualized-aftercare-or-scene-closure",
+          "label": "Ritualized aftercare or scene closure",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-object-retrieval-on-all-fours-with-item-in-mouth",
+          "label": "Object retrieval on all fours with item in mouth",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-fetching-hairbrush-or-punishment-tool-from-dresser-while-crawling",
+          "label": "Fetching hairbrush or punishment tool from dresser while crawling",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-presenting-chosen-discipline-tool-in-kneeling-posture",
+          "label": "Presenting chosen discipline tool in kneeling posture",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-assigned-posture-or-kneeling-positions-as-ritual",
+          "label": "Assigned posture or kneeling positions as ritual",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-requesting-permission-using-specific-protocol-phrases",
+          "label": "Requesting permission using specific protocol phrases",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-carrying-items-in-mouth-as-submissive-gesture",
+          "label": "Carrying items in mouth as submissive gesture",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-crawling-back-with-object-to-dominant-after-retrieval",
+          "label": "Crawling back with object to Dominant after retrieval",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-following-via-nipple-leash-as-protocol-or-punishment",
+          "label": "Following via nipple leash as protocol or punishment",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-crawling-assigned-paths-as-ritual-or-obedience-training",
+          "label": "Crawling assigned paths as ritual or obedience training",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-crawling-rituals-e-g-object-retrieval",
+          "label": "Crawling rituals (e.g., object retrieval)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-carrying-objects-in-mouth-as-obedience",
+          "label": "Carrying objects in mouth as obedience",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-presenting-tools-or-toys-in-posture",
+          "label": "Presenting tools or toys in posture",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-using-honorifics-or-preset-protocol-language",
+          "label": "Using honorifics or preset protocol language",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-greeting-rituals-e-g-kneeling-kissing-feet",
+          "label": "Greeting rituals (e.g., kneeling, kissing feet)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-daily-check-ins-or-structured-reports",
+          "label": "Daily check-ins or structured reports",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-clothing-restrictions-or-uniforms",
+          "label": "Clothing restrictions or uniforms",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-posture-training-sitting-kneeling-standing",
+          "label": "Posture training (sitting, kneeling, standing)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-punishments-for-incorrect-behavior-or-tone",
+          "label": "Punishments for incorrect behavior or tone",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-crawling-with-items-in-mouth-e-g-hairbrush-spoon",
+          "label": "Crawling with items in mouth (e.g., hairbrush, spoon)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-earning-permission-for-meals-bathroom-use-or-rest",
+          "label": "Earning permission for meals, bathroom use, or rest",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-following-daily-rituals-or-protocol",
+          "label": "Following daily rituals or protocol",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-structured-speech-rules-e-g-titles-third-person",
+          "label": "Structured speech rules (e.g., titles, third person)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-receiving-correction-when-out-of-line",
+          "label": "Receiving correction when out of line",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-inspection-rituals-or-readiness-checks",
+          "label": "Inspection rituals or readiness checks",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Primal & Bratting",
+      "items": [
+        {
+          "id": "primal-bratting-chase-and-capture-play",
+          "label": "Chase and capture play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-bratting-for-punishment",
+          "label": "Bratting for punishment",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-playful-growling-and-biting",
+          "label": "Playful growling and biting",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-provoking-with-teasing-or-taunts",
+          "label": "Provoking with teasing or taunts",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-escaping-or-hiding-to-encourage-pursuit",
+          "label": "Escaping or hiding to encourage pursuit",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-refusing-commands-just-for-fun",
+          "label": "Refusing commands just for fun",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-provoking-your-partner-to-chase-or-discipline-you",
+          "label": "Provoking your partner to chase or discipline you",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-taunting-or-teasing-as-a-form-of-play",
+          "label": "Taunting or teasing as a form of play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-intentional-resistance-during-power-exchange",
+          "label": "Intentional resistance during power exchange",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-being-caught-and-overpowered",
+          "label": "Being caught and overpowered",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Headspace & Regression",
+      "items": [
+        {
+          "id": "headspace-regression-caregiver-little-regression-play",
+          "label": "Caregiver/little regression play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-using-pacifiers-or-sippy-cups",
+          "label": "Using pacifiers or sippy cups",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-coloring-or-childlike-crafts",
+          "label": "Coloring or childlike crafts",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-stuffed-animal-comfort",
+          "label": "Stuffed animal comfort",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-speaking-in-a-childlike-voice",
+          "label": "Speaking in a childlike voice",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-bedtime-stories-or-lullabies",
+          "label": "Bedtime stories or lullabies",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-entering-altered-headspaces-e-g-prey-pet-little",
+          "label": "Entering altered headspaces (e.g., prey, pet, little)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-regressive-behaviors-as-comfort-coloring-babytalk",
+          "label": "Regressive behaviors as comfort (coloring, babytalk)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-being-cared-for-during-emotional-vulnerability",
+          "label": "Being cared for during emotional vulnerability",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-guided-emotional-headspace-entry",
+          "label": "Guided emotional headspace entry",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Performance & Internal Struggle",
+      "items": [
+        {
+          "id": "performance-internal-struggle-obedience-under-observation",
+          "label": "Obedience under observation",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-speech-restriction-and-self-denial",
+          "label": "Speech restriction and self-denial",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-maintaining-composure-during-humiliation",
+          "label": "Maintaining composure during humiliation",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-obedience-drills-for-an-audience",
+          "label": "Obedience drills for an audience",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-struggling-against-personal-urges",
+          "label": "Struggling against personal urges",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-displaying-submission-despite-conflict",
+          "label": "Displaying submission despite conflict",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-being-told-to-act-normal-while-struggling-internally",
+          "label": "Being told to act normal while struggling internally",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-pleasing-through-high-functioning-obedience",
+          "label": "Pleasing through high-functioning obedience",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-performing-submission-while-masking-resistance",
+          "label": "Performing submission while masking resistance",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-the-pressure-of-appearing-good-while-feeling-conflicted",
+          "label": "The pressure of appearing 'good' while feeling conflicted",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-being-made-to-perform-emotions-on-command-cry-beg-moan",
+          "label": "Being made to perform emotions on command (cry, beg, moan)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-struggling-openly-while-still-obeying",
+          "label": "Struggling openly while still obeying",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-performing-exaggerated-resistance-or-denial",
+          "label": "Performing exaggerated resistance or denial",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-being-punished-for-breaking-character",
+          "label": "Being punished for 'breaking character'",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-putting-on-a-show-for-someone-else-s-pleasure",
+          "label": "Putting on a show for someone else’s pleasure",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-rehearsed-degradation-or-humiliation-scripts",
+          "label": "Rehearsed degradation or humiliation scripts",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Mindfuck & Manipulation",
+      "items": [
+        {
+          "id": "mindfuck-manipulation-confusing-commands-and-reality-shifts",
+          "label": "Confusing commands and reality shifts",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-gaslighting-or-contradictory-cues",
+          "label": "Gaslighting or contradictory cues",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-presenting-false-choices",
+          "label": "Presenting false choices",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-hidden-motives-or-secret-tasks",
+          "label": "Hidden motives or secret tasks",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-illogical-rules-meant-to-confuse",
+          "label": "Illogical rules meant to confuse",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-gaslight-style-scenes-with-consent-and-clarity",
+          "label": "Gaslight-style scenes (with consent and clarity)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-false-threats-or-staged-surprises",
+          "label": "False threats or staged surprises",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-confusing-commands-to-prompt-hesitation",
+          "label": "Confusing commands to prompt hesitation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-emotional-trickery-as-arousal",
+          "label": "Emotional trickery as arousal",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-being-misled-or-deceived-on-purpose-during-play",
+          "label": "Being misled or deceived on purpose during play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-surprise-rule-changes-or-twists-mid-scene",
+          "label": "Surprise rule changes or twists mid-scene",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-false-safeword-games-with-negotiated-limits",
+          "label": "False safeword games (with negotiated limits)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-withholding-or-delaying-aftercare-for-effect",
+          "label": "Withholding or delaying aftercare for effect",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-being-gaslit-or-doubted-in-a-controlled-roleplay",
+          "label": "Being gaslit or doubted in a controlled roleplay",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-told-you-asked-for-this-or-you-love-this-when-resisting",
+          "label": "Told 'you asked for this' or 'you love this' when resisting",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Mouth Play",
+      "items": [
+        {
+          "id": "mouth-play-holding-tools-or-restraints-in-teeth-while-crawling",
+          "label": "Holding tools or restraints in teeth while crawling",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-placing-objects-from-mouth-into-dominant-s-palm",
+          "label": "Placing objects from mouth into Dominant’s palm",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-using-mouth-instead-of-hands-for-service-rituals",
+          "label": "Using mouth instead of hands for service rituals",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-gag-presentation-and-silent-waiting-protocol",
+          "label": "Gag presentation and silent waiting protocol",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-holding-objects-in-teeth-while-crawling",
+          "label": "Holding objects in teeth while crawling",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-returning-items-using-mouth-only",
+          "label": "Returning items using mouth only",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-gag-rituals-or-waiting-silently",
+          "label": "Gag rituals or waiting silently",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-leash-held-in-mouth",
+          "label": "Leash held in mouth",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-being-gagged-or-forced-silent",
+          "label": "Being gagged or forced silent",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-having-to-hold-objects-in-your-mouth-spoon-hairbrush-leash",
+          "label": "Having to hold objects in your mouth (spoon, hairbrush, leash)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-being-used-for-oral-service-without-reciprocal-pleasure",
+          "label": "Being used for oral service without reciprocal pleasure",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-being-fed-by-hand-mouth-to-mouth-or-with-utensils",
+          "label": "Being fed by hand, mouth-to-mouth, or with utensils",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-verbal-control-e-g-only-speak-when-spoken-to",
+          "label": "Verbal control (e.g., only speak when spoken to)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-mouth-as-a-symbol-of-ownership-or-control",
+          "label": "Mouth as a symbol of ownership or control",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Impact Play",
+      "items": [
+        {
+          "id": "impact-play-hand-spanking",
+          "label": "Hand spanking",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "impact-play-paddle-strikes",
+          "label": "Paddle strikes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "impact-play-crop-snaps",
+          "label": "Crop snaps",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "impact-play-flogger-swings",
+          "label": "Flogger swings",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "impact-play-cane-strokes",
+          "label": "Cane strokes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "impact-play-belt-or-strap-hits",
+          "label": "Belt or strap hits",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "impact-play-whip-cracks",
+          "label": "Whip cracks",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "impact-play-preferred-intensity-levels",
+          "label": "Preferred intensity levels",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "impact-play-aftercare-for-bruises",
+          "label": "Aftercare for bruises",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "impact-play-target-body-areas",
+          "label": "Target body areas",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "impact-play-implement-selection",
+          "label": "Implement selection",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Medical Play",
+      "items": [
+        {
+          "id": "medical-play-needle-play",
+          "label": "Needle play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "medical-play-catheter-insertion",
+          "label": "Catheter insertion",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "medical-play-speculum-exams",
+          "label": "Speculum exams",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "medical-play-enema-administration",
+          "label": "Enema administration",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "medical-play-temperature-taking",
+          "label": "Temperature taking",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "medical-play-medical-restraints",
+          "label": "Medical restraints",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "medical-play-doctor-nurse-roleplay",
+          "label": "Doctor/nurse roleplay",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "medical-play-sterilization-procedures",
+          "label": "Sterilization procedures",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "medical-play-professional-vs-roleplay-scenes",
+          "label": "Professional vs roleplay scenes",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "medical-play-consent-for-invasive-acts",
+          "label": "Consent for invasive acts",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "medical-play-access-to-medical-equipment",
+          "label": "Access to medical equipment",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Pet Play",
+      "items": [
+        {
+          "id": "pet-play-puppy-or-kitten-play",
+          "label": "Puppy or kitten play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "pet-play-pony-play",
+          "label": "Pony play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "pet-play-wearing-collar-and-leash",
+          "label": "Wearing collar and leash",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "pet-play-eating-from-a-bowl",
+          "label": "Eating from a bowl",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "pet-play-kenneling-or-caging",
+          "label": "Kenneling or caging",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "pet-play-pet-training-commands",
+          "label": "Pet training commands",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "pet-play-animal-costumes-or-gear",
+          "label": "Animal costumes or gear",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "pet-play-preferred-animal-identities",
+          "label": "Preferred animal identities",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "pet-play-public-vs-private-play",
+          "label": "Public vs private play",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "pet-play-training-style-and-discipline",
+          "label": "Training style and discipline",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "pet-play-use-of-pet-names-and-commands",
+          "label": "Use of pet names and commands",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Body Modification",
+      "items": [
+        {
+          "id": "body-modification-piercings",
+          "label": "Piercings",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-modification-tattoos",
+          "label": "Tattoos",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-modification-branding",
+          "label": "Branding",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-modification-scarification",
+          "label": "Scarification",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-modification-permanent-chastity-devices",
+          "label": "Permanent chastity devices",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-modification-cosmetic-implants",
+          "label": "Cosmetic implants",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-modification-stretching-or-gauges",
+          "label": "Stretching or gauges",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-modification-temporary-vs-permanent-changes",
+          "label": "Temporary vs permanent changes",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-modification-professional-vs-diy-methods",
+          "label": "Professional vs DIY methods",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-modification-body-placement-considerations",
+          "label": "Body placement considerations",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-modification-healing-and-aftercare",
+          "label": "Healing and aftercare",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Relationship Preferences",
+      "items": [
+        {
+          "id": "relationship-preferences-preferred-relationship-style",
+          "label": "Preferred relationship style",
+          "type": "text",
+          "options": [
+            "Monogamous",
+            "Open relationship",
+            "Polyamorous",
+            "No preference"
+          ],
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-relationship-goals",
+          "label": "Relationship goals",
+          "type": "text",
+          "options": [
+            "One night stand",
+            "Short-term play",
+            "Long-term relationship",
+            "Platonic play partners",
+            "Romantic partners",
+            "Kink partners"
+          ],
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-monogamous",
+          "label": "Monogamous",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-polyamorous",
+          "label": "Polyamorous",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-hierarchical-dynamics",
+          "label": "Hierarchical dynamics",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-non-hierarchical-poly",
+          "label": "Non-hierarchical poly",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-solo-poly",
+          "label": "Solo-poly",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-open-with-boundaries",
+          "label": "Open with boundaries",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-closed-but-kinky-with-others",
+          "label": "Closed but kinky with others",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-switch-friendly-dynamics",
+          "label": "Switch-friendly dynamics",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Gender Play & Transformation",
+      "items": [
+        {
+          "id": "gender-play-transformation-crossdressing",
+          "label": "Crossdressing",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-forced-feminization",
+          "label": "Forced feminization",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-forced-masculinization",
+          "label": "Forced masculinization",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-gender-role-reversal",
+          "label": "Gender role reversal",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-pronoun-changes",
+          "label": "Pronoun changes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-voice-or-mannerism-training",
+          "label": "Voice or mannerism training",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-sissy-or-tomboy-persona",
+          "label": "Sissy or tomboy persona",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-preferred-pronouns-and-names",
+          "label": "Preferred pronouns and names",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-public-presentation-comfort",
+          "label": "Public presentation comfort",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-clothing-and-appearance",
+          "label": "Clothing and appearance",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-exploration-of-identity",
+          "label": "Exploration of identity",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Chastity Devices",
+      "items": [
+        {
+          "id": "chastity-devices-wearing-a-chastity-cage-short-term",
+          "label": "Wearing a chastity cage (short term)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-long-term-chastity-training",
+          "label": "Long-term chastity training",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-chastity-device-control-with-permission-to-unlock",
+          "label": "Chastity device control with permission to unlock",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-locked-remotely-by-another-person",
+          "label": "Locked remotely by another person",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-orgasm-denial-enforced-by-chastity",
+          "label": "Orgasm denial enforced by chastity",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-wearing-a-belt-style-chastity-device",
+          "label": "Wearing a belt-style chastity device",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-humiliation-while-locked-in-chastity",
+          "label": "Humiliation while locked in chastity",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-sleep-in-chastity-overnight",
+          "label": "Sleep in chastity (overnight)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-being-teased-while-unable-to-touch-yourself",
+          "label": "Being teased while unable to touch yourself",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-begging-for-release-from-chastity",
+          "label": "Begging for release from chastity",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Shibari & Rope Bondage",
+      "items": [
+        {
+          "id": "shibari-rope-bondage-being-tied-in-aesthetic-rope-patterns-shibari",
+          "label": "Being tied in aesthetic rope patterns (Shibari)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-rope-bondage-for-restraint-and-control",
+          "label": "Rope bondage for restraint and control",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-rope-suspension-partial-or-full",
+          "label": "Rope suspension (partial or full)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-learning-to-tie-rope-as-a-form-of-dominance",
+          "label": "Learning to tie rope as a form of dominance",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-being-tied-in-vulnerable-or-exposing-poses",
+          "label": "Being tied in vulnerable or exposing poses",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-practicing-rope-with-emotional-connection",
+          "label": "Practicing rope with emotional connection",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-enduring-discomfort-for-the-beauty-of-the-rope",
+          "label": "Enduring discomfort for the beauty of the rope",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-being-tied-in-a-mirror-and-told-to-look",
+          "label": "Being tied in a mirror and told to look",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-punishment-ties-e-g-uncomfortable-or-humiliating-positions",
+          "label": "Punishment ties (e.g., uncomfortable or humiliating positions)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-solo-rope-practice-for-mindfulness-or-masochism",
+          "label": "Solo rope practice for mindfulness or masochism",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Cosplay & Identity Play",
+      "items": [
+        {
+          "id": "cosplay-identity-play-dressing-up-in-costumes-for-scenes",
+          "label": "Dressing up in costumes for scenes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "cosplay-identity-play-playing-as-fictional-characters",
+          "label": "Playing as fictional characters",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "cosplay-identity-play-petplay-with-collars-ears-or-tails",
+          "label": "Petplay with collars, ears, or tails",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "cosplay-identity-play-pretending-to-be-a-doll-robot-or-object",
+          "label": "Pretending to be a doll, robot, or object",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "cosplay-identity-play-master-slave-cosplay-dynamic-non-24-7",
+          "label": "Master/slave cosplay dynamic (non-24/7)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "cosplay-identity-play-roleplaying-as-a-fantasy-species-or-non-human",
+          "label": "Roleplaying as a fantasy species or non-human",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "cosplay-identity-play-using-cosplay-to-deepen-power-exchange",
+          "label": "Using cosplay to deepen power exchange",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "cosplay-identity-play-scene-built-around-a-character-s-story-or-world",
+          "label": "Scene built around a character’s story or world",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "cosplay-identity-play-fantasy-uniforms-nurse-teacher-etc",
+          "label": "Fantasy uniforms (nurse, teacher, etc.)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "High-Intensity Kinks (SSC-Aware)",
+      "items": [
+        {
+          "id": "high-intensity-kinks-ssc-aware-intense-breath-play-e-g-smothering-or-pressure",
+          "label": "Intense breath play (e.g., smothering or pressure)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-knife-play-or-blade-play-without-injury",
+          "label": "Knife play or blade play (without injury)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-fear-play-using-known-or-negotiated-triggers",
+          "label": "Fear play using known or negotiated triggers",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-abduction-or-home-invasion-style-roleplay-negotiated",
+          "label": "Abduction or home-invasion style roleplay (negotiated)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-medical-themed-scenes-with-sharp-objects-not-bloodletting",
+          "label": "Medical-themed scenes with sharp objects (not bloodletting)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-sensory-deprivation-with-added-disorientation-or-helplessness",
+          "label": "Sensory deprivation with added disorientation or helplessness",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-scenes-involving-heavy-objectification-or-emotional-manipulation-with-care",
+          "label": "Scenes involving heavy objectification or emotional manipulation (with care)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-mock-interrogation-or-intense-role-pressure",
+          "label": "Mock interrogation or intense role pressure",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-consensual-threats-without-follow-through-e-g-if-you-don-t",
+          "label": "Consensual threats without follow-through (e.g. 'If you don’t...')",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-high-intensity-primal-scenes-involving-struggle-or-fear",
+          "label": "High-intensity primal scenes involving struggle or fear",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Behavioral Play",
+      "items": [
+        {
+          "id": "behavioral-play-assigning-corner-time-or-time-outs",
+          "label": "Assigning corner time or time-outs",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "behavioral-play-writing-lines-or-apology-letters-as-correction",
+          "label": "Writing lines or apology letters as correction",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "behavioral-play-removing-privileges-phone-tv-sweets",
+          "label": "Removing privileges (phone, TV, sweets)",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "behavioral-play-playful-punishments-that-still-reinforce-rules",
+          "label": "Playful punishments that still reinforce rules",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "behavioral-play-lecturing-or-scolding-to-modify-behavior",
+          "label": "Lecturing or scolding to modify behavior",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "behavioral-play-being-placed-in-the-corner-or-given-a-time-out",
+          "label": "Being placed in the corner or given a time-out",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "behavioral-play-writing-lines-or-apology-letters-when-misbehaving",
+          "label": "Writing lines or apology letters when misbehaving",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "behavioral-play-having-privileges-revoked-phone-tv",
+          "label": "Having privileges revoked (phone, TV)",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "behavioral-play-receiving-playful-funishments-for-minor-rule-breaking",
+          "label": "Receiving playful 'funishments' for minor rule-breaking",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "behavioral-play-getting-scolded-or-lectured-for-correction",
+          "label": "Getting scolded or lectured for correction",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "behavioral-play-preferred-style-of-discipline-strict-vs-lenient",
+          "label": "Preferred style of discipline (strict vs lenient)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "behavioral-play-attitude-toward-funishment-vs-serious-correction",
+          "label": "Attitude toward funishment vs serious correction",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "behavioral-play-use-of-behavior-contracts-or-rule-agreements",
+          "label": "Use of behavior contracts or rule agreements",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Appearance Play",
+      "items": [
+        {
+          "id": "appearance-play-choosing-my-partner-s-outfit-for-the-day-or-a-scene",
+          "label": "Choosing my partner’s outfit for the day or a scene",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-selecting-their-underwear-lingerie-or-base-layers",
+          "label": "Selecting their underwear, lingerie, or base layers",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-styling-their-hair-braiding-brushing-tying-etc",
+          "label": "Styling their hair (braiding, brushing, tying, etc.)",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-picking-head-coverings-bonnets-veils-hoods-hats-for-mood-or-protocol",
+          "label": "Picking head coverings (bonnets, veils, hoods, hats) for mood or protocol",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-offering-makeup-polish-or-accessories-as-part-of-ritual-or-play",
+          "label": "Offering makeup, polish, or accessories as part of ritual or play",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-creating-themed-looks-slutty-innocent-doll-like-sharp-etc",
+          "label": "Creating themed looks (slutty, innocent, doll-like, sharp, etc.)",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-dressing-them-in-role-specific-costumes-maid-bunny-doll-etc",
+          "label": "Dressing them in role-specific costumes (maid, bunny, doll, etc.)",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-curating-time-period-or-historical-outfits-e-g-victorian-50s",
+          "label": "Curating time-period or historical outfits (e.g., Victorian, 50s)",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-helping-them-present-more-femme-masc-or-androgynous-by-request",
+          "label": "Helping them present more femme, masc, or androgynous by request",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-coordinating-their-look-with-mine-for-public-or-private-scenes",
+          "label": "Coordinating their look with mine for public or private scenes",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-implementing-a-dress-ritual-or-aesthetic-preparation",
+          "label": "Implementing a “dress ritual” or aesthetic preparation",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-enforcing-a-visual-protocol-e-g-no-bra-heels-required-tied-hair",
+          "label": "Enforcing a visual protocol (e.g., no bra, heels required, tied hair)",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-having-my-outfit-selected-for-me-by-a-partner",
+          "label": "Having my outfit selected for me by a partner",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-wearing-the-underwear-or-lingerie-they-choose",
+          "label": "Wearing the underwear or lingerie they choose",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-having-my-hair-brushed-braided-tied-or-styled-for-them",
+          "label": "Having my hair brushed, braided, tied, or styled for them",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-putting-on-a-head-covering-e-g-bonnet-veil-hood-they-chose",
+          "label": "Putting on a head covering (e.g., bonnet, veil, hood) they chose",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-following-visual-appearance-rules-as-part-of-submission",
+          "label": "Following visual appearance rules as part of submission",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-wearing-makeup-polish-or-accessories-they-request",
+          "label": "Wearing makeup, polish, or accessories they request",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-dressing-to-please-their-vision-cute-filthy-classy-etc",
+          "label": "Dressing to please their vision (cute, filthy, classy, etc.)",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-wearing-roleplay-costumes-or-character-looks",
+          "label": "Wearing roleplay costumes or character looks",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-presenting-in-a-way-that-matches-their-chosen-aesthetic",
+          "label": "Presenting in a way that matches their chosen aesthetic",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-participating-in-dressing-rituals-or-undressing-ceremonies",
+          "label": "Participating in dressing rituals or undressing ceremonies",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-being-admired-for-the-way-i-look-under-their-direction",
+          "label": "Being admired for the way I look under their direction",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-receiving-praise-or-gentle-teasing-about-my-appearance",
+          "label": "Receiving praise or gentle teasing about my appearance",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-cosplay-or-fantasy-looks-anime-game-fairytale-etc",
+          "label": "Cosplay or fantasy looks (anime, game, fairytale, etc.)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-time-period-dress-up-regency-gothic-1920s-etc",
+          "label": "Time-period dress-up (regency, gothic, 1920s, etc.)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-dollification-or-polished-presented-object-aesthetics",
+          "label": "Dollification or polished/presented object aesthetics",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-uniforms-schoolgirl-military-clerical-nurse-etc",
+          "label": "Uniforms (schoolgirl, military, clerical, nurse, etc.)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-hair-based-play-forced-brushing-ribbons-or-tied-styles",
+          "label": "Hair-based play (forced brushing, ribbons, or tied styles)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-head-coverings-or-symbolic-hoods-in-ritualized-dynamics",
+          "label": "Head coverings or symbolic hoods in ritualized dynamics",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-matching-looks-or-coordinated-dress-codes",
+          "label": "Matching looks or coordinated dress codes",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-ritualized-grooming-before-scenes",
+          "label": "Ritualized grooming before scenes",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-praise-or-positive-attention-for-pleasing-visual-display",
+          "label": "Praise or positive attention for pleasing visual display",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-formal-appearance-protocols-for-scenes-or-dynamics",
+          "label": "Formal appearance protocols for scenes or dynamics",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-using-clothing-or-style-to-embody-emotional-or-power-roles",
+          "label": "Using clothing or style to embody emotional or power roles",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Psychology Play",
+      "items": [
+        {
+          "id": "psychology-play-emotional-sadism-giving-teasing-feelings-orchestrating-reactions-savoring-anticipation-without-shame-based-harm",
+          "label": "Emotional Sadism (giving): teasing feelings, orchestrating reactions, savoring anticipation without shame-based harm",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "psychology-play-psychological-control-mind-games-double-binds-deliberate-pacing-and-strategic-ambiguity",
+          "label": "Psychological Control: mind games, double binds, deliberate pacing, and strategic ambiguity",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "psychology-play-sadistic-attention-enjoying-being-the-focal-point-of-a-partner-s-fear-arousal-or-resistance",
+          "label": "Sadistic Attention: enjoying being the focal point of a partner’s fear, arousal, or resistance",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "psychology-play-teasing-humiliation-playful-status-play-without-degradation-or-shame",
+          "label": "Teasing Humiliation: playful status play without degradation or shame",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "psychology-play-emotional-sadism-receiving-enjoying-engineered-emotional-intensity-such-as-fluster-exposure-or-playful-embarrassment",
+          "label": "Emotional Sadism (receiving): enjoying engineered emotional intensity such as fluster, exposure, or playful embarrassment",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychology-play-psychological-control-receiving-arousal-from-being-studied-contained-or-outmaneuvered",
+          "label": "Psychological Control (receiving): arousal from being studied, contained, or outmaneuvered",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychology-play-being-the-focus-enjoying-being-watched-tracked-or-held-in-a-partner-s-intense-focus",
+          "label": "Being the Focus: enjoying being watched, tracked, or held in a partner’s intense focus",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychology-play-teasing-humiliation-receiving-enjoying-playful-embarrassment-or-affectionate-mockery-that-builds-intimacy",
+          "label": "Teasing Humiliation (receiving): enjoying playful embarrassment or affectionate mockery that builds intimacy",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychology-play-prey-attention-neediness-craving-focus-pursuit-or-intense-awareness-from-a-partner",
+          "label": "Prey Attention/Neediness: craving focus, pursuit, or intense awareness from a partner",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychology-play-primal-recognition-being-seen-understood-or-tracked-without-needing-words",
+          "label": "Primal Recognition: being seen, understood, or tracked without needing words",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Breeding",
+      "items": [
+        {
+          "id": "breeding-impregnation-giving-arousal-from-attempting-to-impregnate-a-partner",
+          "label": "Impregnation (giving): arousal from attempting to impregnate a partner",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "breeding-feeding-milk-giving-arousal-from-producing-and-feeding-milk-to-a-partner",
+          "label": "Feeding Milk (giving): arousal from producing and feeding milk to a partner",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "breeding-impregnation-receiving-arousal-from-being-inseminated-pregnancy-risk-or-being-bred",
+          "label": "Impregnation (receiving): arousal from being inseminated, pregnancy risk, or being bred",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "breeding-feeding-milk-receiving-arousal-from-drinking-a-partner-s-milk",
+          "label": "Feeding Milk (receiving): arousal from drinking a partner’s milk",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "breeding-pregnancy-fantasy-erotic-focus-on-pregnancy-mine-partner-s-or-fictional-scenarios",
+          "label": "Pregnancy Fantasy: erotic focus on pregnancy (mine, partner’s, or fictional scenarios)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-primal-breeding-drive-animalistic-instinctual-framing-of-sex-reproduction-territory",
+          "label": "Primal Breeding Drive: animalistic/instinctual framing of sex, reproduction, territory",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-breeding-as-control-ownership-authority-expressed-through-breeding-talk-or-pregnancy-risk",
+          "label": "Breeding as Control: ownership/authority expressed through breeding talk or pregnancy risk",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-creampie-marking-erotic-meaning-placed-on-internal-ejaculation-or-visible-claimed-markers",
+          "label": "Creampie/Marking: erotic meaning placed on internal ejaculation or visible ‘claimed’ markers",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-risk-no-contraception-talk-fantasy-dirty-talk-about-risk-or-breeding-without-actual-risk",
+          "label": "Risk/‘No Contraception’ Talk (fantasy): dirty talk about risk or breeding without actual risk",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-heat-ovulation-tracking-timing-in-heat-roleplay-or-cycle-focused-arousal",
+          "label": "Heat/Ovulation Tracking: timing, ‘in heat’ roleplay, or cycle-focused arousal",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-artificial-insemination-device-play-syringes-cups-or-medical-style-scenarios-consensual-fantasy",
+          "label": "Artificial Insemination/Device Play: syringes, cups, or medical-style scenarios (consensual fantasy)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-breeding-denial-ruined-breeding-building-toward-impregnation-talk-then-denying-or-ruining-it",
+          "label": "Breeding Denial/Ruined Breeding: building toward impregnation talk then denying or ‘ruining’ it",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-pregnancy-body-focus-belly-worship-movement-weight-changes-glow-and-attention",
+          "label": "Pregnancy Body Focus: belly worship, movement/weight changes, glow, and attention",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-pregnancy-protocol-care-protective-rules-pedestal-treatment-dedicated-aftercare",
+          "label": "Pregnancy Protocol/Care: protective rules, pedestal treatment, dedicated aftercare",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-lactation-induction-maintenance-interest-in-inducing-or-sustaining-milk-production",
+          "label": "Lactation Induction/Maintenance: interest in inducing or sustaining milk production",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-milking-scenes-manual-oral-or-pump-based-milking-as-play-or-ritual",
+          "label": "Milking Scenes: manual, oral, or pump-based ‘milking’ as play or ritual",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-contraception-boundaries-preference-to-use-protection-bc-methods-or-simulation-only",
+          "label": "Contraception Boundaries: preference to use protection, BC methods, or simulation-only",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-sti-testing-medical-boundaries-testing-cadence-disclosures-and-comfort-levels",
+          "label": "STI/Testing & Medical Boundaries: testing cadence, disclosures, and comfort levels",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    }
+  ],
+  "kinks": [
+    {
+      "id": "body-part-torture-nipple-clips",
+      "label": "Nipple clips",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-nipple-weights",
+      "label": "Nipple weights",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-nipple-suction-cups",
+      "label": "Nipple suction cups",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-cock-ball-torture-cbt",
+      "label": "Cock, Ball Torture (CBT)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-clit-clips-weights-suction",
+      "label": "Clit clips/weights/suction",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-hair-pulling",
+      "label": "Hair pulling",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-face-slapping",
+      "label": "Face slapping",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-butt-slapping",
+      "label": "Butt slapping",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-breast-slapping",
+      "label": "Breast slapping",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-genital-slapping",
+      "label": "Genital slapping",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "bondage-and-suspension-blindfolds",
+      "label": "Blindfolds",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-bondage-heavy",
+      "label": "Bondage (heavy)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-bondage-light",
+      "label": "Bondage (light)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-immobilisation",
+      "label": "Immobilisation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-bondage-multi-day",
+      "label": "Bondage (multi-day)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-bondage-public-under-clothing",
+      "label": "Bondage (public, under clothing)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-leather-restraints",
+      "label": "Leather restraints",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-chains",
+      "label": "Chains",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-ropes",
+      "label": "Ropes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-intricate-japanese-rope-bondage",
+      "label": "Intricate (Japanese) rope bondage",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-rope-body-harness",
+      "label": "Rope body harness",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-arm-leg-sleeves-armbinders",
+      "label": "Arm & leg sleeves (armbinders)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-harnesses-leather",
+      "label": "Harnesses (leather)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-harnesses-rope",
+      "label": "Harnesses (rope)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-cuffs-leather",
+      "label": "Cuffs (leather)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-cuffs-metal",
+      "label": "Cuffs (metal)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-manacles-irons",
+      "label": "Manacles & Irons",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-gags-cloth",
+      "label": "Gags (cloth)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-gags-rubber",
+      "label": "Gags (rubber)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-gags-tape",
+      "label": "Gags (tape)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-gags-phallic",
+      "label": "Gags (phallic)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-gags-ring",
+      "label": "Gags (ring)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-gags-ball",
+      "label": "Gags (ball)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-mouth-bits",
+      "label": "Mouth bits",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-full-head-hoods",
+      "label": "Full head hoods",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-mummification-saran-wrapping",
+      "label": "Mummification/saran wrapping",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-straight-jackets",
+      "label": "Straight jackets",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-suspension-upright",
+      "label": "Suspension (upright)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-suspension-horizontal",
+      "label": "Suspension (horizontal)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-suspension-inverted",
+      "label": "Suspension (inverted)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-breath-play",
+      "label": "Breath play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-smothering",
+      "label": "Smothering",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-forced-self-breath-control",
+      "label": "Forced self-breath-control",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-gas-mask",
+      "label": "Gas mask",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "breath-play-asphyxiation",
+      "label": "Asphyxiation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Breath Play"
+    },
+    {
+      "id": "breath-play-breath-control",
+      "label": "Breath control",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Breath Play"
+    },
+    {
+      "id": "breath-play-choking",
+      "label": "Choking",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Breath Play"
+    },
+    {
+      "id": "breath-play-drowning",
+      "label": "Drowning",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Breath Play"
+    },
+    {
+      "id": "breath-play-rebreathing-into-a-bag-or-object",
+      "label": "Rebreathing into a bag or object",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Breath Play"
+    },
+    {
+      "id": "breath-play-verbal-control-of-breath-e-g-hold-it-on-command",
+      "label": "Verbal control of breath (e.g., 'hold it' on command)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Breath Play"
+    },
+    {
+      "id": "sexual-activity-licking",
+      "label": "Licking",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-fellatio-cunnilingus",
+      "label": "Fellatio/Cunnilingus",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-swallowing-semen",
+      "label": "Swallowing semen",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-cumming-on-partner",
+      "label": "Cumming on Partner",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-hand-jobs",
+      "label": "Hand jobs",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-anal-sex",
+      "label": "Anal sex",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-anal-plugs-small",
+      "label": "Anal plugs (small)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-anal-plugs-large",
+      "label": "Anal plugs (large)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-anal-beads",
+      "label": "Anal beads",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-vibrator-on-genitals",
+      "label": "Vibrator on genitals",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-fisting",
+      "label": "Fisting",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-oral-anal-play-rimming",
+      "label": "Oral/anal play (rimming)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-double-penetration-oral-and-vaginal",
+      "label": "Double penetration (oral and vaginal)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-double-penetration-oral-and-anal",
+      "label": "Double penetration (oral and anal)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-double-penetration-anal-and-vaginal",
+      "label": "Double penetration (anal and vaginal)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-triple-oral-vaginal-and-anal",
+      "label": "Triple (Oral, Vaginal and Anal)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sensation-play-abrasion",
+      "label": "Abrasion",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-scratching",
+      "label": "Scratching",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-biting",
+      "label": "Biting",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-tickling",
+      "label": "Tickling",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-kissing",
+      "label": "Kissing",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-zapping-e-g-electric-fly-swatter",
+      "label": "Zapping (e.g. electric fly swatter)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-ice-cubes",
+      "label": "Ice cubes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-wax-play",
+      "label": "Wax Play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-fire",
+      "label": "Fire",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-clothespins",
+      "label": "Clothespins",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-needles",
+      "label": "Needles",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-sensory-deprivation",
+      "label": "Sensory deprivation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-physical-overpowering-manhandling",
+      "label": "Physical overpowering / Manhandling",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-figging",
+      "label": "Figging",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "other-feet",
+      "label": "Feet",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-boots",
+      "label": "Boots",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-underwear",
+      "label": "Underwear",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-chastity-devices",
+      "label": "Chastity devices",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-masks",
+      "label": "Masks",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-breeding",
+      "label": "Breeding",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-leather-clothing",
+      "label": "Leather clothing",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-training-protocols-outside-scenes-e-g-etiquette-memory",
+      "label": "Training protocols outside scenes (e.g., etiquette, memory)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-long-distance-training-structure",
+      "label": "Long-distance training/structure",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-scene-journaling-and-reflection",
+      "label": "Scene journaling and reflection",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "roleplaying-fantasy-abandonment",
+      "label": "Fantasy abandonment",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-kidnapping",
+      "label": "Kidnapping",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-interrogation",
+      "label": "Interrogation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-sleep-deprivation",
+      "label": "Sleep deprivation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-cnc",
+      "label": "CNC",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-gang-bang",
+      "label": "Gang bang",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-initiation-rites",
+      "label": "Initiation rites",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-religious-scenes",
+      "label": "Religious scenes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-medical-scenes",
+      "label": "Medical scenes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-prison-scenes",
+      "label": "Prison scenes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-primal-prey",
+      "label": "Primal/Prey",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-schoolroom-scenes",
+      "label": "Schoolroom scenes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-following-orders",
+      "label": "(Following) orders",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-forced-servitude",
+      "label": "Forced servitude",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-restrictive-rules-on-behaviour",
+      "label": "Restrictive rules on behaviour",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-eye-contact-restrictions",
+      "label": "Eye contact restrictions",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-speech-restrictions-when-what-to-whom",
+      "label": "Speech restrictions (when, what, to whom)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-washroom-restrictions",
+      "label": "Washroom restrictions",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-punishments",
+      "label": "Punishments",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-tasks",
+      "label": "Tasks",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-massage",
+      "label": "Massage",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-domestic-tasks",
+      "label": "Domestic tasks",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-serving-food-and-drink",
+      "label": "Serving food and drink",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-personal-care-rituals",
+      "label": "Personal care rituals",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-being-on-call-at-specified-times",
+      "label": "Being on-call at specified times",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-daily-task-assignments",
+      "label": "Daily task assignments",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-corrections-for-imperfection",
+      "label": "Corrections for imperfection",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-uniforms-dress-codes",
+      "label": "Uniforms / Dress codes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-kneeling-posture-presentation",
+      "label": "Kneeling / Posture presentation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-silent-service",
+      "label": "Silent service",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-public-service-at-parties-or-events",
+      "label": "Public service (at parties or events)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-erotic-service-pleasure-on-command-without-seeking-your-own",
+      "label": "Erotic service (pleasure on command, without seeking your own)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "voyeurism-exhibitionism-forced-nudity-private",
+      "label": "Forced nudity (private)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Voyeurism/Exhibitionism"
+    },
+    {
+      "id": "voyeurism-exhibitionism-forced-nudity-around-others",
+      "label": "Forced nudity (around others)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Voyeurism/Exhibitionism"
+    },
+    {
+      "id": "voyeurism-exhibitionism-exhibitionism-friends",
+      "label": "Exhibitionism (friends)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Voyeurism/Exhibitionism"
+    },
+    {
+      "id": "voyeurism-exhibitionism-exhibitionism-strangers",
+      "label": "Exhibitionism (strangers)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Voyeurism/Exhibitionism"
+    },
+    {
+      "id": "voyeurism-exhibitionism-modelling-for-erotic-photos",
+      "label": "Modelling for erotic photos",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Voyeurism/Exhibitionism"
+    },
+    {
+      "id": "voyeurism-exhibitionism-toys-under-clothes-in-public",
+      "label": "Toys under clothes in public",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Voyeurism/Exhibitionism"
+    },
+    {
+      "id": "virtual-long-distance-play-sending-tasks-or-orders-digitally",
+      "label": "Sending tasks or orders digitally",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-recording-dominant-voice-clips-commands-edging-praise-degradation-etc",
+      "label": "Recording dominant voice clips (commands, edging, praise, degradation, etc.)",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-remote-control-of-a-sex-toy",
+      "label": "Remote control of a sex toy",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-monitoring-behavior-via-app-or-shared-doc",
+      "label": "Monitoring behavior via app or shared doc",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-giving-punishment-assignments-remotely",
+      "label": "Giving punishment assignments remotely",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-creating-countdowns-timers-or-denial-periods",
+      "label": "Creating countdowns, timers, or denial periods",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-sending-written-instructions-with-delayed-permissions",
+      "label": "Sending written instructions with delayed permissions",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-creating-custom-video-or-audio-tasks",
+      "label": "Creating custom video or audio tasks",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-voice-message-control-during-scenes",
+      "label": "Voice message control during scenes",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-being-on-call-at-specified-times",
+      "label": "Being on-call at specified times",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-receiving-tasks-or-orders-digitally",
+      "label": "Receiving tasks or orders digitally",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-listening-to-dominant-voice-clips",
+      "label": "Listening to dominant voice clips",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-using-a-remote-controlled-toy-controlled-by-another",
+      "label": "Using a remote-controlled toy controlled by another",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-completing-daily-protocol-assignments",
+      "label": "Completing daily protocol assignments",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-submitting-proof-photo-video-text",
+      "label": "Submitting proof (photo, video, text)",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-following-recorded-or-timed-commands",
+      "label": "Following recorded or timed commands",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-receiving-surprise-instructions",
+      "label": "Receiving surprise instructions",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-hearing-name-praise-spoken-in-a-custom-clip",
+      "label": "Hearing name/praise spoken in a custom clip",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-sending-submissive-voice-clips-obedience-begging-thank-you-messages-affirmations-etc",
+      "label": "Sending submissive voice clips (obedience, begging, thank-you messages, affirmations, etc.)",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-scheduling-digital-rituals-or-reminders",
+      "label": "Scheduling digital rituals or reminders",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-using-training-habit-or-behavior-tracking-apps",
+      "label": "Using training, habit, or behavior-tracking apps",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-online-rituals-digital-kneeling-posture-protocols",
+      "label": "Online rituals (digital kneeling, posture protocols)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-role-based-texting-e-g-use-honorifics-in-chat",
+      "label": "Role-based texting (e.g., \"Use honorifics in chat\")",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-shared-playlists-affirmations-or-mantras",
+      "label": "Shared playlists, affirmations, or mantras",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-countdown-timers-to-next-task-release-or-interaction",
+      "label": "Countdown timers to next task, release, or interaction",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-scheduled-good-morning-night-rituals",
+      "label": "Scheduled good morning/night rituals",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-participating-in-video-call-scenes",
+      "label": "Participating in video call scenes",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-digital-aftercare-texts-voice-images",
+      "label": "Digital aftercare (texts, voice, images)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-sexting-or-digital-roleplay-scenes",
+      "label": "Sexting or digital roleplay scenes",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-voice-notes-or-submissive-dominant-affirmations",
+      "label": "Voice notes or submissive/dominant affirmations",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "communication-playful-and-teasing",
+      "label": "Playful and teasing",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-quiet-and-intense",
+      "label": "Quiet and intense",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-observant-and-intentional",
+      "label": "Observant and intentional",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-praise-heavy",
+      "label": "Praise-heavy",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-blunt-and-efficient",
+      "label": "Blunt and efficient",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-affirming-and-soft",
+      "label": "Affirming and soft",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-psychological-interrogation",
+      "label": "Psychological interrogation",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-verbal-coercion-teasing-traps",
+      "label": "Verbal coercion / teasing traps",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-verbal-misdirection",
+      "label": "Verbal misdirection",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-mocking-shaming",
+      "label": "Mocking / shaming",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-predatory-pacing",
+      "label": "Predatory pacing",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-reluctant-obedience",
+      "label": "Reluctant obedience",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-stammering-submission",
+      "label": "Stammering submission",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-challenging-until-caught",
+      "label": "Challenging until caught",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-quiet-surrender",
+      "label": "Quiet surrender",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-sarcastic-teasing",
+      "label": "Sarcastic teasing",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-provoking-tone",
+      "label": "Provoking tone",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-challenge-based-dialogue",
+      "label": "Challenge-based dialogue",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-double-meaning-banter",
+      "label": "Double-meaning banter",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-soft-spoken-guidance",
+      "label": "Soft-spoken guidance",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-protective-but-firm-tone",
+      "label": "Protective but firm tone",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-emotional-redirection",
+      "label": "Emotional redirection",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-steady-reassurance",
+      "label": "Steady reassurance",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-direct-and-clear",
+      "label": "Direct and clear",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-gentle-and-nurturing",
+      "label": "Gentle and nurturing",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-commanding-and-firm",
+      "label": "Commanding and firm",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-quiet-and-observant",
+      "label": "Quiet and observant",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-instructive-teacher-like",
+      "label": "Instructive / teacher-like",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-emotionally-intense",
+      "label": "Emotionally intense",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-dismissive-withholding",
+      "label": "Dismissive / withholding",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-mocking-sarcastic",
+      "label": "Mocking / sarcastic",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-blunt-tactless",
+      "label": "Blunt / tactless",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-predatory-hunting-tone",
+      "label": "Predatory / hunting tone",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-stalking-or-circling-speech",
+      "label": "Stalking or circling speech",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-you-re-mine-control-language",
+      "label": "You’re mine / control language",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-threatening-consensual",
+      "label": "Threatening (consensual)",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-verbal-cornering-coaxing",
+      "label": "Verbal cornering / coaxing",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-watching-you-unravel",
+      "label": "Watching you unravel",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-cruel-and-cutting",
+      "label": "Cruel and cutting",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-psychological-baiting",
+      "label": "Psychological baiting",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-brat-breaking-language",
+      "label": "Brat-breaking language",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-mock-affection",
+      "label": "Mock affection",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-shaming-or-emotional-edge",
+      "label": "Shaming or emotional edge",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-disappointed-dom-voice",
+      "label": "Disappointed dom voice",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-mild-scolding-mocking-affection",
+      "label": "Mild scolding / mocking affection",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-verbal-power-struggle",
+      "label": "Verbal power struggle",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-challenge-response-dynamics",
+      "label": "Challenge-response dynamics",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-warm-tone-with-expectation",
+      "label": "Warm tone with expectation",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-nurturing-dominance",
+      "label": "Nurturing dominance",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-reassuring-commands",
+      "label": "Reassuring commands",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-phrases-that-work-on-you",
+      "label": "Phrases that work on you",
+      "type": "text",
+      "roles": [
+        "General"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-phrases-you-use-or-like-to-give",
+      "label": "Phrases you use or like to give",
+      "type": "text",
+      "roles": [
+        "General"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-what-helps-you-feel-emotionally-safe",
+      "label": "What helps you feel emotionally safe",
+      "type": "text",
+      "roles": [
+        "General"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-how-you-tend-to-show-affection",
+      "label": "How you tend to show affection",
+      "type": "text",
+      "roles": [
+        "General"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-emotional-check-in-style",
+      "label": "Emotional check-in style",
+      "type": "text",
+      "roles": [
+        "General"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-when-emotionally-activated-i-tend-to",
+      "label": "When emotionally activated, I tend to...",
+      "type": "text",
+      "roles": [
+        "General"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "body-fluids-and-functions-watersports-golden-showers",
+      "label": "Watersports/golden showers",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Fluids and Functions"
+    },
+    {
+      "id": "body-fluids-and-functions-cum",
+      "label": "Cum",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Fluids and Functions"
+    },
+    {
+      "id": "body-fluids-and-functions-blood",
+      "label": "Blood",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Fluids and Functions"
+    },
+    {
+      "id": "body-fluids-and-functions-scat",
+      "label": "Scat",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Fluids and Functions"
+    },
+    {
+      "id": "body-fluids-and-functions-sweat",
+      "label": "Sweat",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Fluids and Functions"
+    },
+    {
+      "id": "body-fluids-and-functions-vomit",
+      "label": "Vomit",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Fluids and Functions"
+    },
+    {
+      "id": "body-fluids-and-functions-tears-crying",
+      "label": "Tears/crying",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Fluids and Functions"
+    },
+    {
+      "id": "psychological-primal-prey-primal-prey",
+      "label": "Primal/Prey",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-conditioning",
+      "label": "Conditioning",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-coc",
+      "label": "COC",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-psycholagny-hands-free-mentally-stimulated-orgasm",
+      "label": "Psycholagny (hands free, mentally stimulated orgasm)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-hypno-play",
+      "label": "Hypno Play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-praise",
+      "label": "Praise",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-degradation",
+      "label": "Degradation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-traditional-primal-prey",
+      "label": "Traditional primal/prey",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-fear-play",
+      "label": "Fear play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-objectification",
+      "label": "Objectification",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-gaslighting",
+      "label": "Gaslighting",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-role-erosion-identity-play-loss-of-self",
+      "label": "Role erosion (identity play / loss of self)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-jealousy-play",
+      "label": "Jealousy play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-manipulation",
+      "label": "Manipulation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "body-part-fetish-play-belly-fucking",
+      "label": "Belly fucking",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-navel-play",
+      "label": "Navel play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-feet-foot-worship",
+      "label": "Feet / Foot worship",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-hands",
+      "label": "Hands",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-hair",
+      "label": "Hair",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-thighs",
+      "label": "Thighs",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-neck",
+      "label": "Neck",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-ears",
+      "label": "Ears",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-belly",
+      "label": "Belly",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-voice-fetish",
+      "label": "Voice fetish",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-nails-makeup-fetish",
+      "label": "Nails / Makeup fetish",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-cuddles",
+      "label": "Cuddles",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-food-play",
+      "label": "Food Play",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-kisses",
+      "label": "Kisses",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-masturbation",
+      "label": "Masturbation",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-romance-affection",
+      "label": "Romance / affection",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-sex-toys",
+      "label": "Sex toys",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-sexting-chat-etc",
+      "label": "Sexting /Chat etc",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-sexting-via-phone-or-video-call",
+      "label": "Sexting via phone or video call",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-strip-tease",
+      "label": "Strip tease",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-vanilla-sex",
+      "label": "Vanilla Sex",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-voice-notes",
+      "label": "Voice Notes",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-shaving-body-hair",
+      "label": "Shaving (body hair)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-sexy-clothing-private",
+      "label": "Sexy clothing (private)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-sexy-clothing-public",
+      "label": "Sexy clothing (public)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-outdoor-scenes",
+      "label": "Outdoor scenes",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-public-exposure",
+      "label": "Public exposure",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-edging",
+      "label": "Edging",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-short-term-denial",
+      "label": "Short term denial",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-long-term-denial",
+      "label": "Long term denial",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-forced-orgasms-overstimulation",
+      "label": "Forced orgasms / Overstimulation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-ruined-orgasms",
+      "label": "Ruined orgasms",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-no-touch-periods",
+      "label": "No touch periods",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-milking",
+      "label": "Milking",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-chastity-devices",
+      "label": "Chastity devices",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-consensual-orgasm-control",
+      "label": "Consensual orgasm control",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-forced-masturbation",
+      "label": "Forced masturbation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "protocol-and-ritual-formal-language",
+      "label": "Formal language",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-greeting-and-departure-rituals-kneeling-verbal-scripts-gestures",
+      "label": "Greeting and departure rituals (kneeling, verbal scripts, gestures)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-requiring-permission-for-things-speech-movement-attire",
+      "label": "Requiring permission for things (speech, movement, attire)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-daily-rituals-morning-check-ins-status-reports-mantra-repetitions",
+      "label": "Daily rituals (morning check-ins, status reports, mantra repetitions)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-specific-postures-for-rest-attention-punishment-waiting",
+      "label": "Specific postures for rest, attention, punishment, waiting",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-restricted-behavior-no-eye-contact-silence-no-questions",
+      "label": "Restricted behavior (no eye contact, silence, no questions)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-ritual-object-use-collar-cuffs-leash-tokens",
+      "label": "Ritual object use (collar, cuffs, leash, tokens)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-tracking-obedience-journals-apps",
+      "label": "Tracking obedience (journals, apps)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-formalized-rules-for-misbehavior-and-correction",
+      "label": "Formalized rules for misbehavior and correction",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-ritualized-aftercare-or-scene-closure",
+      "label": "Ritualized aftercare or scene closure",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-object-retrieval-on-all-fours-with-item-in-mouth",
+      "label": "Object retrieval on all fours with item in mouth",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-fetching-hairbrush-or-punishment-tool-from-dresser-while-crawling",
+      "label": "Fetching hairbrush or punishment tool from dresser while crawling",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-presenting-chosen-discipline-tool-in-kneeling-posture",
+      "label": "Presenting chosen discipline tool in kneeling posture",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-assigned-posture-or-kneeling-positions-as-ritual",
+      "label": "Assigned posture or kneeling positions as ritual",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-requesting-permission-using-specific-protocol-phrases",
+      "label": "Requesting permission using specific protocol phrases",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-carrying-items-in-mouth-as-submissive-gesture",
+      "label": "Carrying items in mouth as submissive gesture",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-crawling-back-with-object-to-dominant-after-retrieval",
+      "label": "Crawling back with object to Dominant after retrieval",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-following-via-nipple-leash-as-protocol-or-punishment",
+      "label": "Following via nipple leash as protocol or punishment",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-crawling-assigned-paths-as-ritual-or-obedience-training",
+      "label": "Crawling assigned paths as ritual or obedience training",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-crawling-rituals-e-g-object-retrieval",
+      "label": "Crawling rituals (e.g., object retrieval)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-carrying-objects-in-mouth-as-obedience",
+      "label": "Carrying objects in mouth as obedience",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-presenting-tools-or-toys-in-posture",
+      "label": "Presenting tools or toys in posture",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-using-honorifics-or-preset-protocol-language",
+      "label": "Using honorifics or preset protocol language",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-greeting-rituals-e-g-kneeling-kissing-feet",
+      "label": "Greeting rituals (e.g., kneeling, kissing feet)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-daily-check-ins-or-structured-reports",
+      "label": "Daily check-ins or structured reports",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-clothing-restrictions-or-uniforms",
+      "label": "Clothing restrictions or uniforms",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-posture-training-sitting-kneeling-standing",
+      "label": "Posture training (sitting, kneeling, standing)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-punishments-for-incorrect-behavior-or-tone",
+      "label": "Punishments for incorrect behavior or tone",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-crawling-with-items-in-mouth-e-g-hairbrush-spoon",
+      "label": "Crawling with items in mouth (e.g., hairbrush, spoon)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-earning-permission-for-meals-bathroom-use-or-rest",
+      "label": "Earning permission for meals, bathroom use, or rest",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-following-daily-rituals-or-protocol",
+      "label": "Following daily rituals or protocol",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-structured-speech-rules-e-g-titles-third-person",
+      "label": "Structured speech rules (e.g., titles, third person)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-receiving-correction-when-out-of-line",
+      "label": "Receiving correction when out of line",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-inspection-rituals-or-readiness-checks",
+      "label": "Inspection rituals or readiness checks",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "primal-bratting-chase-and-capture-play",
+      "label": "Chase and capture play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-bratting-for-punishment",
+      "label": "Bratting for punishment",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-playful-growling-and-biting",
+      "label": "Playful growling and biting",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-provoking-with-teasing-or-taunts",
+      "label": "Provoking with teasing or taunts",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-escaping-or-hiding-to-encourage-pursuit",
+      "label": "Escaping or hiding to encourage pursuit",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-refusing-commands-just-for-fun",
+      "label": "Refusing commands just for fun",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-provoking-your-partner-to-chase-or-discipline-you",
+      "label": "Provoking your partner to chase or discipline you",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-taunting-or-teasing-as-a-form-of-play",
+      "label": "Taunting or teasing as a form of play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-intentional-resistance-during-power-exchange",
+      "label": "Intentional resistance during power exchange",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-being-caught-and-overpowered",
+      "label": "Being caught and overpowered",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "headspace-regression-caregiver-little-regression-play",
+      "label": "Caregiver/little regression play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-using-pacifiers-or-sippy-cups",
+      "label": "Using pacifiers or sippy cups",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-coloring-or-childlike-crafts",
+      "label": "Coloring or childlike crafts",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-stuffed-animal-comfort",
+      "label": "Stuffed animal comfort",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-speaking-in-a-childlike-voice",
+      "label": "Speaking in a childlike voice",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-bedtime-stories-or-lullabies",
+      "label": "Bedtime stories or lullabies",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-entering-altered-headspaces-e-g-prey-pet-little",
+      "label": "Entering altered headspaces (e.g., prey, pet, little)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-regressive-behaviors-as-comfort-coloring-babytalk",
+      "label": "Regressive behaviors as comfort (coloring, babytalk)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-being-cared-for-during-emotional-vulnerability",
+      "label": "Being cared for during emotional vulnerability",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-guided-emotional-headspace-entry",
+      "label": "Guided emotional headspace entry",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "performance-internal-struggle-obedience-under-observation",
+      "label": "Obedience under observation",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-speech-restriction-and-self-denial",
+      "label": "Speech restriction and self-denial",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-maintaining-composure-during-humiliation",
+      "label": "Maintaining composure during humiliation",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-obedience-drills-for-an-audience",
+      "label": "Obedience drills for an audience",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-struggling-against-personal-urges",
+      "label": "Struggling against personal urges",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-displaying-submission-despite-conflict",
+      "label": "Displaying submission despite conflict",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-being-told-to-act-normal-while-struggling-internally",
+      "label": "Being told to act normal while struggling internally",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-pleasing-through-high-functioning-obedience",
+      "label": "Pleasing through high-functioning obedience",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-performing-submission-while-masking-resistance",
+      "label": "Performing submission while masking resistance",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-the-pressure-of-appearing-good-while-feeling-conflicted",
+      "label": "The pressure of appearing 'good' while feeling conflicted",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-being-made-to-perform-emotions-on-command-cry-beg-moan",
+      "label": "Being made to perform emotions on command (cry, beg, moan)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-struggling-openly-while-still-obeying",
+      "label": "Struggling openly while still obeying",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-performing-exaggerated-resistance-or-denial",
+      "label": "Performing exaggerated resistance or denial",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-being-punished-for-breaking-character",
+      "label": "Being punished for 'breaking character'",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-putting-on-a-show-for-someone-else-s-pleasure",
+      "label": "Putting on a show for someone else’s pleasure",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-rehearsed-degradation-or-humiliation-scripts",
+      "label": "Rehearsed degradation or humiliation scripts",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "mindfuck-manipulation-confusing-commands-and-reality-shifts",
+      "label": "Confusing commands and reality shifts",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-gaslighting-or-contradictory-cues",
+      "label": "Gaslighting or contradictory cues",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-presenting-false-choices",
+      "label": "Presenting false choices",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-hidden-motives-or-secret-tasks",
+      "label": "Hidden motives or secret tasks",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-illogical-rules-meant-to-confuse",
+      "label": "Illogical rules meant to confuse",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-gaslight-style-scenes-with-consent-and-clarity",
+      "label": "Gaslight-style scenes (with consent and clarity)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-false-threats-or-staged-surprises",
+      "label": "False threats or staged surprises",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-confusing-commands-to-prompt-hesitation",
+      "label": "Confusing commands to prompt hesitation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-emotional-trickery-as-arousal",
+      "label": "Emotional trickery as arousal",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-being-misled-or-deceived-on-purpose-during-play",
+      "label": "Being misled or deceived on purpose during play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-surprise-rule-changes-or-twists-mid-scene",
+      "label": "Surprise rule changes or twists mid-scene",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-false-safeword-games-with-negotiated-limits",
+      "label": "False safeword games (with negotiated limits)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-withholding-or-delaying-aftercare-for-effect",
+      "label": "Withholding or delaying aftercare for effect",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-being-gaslit-or-doubted-in-a-controlled-roleplay",
+      "label": "Being gaslit or doubted in a controlled roleplay",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-told-you-asked-for-this-or-you-love-this-when-resisting",
+      "label": "Told 'you asked for this' or 'you love this' when resisting",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mouth-play-holding-tools-or-restraints-in-teeth-while-crawling",
+      "label": "Holding tools or restraints in teeth while crawling",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-placing-objects-from-mouth-into-dominant-s-palm",
+      "label": "Placing objects from mouth into Dominant’s palm",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-using-mouth-instead-of-hands-for-service-rituals",
+      "label": "Using mouth instead of hands for service rituals",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-gag-presentation-and-silent-waiting-protocol",
+      "label": "Gag presentation and silent waiting protocol",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-holding-objects-in-teeth-while-crawling",
+      "label": "Holding objects in teeth while crawling",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-returning-items-using-mouth-only",
+      "label": "Returning items using mouth only",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-gag-rituals-or-waiting-silently",
+      "label": "Gag rituals or waiting silently",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-leash-held-in-mouth",
+      "label": "Leash held in mouth",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-being-gagged-or-forced-silent",
+      "label": "Being gagged or forced silent",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-having-to-hold-objects-in-your-mouth-spoon-hairbrush-leash",
+      "label": "Having to hold objects in your mouth (spoon, hairbrush, leash)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-being-used-for-oral-service-without-reciprocal-pleasure",
+      "label": "Being used for oral service without reciprocal pleasure",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-being-fed-by-hand-mouth-to-mouth-or-with-utensils",
+      "label": "Being fed by hand, mouth-to-mouth, or with utensils",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-verbal-control-e-g-only-speak-when-spoken-to",
+      "label": "Verbal control (e.g., only speak when spoken to)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-mouth-as-a-symbol-of-ownership-or-control",
+      "label": "Mouth as a symbol of ownership or control",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "impact-play-hand-spanking",
+      "label": "Hand spanking",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-paddle-strikes",
+      "label": "Paddle strikes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-crop-snaps",
+      "label": "Crop snaps",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-flogger-swings",
+      "label": "Flogger swings",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-cane-strokes",
+      "label": "Cane strokes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-belt-or-strap-hits",
+      "label": "Belt or strap hits",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-whip-cracks",
+      "label": "Whip cracks",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-preferred-intensity-levels",
+      "label": "Preferred intensity levels",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-aftercare-for-bruises",
+      "label": "Aftercare for bruises",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-target-body-areas",
+      "label": "Target body areas",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-implement-selection",
+      "label": "Implement selection",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "medical-play-needle-play",
+      "label": "Needle play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-catheter-insertion",
+      "label": "Catheter insertion",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-speculum-exams",
+      "label": "Speculum exams",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-enema-administration",
+      "label": "Enema administration",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-temperature-taking",
+      "label": "Temperature taking",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-medical-restraints",
+      "label": "Medical restraints",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-doctor-nurse-roleplay",
+      "label": "Doctor/nurse roleplay",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-sterilization-procedures",
+      "label": "Sterilization procedures",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-professional-vs-roleplay-scenes",
+      "label": "Professional vs roleplay scenes",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-consent-for-invasive-acts",
+      "label": "Consent for invasive acts",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-access-to-medical-equipment",
+      "label": "Access to medical equipment",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "pet-play-puppy-or-kitten-play",
+      "label": "Puppy or kitten play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-pony-play",
+      "label": "Pony play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-wearing-collar-and-leash",
+      "label": "Wearing collar and leash",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-eating-from-a-bowl",
+      "label": "Eating from a bowl",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-kenneling-or-caging",
+      "label": "Kenneling or caging",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-pet-training-commands",
+      "label": "Pet training commands",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-animal-costumes-or-gear",
+      "label": "Animal costumes or gear",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-preferred-animal-identities",
+      "label": "Preferred animal identities",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-public-vs-private-play",
+      "label": "Public vs private play",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-training-style-and-discipline",
+      "label": "Training style and discipline",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-use-of-pet-names-and-commands",
+      "label": "Use of pet names and commands",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "body-modification-piercings",
+      "label": "Piercings",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-tattoos",
+      "label": "Tattoos",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-branding",
+      "label": "Branding",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-scarification",
+      "label": "Scarification",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-permanent-chastity-devices",
+      "label": "Permanent chastity devices",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-cosmetic-implants",
+      "label": "Cosmetic implants",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-stretching-or-gauges",
+      "label": "Stretching or gauges",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-temporary-vs-permanent-changes",
+      "label": "Temporary vs permanent changes",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-professional-vs-diy-methods",
+      "label": "Professional vs DIY methods",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-body-placement-considerations",
+      "label": "Body placement considerations",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-healing-and-aftercare",
+      "label": "Healing and aftercare",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "relationship-preferences-preferred-relationship-style",
+      "label": "Preferred relationship style",
+      "type": "text",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-relationship-goals",
+      "label": "Relationship goals",
+      "type": "text",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-monogamous",
+      "label": "Monogamous",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-polyamorous",
+      "label": "Polyamorous",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-hierarchical-dynamics",
+      "label": "Hierarchical dynamics",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-non-hierarchical-poly",
+      "label": "Non-hierarchical poly",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-solo-poly",
+      "label": "Solo-poly",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-open-with-boundaries",
+      "label": "Open with boundaries",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-closed-but-kinky-with-others",
+      "label": "Closed but kinky with others",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-switch-friendly-dynamics",
+      "label": "Switch-friendly dynamics",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "gender-play-transformation-crossdressing",
+      "label": "Crossdressing",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-forced-feminization",
+      "label": "Forced feminization",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-forced-masculinization",
+      "label": "Forced masculinization",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-gender-role-reversal",
+      "label": "Gender role reversal",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-pronoun-changes",
+      "label": "Pronoun changes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-voice-or-mannerism-training",
+      "label": "Voice or mannerism training",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-sissy-or-tomboy-persona",
+      "label": "Sissy or tomboy persona",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-preferred-pronouns-and-names",
+      "label": "Preferred pronouns and names",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-public-presentation-comfort",
+      "label": "Public presentation comfort",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-clothing-and-appearance",
+      "label": "Clothing and appearance",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-exploration-of-identity",
+      "label": "Exploration of identity",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "chastity-devices-wearing-a-chastity-cage-short-term",
+      "label": "Wearing a chastity cage (short term)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-long-term-chastity-training",
+      "label": "Long-term chastity training",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-chastity-device-control-with-permission-to-unlock",
+      "label": "Chastity device control with permission to unlock",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-locked-remotely-by-another-person",
+      "label": "Locked remotely by another person",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-orgasm-denial-enforced-by-chastity",
+      "label": "Orgasm denial enforced by chastity",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-wearing-a-belt-style-chastity-device",
+      "label": "Wearing a belt-style chastity device",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-humiliation-while-locked-in-chastity",
+      "label": "Humiliation while locked in chastity",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-sleep-in-chastity-overnight",
+      "label": "Sleep in chastity (overnight)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-being-teased-while-unable-to-touch-yourself",
+      "label": "Being teased while unable to touch yourself",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-begging-for-release-from-chastity",
+      "label": "Begging for release from chastity",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "shibari-rope-bondage-being-tied-in-aesthetic-rope-patterns-shibari",
+      "label": "Being tied in aesthetic rope patterns (Shibari)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-rope-bondage-for-restraint-and-control",
+      "label": "Rope bondage for restraint and control",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-rope-suspension-partial-or-full",
+      "label": "Rope suspension (partial or full)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-learning-to-tie-rope-as-a-form-of-dominance",
+      "label": "Learning to tie rope as a form of dominance",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-being-tied-in-vulnerable-or-exposing-poses",
+      "label": "Being tied in vulnerable or exposing poses",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-practicing-rope-with-emotional-connection",
+      "label": "Practicing rope with emotional connection",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-enduring-discomfort-for-the-beauty-of-the-rope",
+      "label": "Enduring discomfort for the beauty of the rope",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-being-tied-in-a-mirror-and-told-to-look",
+      "label": "Being tied in a mirror and told to look",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-punishment-ties-e-g-uncomfortable-or-humiliating-positions",
+      "label": "Punishment ties (e.g., uncomfortable or humiliating positions)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-solo-rope-practice-for-mindfulness-or-masochism",
+      "label": "Solo rope practice for mindfulness or masochism",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "cosplay-identity-play-dressing-up-in-costumes-for-scenes",
+      "label": "Dressing up in costumes for scenes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "cosplay-identity-play-playing-as-fictional-characters",
+      "label": "Playing as fictional characters",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "cosplay-identity-play-petplay-with-collars-ears-or-tails",
+      "label": "Petplay with collars, ears, or tails",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "cosplay-identity-play-pretending-to-be-a-doll-robot-or-object",
+      "label": "Pretending to be a doll, robot, or object",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "cosplay-identity-play-master-slave-cosplay-dynamic-non-24-7",
+      "label": "Master/slave cosplay dynamic (non-24/7)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "cosplay-identity-play-roleplaying-as-a-fantasy-species-or-non-human",
+      "label": "Roleplaying as a fantasy species or non-human",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "cosplay-identity-play-using-cosplay-to-deepen-power-exchange",
+      "label": "Using cosplay to deepen power exchange",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "cosplay-identity-play-scene-built-around-a-character-s-story-or-world",
+      "label": "Scene built around a character’s story or world",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "cosplay-identity-play-fantasy-uniforms-nurse-teacher-etc",
+      "label": "Fantasy uniforms (nurse, teacher, etc.)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-intense-breath-play-e-g-smothering-or-pressure",
+      "label": "Intense breath play (e.g., smothering or pressure)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-knife-play-or-blade-play-without-injury",
+      "label": "Knife play or blade play (without injury)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-fear-play-using-known-or-negotiated-triggers",
+      "label": "Fear play using known or negotiated triggers",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-abduction-or-home-invasion-style-roleplay-negotiated",
+      "label": "Abduction or home-invasion style roleplay (negotiated)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-medical-themed-scenes-with-sharp-objects-not-bloodletting",
+      "label": "Medical-themed scenes with sharp objects (not bloodletting)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-sensory-deprivation-with-added-disorientation-or-helplessness",
+      "label": "Sensory deprivation with added disorientation or helplessness",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-scenes-involving-heavy-objectification-or-emotional-manipulation-with-care",
+      "label": "Scenes involving heavy objectification or emotional manipulation (with care)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-mock-interrogation-or-intense-role-pressure",
+      "label": "Mock interrogation or intense role pressure",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-consensual-threats-without-follow-through-e-g-if-you-don-t",
+      "label": "Consensual threats without follow-through (e.g. 'If you don’t...')",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-high-intensity-primal-scenes-involving-struggle-or-fear",
+      "label": "High-intensity primal scenes involving struggle or fear",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "behavioral-play-assigning-corner-time-or-time-outs",
+      "label": "Assigning corner time or time-outs",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-writing-lines-or-apology-letters-as-correction",
+      "label": "Writing lines or apology letters as correction",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-removing-privileges-phone-tv-sweets",
+      "label": "Removing privileges (phone, TV, sweets)",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-playful-punishments-that-still-reinforce-rules",
+      "label": "Playful punishments that still reinforce rules",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-lecturing-or-scolding-to-modify-behavior",
+      "label": "Lecturing or scolding to modify behavior",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-being-placed-in-the-corner-or-given-a-time-out",
+      "label": "Being placed in the corner or given a time-out",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-writing-lines-or-apology-letters-when-misbehaving",
+      "label": "Writing lines or apology letters when misbehaving",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-having-privileges-revoked-phone-tv",
+      "label": "Having privileges revoked (phone, TV)",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-receiving-playful-funishments-for-minor-rule-breaking",
+      "label": "Receiving playful 'funishments' for minor rule-breaking",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-getting-scolded-or-lectured-for-correction",
+      "label": "Getting scolded or lectured for correction",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-preferred-style-of-discipline-strict-vs-lenient",
+      "label": "Preferred style of discipline (strict vs lenient)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-attitude-toward-funishment-vs-serious-correction",
+      "label": "Attitude toward funishment vs serious correction",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-use-of-behavior-contracts-or-rule-agreements",
+      "label": "Use of behavior contracts or rule agreements",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "appearance-play-choosing-my-partner-s-outfit-for-the-day-or-a-scene",
+      "label": "Choosing my partner’s outfit for the day or a scene",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-selecting-their-underwear-lingerie-or-base-layers",
+      "label": "Selecting their underwear, lingerie, or base layers",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-styling-their-hair-braiding-brushing-tying-etc",
+      "label": "Styling their hair (braiding, brushing, tying, etc.)",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-picking-head-coverings-bonnets-veils-hoods-hats-for-mood-or-protocol",
+      "label": "Picking head coverings (bonnets, veils, hoods, hats) for mood or protocol",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-offering-makeup-polish-or-accessories-as-part-of-ritual-or-play",
+      "label": "Offering makeup, polish, or accessories as part of ritual or play",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-creating-themed-looks-slutty-innocent-doll-like-sharp-etc",
+      "label": "Creating themed looks (slutty, innocent, doll-like, sharp, etc.)",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-dressing-them-in-role-specific-costumes-maid-bunny-doll-etc",
+      "label": "Dressing them in role-specific costumes (maid, bunny, doll, etc.)",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-curating-time-period-or-historical-outfits-e-g-victorian-50s",
+      "label": "Curating time-period or historical outfits (e.g., Victorian, 50s)",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-helping-them-present-more-femme-masc-or-androgynous-by-request",
+      "label": "Helping them present more femme, masc, or androgynous by request",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-coordinating-their-look-with-mine-for-public-or-private-scenes",
+      "label": "Coordinating their look with mine for public or private scenes",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-implementing-a-dress-ritual-or-aesthetic-preparation",
+      "label": "Implementing a “dress ritual” or aesthetic preparation",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-enforcing-a-visual-protocol-e-g-no-bra-heels-required-tied-hair",
+      "label": "Enforcing a visual protocol (e.g., no bra, heels required, tied hair)",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-having-my-outfit-selected-for-me-by-a-partner",
+      "label": "Having my outfit selected for me by a partner",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-wearing-the-underwear-or-lingerie-they-choose",
+      "label": "Wearing the underwear or lingerie they choose",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-having-my-hair-brushed-braided-tied-or-styled-for-them",
+      "label": "Having my hair brushed, braided, tied, or styled for them",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-putting-on-a-head-covering-e-g-bonnet-veil-hood-they-chose",
+      "label": "Putting on a head covering (e.g., bonnet, veil, hood) they chose",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-following-visual-appearance-rules-as-part-of-submission",
+      "label": "Following visual appearance rules as part of submission",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-wearing-makeup-polish-or-accessories-they-request",
+      "label": "Wearing makeup, polish, or accessories they request",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-dressing-to-please-their-vision-cute-filthy-classy-etc",
+      "label": "Dressing to please their vision (cute, filthy, classy, etc.)",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-wearing-roleplay-costumes-or-character-looks",
+      "label": "Wearing roleplay costumes or character looks",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-presenting-in-a-way-that-matches-their-chosen-aesthetic",
+      "label": "Presenting in a way that matches their chosen aesthetic",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-participating-in-dressing-rituals-or-undressing-ceremonies",
+      "label": "Participating in dressing rituals or undressing ceremonies",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-being-admired-for-the-way-i-look-under-their-direction",
+      "label": "Being admired for the way I look under their direction",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-receiving-praise-or-gentle-teasing-about-my-appearance",
+      "label": "Receiving praise or gentle teasing about my appearance",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-cosplay-or-fantasy-looks-anime-game-fairytale-etc",
+      "label": "Cosplay or fantasy looks (anime, game, fairytale, etc.)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-time-period-dress-up-regency-gothic-1920s-etc",
+      "label": "Time-period dress-up (regency, gothic, 1920s, etc.)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-dollification-or-polished-presented-object-aesthetics",
+      "label": "Dollification or polished/presented object aesthetics",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-uniforms-schoolgirl-military-clerical-nurse-etc",
+      "label": "Uniforms (schoolgirl, military, clerical, nurse, etc.)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-hair-based-play-forced-brushing-ribbons-or-tied-styles",
+      "label": "Hair-based play (forced brushing, ribbons, or tied styles)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-head-coverings-or-symbolic-hoods-in-ritualized-dynamics",
+      "label": "Head coverings or symbolic hoods in ritualized dynamics",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-matching-looks-or-coordinated-dress-codes",
+      "label": "Matching looks or coordinated dress codes",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-ritualized-grooming-before-scenes",
+      "label": "Ritualized grooming before scenes",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-praise-or-positive-attention-for-pleasing-visual-display",
+      "label": "Praise or positive attention for pleasing visual display",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-formal-appearance-protocols-for-scenes-or-dynamics",
+      "label": "Formal appearance protocols for scenes or dynamics",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-using-clothing-or-style-to-embody-emotional-or-power-roles",
+      "label": "Using clothing or style to embody emotional or power roles",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "psychology-play-emotional-sadism-giving-teasing-feelings-orchestrating-reactions-savoring-anticipation-without-shame-based-harm",
+      "label": "Emotional Sadism (giving): teasing feelings, orchestrating reactions, savoring anticipation without shame-based harm",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-psychological-control-mind-games-double-binds-deliberate-pacing-and-strategic-ambiguity",
+      "label": "Psychological Control: mind games, double binds, deliberate pacing, and strategic ambiguity",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-sadistic-attention-enjoying-being-the-focal-point-of-a-partner-s-fear-arousal-or-resistance",
+      "label": "Sadistic Attention: enjoying being the focal point of a partner’s fear, arousal, or resistance",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-teasing-humiliation-playful-status-play-without-degradation-or-shame",
+      "label": "Teasing Humiliation: playful status play without degradation or shame",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-emotional-sadism-receiving-enjoying-engineered-emotional-intensity-such-as-fluster-exposure-or-playful-embarrassment",
+      "label": "Emotional Sadism (receiving): enjoying engineered emotional intensity such as fluster, exposure, or playful embarrassment",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-psychological-control-receiving-arousal-from-being-studied-contained-or-outmaneuvered",
+      "label": "Psychological Control (receiving): arousal from being studied, contained, or outmaneuvered",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-being-the-focus-enjoying-being-watched-tracked-or-held-in-a-partner-s-intense-focus",
+      "label": "Being the Focus: enjoying being watched, tracked, or held in a partner’s intense focus",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-teasing-humiliation-receiving-enjoying-playful-embarrassment-or-affectionate-mockery-that-builds-intimacy",
+      "label": "Teasing Humiliation (receiving): enjoying playful embarrassment or affectionate mockery that builds intimacy",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-prey-attention-neediness-craving-focus-pursuit-or-intense-awareness-from-a-partner",
+      "label": "Prey Attention/Neediness: craving focus, pursuit, or intense awareness from a partner",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-primal-recognition-being-seen-understood-or-tracked-without-needing-words",
+      "label": "Primal Recognition: being seen, understood, or tracked without needing words",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "breeding-impregnation-giving-arousal-from-attempting-to-impregnate-a-partner",
+      "label": "Impregnation (giving): arousal from attempting to impregnate a partner",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-feeding-milk-giving-arousal-from-producing-and-feeding-milk-to-a-partner",
+      "label": "Feeding Milk (giving): arousal from producing and feeding milk to a partner",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-impregnation-receiving-arousal-from-being-inseminated-pregnancy-risk-or-being-bred",
+      "label": "Impregnation (receiving): arousal from being inseminated, pregnancy risk, or being bred",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-feeding-milk-receiving-arousal-from-drinking-a-partner-s-milk",
+      "label": "Feeding Milk (receiving): arousal from drinking a partner’s milk",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-pregnancy-fantasy-erotic-focus-on-pregnancy-mine-partner-s-or-fictional-scenarios",
+      "label": "Pregnancy Fantasy: erotic focus on pregnancy (mine, partner’s, or fictional scenarios)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-primal-breeding-drive-animalistic-instinctual-framing-of-sex-reproduction-territory",
+      "label": "Primal Breeding Drive: animalistic/instinctual framing of sex, reproduction, territory",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-breeding-as-control-ownership-authority-expressed-through-breeding-talk-or-pregnancy-risk",
+      "label": "Breeding as Control: ownership/authority expressed through breeding talk or pregnancy risk",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-creampie-marking-erotic-meaning-placed-on-internal-ejaculation-or-visible-claimed-markers",
+      "label": "Creampie/Marking: erotic meaning placed on internal ejaculation or visible ‘claimed’ markers",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-risk-no-contraception-talk-fantasy-dirty-talk-about-risk-or-breeding-without-actual-risk",
+      "label": "Risk/‘No Contraception’ Talk (fantasy): dirty talk about risk or breeding without actual risk",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-heat-ovulation-tracking-timing-in-heat-roleplay-or-cycle-focused-arousal",
+      "label": "Heat/Ovulation Tracking: timing, ‘in heat’ roleplay, or cycle-focused arousal",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-artificial-insemination-device-play-syringes-cups-or-medical-style-scenarios-consensual-fantasy",
+      "label": "Artificial Insemination/Device Play: syringes, cups, or medical-style scenarios (consensual fantasy)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-breeding-denial-ruined-breeding-building-toward-impregnation-talk-then-denying-or-ruining-it",
+      "label": "Breeding Denial/Ruined Breeding: building toward impregnation talk then denying or ‘ruining’ it",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-pregnancy-body-focus-belly-worship-movement-weight-changes-glow-and-attention",
+      "label": "Pregnancy Body Focus: belly worship, movement/weight changes, glow, and attention",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-pregnancy-protocol-care-protective-rules-pedestal-treatment-dedicated-aftercare",
+      "label": "Pregnancy Protocol/Care: protective rules, pedestal treatment, dedicated aftercare",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-lactation-induction-maintenance-interest-in-inducing-or-sustaining-milk-production",
+      "label": "Lactation Induction/Maintenance: interest in inducing or sustaining milk production",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-milking-scenes-manual-oral-or-pump-based-milking-as-play-or-ritual",
+      "label": "Milking Scenes: manual, oral, or pump-based ‘milking’ as play or ritual",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-contraception-boundaries-preference-to-use-protection-bc-methods-or-simulation-only",
+      "label": "Contraception Boundaries: preference to use protection, BC methods, or simulation-only",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-sti-testing-medical-boundaries-testing-cadence-disclosures-and-comfort-levels",
+      "label": "STI/Testing & Medical Boundaries: testing cadence, disclosures, and comfort levels",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    }
+  ]
+}

--- a/js/kinks_data_guard.js
+++ b/js/kinks_data_guard.js
@@ -17,14 +17,22 @@
         if (/^<!doctype html/i.test(t)||/<html[\s>]/i.test(t)||/text\/html/i.test(ct)) continue;
         try{
           const j=JSON.parse(t);
-          return Array.isArray(j)?j:(j&&Array.isArray(j.kinks)?j.kinks:[]);
+          if (Array.isArray(j)) return j;
+          if (j && Array.isArray(j.categories)) return j.categories;
+          if (j && Array.isArray(j.kinks)) return j.kinks;
+          return [];
         }catch{}
       }catch{}
     }
     // embedded <script type="application/json" id="kinks-embedded-data">
     try{
       const emb=$("#kinks-embedded-data");
-      if (emb) { const j=JSON.parse(emb.textContent||"[]"); return Array.isArray(j)?j:(j.kinks||[]); }
+      if (emb) {
+        const j=JSON.parse(emb.textContent||"[]");
+        if (Array.isArray(j)) return j;
+        if (j && Array.isArray(j.categories)) return j.categories;
+        if (j && Array.isArray(j.kinks)) return j.kinks;
+      }
     }catch{}
     // final local fallback (very small) so UI is usable
     try{

--- a/js/kinks_fetch_compat.js
+++ b/js/kinks_fetch_compat.js
@@ -35,8 +35,12 @@
 
   const norm = s => String(s ?? '').trim();
   function toFlat(data){
+    if (data && typeof data === 'object' && !Array.isArray(data)) {
+      if (Array.isArray(data.categories)) return toFlat(data.categories);
+      if (Array.isArray(data.kinks)) return toFlat(data.kinks);
+      if (Array.isArray(data.data)) return toFlat(data.data);
+    }
     if (Array.isArray(data) && data.length && !('items' in (data[0]||{}))) return data;
-    if (data && Array.isArray(data.kinks)) return data.kinks;
     if (Array.isArray(data) && data.length && Array.isArray(data[0]?.items)) {
       const out=[]; for (const g of data) {
         const cat = norm(g.category ?? g.cat ?? '');

--- a/js/tk-labels.js
+++ b/js/tk-labels.js
@@ -1,0 +1,113 @@
+(() => {
+  const DICT_URLS = ["/data/kinks.json", "/kinksurvey/data/kinks.json", "/kinks.json"];
+  const LABELS = Object.create(null);
+  const UNKNOWN = new Set();
+
+  function log(...a){ try{ console.log("[labels]", ...a);}catch{} }
+  function warn(...a){ try{ console.warn("[labels]", ...a);}catch{} }
+
+  async function fetchFirst(urls){
+    for(const url of urls){
+      try{
+        const r = await fetch(url, {cache:"no-store"});
+        if(!r.ok) throw new Error(r.status+" "+r.statusText);
+        const json = await r.json();
+        if(json && typeof json==="object" && json.labels){
+          Object.assign(LABELS, json.labels);
+          log("loaded", Object.keys(json.labels).length, "labels from", url);
+          return true;
+        }
+      }catch(e){ /* try next */ }
+    }
+    warn("no label dictionary found at", urls.join(", "));
+    return false;
+  }
+
+  function getCompatTables(){
+    // find tables whose header includes “Category” and “Partner A”
+    const tables = Array.from(document.querySelectorAll("table"));
+    return tables.filter(t=>{
+      const th = Array.from(t.querySelectorAll("thead th,th"));
+      const h  = th.map(x=>x.textContent.trim().toLowerCase());
+      return h.includes("category") && h.some(x=>x.includes("partner a"));
+    });
+  }
+
+  function relabelCell(td){
+    if(!td || td.dataset.tkLabeled === "1") return;
+    const raw = (td.textContent||"").trim();
+    if(!raw) return;
+
+    const pretty = LABELS[raw];
+    if(pretty){
+      td.textContent = pretty;              // replace text only (no layout change)
+      td.setAttribute("title", raw);        // keep original id as tooltip
+      td.dataset.tkLabeled = "1";
+    }else if(/^cb_[a-z0-9]{4,}$/i.test(raw)){
+      // looks like a code but we don't have a label yet
+      if(!UNKNOWN.has(raw)){ UNKNOWN.add(raw); warn("missing label for", raw); }
+      td.dataset.tkLabeled = "0";
+    }else{
+      td.dataset.tkLabeled = "1";           // already human
+    }
+  }
+
+  function relabelAll(){
+    for(const table of getCompatTables()){
+      const rows = table.tBodies.length ? table.tBodies[0].rows : table.rows;
+      for(const tr of rows){
+        const td = tr.cells && tr.cells[0];
+        relabelCell(td);
+      }
+    }
+  }
+
+  function watchMutations(){
+    const mo = new MutationObserver((muts)=>{
+      let changed = false;
+      for(const m of muts){
+        if(m.addedNodes && m.addedNodes.length) changed = true;
+        if(m.type==="attributes") changed = true;
+        if(changed) break;
+      }
+      if(changed) relabelAll();
+    });
+    mo.observe(document.body, {subtree:true, childList:true, attributes:true});
+  }
+
+  // If survey JSON uploads include a {labels:{...}} block, merge that too.
+  function tapFileInputs(){
+    document.addEventListener("change", async (e)=>{
+      const el = e.target;
+      if(!(el instanceof HTMLInputElement)) return;
+      if(el.type !== "file") return;
+      for(const file of el.files||[]){
+        if(!/\.json$/i.test(file.name)) continue;
+        try{
+          const text = await file.text();
+          const data = JSON.parse(text);
+          if(data && typeof data==="object" && data.labels){
+            Object.assign(LABELS, data.labels);
+            log("merged", Object.keys(data.labels).length, "labels from upload", file.name);
+            relabelAll();
+          }
+        }catch{}
+      }
+    }, true);
+  }
+
+  // Boot
+  document.addEventListener("DOMContentLoaded", async ()=>{
+    await fetchFirst(DICT_URLS);
+    relabelAll();
+    watchMutations();
+    tapFileInputs();
+
+    // Helpful report (open DevTools console after uploading both surveys):
+    setTimeout(()=>{
+      if(UNKNOWN.size){
+        warn("Add these to /data/kinks.json → \"labels\": { ... }", Array.from(UNKNOWN).sort());
+      }
+    }, 1200);
+  });
+})();

--- a/js/tk_failopen.js
+++ b/js/tk_failopen.js
@@ -37,7 +37,10 @@
       if (/^<!doctype html/i.test(txt) || /<html[\s>]/i.test(txt) || /text\/html/i.test(ct))
         return { ok:false, why:'html rewrite' };
       let j=null; try { j = JSON.parse(txt); } catch(e){ return { ok:false, why:'invalid json' }; }
-      const arr = Array.isArray(j) ? j : (j && Array.isArray(j.kinks) ? j.kinks : []);
+      let arr = [];
+      if (Array.isArray(j)) arr = j;
+      else if (j && Array.isArray(j.categories)) arr = j.categories;
+      else if (j && Array.isArray(j.kinks)) arr = j.kinks;
       const cats = [...new Set(arr.map(x=>String(x?.category||x?.cat||'').trim().toLowerCase()).filter(Boolean))];
       return { ok:true, count:arr.length, cats };
     } catch (e) {

--- a/kinks.json
+++ b/kinks.json
@@ -1,4943 +1,10247 @@
-[
-  {
-    "category": "Body Part Torture",
-    "items": [
-      {
-        "id": "body-part-torture-nipple-clips",
-        "label": "Nipple clips",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-nipple-weights",
-        "label": "Nipple weights",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-nipple-suction-cups",
-        "label": "Nipple suction cups",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-cock-ball-torture-cbt",
-        "label": "Cock, Ball Torture (CBT)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-clit-clips-weights-suction",
-        "label": "Clit clips/weights/suction",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-hair-pulling",
-        "label": "Hair pulling",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-face-slapping",
-        "label": "Face slapping",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-butt-slapping",
-        "label": "Butt slapping",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-breast-slapping",
-        "label": "Breast slapping",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-torture-genital-slapping",
-        "label": "Genital slapping",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
+{
+  "labels": {
+    "cb_169ma": "Time-period dress-up",
+    "cb_2c0f9": "Hair-based play (brushing, ribbons, tying)",
+    "cb_2gxmo": "Uniforms (school, military, nurse, etc.)",
+    "cb_3ozhq": "Praise for pleasing visual display",
+    "cb_4yyxa": "Dollification / polished object aesthetics",
+    "cb_065gv": "Formal appearance protocols",
+    "cb_6jd2f": "Pick lingerie / base layers",
+    "cb_fsnmj": "Praise for pleasing visual display",
+    "cb_gkzbu": "Hair-based play (brushing, ribbons, tying)",
+    "cb_hqakm": "Formal appearance protocols",
+    "cb_ifkmg": "Clothing as power-role signal",
+    "cb_kaku7": "Time-period dress-up",
+    "cb_kgrnn": "Uniforms (school, military, nurse, etc.)",
+    "cb_kua8l": "Dress partner’s outfit",
+    "cb_qflrp": "Dollification / polished object aesthetics",
+    "cb_qw9jg": "Ritualized grooming",
+    "cb_qwnhi": "Head coverings / symbolic hoods",
+    "cb_r7cwr": "Head coverings / symbolic hoods",
+    "cb_rn136": "Clothing as power-role signal",
+    "cb_ss4gf": "Ritualized grooming",
+    "cb_w2dc1": "Coordinated looks / dress codes",
+    "cb_yzegd": "Pick lingerie / base layers",
+    "cb_zsnrb": "Dress partner’s outfit",
+    "cb_zvchg": "Coordinated looks / dress codes"
   },
-  {
-    "category": "Bondage and Suspension",
-    "items": [
-      {
-        "id": "bondage-and-suspension-blindfolds",
-        "label": "Blindfolds",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-bondage-heavy",
-        "label": "Bondage (heavy)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-bondage-light",
-        "label": "Bondage (light)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-immobilisation",
-        "label": "Immobilisation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-bondage-multi-day",
-        "label": "Bondage (multi-day)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-bondage-public-under-clothing",
-        "label": "Bondage (public, under clothing)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-leather-restraints",
-        "label": "Leather restraints",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-chains",
-        "label": "Chains",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-ropes",
-        "label": "Ropes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-intricate-japanese-rope-bondage",
-        "label": "Intricate (Japanese) rope bondage",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-rope-body-harness",
-        "label": "Rope body harness",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-arm-leg-sleeves-armbinders",
-        "label": "Arm & leg sleeves (armbinders)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-harnesses-leather",
-        "label": "Harnesses (leather)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-harnesses-rope",
-        "label": "Harnesses (rope)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-cuffs-leather",
-        "label": "Cuffs (leather)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-cuffs-metal",
-        "label": "Cuffs (metal)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-manacles-irons",
-        "label": "Manacles & Irons",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-gags-cloth",
-        "label": "Gags (cloth)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-gags-rubber",
-        "label": "Gags (rubber)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-gags-tape",
-        "label": "Gags (tape)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-gags-phallic",
-        "label": "Gags (phallic)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-gags-ring",
-        "label": "Gags (ring)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-gags-ball",
-        "label": "Gags (ball)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-mouth-bits",
-        "label": "Mouth bits",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-full-head-hoods",
-        "label": "Full head hoods",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-mummification-saran-wrapping",
-        "label": "Mummification/saran wrapping",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-straight-jackets",
-        "label": "Straight jackets",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-suspension-upright",
-        "label": "Suspension (upright)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-suspension-horizontal",
-        "label": "Suspension (horizontal)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-suspension-inverted",
-        "label": "Suspension (inverted)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-breath-play",
-        "label": "Breath play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-smothering",
-        "label": "Smothering",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-forced-self-breath-control",
-        "label": "Forced self-breath-control",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "bondage-and-suspension-gas-mask",
-        "label": "Gas mask",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Breath Play",
-    "items": [
-      {
-        "id": "breath-play-asphyxiation",
-        "label": "Asphyxiation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "breath-play-breath-control",
-        "label": "Breath control",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "breath-play-choking",
-        "label": "Choking",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "breath-play-drowning",
-        "label": "Drowning",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "breath-play-rebreathing-into-a-bag-or-object",
-        "label": "Rebreathing into a bag or object",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "breath-play-verbal-control-of-breath-e-g-hold-it-on-command",
-        "label": "Verbal control of breath (e.g., 'hold it' on command)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Sexual Activity",
-    "items": [
-      {
-        "id": "sexual-activity-licking",
-        "label": "Licking",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-fellatio-cunnilingus",
-        "label": "Fellatio/Cunnilingus",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-swallowing-semen",
-        "label": "Swallowing semen",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-cumming-on-partner",
-        "label": "Cumming on Partner",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-hand-jobs",
-        "label": "Hand jobs",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-anal-sex",
-        "label": "Anal sex",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-anal-plugs-small",
-        "label": "Anal plugs (small)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-anal-plugs-large",
-        "label": "Anal plugs (large)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-anal-beads",
-        "label": "Anal beads",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-vibrator-on-genitals",
-        "label": "Vibrator on genitals",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-fisting",
-        "label": "Fisting",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-oral-anal-play-rimming",
-        "label": "Oral/anal play (rimming)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-double-penetration-oral-and-vaginal",
-        "label": "Double penetration (oral and vaginal)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-double-penetration-oral-and-anal",
-        "label": "Double penetration (oral and anal)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-double-penetration-anal-and-vaginal",
-        "label": "Double penetration (anal and vaginal)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sexual-activity-triple-oral-vaginal-and-anal",
-        "label": "Triple (Oral, Vaginal and Anal)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Sensation Play",
-    "items": [
-      {
-        "id": "sensation-play-abrasion",
-        "label": "Abrasion",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-scratching",
-        "label": "Scratching",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-biting",
-        "label": "Biting",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-tickling",
-        "label": "Tickling",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-kissing",
-        "label": "Kissing",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-zapping-e-g-electric-fly-swatter",
-        "label": "Zapping (e.g. electric fly swatter)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-ice-cubes",
-        "label": "Ice cubes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-wax-play",
-        "label": "Wax Play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-fire",
-        "label": "Fire",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-clothespins",
-        "label": "Clothespins",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-needles",
-        "label": "Needles",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-sensory-deprivation",
-        "label": "Sensory deprivation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-physical-overpowering-manhandling",
-        "label": "Physical overpowering / Manhandling",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "sensation-play-figging",
-        "label": "Figging",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Other",
-    "items": [
-      {
-        "id": "other-feet",
-        "label": "Feet",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-boots",
-        "label": "Boots",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-underwear",
-        "label": "Underwear",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-chastity-devices",
-        "label": "Chastity devices",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-masks",
-        "label": "Masks",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-breeding",
-        "label": "Breeding",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-leather-clothing",
-        "label": "Leather clothing",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-training-protocols-outside-scenes-e-g-etiquette-memory",
-        "label": "Training protocols outside scenes (e.g., etiquette, memory)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-long-distance-training-structure",
-        "label": "Long-distance training/structure",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "other-scene-journaling-and-reflection",
-        "label": "Scene journaling and reflection",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Roleplaying",
-    "items": [
-      {
-        "id": "roleplaying-fantasy-abandonment",
-        "label": "Fantasy abandonment",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-kidnapping",
-        "label": "Kidnapping",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-interrogation",
-        "label": "Interrogation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-sleep-deprivation",
-        "label": "Sleep deprivation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-cnc",
-        "label": "CNC",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-gang-bang",
-        "label": "Gang bang",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-initiation-rites",
-        "label": "Initiation rites",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-religious-scenes",
-        "label": "Religious scenes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-medical-scenes",
-        "label": "Medical scenes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-prison-scenes",
-        "label": "Prison scenes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-primal-prey",
-        "label": "Primal/Prey",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "roleplaying-schoolroom-scenes",
-        "label": "Schoolroom scenes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Service and Restrictive Behaviour",
-    "items": [
-      {
-        "id": "service-and-restrictive-behaviour-following-orders",
-        "label": "(Following) orders",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-forced-servitude",
-        "label": "Forced servitude",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-restrictive-rules-on-behaviour",
-        "label": "Restrictive rules on behaviour",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-eye-contact-restrictions",
-        "label": "Eye contact restrictions",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-speech-restrictions-when-what-to-whom",
-        "label": "Speech restrictions (when, what, to whom)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-washroom-restrictions",
-        "label": "Washroom restrictions",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-punishments",
-        "label": "Punishments",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-tasks",
-        "label": "Tasks",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-massage",
-        "label": "Massage",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-domestic-tasks",
-        "label": "Domestic tasks",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-serving-food-and-drink",
-        "label": "Serving food and drink",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-personal-care-rituals",
-        "label": "Personal care rituals",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-being-on-call-at-specified-times",
-        "label": "Being on-call at specified times",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-daily-task-assignments",
-        "label": "Daily task assignments",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-corrections-for-imperfection",
-        "label": "Corrections for imperfection",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-uniforms-dress-codes",
-        "label": "Uniforms / Dress codes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-kneeling-posture-presentation",
-        "label": "Kneeling / Posture presentation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-silent-service",
-        "label": "Silent service",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-public-service-at-parties-or-events",
-        "label": "Public service (at parties or events)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "service-and-restrictive-behaviour-erotic-service-pleasure-on-command-without-seeking-your-own",
-        "label": "Erotic service (pleasure on command, without seeking your own)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Voyeurism/Exhibitionism",
-    "items": [
-      {
-        "id": "voyeurism-exhibitionism-forced-nudity-private",
-        "label": "Forced nudity (private)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "voyeurism-exhibitionism-forced-nudity-around-others",
-        "label": "Forced nudity (around others)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "voyeurism-exhibitionism-exhibitionism-friends",
-        "label": "Exhibitionism (friends)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "voyeurism-exhibitionism-exhibitionism-strangers",
-        "label": "Exhibitionism (strangers)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "voyeurism-exhibitionism-modelling-for-erotic-photos",
-        "label": "Modelling for erotic photos",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "voyeurism-exhibitionism-toys-under-clothes-in-public",
-        "label": "Toys under clothes in public",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Virtual & Long-Distance Play",
-    "items": [
-      {
-        "id": "virtual-long-distance-play-sending-tasks-or-orders-digitally",
-        "label": "Sending tasks or orders digitally",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-recording-dominant-voice-clips-commands-edging-praise-degradation-etc",
-        "label": "Recording dominant voice clips (commands, edging, praise, degradation, etc.)",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-remote-control-of-a-sex-toy",
-        "label": "Remote control of a sex toy",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-monitoring-behavior-via-app-or-shared-doc",
-        "label": "Monitoring behavior via app or shared doc",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-giving-punishment-assignments-remotely",
-        "label": "Giving punishment assignments remotely",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-creating-countdowns-timers-or-denial-periods",
-        "label": "Creating countdowns, timers, or denial periods",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-sending-written-instructions-with-delayed-permissions",
-        "label": "Sending written instructions with delayed permissions",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-creating-custom-video-or-audio-tasks",
-        "label": "Creating custom video or audio tasks",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-voice-message-control-during-scenes",
-        "label": "Voice message control during scenes",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-being-on-call-at-specified-times",
-        "label": "Being on-call at specified times",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-receiving-tasks-or-orders-digitally",
-        "label": "Receiving tasks or orders digitally",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-listening-to-dominant-voice-clips",
-        "label": "Listening to dominant voice clips",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-using-a-remote-controlled-toy-controlled-by-another",
-        "label": "Using a remote-controlled toy controlled by another",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-completing-daily-protocol-assignments",
-        "label": "Completing daily protocol assignments",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-submitting-proof-photo-video-text",
-        "label": "Submitting proof (photo, video, text)",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-following-recorded-or-timed-commands",
-        "label": "Following recorded or timed commands",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-receiving-surprise-instructions",
-        "label": "Receiving surprise instructions",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-hearing-name-praise-spoken-in-a-custom-clip",
-        "label": "Hearing name/praise spoken in a custom clip",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-sending-submissive-voice-clips-obedience-begging-thank-you-messages-affirmations-etc",
-        "label": "Sending submissive voice clips (obedience, begging, thank-you messages, affirmations, etc.)",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-scheduling-digital-rituals-or-reminders",
-        "label": "Scheduling digital rituals or reminders",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-using-training-habit-or-behavior-tracking-apps",
-        "label": "Using training, habit, or behavior-tracking apps",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-online-rituals-digital-kneeling-posture-protocols",
-        "label": "Online rituals (digital kneeling, posture protocols)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-role-based-texting-e-g-use-honorifics-in-chat",
-        "label": "Role-based texting (e.g., \"Use honorifics in chat\")",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-shared-playlists-affirmations-or-mantras",
-        "label": "Shared playlists, affirmations, or mantras",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-countdown-timers-to-next-task-release-or-interaction",
-        "label": "Countdown timers to next task, release, or interaction",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-scheduled-good-morning-night-rituals",
-        "label": "Scheduled good morning/night rituals",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-participating-in-video-call-scenes",
-        "label": "Participating in video call scenes",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-digital-aftercare-texts-voice-images",
-        "label": "Digital aftercare (texts, voice, images)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-sexting-or-digital-roleplay-scenes",
-        "label": "Sexting or digital roleplay scenes",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "virtual-long-distance-play-voice-notes-or-submissive-dominant-affirmations",
-        "label": "Voice notes or submissive/dominant affirmations",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Communication",
-    "items": [
-      {
-        "id": "communication-playful-and-teasing",
-        "label": "Playful and teasing",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-quiet-and-intense",
-        "label": "Quiet and intense",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-observant-and-intentional",
-        "label": "Observant and intentional",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-praise-heavy",
-        "label": "Praise-heavy",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-blunt-and-efficient",
-        "label": "Blunt and efficient",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-affirming-and-soft",
-        "label": "Affirming and soft",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-psychological-interrogation",
-        "label": "Psychological interrogation",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-verbal-coercion-teasing-traps",
-        "label": "Verbal coercion / teasing traps",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-verbal-misdirection",
-        "label": "Verbal misdirection",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-mocking-shaming",
-        "label": "Mocking / shaming",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-predatory-pacing",
-        "label": "Predatory pacing",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-reluctant-obedience",
-        "label": "Reluctant obedience",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-stammering-submission",
-        "label": "Stammering submission",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-challenging-until-caught",
-        "label": "Challenging until caught",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-quiet-surrender",
-        "label": "Quiet surrender",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-sarcastic-teasing",
-        "label": "Sarcastic teasing",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-provoking-tone",
-        "label": "Provoking tone",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-challenge-based-dialogue",
-        "label": "Challenge-based dialogue",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-double-meaning-banter",
-        "label": "Double-meaning banter",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-soft-spoken-guidance",
-        "label": "Soft-spoken guidance",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-protective-but-firm-tone",
-        "label": "Protective but firm tone",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-emotional-redirection",
-        "label": "Emotional redirection",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-steady-reassurance",
-        "label": "Steady reassurance",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "communication-direct-and-clear",
-        "label": "Direct and clear",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-gentle-and-nurturing",
-        "label": "Gentle and nurturing",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-commanding-and-firm",
-        "label": "Commanding and firm",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-quiet-and-observant",
-        "label": "Quiet and observant",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-instructive-teacher-like",
-        "label": "Instructive / teacher-like",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-emotionally-intense",
-        "label": "Emotionally intense",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-dismissive-withholding",
-        "label": "Dismissive / withholding",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-mocking-sarcastic",
-        "label": "Mocking / sarcastic",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-blunt-tactless",
-        "label": "Blunt / tactless",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-predatory-hunting-tone",
-        "label": "Predatory / hunting tone",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-stalking-or-circling-speech",
-        "label": "Stalking or circling speech",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-you-re-mine-control-language",
-        "label": "You’re mine / control language",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-threatening-consensual",
-        "label": "Threatening (consensual)",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-verbal-cornering-coaxing",
-        "label": "Verbal cornering / coaxing",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-watching-you-unravel",
-        "label": "Watching you unravel",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-cruel-and-cutting",
-        "label": "Cruel and cutting",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-psychological-baiting",
-        "label": "Psychological baiting",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-brat-breaking-language",
-        "label": "Brat-breaking language",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-mock-affection",
-        "label": "Mock affection",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-shaming-or-emotional-edge",
-        "label": "Shaming or emotional edge",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-disappointed-dom-voice",
-        "label": "Disappointed dom voice",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-mild-scolding-mocking-affection",
-        "label": "Mild scolding / mocking affection",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-verbal-power-struggle",
-        "label": "Verbal power struggle",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-challenge-response-dynamics",
-        "label": "Challenge-response dynamics",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-warm-tone-with-expectation",
-        "label": "Warm tone with expectation",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-nurturing-dominance",
-        "label": "Nurturing dominance",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-reassuring-commands",
-        "label": "Reassuring commands",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "communication-phrases-that-work-on-you",
-        "label": "Phrases that work on you",
-        "type": "text",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "communication-phrases-you-use-or-like-to-give",
-        "label": "Phrases you use or like to give",
-        "type": "text",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "communication-what-helps-you-feel-emotionally-safe",
-        "label": "What helps you feel emotionally safe",
-        "type": "text",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "communication-how-you-tend-to-show-affection",
-        "label": "How you tend to show affection",
-        "type": "text",
-        "options": [
-          "Words of affirmation",
-          "Acts of service",
-          "Through teasing / play",
-          "Through obedience",
-          "Through caretaking",
-          "Withholding / teasing love",
-          "Physical closeness",
-          "Quality time"
-        ],
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "communication-emotional-check-in-style",
-        "label": "Emotional check-in style",
-        "type": "text",
-        "options": [
-          "Daily texting",
-          "After-scene debriefs",
-          "Scheduled check-ins",
-          "Mix of text/video check-ins",
-          "In-person check-ins",
-          "Journaling together",
-          "Minimal / low contact",
-          "Other"
-        ],
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "communication-when-emotionally-activated-i-tend-to",
-        "label": "When emotionally activated, I tend to...",
-        "type": "text",
-        "options": [
-          "Shut down",
-          "Overexplain / fawn",
-          "Get sarcastic / prickly",
-          "Spiral internally",
-          "Ask for reassurance",
-          "Withdraw",
-          "Other"
-        ],
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Body Fluids and Functions",
-    "items": [
-      {
-        "id": "body-fluids-and-functions-watersports-golden-showers",
-        "label": "Watersports/golden showers",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-fluids-and-functions-cum",
-        "label": "Cum",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-fluids-and-functions-blood",
-        "label": "Blood",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-fluids-and-functions-scat",
-        "label": "Scat",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-fluids-and-functions-sweat",
-        "label": "Sweat",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-fluids-and-functions-vomit",
-        "label": "Vomit",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-fluids-and-functions-tears-crying",
-        "label": "Tears/crying",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Psychological Primal / Prey",
-    "items": [
-      {
-        "id": "psychological-primal-prey-primal-prey",
-        "label": "Primal/Prey",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-conditioning",
-        "label": "Conditioning",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-coc",
-        "label": "COC",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-psycholagny-hands-free-mentally-stimulated-orgasm",
-        "label": "Psycholagny (hands free, mentally stimulated orgasm)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-hypno-play",
-        "label": "Hypno Play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-praise",
-        "label": "Praise",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-degradation",
-        "label": "Degradation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-traditional-primal-prey",
-        "label": "Traditional primal/prey",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-fear-play",
-        "label": "Fear play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-objectification",
-        "label": "Objectification",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-gaslighting",
-        "label": "Gaslighting",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-role-erosion-identity-play-loss-of-self",
-        "label": "Role erosion (identity play / loss of self)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-jealousy-play",
-        "label": "Jealousy play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychological-primal-prey-manipulation",
-        "label": "Manipulation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Body Part / Fetish Play",
-    "items": [
-      {
-        "id": "body-part-fetish-play-belly-fucking",
-        "label": "Belly fucking",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-navel-play",
-        "label": "Navel play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-feet-foot-worship",
-        "label": "Feet / Foot worship",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-hands",
-        "label": "Hands",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-hair",
-        "label": "Hair",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-thighs",
-        "label": "Thighs",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-neck",
-        "label": "Neck",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-ears",
-        "label": "Ears",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-belly",
-        "label": "Belly",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-voice-fetish",
-        "label": "Voice fetish",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-nails-makeup-fetish",
-        "label": "Nails / Makeup fetish",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-cuddles",
-        "label": "Cuddles",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-food-play",
-        "label": "Food Play",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-kisses",
-        "label": "Kisses",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-masturbation",
-        "label": "Masturbation",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-romance-affection",
-        "label": "Romance / affection",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-sex-toys",
-        "label": "Sex toys",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-sexting-chat-etc",
-        "label": "Sexting /Chat etc",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-sexting-via-phone-or-video-call",
-        "label": "Sexting via phone or video call",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-strip-tease",
-        "label": "Strip tease",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-vanilla-sex",
-        "label": "Vanilla Sex",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-voice-notes",
-        "label": "Voice Notes",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-shaving-body-hair",
-        "label": "Shaving (body hair)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-sexy-clothing-private",
-        "label": "Sexy clothing (private)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-sexy-clothing-public",
-        "label": "Sexy clothing (public)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-outdoor-scenes",
-        "label": "Outdoor scenes",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-part-fetish-play-public-exposure",
-        "label": "Public exposure",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Orgasm Control & Sexual Manipulation",
-    "items": [
-      {
-        "id": "orgasm-control-sexual-manipulation-edging",
-        "label": "Edging",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-short-term-denial",
-        "label": "Short term denial",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-long-term-denial",
-        "label": "Long term denial",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-forced-orgasms-overstimulation",
-        "label": "Forced orgasms / Overstimulation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-ruined-orgasms",
-        "label": "Ruined orgasms",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-no-touch-periods",
-        "label": "No touch periods",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-milking",
-        "label": "Milking",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-chastity-devices",
-        "label": "Chastity devices",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-consensual-orgasm-control",
-        "label": "Consensual orgasm control",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "orgasm-control-sexual-manipulation-forced-masturbation",
-        "label": "Forced masturbation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Protocol and Ritual",
-    "items": [
-      {
-        "id": "protocol-and-ritual-formal-language",
-        "label": "Formal language",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-greeting-and-departure-rituals-kneeling-verbal-scripts-gestures",
-        "label": "Greeting and departure rituals (kneeling, verbal scripts, gestures)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-requiring-permission-for-things-speech-movement-attire",
-        "label": "Requiring permission for things (speech, movement, attire)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-daily-rituals-morning-check-ins-status-reports-mantra-repetitions",
-        "label": "Daily rituals (morning check-ins, status reports, mantra repetitions)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-specific-postures-for-rest-attention-punishment-waiting",
-        "label": "Specific postures for rest, attention, punishment, waiting",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-restricted-behavior-no-eye-contact-silence-no-questions",
-        "label": "Restricted behavior (no eye contact, silence, no questions)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-ritual-object-use-collar-cuffs-leash-tokens",
-        "label": "Ritual object use (collar, cuffs, leash, tokens)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-tracking-obedience-journals-apps",
-        "label": "Tracking obedience (journals, apps)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-formalized-rules-for-misbehavior-and-correction",
-        "label": "Formalized rules for misbehavior and correction",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-ritualized-aftercare-or-scene-closure",
-        "label": "Ritualized aftercare or scene closure",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-object-retrieval-on-all-fours-with-item-in-mouth",
-        "label": "Object retrieval on all fours with item in mouth",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-fetching-hairbrush-or-punishment-tool-from-dresser-while-crawling",
-        "label": "Fetching hairbrush or punishment tool from dresser while crawling",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-presenting-chosen-discipline-tool-in-kneeling-posture",
-        "label": "Presenting chosen discipline tool in kneeling posture",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-assigned-posture-or-kneeling-positions-as-ritual",
-        "label": "Assigned posture or kneeling positions as ritual",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-requesting-permission-using-specific-protocol-phrases",
-        "label": "Requesting permission using specific protocol phrases",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-carrying-items-in-mouth-as-submissive-gesture",
-        "label": "Carrying items in mouth as submissive gesture",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-crawling-back-with-object-to-dominant-after-retrieval",
-        "label": "Crawling back with object to Dominant after retrieval",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-following-via-nipple-leash-as-protocol-or-punishment",
-        "label": "Following via nipple leash as protocol or punishment",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-crawling-assigned-paths-as-ritual-or-obedience-training",
-        "label": "Crawling assigned paths as ritual or obedience training",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-crawling-rituals-e-g-object-retrieval",
-        "label": "Crawling rituals (e.g., object retrieval)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-carrying-objects-in-mouth-as-obedience",
-        "label": "Carrying objects in mouth as obedience",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-presenting-tools-or-toys-in-posture",
-        "label": "Presenting tools or toys in posture",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-using-honorifics-or-preset-protocol-language",
-        "label": "Using honorifics or preset protocol language",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-greeting-rituals-e-g-kneeling-kissing-feet",
-        "label": "Greeting rituals (e.g., kneeling, kissing feet)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-daily-check-ins-or-structured-reports",
-        "label": "Daily check-ins or structured reports",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-clothing-restrictions-or-uniforms",
-        "label": "Clothing restrictions or uniforms",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-posture-training-sitting-kneeling-standing",
-        "label": "Posture training (sitting, kneeling, standing)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-punishments-for-incorrect-behavior-or-tone",
-        "label": "Punishments for incorrect behavior or tone",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-crawling-with-items-in-mouth-e-g-hairbrush-spoon",
-        "label": "Crawling with items in mouth (e.g., hairbrush, spoon)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-earning-permission-for-meals-bathroom-use-or-rest",
-        "label": "Earning permission for meals, bathroom use, or rest",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-following-daily-rituals-or-protocol",
-        "label": "Following daily rituals or protocol",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-structured-speech-rules-e-g-titles-third-person",
-        "label": "Structured speech rules (e.g., titles, third person)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-receiving-correction-when-out-of-line",
-        "label": "Receiving correction when out of line",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "protocol-and-ritual-inspection-rituals-or-readiness-checks",
-        "label": "Inspection rituals or readiness checks",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Primal & Bratting",
-    "items": [
-      {
-        "id": "primal-bratting-chase-and-capture-play",
-        "label": "Chase and capture play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-bratting-for-punishment",
-        "label": "Bratting for punishment",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-playful-growling-and-biting",
-        "label": "Playful growling and biting",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-provoking-with-teasing-or-taunts",
-        "label": "Provoking with teasing or taunts",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-escaping-or-hiding-to-encourage-pursuit",
-        "label": "Escaping or hiding to encourage pursuit",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-refusing-commands-just-for-fun",
-        "label": "Refusing commands just for fun",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-provoking-your-partner-to-chase-or-discipline-you",
-        "label": "Provoking your partner to chase or discipline you",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-taunting-or-teasing-as-a-form-of-play",
-        "label": "Taunting or teasing as a form of play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-intentional-resistance-during-power-exchange",
-        "label": "Intentional resistance during power exchange",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "primal-bratting-being-caught-and-overpowered",
-        "label": "Being caught and overpowered",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Headspace & Regression",
-    "items": [
-      {
-        "id": "headspace-regression-caregiver-little-regression-play",
-        "label": "Caregiver/little regression play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-using-pacifiers-or-sippy-cups",
-        "label": "Using pacifiers or sippy cups",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-coloring-or-childlike-crafts",
-        "label": "Coloring or childlike crafts",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-stuffed-animal-comfort",
-        "label": "Stuffed animal comfort",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-speaking-in-a-childlike-voice",
-        "label": "Speaking in a childlike voice",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-bedtime-stories-or-lullabies",
-        "label": "Bedtime stories or lullabies",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-entering-altered-headspaces-e-g-prey-pet-little",
-        "label": "Entering altered headspaces (e.g., prey, pet, little)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-regressive-behaviors-as-comfort-coloring-babytalk",
-        "label": "Regressive behaviors as comfort (coloring, babytalk)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-being-cared-for-during-emotional-vulnerability",
-        "label": "Being cared for during emotional vulnerability",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "headspace-regression-guided-emotional-headspace-entry",
-        "label": "Guided emotional headspace entry",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Performance & Internal Struggle",
-    "items": [
-      {
-        "id": "performance-internal-struggle-obedience-under-observation",
-        "label": "Obedience under observation",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-speech-restriction-and-self-denial",
-        "label": "Speech restriction and self-denial",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-maintaining-composure-during-humiliation",
-        "label": "Maintaining composure during humiliation",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-obedience-drills-for-an-audience",
-        "label": "Obedience drills for an audience",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-struggling-against-personal-urges",
-        "label": "Struggling against personal urges",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-displaying-submission-despite-conflict",
-        "label": "Displaying submission despite conflict",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-being-told-to-act-normal-while-struggling-internally",
-        "label": "Being told to act normal while struggling internally",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-pleasing-through-high-functioning-obedience",
-        "label": "Pleasing through high-functioning obedience",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-performing-submission-while-masking-resistance",
-        "label": "Performing submission while masking resistance",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-the-pressure-of-appearing-good-while-feeling-conflicted",
-        "label": "The pressure of appearing 'good' while feeling conflicted",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-being-made-to-perform-emotions-on-command-cry-beg-moan",
-        "label": "Being made to perform emotions on command (cry, beg, moan)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-struggling-openly-while-still-obeying",
-        "label": "Struggling openly while still obeying",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-performing-exaggerated-resistance-or-denial",
-        "label": "Performing exaggerated resistance or denial",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-being-punished-for-breaking-character",
-        "label": "Being punished for 'breaking character'",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-putting-on-a-show-for-someone-else-s-pleasure",
-        "label": "Putting on a show for someone else’s pleasure",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "performance-internal-struggle-rehearsed-degradation-or-humiliation-scripts",
-        "label": "Rehearsed degradation or humiliation scripts",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Mindfuck & Manipulation",
-    "items": [
-      {
-        "id": "mindfuck-manipulation-confusing-commands-and-reality-shifts",
-        "label": "Confusing commands and reality shifts",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-gaslighting-or-contradictory-cues",
-        "label": "Gaslighting or contradictory cues",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-presenting-false-choices",
-        "label": "Presenting false choices",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-hidden-motives-or-secret-tasks",
-        "label": "Hidden motives or secret tasks",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-illogical-rules-meant-to-confuse",
-        "label": "Illogical rules meant to confuse",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-gaslight-style-scenes-with-consent-and-clarity",
-        "label": "Gaslight-style scenes (with consent and clarity)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-false-threats-or-staged-surprises",
-        "label": "False threats or staged surprises",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-confusing-commands-to-prompt-hesitation",
-        "label": "Confusing commands to prompt hesitation",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-emotional-trickery-as-arousal",
-        "label": "Emotional trickery as arousal",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-being-misled-or-deceived-on-purpose-during-play",
-        "label": "Being misled or deceived on purpose during play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-surprise-rule-changes-or-twists-mid-scene",
-        "label": "Surprise rule changes or twists mid-scene",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-false-safeword-games-with-negotiated-limits",
-        "label": "False safeword games (with negotiated limits)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-withholding-or-delaying-aftercare-for-effect",
-        "label": "Withholding or delaying aftercare for effect",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-being-gaslit-or-doubted-in-a-controlled-roleplay",
-        "label": "Being gaslit or doubted in a controlled roleplay",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mindfuck-manipulation-told-you-asked-for-this-or-you-love-this-when-resisting",
-        "label": "Told 'you asked for this' or 'you love this' when resisting",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Mouth Play",
-    "items": [
-      {
-        "id": "mouth-play-holding-tools-or-restraints-in-teeth-while-crawling",
-        "label": "Holding tools or restraints in teeth while crawling",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-placing-objects-from-mouth-into-dominant-s-palm",
-        "label": "Placing objects from mouth into Dominant’s palm",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-using-mouth-instead-of-hands-for-service-rituals",
-        "label": "Using mouth instead of hands for service rituals",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-gag-presentation-and-silent-waiting-protocol",
-        "label": "Gag presentation and silent waiting protocol",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-holding-objects-in-teeth-while-crawling",
-        "label": "Holding objects in teeth while crawling",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-returning-items-using-mouth-only",
-        "label": "Returning items using mouth only",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-gag-rituals-or-waiting-silently",
-        "label": "Gag rituals or waiting silently",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-leash-held-in-mouth",
-        "label": "Leash held in mouth",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-being-gagged-or-forced-silent",
-        "label": "Being gagged or forced silent",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-having-to-hold-objects-in-your-mouth-spoon-hairbrush-leash",
-        "label": "Having to hold objects in your mouth (spoon, hairbrush, leash)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-being-used-for-oral-service-without-reciprocal-pleasure",
-        "label": "Being used for oral service without reciprocal pleasure",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-being-fed-by-hand-mouth-to-mouth-or-with-utensils",
-        "label": "Being fed by hand, mouth-to-mouth, or with utensils",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-verbal-control-e-g-only-speak-when-spoken-to",
-        "label": "Verbal control (e.g., only speak when spoken to)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "mouth-play-mouth-as-a-symbol-of-ownership-or-control",
-        "label": "Mouth as a symbol of ownership or control",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Impact Play",
-    "items": [
-      {
-        "id": "impact-play-hand-spanking",
-        "label": "Hand spanking",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "impact-play-paddle-strikes",
-        "label": "Paddle strikes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "impact-play-crop-snaps",
-        "label": "Crop snaps",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "impact-play-flogger-swings",
-        "label": "Flogger swings",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "impact-play-cane-strokes",
-        "label": "Cane strokes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "impact-play-belt-or-strap-hits",
-        "label": "Belt or strap hits",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "impact-play-whip-cracks",
-        "label": "Whip cracks",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "impact-play-preferred-intensity-levels",
-        "label": "Preferred intensity levels",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "impact-play-aftercare-for-bruises",
-        "label": "Aftercare for bruises",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "impact-play-target-body-areas",
-        "label": "Target body areas",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "impact-play-implement-selection",
-        "label": "Implement selection",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Medical Play",
-    "items": [
-      {
-        "id": "medical-play-needle-play",
-        "label": "Needle play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "medical-play-catheter-insertion",
-        "label": "Catheter insertion",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "medical-play-speculum-exams",
-        "label": "Speculum exams",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "medical-play-enema-administration",
-        "label": "Enema administration",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "medical-play-temperature-taking",
-        "label": "Temperature taking",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "medical-play-medical-restraints",
-        "label": "Medical restraints",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "medical-play-doctor-nurse-roleplay",
-        "label": "Doctor/nurse roleplay",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "medical-play-sterilization-procedures",
-        "label": "Sterilization procedures",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "medical-play-professional-vs-roleplay-scenes",
-        "label": "Professional vs roleplay scenes",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "medical-play-consent-for-invasive-acts",
-        "label": "Consent for invasive acts",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "medical-play-access-to-medical-equipment",
-        "label": "Access to medical equipment",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Pet Play",
-    "items": [
-      {
-        "id": "pet-play-puppy-or-kitten-play",
-        "label": "Puppy or kitten play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "pet-play-pony-play",
-        "label": "Pony play",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "pet-play-wearing-collar-and-leash",
-        "label": "Wearing collar and leash",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "pet-play-eating-from-a-bowl",
-        "label": "Eating from a bowl",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "pet-play-kenneling-or-caging",
-        "label": "Kenneling or caging",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "pet-play-pet-training-commands",
-        "label": "Pet training commands",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "pet-play-animal-costumes-or-gear",
-        "label": "Animal costumes or gear",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "pet-play-preferred-animal-identities",
-        "label": "Preferred animal identities",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "pet-play-public-vs-private-play",
-        "label": "Public vs private play",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "pet-play-training-style-and-discipline",
-        "label": "Training style and discipline",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "pet-play-use-of-pet-names-and-commands",
-        "label": "Use of pet names and commands",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Body Modification",
-    "items": [
-      {
-        "id": "body-modification-piercings",
-        "label": "Piercings",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-modification-tattoos",
-        "label": "Tattoos",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-modification-branding",
-        "label": "Branding",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-modification-scarification",
-        "label": "Scarification",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-modification-permanent-chastity-devices",
-        "label": "Permanent chastity devices",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-modification-cosmetic-implants",
-        "label": "Cosmetic implants",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-modification-stretching-or-gauges",
-        "label": "Stretching or gauges",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "body-modification-temporary-vs-permanent-changes",
-        "label": "Temporary vs permanent changes",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-modification-professional-vs-diy-methods",
-        "label": "Professional vs DIY methods",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-modification-body-placement-considerations",
-        "label": "Body placement considerations",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "body-modification-healing-and-aftercare",
-        "label": "Healing and aftercare",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Relationship Preferences",
-    "items": [
-      {
-        "id": "relationship-preferences-preferred-relationship-style",
-        "label": "Preferred relationship style",
-        "type": "text",
-        "options": [
-          "Monogamous",
-          "Open relationship",
-          "Polyamorous",
-          "No preference"
-        ],
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-relationship-goals",
-        "label": "Relationship goals",
-        "type": "text",
-        "options": [
-          "One night stand",
-          "Short-term play",
-          "Long-term relationship",
-          "Platonic play partners",
-          "Romantic partners",
-          "Kink partners"
-        ],
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-monogamous",
-        "label": "Monogamous",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-polyamorous",
-        "label": "Polyamorous",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-hierarchical-dynamics",
-        "label": "Hierarchical dynamics",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-non-hierarchical-poly",
-        "label": "Non-hierarchical poly",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-solo-poly",
-        "label": "Solo-poly",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-open-with-boundaries",
-        "label": "Open with boundaries",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-closed-but-kinky-with-others",
-        "label": "Closed but kinky with others",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "relationship-preferences-switch-friendly-dynamics",
-        "label": "Switch-friendly dynamics",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Gender Play & Transformation",
-    "items": [
-      {
-        "id": "gender-play-transformation-crossdressing",
-        "label": "Crossdressing",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-forced-feminization",
-        "label": "Forced feminization",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-forced-masculinization",
-        "label": "Forced masculinization",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-gender-role-reversal",
-        "label": "Gender role reversal",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-pronoun-changes",
-        "label": "Pronoun changes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-voice-or-mannerism-training",
-        "label": "Voice or mannerism training",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-sissy-or-tomboy-persona",
-        "label": "Sissy or tomboy persona",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-preferred-pronouns-and-names",
-        "label": "Preferred pronouns and names",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-public-presentation-comfort",
-        "label": "Public presentation comfort",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-clothing-and-appearance",
-        "label": "Clothing and appearance",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "gender-play-transformation-exploration-of-identity",
-        "label": "Exploration of identity",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Chastity Devices",
-    "items": [
-      {
-        "id": "chastity-devices-wearing-a-chastity-cage-short-term",
-        "label": "Wearing a chastity cage (short term)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-long-term-chastity-training",
-        "label": "Long-term chastity training",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-chastity-device-control-with-permission-to-unlock",
-        "label": "Chastity device control with permission to unlock",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-locked-remotely-by-another-person",
-        "label": "Locked remotely by another person",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-orgasm-denial-enforced-by-chastity",
-        "label": "Orgasm denial enforced by chastity",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-wearing-a-belt-style-chastity-device",
-        "label": "Wearing a belt-style chastity device",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-humiliation-while-locked-in-chastity",
-        "label": "Humiliation while locked in chastity",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-sleep-in-chastity-overnight",
-        "label": "Sleep in chastity (overnight)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-being-teased-while-unable-to-touch-yourself",
-        "label": "Being teased while unable to touch yourself",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "chastity-devices-begging-for-release-from-chastity",
-        "label": "Begging for release from chastity",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Shibari & Rope Bondage",
-    "items": [
-      {
-        "id": "shibari-rope-bondage-being-tied-in-aesthetic-rope-patterns-shibari",
-        "label": "Being tied in aesthetic rope patterns (Shibari)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-rope-bondage-for-restraint-and-control",
-        "label": "Rope bondage for restraint and control",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-rope-suspension-partial-or-full",
-        "label": "Rope suspension (partial or full)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-learning-to-tie-rope-as-a-form-of-dominance",
-        "label": "Learning to tie rope as a form of dominance",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-being-tied-in-vulnerable-or-exposing-poses",
-        "label": "Being tied in vulnerable or exposing poses",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-practicing-rope-with-emotional-connection",
-        "label": "Practicing rope with emotional connection",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-enduring-discomfort-for-the-beauty-of-the-rope",
-        "label": "Enduring discomfort for the beauty of the rope",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-being-tied-in-a-mirror-and-told-to-look",
-        "label": "Being tied in a mirror and told to look",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-punishment-ties-e-g-uncomfortable-or-humiliating-positions",
-        "label": "Punishment ties (e.g., uncomfortable or humiliating positions)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "shibari-rope-bondage-solo-rope-practice-for-mindfulness-or-masochism",
-        "label": "Solo rope practice for mindfulness or masochism",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Cosplay & Identity Play",
-    "items": [
-      {
-        "id": "cosplay-identity-play-dressing-up-in-costumes-for-scenes",
-        "label": "Dressing up in costumes for scenes",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "cosplay-identity-play-playing-as-fictional-characters",
-        "label": "Playing as fictional characters",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "cosplay-identity-play-petplay-with-collars-ears-or-tails",
-        "label": "Petplay with collars, ears, or tails",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "cosplay-identity-play-pretending-to-be-a-doll-robot-or-object",
-        "label": "Pretending to be a doll, robot, or object",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "cosplay-identity-play-master-slave-cosplay-dynamic-non-24-7",
-        "label": "Master/slave cosplay dynamic (non-24/7)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "cosplay-identity-play-roleplaying-as-a-fantasy-species-or-non-human",
-        "label": "Roleplaying as a fantasy species or non-human",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "cosplay-identity-play-using-cosplay-to-deepen-power-exchange",
-        "label": "Using cosplay to deepen power exchange",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "cosplay-identity-play-scene-built-around-a-character-s-story-or-world",
-        "label": "Scene built around a character’s story or world",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "cosplay-identity-play-fantasy-uniforms-nurse-teacher-etc",
-        "label": "Fantasy uniforms (nurse, teacher, etc.)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "High-Intensity Kinks (SSC-Aware)",
-    "items": [
-      {
-        "id": "high-intensity-kinks-ssc-aware-intense-breath-play-e-g-smothering-or-pressure",
-        "label": "Intense breath play (e.g., smothering or pressure)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-knife-play-or-blade-play-without-injury",
-        "label": "Knife play or blade play (without injury)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-fear-play-using-known-or-negotiated-triggers",
-        "label": "Fear play using known or negotiated triggers",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-abduction-or-home-invasion-style-roleplay-negotiated",
-        "label": "Abduction or home-invasion style roleplay (negotiated)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-medical-themed-scenes-with-sharp-objects-not-bloodletting",
-        "label": "Medical-themed scenes with sharp objects (not bloodletting)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-sensory-deprivation-with-added-disorientation-or-helplessness",
-        "label": "Sensory deprivation with added disorientation or helplessness",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-scenes-involving-heavy-objectification-or-emotional-manipulation-with-care",
-        "label": "Scenes involving heavy objectification or emotional manipulation (with care)",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-mock-interrogation-or-intense-role-pressure",
-        "label": "Mock interrogation or intense role pressure",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-consensual-threats-without-follow-through-e-g-if-you-don-t",
-        "label": "Consensual threats without follow-through (e.g. 'If you don’t...')",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      },
-      {
-        "id": "high-intensity-kinks-ssc-aware-high-intensity-primal-scenes-involving-struggle-or-fear",
-        "label": "High-intensity primal scenes involving struggle or fear",
-        "type": "scale",
-        "roles": [
-          "Giving",
-          "Receiving"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Behavioral Play",
-    "items": [
-      {
-        "id": "behavioral-play-assigning-corner-time-or-time-outs",
-        "label": "Assigning corner time or time-outs",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "behavioral-play-writing-lines-or-apology-letters-as-correction",
-        "label": "Writing lines or apology letters as correction",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "behavioral-play-removing-privileges-phone-tv-sweets",
-        "label": "Removing privileges (phone, TV, sweets)",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "behavioral-play-playful-punishments-that-still-reinforce-rules",
-        "label": "Playful punishments that still reinforce rules",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "behavioral-play-lecturing-or-scolding-to-modify-behavior",
-        "label": "Lecturing or scolding to modify behavior",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "behavioral-play-being-placed-in-the-corner-or-given-a-time-out",
-        "label": "Being placed in the corner or given a time-out",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "behavioral-play-writing-lines-or-apology-letters-when-misbehaving",
-        "label": "Writing lines or apology letters when misbehaving",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "behavioral-play-having-privileges-revoked-phone-tv",
-        "label": "Having privileges revoked (phone, TV)",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "behavioral-play-receiving-playful-funishments-for-minor-rule-breaking",
-        "label": "Receiving playful 'funishments' for minor rule-breaking",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "behavioral-play-getting-scolded-or-lectured-for-correction",
-        "label": "Getting scolded or lectured for correction",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "behavioral-play-preferred-style-of-discipline-strict-vs-lenient",
-        "label": "Preferred style of discipline (strict vs lenient)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "behavioral-play-attitude-toward-funishment-vs-serious-correction",
-        "label": "Attitude toward funishment vs serious correction",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "behavioral-play-use-of-behavior-contracts-or-rule-agreements",
-        "label": "Use of behavior contracts or rule agreements",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Appearance Play",
-    "items": [
-      {
-        "id": "appearance-play-choosing-my-partner-s-outfit-for-the-day-or-a-scene",
-        "label": "Choosing my partner’s outfit for the day or a scene",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-selecting-their-underwear-lingerie-or-base-layers",
-        "label": "Selecting their underwear, lingerie, or base layers",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-styling-their-hair-braiding-brushing-tying-etc",
-        "label": "Styling their hair (braiding, brushing, tying, etc.)",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-picking-head-coverings-bonnets-veils-hoods-hats-for-mood-or-protocol",
-        "label": "Picking head coverings (bonnets, veils, hoods, hats) for mood or protocol",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-offering-makeup-polish-or-accessories-as-part-of-ritual-or-play",
-        "label": "Offering makeup, polish, or accessories as part of ritual or play",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-creating-themed-looks-slutty-innocent-doll-like-sharp-etc",
-        "label": "Creating themed looks (slutty, innocent, doll-like, sharp, etc.)",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-dressing-them-in-role-specific-costumes-maid-bunny-doll-etc",
-        "label": "Dressing them in role-specific costumes (maid, bunny, doll, etc.)",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-curating-time-period-or-historical-outfits-e-g-victorian-50s",
-        "label": "Curating time-period or historical outfits (e.g., Victorian, 50s)",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-helping-them-present-more-femme-masc-or-androgynous-by-request",
-        "label": "Helping them present more femme, masc, or androgynous by request",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-coordinating-their-look-with-mine-for-public-or-private-scenes",
-        "label": "Coordinating their look with mine for public or private scenes",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-implementing-a-dress-ritual-or-aesthetic-preparation",
-        "label": "Implementing a “dress ritual” or aesthetic preparation",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-enforcing-a-visual-protocol-e-g-no-bra-heels-required-tied-hair",
-        "label": "Enforcing a visual protocol (e.g., no bra, heels required, tied hair)",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "appearance-play-having-my-outfit-selected-for-me-by-a-partner",
-        "label": "Having my outfit selected for me by a partner",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-wearing-the-underwear-or-lingerie-they-choose",
-        "label": "Wearing the underwear or lingerie they choose",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-having-my-hair-brushed-braided-tied-or-styled-for-them",
-        "label": "Having my hair brushed, braided, tied, or styled for them",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-putting-on-a-head-covering-e-g-bonnet-veil-hood-they-chose",
-        "label": "Putting on a head covering (e.g., bonnet, veil, hood) they chose",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-following-visual-appearance-rules-as-part-of-submission",
-        "label": "Following visual appearance rules as part of submission",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-wearing-makeup-polish-or-accessories-they-request",
-        "label": "Wearing makeup, polish, or accessories they request",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-dressing-to-please-their-vision-cute-filthy-classy-etc",
-        "label": "Dressing to please their vision (cute, filthy, classy, etc.)",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-wearing-roleplay-costumes-or-character-looks",
-        "label": "Wearing roleplay costumes or character looks",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-presenting-in-a-way-that-matches-their-chosen-aesthetic",
-        "label": "Presenting in a way that matches their chosen aesthetic",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-participating-in-dressing-rituals-or-undressing-ceremonies",
-        "label": "Participating in dressing rituals or undressing ceremonies",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-being-admired-for-the-way-i-look-under-their-direction",
-        "label": "Being admired for the way I look under their direction",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-receiving-praise-or-gentle-teasing-about-my-appearance",
-        "label": "Receiving praise or gentle teasing about my appearance",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "appearance-play-cosplay-or-fantasy-looks-anime-game-fairytale-etc",
-        "label": "Cosplay or fantasy looks (anime, game, fairytale, etc.)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-time-period-dress-up-regency-gothic-1920s-etc",
-        "label": "Time-period dress-up (regency, gothic, 1920s, etc.)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-dollification-or-polished-presented-object-aesthetics",
-        "label": "Dollification or polished/presented object aesthetics",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-uniforms-schoolgirl-military-clerical-nurse-etc",
-        "label": "Uniforms (schoolgirl, military, clerical, nurse, etc.)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-hair-based-play-forced-brushing-ribbons-or-tied-styles",
-        "label": "Hair-based play (forced brushing, ribbons, or tied styles)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-head-coverings-or-symbolic-hoods-in-ritualized-dynamics",
-        "label": "Head coverings or symbolic hoods in ritualized dynamics",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-matching-looks-or-coordinated-dress-codes",
-        "label": "Matching looks or coordinated dress codes",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-ritualized-grooming-before-scenes",
-        "label": "Ritualized grooming before scenes",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-praise-or-positive-attention-for-pleasing-visual-display",
-        "label": "Praise or positive attention for pleasing visual display",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-formal-appearance-protocols-for-scenes-or-dynamics",
-        "label": "Formal appearance protocols for scenes or dynamics",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "appearance-play-using-clothing-or-style-to-embody-emotional-or-power-roles",
-        "label": "Using clothing or style to embody emotional or power roles",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Psychology Play",
-    "items": [
-      {
-        "id": "psychology-play-emotional-sadism-giving-teasing-feelings-orchestrating-reactions-savoring-anticipation-without-shame-based-harm",
-        "label": "Emotional Sadism (giving): teasing feelings, orchestrating reactions, savoring anticipation without shame-based harm",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "psychology-play-psychological-control-mind-games-double-binds-deliberate-pacing-and-strategic-ambiguity",
-        "label": "Psychological Control: mind games, double binds, deliberate pacing, and strategic ambiguity",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "psychology-play-sadistic-attention-enjoying-being-the-focal-point-of-a-partner-s-fear-arousal-or-resistance",
-        "label": "Sadistic Attention: enjoying being the focal point of a partner’s fear, arousal, or resistance",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "psychology-play-teasing-humiliation-playful-status-play-without-degradation-or-shame",
-        "label": "Teasing Humiliation: playful status play without degradation or shame",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "psychology-play-emotional-sadism-receiving-enjoying-engineered-emotional-intensity-such-as-fluster-exposure-or-playful-embarrassment",
-        "label": "Emotional Sadism (receiving): enjoying engineered emotional intensity such as fluster, exposure, or playful embarrassment",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychology-play-psychological-control-receiving-arousal-from-being-studied-contained-or-outmaneuvered",
-        "label": "Psychological Control (receiving): arousal from being studied, contained, or outmaneuvered",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychology-play-being-the-focus-enjoying-being-watched-tracked-or-held-in-a-partner-s-intense-focus",
-        "label": "Being the Focus: enjoying being watched, tracked, or held in a partner’s intense focus",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychology-play-teasing-humiliation-receiving-enjoying-playful-embarrassment-or-affectionate-mockery-that-builds-intimacy",
-        "label": "Teasing Humiliation (receiving): enjoying playful embarrassment or affectionate mockery that builds intimacy",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychology-play-prey-attention-neediness-craving-focus-pursuit-or-intense-awareness-from-a-partner",
-        "label": "Prey Attention/Neediness: craving focus, pursuit, or intense awareness from a partner",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "psychology-play-primal-recognition-being-seen-understood-or-tracked-without-needing-words",
-        "label": "Primal Recognition: being seen, understood, or tracked without needing words",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  },
-  {
-    "category": "Breeding",
-    "items": [
-      {
-        "id": "breeding-impregnation-giving-arousal-from-attempting-to-impregnate-a-partner",
-        "label": "Impregnation (giving): arousal from attempting to impregnate a partner",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "breeding-feeding-milk-giving-arousal-from-producing-and-feeding-milk-to-a-partner",
-        "label": "Feeding Milk (giving): arousal from producing and feeding milk to a partner",
-        "type": "scale",
-        "roles": [
-          "Giving"
-        ]
-      },
-      {
-        "id": "breeding-impregnation-receiving-arousal-from-being-inseminated-pregnancy-risk-or-being-bred",
-        "label": "Impregnation (receiving): arousal from being inseminated, pregnancy risk, or being bred",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "breeding-feeding-milk-receiving-arousal-from-drinking-a-partner-s-milk",
-        "label": "Feeding Milk (receiving): arousal from drinking a partner’s milk",
-        "type": "scale",
-        "roles": [
-          "Receiving"
-        ]
-      },
-      {
-        "id": "breeding-pregnancy-fantasy-erotic-focus-on-pregnancy-mine-partner-s-or-fictional-scenarios",
-        "label": "Pregnancy Fantasy: erotic focus on pregnancy (mine, partner’s, or fictional scenarios)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-primal-breeding-drive-animalistic-instinctual-framing-of-sex-reproduction-territory",
-        "label": "Primal Breeding Drive: animalistic/instinctual framing of sex, reproduction, territory",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-breeding-as-control-ownership-authority-expressed-through-breeding-talk-or-pregnancy-risk",
-        "label": "Breeding as Control: ownership/authority expressed through breeding talk or pregnancy risk",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-creampie-marking-erotic-meaning-placed-on-internal-ejaculation-or-visible-claimed-markers",
-        "label": "Creampie/Marking: erotic meaning placed on internal ejaculation or visible ‘claimed’ markers",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-risk-no-contraception-talk-fantasy-dirty-talk-about-risk-or-breeding-without-actual-risk",
-        "label": "Risk/‘No Contraception’ Talk (fantasy): dirty talk about risk or breeding without actual risk",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-heat-ovulation-tracking-timing-in-heat-roleplay-or-cycle-focused-arousal",
-        "label": "Heat/Ovulation Tracking: timing, ‘in heat’ roleplay, or cycle-focused arousal",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-artificial-insemination-device-play-syringes-cups-or-medical-style-scenarios-consensual-fantasy",
-        "label": "Artificial Insemination/Device Play: syringes, cups, or medical-style scenarios (consensual fantasy)",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-breeding-denial-ruined-breeding-building-toward-impregnation-talk-then-denying-or-ruining-it",
-        "label": "Breeding Denial/Ruined Breeding: building toward impregnation talk then denying or ‘ruining’ it",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-pregnancy-body-focus-belly-worship-movement-weight-changes-glow-and-attention",
-        "label": "Pregnancy Body Focus: belly worship, movement/weight changes, glow, and attention",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-pregnancy-protocol-care-protective-rules-pedestal-treatment-dedicated-aftercare",
-        "label": "Pregnancy Protocol/Care: protective rules, pedestal treatment, dedicated aftercare",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-lactation-induction-maintenance-interest-in-inducing-or-sustaining-milk-production",
-        "label": "Lactation Induction/Maintenance: interest in inducing or sustaining milk production",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-milking-scenes-manual-oral-or-pump-based-milking-as-play-or-ritual",
-        "label": "Milking Scenes: manual, oral, or pump-based ‘milking’ as play or ritual",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-contraception-boundaries-preference-to-use-protection-bc-methods-or-simulation-only",
-        "label": "Contraception Boundaries: preference to use protection, BC methods, or simulation-only",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      },
-      {
-        "id": "breeding-sti-testing-medical-boundaries-testing-cadence-disclosures-and-comfort-levels",
-        "label": "STI/Testing & Medical Boundaries: testing cadence, disclosures, and comfort levels",
-        "type": "scale",
-        "roles": [
-          "General"
-        ]
-      }
-    ]
-  }
-]
+  "categories": [
+    {
+      "category": "Body Part Torture",
+      "items": [
+        {
+          "id": "body-part-torture-nipple-clips",
+          "label": "Nipple clips",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-nipple-weights",
+          "label": "Nipple weights",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-nipple-suction-cups",
+          "label": "Nipple suction cups",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-cock-ball-torture-cbt",
+          "label": "Cock, Ball Torture (CBT)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-clit-clips-weights-suction",
+          "label": "Clit clips/weights/suction",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-hair-pulling",
+          "label": "Hair pulling",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-face-slapping",
+          "label": "Face slapping",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-butt-slapping",
+          "label": "Butt slapping",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-breast-slapping",
+          "label": "Breast slapping",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-torture-genital-slapping",
+          "label": "Genital slapping",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Bondage and Suspension",
+      "items": [
+        {
+          "id": "bondage-and-suspension-blindfolds",
+          "label": "Blindfolds",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-bondage-heavy",
+          "label": "Bondage (heavy)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-bondage-light",
+          "label": "Bondage (light)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-immobilisation",
+          "label": "Immobilisation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-bondage-multi-day",
+          "label": "Bondage (multi-day)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-bondage-public-under-clothing",
+          "label": "Bondage (public, under clothing)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-leather-restraints",
+          "label": "Leather restraints",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-chains",
+          "label": "Chains",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-ropes",
+          "label": "Ropes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-intricate-japanese-rope-bondage",
+          "label": "Intricate (Japanese) rope bondage",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-rope-body-harness",
+          "label": "Rope body harness",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-arm-leg-sleeves-armbinders",
+          "label": "Arm & leg sleeves (armbinders)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-harnesses-leather",
+          "label": "Harnesses (leather)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-harnesses-rope",
+          "label": "Harnesses (rope)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-cuffs-leather",
+          "label": "Cuffs (leather)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-cuffs-metal",
+          "label": "Cuffs (metal)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-manacles-irons",
+          "label": "Manacles & Irons",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-gags-cloth",
+          "label": "Gags (cloth)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-gags-rubber",
+          "label": "Gags (rubber)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-gags-tape",
+          "label": "Gags (tape)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-gags-phallic",
+          "label": "Gags (phallic)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-gags-ring",
+          "label": "Gags (ring)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-gags-ball",
+          "label": "Gags (ball)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-mouth-bits",
+          "label": "Mouth bits",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-full-head-hoods",
+          "label": "Full head hoods",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-mummification-saran-wrapping",
+          "label": "Mummification/saran wrapping",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-straight-jackets",
+          "label": "Straight jackets",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-suspension-upright",
+          "label": "Suspension (upright)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-suspension-horizontal",
+          "label": "Suspension (horizontal)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-suspension-inverted",
+          "label": "Suspension (inverted)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-breath-play",
+          "label": "Breath play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-smothering",
+          "label": "Smothering",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-forced-self-breath-control",
+          "label": "Forced self-breath-control",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "bondage-and-suspension-gas-mask",
+          "label": "Gas mask",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Breath Play",
+      "items": [
+        {
+          "id": "breath-play-asphyxiation",
+          "label": "Asphyxiation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "breath-play-breath-control",
+          "label": "Breath control",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "breath-play-choking",
+          "label": "Choking",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "breath-play-drowning",
+          "label": "Drowning",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "breath-play-rebreathing-into-a-bag-or-object",
+          "label": "Rebreathing into a bag or object",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "breath-play-verbal-control-of-breath-e-g-hold-it-on-command",
+          "label": "Verbal control of breath (e.g., 'hold it' on command)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Sexual Activity",
+      "items": [
+        {
+          "id": "sexual-activity-licking",
+          "label": "Licking",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-fellatio-cunnilingus",
+          "label": "Fellatio/Cunnilingus",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-swallowing-semen",
+          "label": "Swallowing semen",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-cumming-on-partner",
+          "label": "Cumming on Partner",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-hand-jobs",
+          "label": "Hand jobs",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-anal-sex",
+          "label": "Anal sex",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-anal-plugs-small",
+          "label": "Anal plugs (small)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-anal-plugs-large",
+          "label": "Anal plugs (large)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-anal-beads",
+          "label": "Anal beads",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-vibrator-on-genitals",
+          "label": "Vibrator on genitals",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-fisting",
+          "label": "Fisting",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-oral-anal-play-rimming",
+          "label": "Oral/anal play (rimming)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-double-penetration-oral-and-vaginal",
+          "label": "Double penetration (oral and vaginal)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-double-penetration-oral-and-anal",
+          "label": "Double penetration (oral and anal)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-double-penetration-anal-and-vaginal",
+          "label": "Double penetration (anal and vaginal)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sexual-activity-triple-oral-vaginal-and-anal",
+          "label": "Triple (Oral, Vaginal and Anal)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Sensation Play",
+      "items": [
+        {
+          "id": "sensation-play-abrasion",
+          "label": "Abrasion",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-scratching",
+          "label": "Scratching",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-biting",
+          "label": "Biting",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-tickling",
+          "label": "Tickling",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-kissing",
+          "label": "Kissing",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-zapping-e-g-electric-fly-swatter",
+          "label": "Zapping (e.g. electric fly swatter)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-ice-cubes",
+          "label": "Ice cubes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-wax-play",
+          "label": "Wax Play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-fire",
+          "label": "Fire",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-clothespins",
+          "label": "Clothespins",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-needles",
+          "label": "Needles",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-sensory-deprivation",
+          "label": "Sensory deprivation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-physical-overpowering-manhandling",
+          "label": "Physical overpowering / Manhandling",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "sensation-play-figging",
+          "label": "Figging",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Other",
+      "items": [
+        {
+          "id": "other-feet",
+          "label": "Feet",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-boots",
+          "label": "Boots",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-underwear",
+          "label": "Underwear",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-chastity-devices",
+          "label": "Chastity devices",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-masks",
+          "label": "Masks",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-breeding",
+          "label": "Breeding",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-leather-clothing",
+          "label": "Leather clothing",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-training-protocols-outside-scenes-e-g-etiquette-memory",
+          "label": "Training protocols outside scenes (e.g., etiquette, memory)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-long-distance-training-structure",
+          "label": "Long-distance training/structure",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "other-scene-journaling-and-reflection",
+          "label": "Scene journaling and reflection",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Roleplaying",
+      "items": [
+        {
+          "id": "roleplaying-fantasy-abandonment",
+          "label": "Fantasy abandonment",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-kidnapping",
+          "label": "Kidnapping",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-interrogation",
+          "label": "Interrogation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-sleep-deprivation",
+          "label": "Sleep deprivation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-cnc",
+          "label": "CNC",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-gang-bang",
+          "label": "Gang bang",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-initiation-rites",
+          "label": "Initiation rites",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-religious-scenes",
+          "label": "Religious scenes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-medical-scenes",
+          "label": "Medical scenes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-prison-scenes",
+          "label": "Prison scenes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-primal-prey",
+          "label": "Primal/Prey",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "roleplaying-schoolroom-scenes",
+          "label": "Schoolroom scenes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Service and Restrictive Behaviour",
+      "items": [
+        {
+          "id": "service-and-restrictive-behaviour-following-orders",
+          "label": "(Following) orders",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-forced-servitude",
+          "label": "Forced servitude",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-restrictive-rules-on-behaviour",
+          "label": "Restrictive rules on behaviour",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-eye-contact-restrictions",
+          "label": "Eye contact restrictions",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-speech-restrictions-when-what-to-whom",
+          "label": "Speech restrictions (when, what, to whom)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-washroom-restrictions",
+          "label": "Washroom restrictions",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-punishments",
+          "label": "Punishments",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-tasks",
+          "label": "Tasks",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-massage",
+          "label": "Massage",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-domestic-tasks",
+          "label": "Domestic tasks",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-serving-food-and-drink",
+          "label": "Serving food and drink",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-personal-care-rituals",
+          "label": "Personal care rituals",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-being-on-call-at-specified-times",
+          "label": "Being on-call at specified times",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-daily-task-assignments",
+          "label": "Daily task assignments",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-corrections-for-imperfection",
+          "label": "Corrections for imperfection",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-uniforms-dress-codes",
+          "label": "Uniforms / Dress codes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-kneeling-posture-presentation",
+          "label": "Kneeling / Posture presentation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-silent-service",
+          "label": "Silent service",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-public-service-at-parties-or-events",
+          "label": "Public service (at parties or events)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "service-and-restrictive-behaviour-erotic-service-pleasure-on-command-without-seeking-your-own",
+          "label": "Erotic service (pleasure on command, without seeking your own)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Voyeurism/Exhibitionism",
+      "items": [
+        {
+          "id": "voyeurism-exhibitionism-forced-nudity-private",
+          "label": "Forced nudity (private)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "voyeurism-exhibitionism-forced-nudity-around-others",
+          "label": "Forced nudity (around others)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "voyeurism-exhibitionism-exhibitionism-friends",
+          "label": "Exhibitionism (friends)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "voyeurism-exhibitionism-exhibitionism-strangers",
+          "label": "Exhibitionism (strangers)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "voyeurism-exhibitionism-modelling-for-erotic-photos",
+          "label": "Modelling for erotic photos",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "voyeurism-exhibitionism-toys-under-clothes-in-public",
+          "label": "Toys under clothes in public",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Virtual & Long-Distance Play",
+      "items": [
+        {
+          "id": "virtual-long-distance-play-sending-tasks-or-orders-digitally",
+          "label": "Sending tasks or orders digitally",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-recording-dominant-voice-clips-commands-edging-praise-degradation-etc",
+          "label": "Recording dominant voice clips (commands, edging, praise, degradation, etc.)",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-remote-control-of-a-sex-toy",
+          "label": "Remote control of a sex toy",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-monitoring-behavior-via-app-or-shared-doc",
+          "label": "Monitoring behavior via app or shared doc",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-giving-punishment-assignments-remotely",
+          "label": "Giving punishment assignments remotely",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-creating-countdowns-timers-or-denial-periods",
+          "label": "Creating countdowns, timers, or denial periods",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-sending-written-instructions-with-delayed-permissions",
+          "label": "Sending written instructions with delayed permissions",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-creating-custom-video-or-audio-tasks",
+          "label": "Creating custom video or audio tasks",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-voice-message-control-during-scenes",
+          "label": "Voice message control during scenes",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-being-on-call-at-specified-times",
+          "label": "Being on-call at specified times",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-receiving-tasks-or-orders-digitally",
+          "label": "Receiving tasks or orders digitally",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-listening-to-dominant-voice-clips",
+          "label": "Listening to dominant voice clips",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-using-a-remote-controlled-toy-controlled-by-another",
+          "label": "Using a remote-controlled toy controlled by another",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-completing-daily-protocol-assignments",
+          "label": "Completing daily protocol assignments",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-submitting-proof-photo-video-text",
+          "label": "Submitting proof (photo, video, text)",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-following-recorded-or-timed-commands",
+          "label": "Following recorded or timed commands",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-receiving-surprise-instructions",
+          "label": "Receiving surprise instructions",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-hearing-name-praise-spoken-in-a-custom-clip",
+          "label": "Hearing name/praise spoken in a custom clip",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-sending-submissive-voice-clips-obedience-begging-thank-you-messages-affirmations-etc",
+          "label": "Sending submissive voice clips (obedience, begging, thank-you messages, affirmations, etc.)",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-scheduling-digital-rituals-or-reminders",
+          "label": "Scheduling digital rituals or reminders",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-using-training-habit-or-behavior-tracking-apps",
+          "label": "Using training, habit, or behavior-tracking apps",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-online-rituals-digital-kneeling-posture-protocols",
+          "label": "Online rituals (digital kneeling, posture protocols)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-role-based-texting-e-g-use-honorifics-in-chat",
+          "label": "Role-based texting (e.g., \"Use honorifics in chat\")",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-shared-playlists-affirmations-or-mantras",
+          "label": "Shared playlists, affirmations, or mantras",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-countdown-timers-to-next-task-release-or-interaction",
+          "label": "Countdown timers to next task, release, or interaction",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-scheduled-good-morning-night-rituals",
+          "label": "Scheduled good morning/night rituals",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-participating-in-video-call-scenes",
+          "label": "Participating in video call scenes",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-digital-aftercare-texts-voice-images",
+          "label": "Digital aftercare (texts, voice, images)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-sexting-or-digital-roleplay-scenes",
+          "label": "Sexting or digital roleplay scenes",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "virtual-long-distance-play-voice-notes-or-submissive-dominant-affirmations",
+          "label": "Voice notes or submissive/dominant affirmations",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Communication",
+      "items": [
+        {
+          "id": "communication-playful-and-teasing",
+          "label": "Playful and teasing",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-quiet-and-intense",
+          "label": "Quiet and intense",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-observant-and-intentional",
+          "label": "Observant and intentional",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-praise-heavy",
+          "label": "Praise-heavy",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-blunt-and-efficient",
+          "label": "Blunt and efficient",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-affirming-and-soft",
+          "label": "Affirming and soft",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-psychological-interrogation",
+          "label": "Psychological interrogation",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-verbal-coercion-teasing-traps",
+          "label": "Verbal coercion / teasing traps",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-verbal-misdirection",
+          "label": "Verbal misdirection",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-mocking-shaming",
+          "label": "Mocking / shaming",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-predatory-pacing",
+          "label": "Predatory pacing",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-reluctant-obedience",
+          "label": "Reluctant obedience",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-stammering-submission",
+          "label": "Stammering submission",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-challenging-until-caught",
+          "label": "Challenging until caught",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-quiet-surrender",
+          "label": "Quiet surrender",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-sarcastic-teasing",
+          "label": "Sarcastic teasing",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-provoking-tone",
+          "label": "Provoking tone",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-challenge-based-dialogue",
+          "label": "Challenge-based dialogue",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-double-meaning-banter",
+          "label": "Double-meaning banter",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-soft-spoken-guidance",
+          "label": "Soft-spoken guidance",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-protective-but-firm-tone",
+          "label": "Protective but firm tone",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-emotional-redirection",
+          "label": "Emotional redirection",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-steady-reassurance",
+          "label": "Steady reassurance",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "communication-direct-and-clear",
+          "label": "Direct and clear",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-gentle-and-nurturing",
+          "label": "Gentle and nurturing",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-commanding-and-firm",
+          "label": "Commanding and firm",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-quiet-and-observant",
+          "label": "Quiet and observant",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-instructive-teacher-like",
+          "label": "Instructive / teacher-like",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-emotionally-intense",
+          "label": "Emotionally intense",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-dismissive-withholding",
+          "label": "Dismissive / withholding",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-mocking-sarcastic",
+          "label": "Mocking / sarcastic",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-blunt-tactless",
+          "label": "Blunt / tactless",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-predatory-hunting-tone",
+          "label": "Predatory / hunting tone",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-stalking-or-circling-speech",
+          "label": "Stalking or circling speech",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-you-re-mine-control-language",
+          "label": "You’re mine / control language",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-threatening-consensual",
+          "label": "Threatening (consensual)",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-verbal-cornering-coaxing",
+          "label": "Verbal cornering / coaxing",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-watching-you-unravel",
+          "label": "Watching you unravel",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-cruel-and-cutting",
+          "label": "Cruel and cutting",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-psychological-baiting",
+          "label": "Psychological baiting",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-brat-breaking-language",
+          "label": "Brat-breaking language",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-mock-affection",
+          "label": "Mock affection",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-shaming-or-emotional-edge",
+          "label": "Shaming or emotional edge",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-disappointed-dom-voice",
+          "label": "Disappointed dom voice",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-mild-scolding-mocking-affection",
+          "label": "Mild scolding / mocking affection",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-verbal-power-struggle",
+          "label": "Verbal power struggle",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-challenge-response-dynamics",
+          "label": "Challenge-response dynamics",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-warm-tone-with-expectation",
+          "label": "Warm tone with expectation",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-nurturing-dominance",
+          "label": "Nurturing dominance",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-reassuring-commands",
+          "label": "Reassuring commands",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "communication-phrases-that-work-on-you",
+          "label": "Phrases that work on you",
+          "type": "text",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "communication-phrases-you-use-or-like-to-give",
+          "label": "Phrases you use or like to give",
+          "type": "text",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "communication-what-helps-you-feel-emotionally-safe",
+          "label": "What helps you feel emotionally safe",
+          "type": "text",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "communication-how-you-tend-to-show-affection",
+          "label": "How you tend to show affection",
+          "type": "text",
+          "options": [
+            "Words of affirmation",
+            "Acts of service",
+            "Through teasing / play",
+            "Through obedience",
+            "Through caretaking",
+            "Withholding / teasing love",
+            "Physical closeness",
+            "Quality time"
+          ],
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "communication-emotional-check-in-style",
+          "label": "Emotional check-in style",
+          "type": "text",
+          "options": [
+            "Daily texting",
+            "After-scene debriefs",
+            "Scheduled check-ins",
+            "Mix of text/video check-ins",
+            "In-person check-ins",
+            "Journaling together",
+            "Minimal / low contact",
+            "Other"
+          ],
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "communication-when-emotionally-activated-i-tend-to",
+          "label": "When emotionally activated, I tend to...",
+          "type": "text",
+          "options": [
+            "Shut down",
+            "Overexplain / fawn",
+            "Get sarcastic / prickly",
+            "Spiral internally",
+            "Ask for reassurance",
+            "Withdraw",
+            "Other"
+          ],
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Body Fluids and Functions",
+      "items": [
+        {
+          "id": "body-fluids-and-functions-watersports-golden-showers",
+          "label": "Watersports/golden showers",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-fluids-and-functions-cum",
+          "label": "Cum",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-fluids-and-functions-blood",
+          "label": "Blood",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-fluids-and-functions-scat",
+          "label": "Scat",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-fluids-and-functions-sweat",
+          "label": "Sweat",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-fluids-and-functions-vomit",
+          "label": "Vomit",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-fluids-and-functions-tears-crying",
+          "label": "Tears/crying",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Psychological Primal / Prey",
+      "items": [
+        {
+          "id": "psychological-primal-prey-primal-prey",
+          "label": "Primal/Prey",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-conditioning",
+          "label": "Conditioning",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-coc",
+          "label": "COC",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-psycholagny-hands-free-mentally-stimulated-orgasm",
+          "label": "Psycholagny (hands free, mentally stimulated orgasm)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-hypno-play",
+          "label": "Hypno Play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-praise",
+          "label": "Praise",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-degradation",
+          "label": "Degradation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-traditional-primal-prey",
+          "label": "Traditional primal/prey",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-fear-play",
+          "label": "Fear play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-objectification",
+          "label": "Objectification",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-gaslighting",
+          "label": "Gaslighting",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-role-erosion-identity-play-loss-of-self",
+          "label": "Role erosion (identity play / loss of self)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-jealousy-play",
+          "label": "Jealousy play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychological-primal-prey-manipulation",
+          "label": "Manipulation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Body Part / Fetish Play",
+      "items": [
+        {
+          "id": "body-part-fetish-play-belly-fucking",
+          "label": "Belly fucking",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-navel-play",
+          "label": "Navel play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-feet-foot-worship",
+          "label": "Feet / Foot worship",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-hands",
+          "label": "Hands",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-hair",
+          "label": "Hair",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-thighs",
+          "label": "Thighs",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-neck",
+          "label": "Neck",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-ears",
+          "label": "Ears",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-belly",
+          "label": "Belly",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-voice-fetish",
+          "label": "Voice fetish",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-nails-makeup-fetish",
+          "label": "Nails / Makeup fetish",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-cuddles",
+          "label": "Cuddles",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-food-play",
+          "label": "Food Play",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-kisses",
+          "label": "Kisses",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-masturbation",
+          "label": "Masturbation",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-romance-affection",
+          "label": "Romance / affection",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-sex-toys",
+          "label": "Sex toys",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-sexting-chat-etc",
+          "label": "Sexting /Chat etc",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-sexting-via-phone-or-video-call",
+          "label": "Sexting via phone or video call",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-strip-tease",
+          "label": "Strip tease",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-vanilla-sex",
+          "label": "Vanilla Sex",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-voice-notes",
+          "label": "Voice Notes",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-shaving-body-hair",
+          "label": "Shaving (body hair)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-sexy-clothing-private",
+          "label": "Sexy clothing (private)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-sexy-clothing-public",
+          "label": "Sexy clothing (public)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-outdoor-scenes",
+          "label": "Outdoor scenes",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-part-fetish-play-public-exposure",
+          "label": "Public exposure",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Orgasm Control & Sexual Manipulation",
+      "items": [
+        {
+          "id": "orgasm-control-sexual-manipulation-edging",
+          "label": "Edging",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-short-term-denial",
+          "label": "Short term denial",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-long-term-denial",
+          "label": "Long term denial",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-forced-orgasms-overstimulation",
+          "label": "Forced orgasms / Overstimulation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-ruined-orgasms",
+          "label": "Ruined orgasms",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-no-touch-periods",
+          "label": "No touch periods",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-milking",
+          "label": "Milking",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-chastity-devices",
+          "label": "Chastity devices",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-consensual-orgasm-control",
+          "label": "Consensual orgasm control",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "orgasm-control-sexual-manipulation-forced-masturbation",
+          "label": "Forced masturbation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Protocol and Ritual",
+      "items": [
+        {
+          "id": "protocol-and-ritual-formal-language",
+          "label": "Formal language",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-greeting-and-departure-rituals-kneeling-verbal-scripts-gestures",
+          "label": "Greeting and departure rituals (kneeling, verbal scripts, gestures)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-requiring-permission-for-things-speech-movement-attire",
+          "label": "Requiring permission for things (speech, movement, attire)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-daily-rituals-morning-check-ins-status-reports-mantra-repetitions",
+          "label": "Daily rituals (morning check-ins, status reports, mantra repetitions)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-specific-postures-for-rest-attention-punishment-waiting",
+          "label": "Specific postures for rest, attention, punishment, waiting",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-restricted-behavior-no-eye-contact-silence-no-questions",
+          "label": "Restricted behavior (no eye contact, silence, no questions)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-ritual-object-use-collar-cuffs-leash-tokens",
+          "label": "Ritual object use (collar, cuffs, leash, tokens)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-tracking-obedience-journals-apps",
+          "label": "Tracking obedience (journals, apps)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-formalized-rules-for-misbehavior-and-correction",
+          "label": "Formalized rules for misbehavior and correction",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-ritualized-aftercare-or-scene-closure",
+          "label": "Ritualized aftercare or scene closure",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-object-retrieval-on-all-fours-with-item-in-mouth",
+          "label": "Object retrieval on all fours with item in mouth",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-fetching-hairbrush-or-punishment-tool-from-dresser-while-crawling",
+          "label": "Fetching hairbrush or punishment tool from dresser while crawling",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-presenting-chosen-discipline-tool-in-kneeling-posture",
+          "label": "Presenting chosen discipline tool in kneeling posture",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-assigned-posture-or-kneeling-positions-as-ritual",
+          "label": "Assigned posture or kneeling positions as ritual",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-requesting-permission-using-specific-protocol-phrases",
+          "label": "Requesting permission using specific protocol phrases",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-carrying-items-in-mouth-as-submissive-gesture",
+          "label": "Carrying items in mouth as submissive gesture",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-crawling-back-with-object-to-dominant-after-retrieval",
+          "label": "Crawling back with object to Dominant after retrieval",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-following-via-nipple-leash-as-protocol-or-punishment",
+          "label": "Following via nipple leash as protocol or punishment",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-crawling-assigned-paths-as-ritual-or-obedience-training",
+          "label": "Crawling assigned paths as ritual or obedience training",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-crawling-rituals-e-g-object-retrieval",
+          "label": "Crawling rituals (e.g., object retrieval)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-carrying-objects-in-mouth-as-obedience",
+          "label": "Carrying objects in mouth as obedience",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-presenting-tools-or-toys-in-posture",
+          "label": "Presenting tools or toys in posture",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-using-honorifics-or-preset-protocol-language",
+          "label": "Using honorifics or preset protocol language",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-greeting-rituals-e-g-kneeling-kissing-feet",
+          "label": "Greeting rituals (e.g., kneeling, kissing feet)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-daily-check-ins-or-structured-reports",
+          "label": "Daily check-ins or structured reports",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-clothing-restrictions-or-uniforms",
+          "label": "Clothing restrictions or uniforms",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-posture-training-sitting-kneeling-standing",
+          "label": "Posture training (sitting, kneeling, standing)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-punishments-for-incorrect-behavior-or-tone",
+          "label": "Punishments for incorrect behavior or tone",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-crawling-with-items-in-mouth-e-g-hairbrush-spoon",
+          "label": "Crawling with items in mouth (e.g., hairbrush, spoon)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-earning-permission-for-meals-bathroom-use-or-rest",
+          "label": "Earning permission for meals, bathroom use, or rest",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-following-daily-rituals-or-protocol",
+          "label": "Following daily rituals or protocol",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-structured-speech-rules-e-g-titles-third-person",
+          "label": "Structured speech rules (e.g., titles, third person)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-receiving-correction-when-out-of-line",
+          "label": "Receiving correction when out of line",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "protocol-and-ritual-inspection-rituals-or-readiness-checks",
+          "label": "Inspection rituals or readiness checks",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Primal & Bratting",
+      "items": [
+        {
+          "id": "primal-bratting-chase-and-capture-play",
+          "label": "Chase and capture play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-bratting-for-punishment",
+          "label": "Bratting for punishment",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-playful-growling-and-biting",
+          "label": "Playful growling and biting",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-provoking-with-teasing-or-taunts",
+          "label": "Provoking with teasing or taunts",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-escaping-or-hiding-to-encourage-pursuit",
+          "label": "Escaping or hiding to encourage pursuit",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-refusing-commands-just-for-fun",
+          "label": "Refusing commands just for fun",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-provoking-your-partner-to-chase-or-discipline-you",
+          "label": "Provoking your partner to chase or discipline you",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-taunting-or-teasing-as-a-form-of-play",
+          "label": "Taunting or teasing as a form of play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-intentional-resistance-during-power-exchange",
+          "label": "Intentional resistance during power exchange",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "primal-bratting-being-caught-and-overpowered",
+          "label": "Being caught and overpowered",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Headspace & Regression",
+      "items": [
+        {
+          "id": "headspace-regression-caregiver-little-regression-play",
+          "label": "Caregiver/little regression play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-using-pacifiers-or-sippy-cups",
+          "label": "Using pacifiers or sippy cups",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-coloring-or-childlike-crafts",
+          "label": "Coloring or childlike crafts",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-stuffed-animal-comfort",
+          "label": "Stuffed animal comfort",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-speaking-in-a-childlike-voice",
+          "label": "Speaking in a childlike voice",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-bedtime-stories-or-lullabies",
+          "label": "Bedtime stories or lullabies",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-entering-altered-headspaces-e-g-prey-pet-little",
+          "label": "Entering altered headspaces (e.g., prey, pet, little)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-regressive-behaviors-as-comfort-coloring-babytalk",
+          "label": "Regressive behaviors as comfort (coloring, babytalk)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-being-cared-for-during-emotional-vulnerability",
+          "label": "Being cared for during emotional vulnerability",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "headspace-regression-guided-emotional-headspace-entry",
+          "label": "Guided emotional headspace entry",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Performance & Internal Struggle",
+      "items": [
+        {
+          "id": "performance-internal-struggle-obedience-under-observation",
+          "label": "Obedience under observation",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-speech-restriction-and-self-denial",
+          "label": "Speech restriction and self-denial",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-maintaining-composure-during-humiliation",
+          "label": "Maintaining composure during humiliation",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-obedience-drills-for-an-audience",
+          "label": "Obedience drills for an audience",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-struggling-against-personal-urges",
+          "label": "Struggling against personal urges",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-displaying-submission-despite-conflict",
+          "label": "Displaying submission despite conflict",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-being-told-to-act-normal-while-struggling-internally",
+          "label": "Being told to act normal while struggling internally",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-pleasing-through-high-functioning-obedience",
+          "label": "Pleasing through high-functioning obedience",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-performing-submission-while-masking-resistance",
+          "label": "Performing submission while masking resistance",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-the-pressure-of-appearing-good-while-feeling-conflicted",
+          "label": "The pressure of appearing 'good' while feeling conflicted",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-being-made-to-perform-emotions-on-command-cry-beg-moan",
+          "label": "Being made to perform emotions on command (cry, beg, moan)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-struggling-openly-while-still-obeying",
+          "label": "Struggling openly while still obeying",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-performing-exaggerated-resistance-or-denial",
+          "label": "Performing exaggerated resistance or denial",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-being-punished-for-breaking-character",
+          "label": "Being punished for 'breaking character'",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-putting-on-a-show-for-someone-else-s-pleasure",
+          "label": "Putting on a show for someone else’s pleasure",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "performance-internal-struggle-rehearsed-degradation-or-humiliation-scripts",
+          "label": "Rehearsed degradation or humiliation scripts",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Mindfuck & Manipulation",
+      "items": [
+        {
+          "id": "mindfuck-manipulation-confusing-commands-and-reality-shifts",
+          "label": "Confusing commands and reality shifts",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-gaslighting-or-contradictory-cues",
+          "label": "Gaslighting or contradictory cues",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-presenting-false-choices",
+          "label": "Presenting false choices",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-hidden-motives-or-secret-tasks",
+          "label": "Hidden motives or secret tasks",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-illogical-rules-meant-to-confuse",
+          "label": "Illogical rules meant to confuse",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-gaslight-style-scenes-with-consent-and-clarity",
+          "label": "Gaslight-style scenes (with consent and clarity)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-false-threats-or-staged-surprises",
+          "label": "False threats or staged surprises",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-confusing-commands-to-prompt-hesitation",
+          "label": "Confusing commands to prompt hesitation",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-emotional-trickery-as-arousal",
+          "label": "Emotional trickery as arousal",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-being-misled-or-deceived-on-purpose-during-play",
+          "label": "Being misled or deceived on purpose during play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-surprise-rule-changes-or-twists-mid-scene",
+          "label": "Surprise rule changes or twists mid-scene",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-false-safeword-games-with-negotiated-limits",
+          "label": "False safeword games (with negotiated limits)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-withholding-or-delaying-aftercare-for-effect",
+          "label": "Withholding or delaying aftercare for effect",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-being-gaslit-or-doubted-in-a-controlled-roleplay",
+          "label": "Being gaslit or doubted in a controlled roleplay",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mindfuck-manipulation-told-you-asked-for-this-or-you-love-this-when-resisting",
+          "label": "Told 'you asked for this' or 'you love this' when resisting",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Mouth Play",
+      "items": [
+        {
+          "id": "mouth-play-holding-tools-or-restraints-in-teeth-while-crawling",
+          "label": "Holding tools or restraints in teeth while crawling",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-placing-objects-from-mouth-into-dominant-s-palm",
+          "label": "Placing objects from mouth into Dominant’s palm",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-using-mouth-instead-of-hands-for-service-rituals",
+          "label": "Using mouth instead of hands for service rituals",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-gag-presentation-and-silent-waiting-protocol",
+          "label": "Gag presentation and silent waiting protocol",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-holding-objects-in-teeth-while-crawling",
+          "label": "Holding objects in teeth while crawling",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-returning-items-using-mouth-only",
+          "label": "Returning items using mouth only",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-gag-rituals-or-waiting-silently",
+          "label": "Gag rituals or waiting silently",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-leash-held-in-mouth",
+          "label": "Leash held in mouth",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-being-gagged-or-forced-silent",
+          "label": "Being gagged or forced silent",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-having-to-hold-objects-in-your-mouth-spoon-hairbrush-leash",
+          "label": "Having to hold objects in your mouth (spoon, hairbrush, leash)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-being-used-for-oral-service-without-reciprocal-pleasure",
+          "label": "Being used for oral service without reciprocal pleasure",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-being-fed-by-hand-mouth-to-mouth-or-with-utensils",
+          "label": "Being fed by hand, mouth-to-mouth, or with utensils",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-verbal-control-e-g-only-speak-when-spoken-to",
+          "label": "Verbal control (e.g., only speak when spoken to)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "mouth-play-mouth-as-a-symbol-of-ownership-or-control",
+          "label": "Mouth as a symbol of ownership or control",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Impact Play",
+      "items": [
+        {
+          "id": "impact-play-hand-spanking",
+          "label": "Hand spanking",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "impact-play-paddle-strikes",
+          "label": "Paddle strikes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "impact-play-crop-snaps",
+          "label": "Crop snaps",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "impact-play-flogger-swings",
+          "label": "Flogger swings",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "impact-play-cane-strokes",
+          "label": "Cane strokes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "impact-play-belt-or-strap-hits",
+          "label": "Belt or strap hits",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "impact-play-whip-cracks",
+          "label": "Whip cracks",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "impact-play-preferred-intensity-levels",
+          "label": "Preferred intensity levels",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "impact-play-aftercare-for-bruises",
+          "label": "Aftercare for bruises",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "impact-play-target-body-areas",
+          "label": "Target body areas",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "impact-play-implement-selection",
+          "label": "Implement selection",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Medical Play",
+      "items": [
+        {
+          "id": "medical-play-needle-play",
+          "label": "Needle play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "medical-play-catheter-insertion",
+          "label": "Catheter insertion",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "medical-play-speculum-exams",
+          "label": "Speculum exams",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "medical-play-enema-administration",
+          "label": "Enema administration",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "medical-play-temperature-taking",
+          "label": "Temperature taking",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "medical-play-medical-restraints",
+          "label": "Medical restraints",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "medical-play-doctor-nurse-roleplay",
+          "label": "Doctor/nurse roleplay",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "medical-play-sterilization-procedures",
+          "label": "Sterilization procedures",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "medical-play-professional-vs-roleplay-scenes",
+          "label": "Professional vs roleplay scenes",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "medical-play-consent-for-invasive-acts",
+          "label": "Consent for invasive acts",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "medical-play-access-to-medical-equipment",
+          "label": "Access to medical equipment",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Pet Play",
+      "items": [
+        {
+          "id": "pet-play-puppy-or-kitten-play",
+          "label": "Puppy or kitten play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "pet-play-pony-play",
+          "label": "Pony play",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "pet-play-wearing-collar-and-leash",
+          "label": "Wearing collar and leash",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "pet-play-eating-from-a-bowl",
+          "label": "Eating from a bowl",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "pet-play-kenneling-or-caging",
+          "label": "Kenneling or caging",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "pet-play-pet-training-commands",
+          "label": "Pet training commands",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "pet-play-animal-costumes-or-gear",
+          "label": "Animal costumes or gear",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "pet-play-preferred-animal-identities",
+          "label": "Preferred animal identities",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "pet-play-public-vs-private-play",
+          "label": "Public vs private play",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "pet-play-training-style-and-discipline",
+          "label": "Training style and discipline",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "pet-play-use-of-pet-names-and-commands",
+          "label": "Use of pet names and commands",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Body Modification",
+      "items": [
+        {
+          "id": "body-modification-piercings",
+          "label": "Piercings",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-modification-tattoos",
+          "label": "Tattoos",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-modification-branding",
+          "label": "Branding",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-modification-scarification",
+          "label": "Scarification",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-modification-permanent-chastity-devices",
+          "label": "Permanent chastity devices",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-modification-cosmetic-implants",
+          "label": "Cosmetic implants",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-modification-stretching-or-gauges",
+          "label": "Stretching or gauges",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "body-modification-temporary-vs-permanent-changes",
+          "label": "Temporary vs permanent changes",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-modification-professional-vs-diy-methods",
+          "label": "Professional vs DIY methods",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-modification-body-placement-considerations",
+          "label": "Body placement considerations",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "body-modification-healing-and-aftercare",
+          "label": "Healing and aftercare",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Relationship Preferences",
+      "items": [
+        {
+          "id": "relationship-preferences-preferred-relationship-style",
+          "label": "Preferred relationship style",
+          "type": "text",
+          "options": [
+            "Monogamous",
+            "Open relationship",
+            "Polyamorous",
+            "No preference"
+          ],
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-relationship-goals",
+          "label": "Relationship goals",
+          "type": "text",
+          "options": [
+            "One night stand",
+            "Short-term play",
+            "Long-term relationship",
+            "Platonic play partners",
+            "Romantic partners",
+            "Kink partners"
+          ],
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-monogamous",
+          "label": "Monogamous",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-polyamorous",
+          "label": "Polyamorous",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-hierarchical-dynamics",
+          "label": "Hierarchical dynamics",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-non-hierarchical-poly",
+          "label": "Non-hierarchical poly",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-solo-poly",
+          "label": "Solo-poly",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-open-with-boundaries",
+          "label": "Open with boundaries",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-closed-but-kinky-with-others",
+          "label": "Closed but kinky with others",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "relationship-preferences-switch-friendly-dynamics",
+          "label": "Switch-friendly dynamics",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Gender Play & Transformation",
+      "items": [
+        {
+          "id": "gender-play-transformation-crossdressing",
+          "label": "Crossdressing",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-forced-feminization",
+          "label": "Forced feminization",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-forced-masculinization",
+          "label": "Forced masculinization",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-gender-role-reversal",
+          "label": "Gender role reversal",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-pronoun-changes",
+          "label": "Pronoun changes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-voice-or-mannerism-training",
+          "label": "Voice or mannerism training",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-sissy-or-tomboy-persona",
+          "label": "Sissy or tomboy persona",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-preferred-pronouns-and-names",
+          "label": "Preferred pronouns and names",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-public-presentation-comfort",
+          "label": "Public presentation comfort",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-clothing-and-appearance",
+          "label": "Clothing and appearance",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "gender-play-transformation-exploration-of-identity",
+          "label": "Exploration of identity",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Chastity Devices",
+      "items": [
+        {
+          "id": "chastity-devices-wearing-a-chastity-cage-short-term",
+          "label": "Wearing a chastity cage (short term)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-long-term-chastity-training",
+          "label": "Long-term chastity training",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-chastity-device-control-with-permission-to-unlock",
+          "label": "Chastity device control with permission to unlock",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-locked-remotely-by-another-person",
+          "label": "Locked remotely by another person",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-orgasm-denial-enforced-by-chastity",
+          "label": "Orgasm denial enforced by chastity",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-wearing-a-belt-style-chastity-device",
+          "label": "Wearing a belt-style chastity device",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-humiliation-while-locked-in-chastity",
+          "label": "Humiliation while locked in chastity",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-sleep-in-chastity-overnight",
+          "label": "Sleep in chastity (overnight)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-being-teased-while-unable-to-touch-yourself",
+          "label": "Being teased while unable to touch yourself",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "chastity-devices-begging-for-release-from-chastity",
+          "label": "Begging for release from chastity",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Shibari & Rope Bondage",
+      "items": [
+        {
+          "id": "shibari-rope-bondage-being-tied-in-aesthetic-rope-patterns-shibari",
+          "label": "Being tied in aesthetic rope patterns (Shibari)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-rope-bondage-for-restraint-and-control",
+          "label": "Rope bondage for restraint and control",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-rope-suspension-partial-or-full",
+          "label": "Rope suspension (partial or full)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-learning-to-tie-rope-as-a-form-of-dominance",
+          "label": "Learning to tie rope as a form of dominance",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-being-tied-in-vulnerable-or-exposing-poses",
+          "label": "Being tied in vulnerable or exposing poses",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-practicing-rope-with-emotional-connection",
+          "label": "Practicing rope with emotional connection",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-enduring-discomfort-for-the-beauty-of-the-rope",
+          "label": "Enduring discomfort for the beauty of the rope",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-being-tied-in-a-mirror-and-told-to-look",
+          "label": "Being tied in a mirror and told to look",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-punishment-ties-e-g-uncomfortable-or-humiliating-positions",
+          "label": "Punishment ties (e.g., uncomfortable or humiliating positions)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "shibari-rope-bondage-solo-rope-practice-for-mindfulness-or-masochism",
+          "label": "Solo rope practice for mindfulness or masochism",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Cosplay & Identity Play",
+      "items": [
+        {
+          "id": "cosplay-identity-play-dressing-up-in-costumes-for-scenes",
+          "label": "Dressing up in costumes for scenes",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "cosplay-identity-play-playing-as-fictional-characters",
+          "label": "Playing as fictional characters",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "cosplay-identity-play-petplay-with-collars-ears-or-tails",
+          "label": "Petplay with collars, ears, or tails",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "cosplay-identity-play-pretending-to-be-a-doll-robot-or-object",
+          "label": "Pretending to be a doll, robot, or object",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "cosplay-identity-play-master-slave-cosplay-dynamic-non-24-7",
+          "label": "Master/slave cosplay dynamic (non-24/7)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "cosplay-identity-play-roleplaying-as-a-fantasy-species-or-non-human",
+          "label": "Roleplaying as a fantasy species or non-human",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "cosplay-identity-play-using-cosplay-to-deepen-power-exchange",
+          "label": "Using cosplay to deepen power exchange",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "cosplay-identity-play-scene-built-around-a-character-s-story-or-world",
+          "label": "Scene built around a character’s story or world",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "cosplay-identity-play-fantasy-uniforms-nurse-teacher-etc",
+          "label": "Fantasy uniforms (nurse, teacher, etc.)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "High-Intensity Kinks (SSC-Aware)",
+      "items": [
+        {
+          "id": "high-intensity-kinks-ssc-aware-intense-breath-play-e-g-smothering-or-pressure",
+          "label": "Intense breath play (e.g., smothering or pressure)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-knife-play-or-blade-play-without-injury",
+          "label": "Knife play or blade play (without injury)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-fear-play-using-known-or-negotiated-triggers",
+          "label": "Fear play using known or negotiated triggers",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-abduction-or-home-invasion-style-roleplay-negotiated",
+          "label": "Abduction or home-invasion style roleplay (negotiated)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-medical-themed-scenes-with-sharp-objects-not-bloodletting",
+          "label": "Medical-themed scenes with sharp objects (not bloodletting)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-sensory-deprivation-with-added-disorientation-or-helplessness",
+          "label": "Sensory deprivation with added disorientation or helplessness",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-scenes-involving-heavy-objectification-or-emotional-manipulation-with-care",
+          "label": "Scenes involving heavy objectification or emotional manipulation (with care)",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-mock-interrogation-or-intense-role-pressure",
+          "label": "Mock interrogation or intense role pressure",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-consensual-threats-without-follow-through-e-g-if-you-don-t",
+          "label": "Consensual threats without follow-through (e.g. 'If you don’t...')",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        },
+        {
+          "id": "high-intensity-kinks-ssc-aware-high-intensity-primal-scenes-involving-struggle-or-fear",
+          "label": "High-intensity primal scenes involving struggle or fear",
+          "type": "scale",
+          "roles": [
+            "Giving",
+            "Receiving"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Behavioral Play",
+      "items": [
+        {
+          "id": "behavioral-play-assigning-corner-time-or-time-outs",
+          "label": "Assigning corner time or time-outs",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "behavioral-play-writing-lines-or-apology-letters-as-correction",
+          "label": "Writing lines or apology letters as correction",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "behavioral-play-removing-privileges-phone-tv-sweets",
+          "label": "Removing privileges (phone, TV, sweets)",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "behavioral-play-playful-punishments-that-still-reinforce-rules",
+          "label": "Playful punishments that still reinforce rules",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "behavioral-play-lecturing-or-scolding-to-modify-behavior",
+          "label": "Lecturing or scolding to modify behavior",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "behavioral-play-being-placed-in-the-corner-or-given-a-time-out",
+          "label": "Being placed in the corner or given a time-out",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "behavioral-play-writing-lines-or-apology-letters-when-misbehaving",
+          "label": "Writing lines or apology letters when misbehaving",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "behavioral-play-having-privileges-revoked-phone-tv",
+          "label": "Having privileges revoked (phone, TV)",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "behavioral-play-receiving-playful-funishments-for-minor-rule-breaking",
+          "label": "Receiving playful 'funishments' for minor rule-breaking",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "behavioral-play-getting-scolded-or-lectured-for-correction",
+          "label": "Getting scolded or lectured for correction",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "behavioral-play-preferred-style-of-discipline-strict-vs-lenient",
+          "label": "Preferred style of discipline (strict vs lenient)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "behavioral-play-attitude-toward-funishment-vs-serious-correction",
+          "label": "Attitude toward funishment vs serious correction",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "behavioral-play-use-of-behavior-contracts-or-rule-agreements",
+          "label": "Use of behavior contracts or rule agreements",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Appearance Play",
+      "items": [
+        {
+          "id": "appearance-play-choosing-my-partner-s-outfit-for-the-day-or-a-scene",
+          "label": "Choosing my partner’s outfit for the day or a scene",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-selecting-their-underwear-lingerie-or-base-layers",
+          "label": "Selecting their underwear, lingerie, or base layers",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-styling-their-hair-braiding-brushing-tying-etc",
+          "label": "Styling their hair (braiding, brushing, tying, etc.)",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-picking-head-coverings-bonnets-veils-hoods-hats-for-mood-or-protocol",
+          "label": "Picking head coverings (bonnets, veils, hoods, hats) for mood or protocol",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-offering-makeup-polish-or-accessories-as-part-of-ritual-or-play",
+          "label": "Offering makeup, polish, or accessories as part of ritual or play",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-creating-themed-looks-slutty-innocent-doll-like-sharp-etc",
+          "label": "Creating themed looks (slutty, innocent, doll-like, sharp, etc.)",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-dressing-them-in-role-specific-costumes-maid-bunny-doll-etc",
+          "label": "Dressing them in role-specific costumes (maid, bunny, doll, etc.)",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-curating-time-period-or-historical-outfits-e-g-victorian-50s",
+          "label": "Curating time-period or historical outfits (e.g., Victorian, 50s)",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-helping-them-present-more-femme-masc-or-androgynous-by-request",
+          "label": "Helping them present more femme, masc, or androgynous by request",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-coordinating-their-look-with-mine-for-public-or-private-scenes",
+          "label": "Coordinating their look with mine for public or private scenes",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-implementing-a-dress-ritual-or-aesthetic-preparation",
+          "label": "Implementing a “dress ritual” or aesthetic preparation",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-enforcing-a-visual-protocol-e-g-no-bra-heels-required-tied-hair",
+          "label": "Enforcing a visual protocol (e.g., no bra, heels required, tied hair)",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "appearance-play-having-my-outfit-selected-for-me-by-a-partner",
+          "label": "Having my outfit selected for me by a partner",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-wearing-the-underwear-or-lingerie-they-choose",
+          "label": "Wearing the underwear or lingerie they choose",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-having-my-hair-brushed-braided-tied-or-styled-for-them",
+          "label": "Having my hair brushed, braided, tied, or styled for them",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-putting-on-a-head-covering-e-g-bonnet-veil-hood-they-chose",
+          "label": "Putting on a head covering (e.g., bonnet, veil, hood) they chose",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-following-visual-appearance-rules-as-part-of-submission",
+          "label": "Following visual appearance rules as part of submission",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-wearing-makeup-polish-or-accessories-they-request",
+          "label": "Wearing makeup, polish, or accessories they request",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-dressing-to-please-their-vision-cute-filthy-classy-etc",
+          "label": "Dressing to please their vision (cute, filthy, classy, etc.)",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-wearing-roleplay-costumes-or-character-looks",
+          "label": "Wearing roleplay costumes or character looks",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-presenting-in-a-way-that-matches-their-chosen-aesthetic",
+          "label": "Presenting in a way that matches their chosen aesthetic",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-participating-in-dressing-rituals-or-undressing-ceremonies",
+          "label": "Participating in dressing rituals or undressing ceremonies",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-being-admired-for-the-way-i-look-under-their-direction",
+          "label": "Being admired for the way I look under their direction",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-receiving-praise-or-gentle-teasing-about-my-appearance",
+          "label": "Receiving praise or gentle teasing about my appearance",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "appearance-play-cosplay-or-fantasy-looks-anime-game-fairytale-etc",
+          "label": "Cosplay or fantasy looks (anime, game, fairytale, etc.)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-time-period-dress-up-regency-gothic-1920s-etc",
+          "label": "Time-period dress-up (regency, gothic, 1920s, etc.)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-dollification-or-polished-presented-object-aesthetics",
+          "label": "Dollification or polished/presented object aesthetics",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-uniforms-schoolgirl-military-clerical-nurse-etc",
+          "label": "Uniforms (schoolgirl, military, clerical, nurse, etc.)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-hair-based-play-forced-brushing-ribbons-or-tied-styles",
+          "label": "Hair-based play (forced brushing, ribbons, or tied styles)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-head-coverings-or-symbolic-hoods-in-ritualized-dynamics",
+          "label": "Head coverings or symbolic hoods in ritualized dynamics",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-matching-looks-or-coordinated-dress-codes",
+          "label": "Matching looks or coordinated dress codes",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-ritualized-grooming-before-scenes",
+          "label": "Ritualized grooming before scenes",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-praise-or-positive-attention-for-pleasing-visual-display",
+          "label": "Praise or positive attention for pleasing visual display",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-formal-appearance-protocols-for-scenes-or-dynamics",
+          "label": "Formal appearance protocols for scenes or dynamics",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "appearance-play-using-clothing-or-style-to-embody-emotional-or-power-roles",
+          "label": "Using clothing or style to embody emotional or power roles",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Psychology Play",
+      "items": [
+        {
+          "id": "psychology-play-emotional-sadism-giving-teasing-feelings-orchestrating-reactions-savoring-anticipation-without-shame-based-harm",
+          "label": "Emotional Sadism (giving): teasing feelings, orchestrating reactions, savoring anticipation without shame-based harm",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "psychology-play-psychological-control-mind-games-double-binds-deliberate-pacing-and-strategic-ambiguity",
+          "label": "Psychological Control: mind games, double binds, deliberate pacing, and strategic ambiguity",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "psychology-play-sadistic-attention-enjoying-being-the-focal-point-of-a-partner-s-fear-arousal-or-resistance",
+          "label": "Sadistic Attention: enjoying being the focal point of a partner’s fear, arousal, or resistance",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "psychology-play-teasing-humiliation-playful-status-play-without-degradation-or-shame",
+          "label": "Teasing Humiliation: playful status play without degradation or shame",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "psychology-play-emotional-sadism-receiving-enjoying-engineered-emotional-intensity-such-as-fluster-exposure-or-playful-embarrassment",
+          "label": "Emotional Sadism (receiving): enjoying engineered emotional intensity such as fluster, exposure, or playful embarrassment",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychology-play-psychological-control-receiving-arousal-from-being-studied-contained-or-outmaneuvered",
+          "label": "Psychological Control (receiving): arousal from being studied, contained, or outmaneuvered",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychology-play-being-the-focus-enjoying-being-watched-tracked-or-held-in-a-partner-s-intense-focus",
+          "label": "Being the Focus: enjoying being watched, tracked, or held in a partner’s intense focus",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychology-play-teasing-humiliation-receiving-enjoying-playful-embarrassment-or-affectionate-mockery-that-builds-intimacy",
+          "label": "Teasing Humiliation (receiving): enjoying playful embarrassment or affectionate mockery that builds intimacy",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychology-play-prey-attention-neediness-craving-focus-pursuit-or-intense-awareness-from-a-partner",
+          "label": "Prey Attention/Neediness: craving focus, pursuit, or intense awareness from a partner",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "psychology-play-primal-recognition-being-seen-understood-or-tracked-without-needing-words",
+          "label": "Primal Recognition: being seen, understood, or tracked without needing words",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    },
+    {
+      "category": "Breeding",
+      "items": [
+        {
+          "id": "breeding-impregnation-giving-arousal-from-attempting-to-impregnate-a-partner",
+          "label": "Impregnation (giving): arousal from attempting to impregnate a partner",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "breeding-feeding-milk-giving-arousal-from-producing-and-feeding-milk-to-a-partner",
+          "label": "Feeding Milk (giving): arousal from producing and feeding milk to a partner",
+          "type": "scale",
+          "roles": [
+            "Giving"
+          ]
+        },
+        {
+          "id": "breeding-impregnation-receiving-arousal-from-being-inseminated-pregnancy-risk-or-being-bred",
+          "label": "Impregnation (receiving): arousal from being inseminated, pregnancy risk, or being bred",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "breeding-feeding-milk-receiving-arousal-from-drinking-a-partner-s-milk",
+          "label": "Feeding Milk (receiving): arousal from drinking a partner’s milk",
+          "type": "scale",
+          "roles": [
+            "Receiving"
+          ]
+        },
+        {
+          "id": "breeding-pregnancy-fantasy-erotic-focus-on-pregnancy-mine-partner-s-or-fictional-scenarios",
+          "label": "Pregnancy Fantasy: erotic focus on pregnancy (mine, partner’s, or fictional scenarios)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-primal-breeding-drive-animalistic-instinctual-framing-of-sex-reproduction-territory",
+          "label": "Primal Breeding Drive: animalistic/instinctual framing of sex, reproduction, territory",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-breeding-as-control-ownership-authority-expressed-through-breeding-talk-or-pregnancy-risk",
+          "label": "Breeding as Control: ownership/authority expressed through breeding talk or pregnancy risk",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-creampie-marking-erotic-meaning-placed-on-internal-ejaculation-or-visible-claimed-markers",
+          "label": "Creampie/Marking: erotic meaning placed on internal ejaculation or visible ‘claimed’ markers",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-risk-no-contraception-talk-fantasy-dirty-talk-about-risk-or-breeding-without-actual-risk",
+          "label": "Risk/‘No Contraception’ Talk (fantasy): dirty talk about risk or breeding without actual risk",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-heat-ovulation-tracking-timing-in-heat-roleplay-or-cycle-focused-arousal",
+          "label": "Heat/Ovulation Tracking: timing, ‘in heat’ roleplay, or cycle-focused arousal",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-artificial-insemination-device-play-syringes-cups-or-medical-style-scenarios-consensual-fantasy",
+          "label": "Artificial Insemination/Device Play: syringes, cups, or medical-style scenarios (consensual fantasy)",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-breeding-denial-ruined-breeding-building-toward-impregnation-talk-then-denying-or-ruining-it",
+          "label": "Breeding Denial/Ruined Breeding: building toward impregnation talk then denying or ‘ruining’ it",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-pregnancy-body-focus-belly-worship-movement-weight-changes-glow-and-attention",
+          "label": "Pregnancy Body Focus: belly worship, movement/weight changes, glow, and attention",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-pregnancy-protocol-care-protective-rules-pedestal-treatment-dedicated-aftercare",
+          "label": "Pregnancy Protocol/Care: protective rules, pedestal treatment, dedicated aftercare",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-lactation-induction-maintenance-interest-in-inducing-or-sustaining-milk-production",
+          "label": "Lactation Induction/Maintenance: interest in inducing or sustaining milk production",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-milking-scenes-manual-oral-or-pump-based-milking-as-play-or-ritual",
+          "label": "Milking Scenes: manual, oral, or pump-based ‘milking’ as play or ritual",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-contraception-boundaries-preference-to-use-protection-bc-methods-or-simulation-only",
+          "label": "Contraception Boundaries: preference to use protection, BC methods, or simulation-only",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        },
+        {
+          "id": "breeding-sti-testing-medical-boundaries-testing-cadence-disclosures-and-comfort-levels",
+          "label": "STI/Testing & Medical Boundaries: testing cadence, disclosures, and comfort levels",
+          "type": "scale",
+          "roles": [
+            "General"
+          ]
+        }
+      ]
+    }
+  ],
+  "kinks": [
+    {
+      "id": "body-part-torture-nipple-clips",
+      "label": "Nipple clips",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-nipple-weights",
+      "label": "Nipple weights",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-nipple-suction-cups",
+      "label": "Nipple suction cups",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-cock-ball-torture-cbt",
+      "label": "Cock, Ball Torture (CBT)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-clit-clips-weights-suction",
+      "label": "Clit clips/weights/suction",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-hair-pulling",
+      "label": "Hair pulling",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-face-slapping",
+      "label": "Face slapping",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-butt-slapping",
+      "label": "Butt slapping",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-breast-slapping",
+      "label": "Breast slapping",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "body-part-torture-genital-slapping",
+      "label": "Genital slapping",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part Torture"
+    },
+    {
+      "id": "bondage-and-suspension-blindfolds",
+      "label": "Blindfolds",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-bondage-heavy",
+      "label": "Bondage (heavy)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-bondage-light",
+      "label": "Bondage (light)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-immobilisation",
+      "label": "Immobilisation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-bondage-multi-day",
+      "label": "Bondage (multi-day)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-bondage-public-under-clothing",
+      "label": "Bondage (public, under clothing)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-leather-restraints",
+      "label": "Leather restraints",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-chains",
+      "label": "Chains",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-ropes",
+      "label": "Ropes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-intricate-japanese-rope-bondage",
+      "label": "Intricate (Japanese) rope bondage",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-rope-body-harness",
+      "label": "Rope body harness",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-arm-leg-sleeves-armbinders",
+      "label": "Arm & leg sleeves (armbinders)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-harnesses-leather",
+      "label": "Harnesses (leather)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-harnesses-rope",
+      "label": "Harnesses (rope)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-cuffs-leather",
+      "label": "Cuffs (leather)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-cuffs-metal",
+      "label": "Cuffs (metal)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-manacles-irons",
+      "label": "Manacles & Irons",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-gags-cloth",
+      "label": "Gags (cloth)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-gags-rubber",
+      "label": "Gags (rubber)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-gags-tape",
+      "label": "Gags (tape)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-gags-phallic",
+      "label": "Gags (phallic)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-gags-ring",
+      "label": "Gags (ring)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-gags-ball",
+      "label": "Gags (ball)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-mouth-bits",
+      "label": "Mouth bits",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-full-head-hoods",
+      "label": "Full head hoods",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-mummification-saran-wrapping",
+      "label": "Mummification/saran wrapping",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-straight-jackets",
+      "label": "Straight jackets",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-suspension-upright",
+      "label": "Suspension (upright)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-suspension-horizontal",
+      "label": "Suspension (horizontal)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-suspension-inverted",
+      "label": "Suspension (inverted)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-breath-play",
+      "label": "Breath play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-smothering",
+      "label": "Smothering",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-forced-self-breath-control",
+      "label": "Forced self-breath-control",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "bondage-and-suspension-gas-mask",
+      "label": "Gas mask",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Bondage and Suspension"
+    },
+    {
+      "id": "breath-play-asphyxiation",
+      "label": "Asphyxiation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Breath Play"
+    },
+    {
+      "id": "breath-play-breath-control",
+      "label": "Breath control",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Breath Play"
+    },
+    {
+      "id": "breath-play-choking",
+      "label": "Choking",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Breath Play"
+    },
+    {
+      "id": "breath-play-drowning",
+      "label": "Drowning",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Breath Play"
+    },
+    {
+      "id": "breath-play-rebreathing-into-a-bag-or-object",
+      "label": "Rebreathing into a bag or object",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Breath Play"
+    },
+    {
+      "id": "breath-play-verbal-control-of-breath-e-g-hold-it-on-command",
+      "label": "Verbal control of breath (e.g., 'hold it' on command)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Breath Play"
+    },
+    {
+      "id": "sexual-activity-licking",
+      "label": "Licking",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-fellatio-cunnilingus",
+      "label": "Fellatio/Cunnilingus",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-swallowing-semen",
+      "label": "Swallowing semen",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-cumming-on-partner",
+      "label": "Cumming on Partner",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-hand-jobs",
+      "label": "Hand jobs",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-anal-sex",
+      "label": "Anal sex",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-anal-plugs-small",
+      "label": "Anal plugs (small)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-anal-plugs-large",
+      "label": "Anal plugs (large)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-anal-beads",
+      "label": "Anal beads",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-vibrator-on-genitals",
+      "label": "Vibrator on genitals",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-fisting",
+      "label": "Fisting",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-oral-anal-play-rimming",
+      "label": "Oral/anal play (rimming)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-double-penetration-oral-and-vaginal",
+      "label": "Double penetration (oral and vaginal)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-double-penetration-oral-and-anal",
+      "label": "Double penetration (oral and anal)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-double-penetration-anal-and-vaginal",
+      "label": "Double penetration (anal and vaginal)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sexual-activity-triple-oral-vaginal-and-anal",
+      "label": "Triple (Oral, Vaginal and Anal)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sexual Activity"
+    },
+    {
+      "id": "sensation-play-abrasion",
+      "label": "Abrasion",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-scratching",
+      "label": "Scratching",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-biting",
+      "label": "Biting",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-tickling",
+      "label": "Tickling",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-kissing",
+      "label": "Kissing",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-zapping-e-g-electric-fly-swatter",
+      "label": "Zapping (e.g. electric fly swatter)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-ice-cubes",
+      "label": "Ice cubes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-wax-play",
+      "label": "Wax Play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-fire",
+      "label": "Fire",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-clothespins",
+      "label": "Clothespins",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-needles",
+      "label": "Needles",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-sensory-deprivation",
+      "label": "Sensory deprivation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-physical-overpowering-manhandling",
+      "label": "Physical overpowering / Manhandling",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "sensation-play-figging",
+      "label": "Figging",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Sensation Play"
+    },
+    {
+      "id": "other-feet",
+      "label": "Feet",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-boots",
+      "label": "Boots",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-underwear",
+      "label": "Underwear",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-chastity-devices",
+      "label": "Chastity devices",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-masks",
+      "label": "Masks",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-breeding",
+      "label": "Breeding",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-leather-clothing",
+      "label": "Leather clothing",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-training-protocols-outside-scenes-e-g-etiquette-memory",
+      "label": "Training protocols outside scenes (e.g., etiquette, memory)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-long-distance-training-structure",
+      "label": "Long-distance training/structure",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "other-scene-journaling-and-reflection",
+      "label": "Scene journaling and reflection",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Other"
+    },
+    {
+      "id": "roleplaying-fantasy-abandonment",
+      "label": "Fantasy abandonment",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-kidnapping",
+      "label": "Kidnapping",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-interrogation",
+      "label": "Interrogation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-sleep-deprivation",
+      "label": "Sleep deprivation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-cnc",
+      "label": "CNC",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-gang-bang",
+      "label": "Gang bang",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-initiation-rites",
+      "label": "Initiation rites",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-religious-scenes",
+      "label": "Religious scenes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-medical-scenes",
+      "label": "Medical scenes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-prison-scenes",
+      "label": "Prison scenes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-primal-prey",
+      "label": "Primal/Prey",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "roleplaying-schoolroom-scenes",
+      "label": "Schoolroom scenes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Roleplaying"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-following-orders",
+      "label": "(Following) orders",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-forced-servitude",
+      "label": "Forced servitude",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-restrictive-rules-on-behaviour",
+      "label": "Restrictive rules on behaviour",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-eye-contact-restrictions",
+      "label": "Eye contact restrictions",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-speech-restrictions-when-what-to-whom",
+      "label": "Speech restrictions (when, what, to whom)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-washroom-restrictions",
+      "label": "Washroom restrictions",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-punishments",
+      "label": "Punishments",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-tasks",
+      "label": "Tasks",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-massage",
+      "label": "Massage",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-domestic-tasks",
+      "label": "Domestic tasks",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-serving-food-and-drink",
+      "label": "Serving food and drink",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-personal-care-rituals",
+      "label": "Personal care rituals",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-being-on-call-at-specified-times",
+      "label": "Being on-call at specified times",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-daily-task-assignments",
+      "label": "Daily task assignments",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-corrections-for-imperfection",
+      "label": "Corrections for imperfection",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-uniforms-dress-codes",
+      "label": "Uniforms / Dress codes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-kneeling-posture-presentation",
+      "label": "Kneeling / Posture presentation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-silent-service",
+      "label": "Silent service",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-public-service-at-parties-or-events",
+      "label": "Public service (at parties or events)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "service-and-restrictive-behaviour-erotic-service-pleasure-on-command-without-seeking-your-own",
+      "label": "Erotic service (pleasure on command, without seeking your own)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Service and Restrictive Behaviour"
+    },
+    {
+      "id": "voyeurism-exhibitionism-forced-nudity-private",
+      "label": "Forced nudity (private)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Voyeurism/Exhibitionism"
+    },
+    {
+      "id": "voyeurism-exhibitionism-forced-nudity-around-others",
+      "label": "Forced nudity (around others)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Voyeurism/Exhibitionism"
+    },
+    {
+      "id": "voyeurism-exhibitionism-exhibitionism-friends",
+      "label": "Exhibitionism (friends)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Voyeurism/Exhibitionism"
+    },
+    {
+      "id": "voyeurism-exhibitionism-exhibitionism-strangers",
+      "label": "Exhibitionism (strangers)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Voyeurism/Exhibitionism"
+    },
+    {
+      "id": "voyeurism-exhibitionism-modelling-for-erotic-photos",
+      "label": "Modelling for erotic photos",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Voyeurism/Exhibitionism"
+    },
+    {
+      "id": "voyeurism-exhibitionism-toys-under-clothes-in-public",
+      "label": "Toys under clothes in public",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Voyeurism/Exhibitionism"
+    },
+    {
+      "id": "virtual-long-distance-play-sending-tasks-or-orders-digitally",
+      "label": "Sending tasks or orders digitally",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-recording-dominant-voice-clips-commands-edging-praise-degradation-etc",
+      "label": "Recording dominant voice clips (commands, edging, praise, degradation, etc.)",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-remote-control-of-a-sex-toy",
+      "label": "Remote control of a sex toy",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-monitoring-behavior-via-app-or-shared-doc",
+      "label": "Monitoring behavior via app or shared doc",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-giving-punishment-assignments-remotely",
+      "label": "Giving punishment assignments remotely",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-creating-countdowns-timers-or-denial-periods",
+      "label": "Creating countdowns, timers, or denial periods",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-sending-written-instructions-with-delayed-permissions",
+      "label": "Sending written instructions with delayed permissions",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-creating-custom-video-or-audio-tasks",
+      "label": "Creating custom video or audio tasks",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-voice-message-control-during-scenes",
+      "label": "Voice message control during scenes",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-being-on-call-at-specified-times",
+      "label": "Being on-call at specified times",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-receiving-tasks-or-orders-digitally",
+      "label": "Receiving tasks or orders digitally",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-listening-to-dominant-voice-clips",
+      "label": "Listening to dominant voice clips",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-using-a-remote-controlled-toy-controlled-by-another",
+      "label": "Using a remote-controlled toy controlled by another",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-completing-daily-protocol-assignments",
+      "label": "Completing daily protocol assignments",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-submitting-proof-photo-video-text",
+      "label": "Submitting proof (photo, video, text)",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-following-recorded-or-timed-commands",
+      "label": "Following recorded or timed commands",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-receiving-surprise-instructions",
+      "label": "Receiving surprise instructions",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-hearing-name-praise-spoken-in-a-custom-clip",
+      "label": "Hearing name/praise spoken in a custom clip",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-sending-submissive-voice-clips-obedience-begging-thank-you-messages-affirmations-etc",
+      "label": "Sending submissive voice clips (obedience, begging, thank-you messages, affirmations, etc.)",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-scheduling-digital-rituals-or-reminders",
+      "label": "Scheduling digital rituals or reminders",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-using-training-habit-or-behavior-tracking-apps",
+      "label": "Using training, habit, or behavior-tracking apps",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-online-rituals-digital-kneeling-posture-protocols",
+      "label": "Online rituals (digital kneeling, posture protocols)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-role-based-texting-e-g-use-honorifics-in-chat",
+      "label": "Role-based texting (e.g., \"Use honorifics in chat\")",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-shared-playlists-affirmations-or-mantras",
+      "label": "Shared playlists, affirmations, or mantras",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-countdown-timers-to-next-task-release-or-interaction",
+      "label": "Countdown timers to next task, release, or interaction",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-scheduled-good-morning-night-rituals",
+      "label": "Scheduled good morning/night rituals",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-participating-in-video-call-scenes",
+      "label": "Participating in video call scenes",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-digital-aftercare-texts-voice-images",
+      "label": "Digital aftercare (texts, voice, images)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-sexting-or-digital-roleplay-scenes",
+      "label": "Sexting or digital roleplay scenes",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "virtual-long-distance-play-voice-notes-or-submissive-dominant-affirmations",
+      "label": "Voice notes or submissive/dominant affirmations",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Virtual & Long-Distance Play"
+    },
+    {
+      "id": "communication-playful-and-teasing",
+      "label": "Playful and teasing",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-quiet-and-intense",
+      "label": "Quiet and intense",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-observant-and-intentional",
+      "label": "Observant and intentional",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-praise-heavy",
+      "label": "Praise-heavy",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-blunt-and-efficient",
+      "label": "Blunt and efficient",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-affirming-and-soft",
+      "label": "Affirming and soft",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-psychological-interrogation",
+      "label": "Psychological interrogation",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-verbal-coercion-teasing-traps",
+      "label": "Verbal coercion / teasing traps",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-verbal-misdirection",
+      "label": "Verbal misdirection",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-mocking-shaming",
+      "label": "Mocking / shaming",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-predatory-pacing",
+      "label": "Predatory pacing",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-reluctant-obedience",
+      "label": "Reluctant obedience",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-stammering-submission",
+      "label": "Stammering submission",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-challenging-until-caught",
+      "label": "Challenging until caught",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-quiet-surrender",
+      "label": "Quiet surrender",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-sarcastic-teasing",
+      "label": "Sarcastic teasing",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-provoking-tone",
+      "label": "Provoking tone",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-challenge-based-dialogue",
+      "label": "Challenge-based dialogue",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-double-meaning-banter",
+      "label": "Double-meaning banter",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-soft-spoken-guidance",
+      "label": "Soft-spoken guidance",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-protective-but-firm-tone",
+      "label": "Protective but firm tone",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-emotional-redirection",
+      "label": "Emotional redirection",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-steady-reassurance",
+      "label": "Steady reassurance",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-direct-and-clear",
+      "label": "Direct and clear",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-gentle-and-nurturing",
+      "label": "Gentle and nurturing",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-commanding-and-firm",
+      "label": "Commanding and firm",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-quiet-and-observant",
+      "label": "Quiet and observant",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-instructive-teacher-like",
+      "label": "Instructive / teacher-like",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-emotionally-intense",
+      "label": "Emotionally intense",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-dismissive-withholding",
+      "label": "Dismissive / withholding",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-mocking-sarcastic",
+      "label": "Mocking / sarcastic",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-blunt-tactless",
+      "label": "Blunt / tactless",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-predatory-hunting-tone",
+      "label": "Predatory / hunting tone",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-stalking-or-circling-speech",
+      "label": "Stalking or circling speech",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-you-re-mine-control-language",
+      "label": "You’re mine / control language",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-threatening-consensual",
+      "label": "Threatening (consensual)",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-verbal-cornering-coaxing",
+      "label": "Verbal cornering / coaxing",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-watching-you-unravel",
+      "label": "Watching you unravel",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-cruel-and-cutting",
+      "label": "Cruel and cutting",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-psychological-baiting",
+      "label": "Psychological baiting",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-brat-breaking-language",
+      "label": "Brat-breaking language",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-mock-affection",
+      "label": "Mock affection",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-shaming-or-emotional-edge",
+      "label": "Shaming or emotional edge",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-disappointed-dom-voice",
+      "label": "Disappointed dom voice",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-mild-scolding-mocking-affection",
+      "label": "Mild scolding / mocking affection",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-verbal-power-struggle",
+      "label": "Verbal power struggle",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-challenge-response-dynamics",
+      "label": "Challenge-response dynamics",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-warm-tone-with-expectation",
+      "label": "Warm tone with expectation",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-nurturing-dominance",
+      "label": "Nurturing dominance",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-reassuring-commands",
+      "label": "Reassuring commands",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-phrases-that-work-on-you",
+      "label": "Phrases that work on you",
+      "type": "text",
+      "roles": [
+        "General"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-phrases-you-use-or-like-to-give",
+      "label": "Phrases you use or like to give",
+      "type": "text",
+      "roles": [
+        "General"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-what-helps-you-feel-emotionally-safe",
+      "label": "What helps you feel emotionally safe",
+      "type": "text",
+      "roles": [
+        "General"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-how-you-tend-to-show-affection",
+      "label": "How you tend to show affection",
+      "type": "text",
+      "roles": [
+        "General"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-emotional-check-in-style",
+      "label": "Emotional check-in style",
+      "type": "text",
+      "roles": [
+        "General"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "communication-when-emotionally-activated-i-tend-to",
+      "label": "When emotionally activated, I tend to...",
+      "type": "text",
+      "roles": [
+        "General"
+      ],
+      "category": "Communication"
+    },
+    {
+      "id": "body-fluids-and-functions-watersports-golden-showers",
+      "label": "Watersports/golden showers",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Fluids and Functions"
+    },
+    {
+      "id": "body-fluids-and-functions-cum",
+      "label": "Cum",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Fluids and Functions"
+    },
+    {
+      "id": "body-fluids-and-functions-blood",
+      "label": "Blood",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Fluids and Functions"
+    },
+    {
+      "id": "body-fluids-and-functions-scat",
+      "label": "Scat",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Fluids and Functions"
+    },
+    {
+      "id": "body-fluids-and-functions-sweat",
+      "label": "Sweat",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Fluids and Functions"
+    },
+    {
+      "id": "body-fluids-and-functions-vomit",
+      "label": "Vomit",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Fluids and Functions"
+    },
+    {
+      "id": "body-fluids-and-functions-tears-crying",
+      "label": "Tears/crying",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Fluids and Functions"
+    },
+    {
+      "id": "psychological-primal-prey-primal-prey",
+      "label": "Primal/Prey",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-conditioning",
+      "label": "Conditioning",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-coc",
+      "label": "COC",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-psycholagny-hands-free-mentally-stimulated-orgasm",
+      "label": "Psycholagny (hands free, mentally stimulated orgasm)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-hypno-play",
+      "label": "Hypno Play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-praise",
+      "label": "Praise",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-degradation",
+      "label": "Degradation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-traditional-primal-prey",
+      "label": "Traditional primal/prey",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-fear-play",
+      "label": "Fear play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-objectification",
+      "label": "Objectification",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-gaslighting",
+      "label": "Gaslighting",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-role-erosion-identity-play-loss-of-self",
+      "label": "Role erosion (identity play / loss of self)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-jealousy-play",
+      "label": "Jealousy play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "psychological-primal-prey-manipulation",
+      "label": "Manipulation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Psychological Primal / Prey"
+    },
+    {
+      "id": "body-part-fetish-play-belly-fucking",
+      "label": "Belly fucking",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-navel-play",
+      "label": "Navel play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-feet-foot-worship",
+      "label": "Feet / Foot worship",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-hands",
+      "label": "Hands",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-hair",
+      "label": "Hair",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-thighs",
+      "label": "Thighs",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-neck",
+      "label": "Neck",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-ears",
+      "label": "Ears",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-belly",
+      "label": "Belly",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-voice-fetish",
+      "label": "Voice fetish",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-nails-makeup-fetish",
+      "label": "Nails / Makeup fetish",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-cuddles",
+      "label": "Cuddles",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-food-play",
+      "label": "Food Play",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-kisses",
+      "label": "Kisses",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-masturbation",
+      "label": "Masturbation",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-romance-affection",
+      "label": "Romance / affection",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-sex-toys",
+      "label": "Sex toys",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-sexting-chat-etc",
+      "label": "Sexting /Chat etc",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-sexting-via-phone-or-video-call",
+      "label": "Sexting via phone or video call",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-strip-tease",
+      "label": "Strip tease",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-vanilla-sex",
+      "label": "Vanilla Sex",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-voice-notes",
+      "label": "Voice Notes",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-shaving-body-hair",
+      "label": "Shaving (body hair)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-sexy-clothing-private",
+      "label": "Sexy clothing (private)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-sexy-clothing-public",
+      "label": "Sexy clothing (public)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-outdoor-scenes",
+      "label": "Outdoor scenes",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "body-part-fetish-play-public-exposure",
+      "label": "Public exposure",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Part / Fetish Play"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-edging",
+      "label": "Edging",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-short-term-denial",
+      "label": "Short term denial",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-long-term-denial",
+      "label": "Long term denial",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-forced-orgasms-overstimulation",
+      "label": "Forced orgasms / Overstimulation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-ruined-orgasms",
+      "label": "Ruined orgasms",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-no-touch-periods",
+      "label": "No touch periods",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-milking",
+      "label": "Milking",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-chastity-devices",
+      "label": "Chastity devices",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-consensual-orgasm-control",
+      "label": "Consensual orgasm control",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "orgasm-control-sexual-manipulation-forced-masturbation",
+      "label": "Forced masturbation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Orgasm Control & Sexual Manipulation"
+    },
+    {
+      "id": "protocol-and-ritual-formal-language",
+      "label": "Formal language",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-greeting-and-departure-rituals-kneeling-verbal-scripts-gestures",
+      "label": "Greeting and departure rituals (kneeling, verbal scripts, gestures)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-requiring-permission-for-things-speech-movement-attire",
+      "label": "Requiring permission for things (speech, movement, attire)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-daily-rituals-morning-check-ins-status-reports-mantra-repetitions",
+      "label": "Daily rituals (morning check-ins, status reports, mantra repetitions)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-specific-postures-for-rest-attention-punishment-waiting",
+      "label": "Specific postures for rest, attention, punishment, waiting",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-restricted-behavior-no-eye-contact-silence-no-questions",
+      "label": "Restricted behavior (no eye contact, silence, no questions)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-ritual-object-use-collar-cuffs-leash-tokens",
+      "label": "Ritual object use (collar, cuffs, leash, tokens)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-tracking-obedience-journals-apps",
+      "label": "Tracking obedience (journals, apps)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-formalized-rules-for-misbehavior-and-correction",
+      "label": "Formalized rules for misbehavior and correction",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-ritualized-aftercare-or-scene-closure",
+      "label": "Ritualized aftercare or scene closure",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-object-retrieval-on-all-fours-with-item-in-mouth",
+      "label": "Object retrieval on all fours with item in mouth",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-fetching-hairbrush-or-punishment-tool-from-dresser-while-crawling",
+      "label": "Fetching hairbrush or punishment tool from dresser while crawling",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-presenting-chosen-discipline-tool-in-kneeling-posture",
+      "label": "Presenting chosen discipline tool in kneeling posture",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-assigned-posture-or-kneeling-positions-as-ritual",
+      "label": "Assigned posture or kneeling positions as ritual",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-requesting-permission-using-specific-protocol-phrases",
+      "label": "Requesting permission using specific protocol phrases",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-carrying-items-in-mouth-as-submissive-gesture",
+      "label": "Carrying items in mouth as submissive gesture",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-crawling-back-with-object-to-dominant-after-retrieval",
+      "label": "Crawling back with object to Dominant after retrieval",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-following-via-nipple-leash-as-protocol-or-punishment",
+      "label": "Following via nipple leash as protocol or punishment",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-crawling-assigned-paths-as-ritual-or-obedience-training",
+      "label": "Crawling assigned paths as ritual or obedience training",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-crawling-rituals-e-g-object-retrieval",
+      "label": "Crawling rituals (e.g., object retrieval)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-carrying-objects-in-mouth-as-obedience",
+      "label": "Carrying objects in mouth as obedience",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-presenting-tools-or-toys-in-posture",
+      "label": "Presenting tools or toys in posture",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-using-honorifics-or-preset-protocol-language",
+      "label": "Using honorifics or preset protocol language",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-greeting-rituals-e-g-kneeling-kissing-feet",
+      "label": "Greeting rituals (e.g., kneeling, kissing feet)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-daily-check-ins-or-structured-reports",
+      "label": "Daily check-ins or structured reports",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-clothing-restrictions-or-uniforms",
+      "label": "Clothing restrictions or uniforms",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-posture-training-sitting-kneeling-standing",
+      "label": "Posture training (sitting, kneeling, standing)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-punishments-for-incorrect-behavior-or-tone",
+      "label": "Punishments for incorrect behavior or tone",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-crawling-with-items-in-mouth-e-g-hairbrush-spoon",
+      "label": "Crawling with items in mouth (e.g., hairbrush, spoon)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-earning-permission-for-meals-bathroom-use-or-rest",
+      "label": "Earning permission for meals, bathroom use, or rest",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-following-daily-rituals-or-protocol",
+      "label": "Following daily rituals or protocol",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-structured-speech-rules-e-g-titles-third-person",
+      "label": "Structured speech rules (e.g., titles, third person)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-receiving-correction-when-out-of-line",
+      "label": "Receiving correction when out of line",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "protocol-and-ritual-inspection-rituals-or-readiness-checks",
+      "label": "Inspection rituals or readiness checks",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Protocol and Ritual"
+    },
+    {
+      "id": "primal-bratting-chase-and-capture-play",
+      "label": "Chase and capture play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-bratting-for-punishment",
+      "label": "Bratting for punishment",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-playful-growling-and-biting",
+      "label": "Playful growling and biting",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-provoking-with-teasing-or-taunts",
+      "label": "Provoking with teasing or taunts",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-escaping-or-hiding-to-encourage-pursuit",
+      "label": "Escaping or hiding to encourage pursuit",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-refusing-commands-just-for-fun",
+      "label": "Refusing commands just for fun",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-provoking-your-partner-to-chase-or-discipline-you",
+      "label": "Provoking your partner to chase or discipline you",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-taunting-or-teasing-as-a-form-of-play",
+      "label": "Taunting or teasing as a form of play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-intentional-resistance-during-power-exchange",
+      "label": "Intentional resistance during power exchange",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "primal-bratting-being-caught-and-overpowered",
+      "label": "Being caught and overpowered",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Primal & Bratting"
+    },
+    {
+      "id": "headspace-regression-caregiver-little-regression-play",
+      "label": "Caregiver/little regression play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-using-pacifiers-or-sippy-cups",
+      "label": "Using pacifiers or sippy cups",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-coloring-or-childlike-crafts",
+      "label": "Coloring or childlike crafts",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-stuffed-animal-comfort",
+      "label": "Stuffed animal comfort",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-speaking-in-a-childlike-voice",
+      "label": "Speaking in a childlike voice",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-bedtime-stories-or-lullabies",
+      "label": "Bedtime stories or lullabies",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-entering-altered-headspaces-e-g-prey-pet-little",
+      "label": "Entering altered headspaces (e.g., prey, pet, little)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-regressive-behaviors-as-comfort-coloring-babytalk",
+      "label": "Regressive behaviors as comfort (coloring, babytalk)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-being-cared-for-during-emotional-vulnerability",
+      "label": "Being cared for during emotional vulnerability",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "headspace-regression-guided-emotional-headspace-entry",
+      "label": "Guided emotional headspace entry",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Headspace & Regression"
+    },
+    {
+      "id": "performance-internal-struggle-obedience-under-observation",
+      "label": "Obedience under observation",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-speech-restriction-and-self-denial",
+      "label": "Speech restriction and self-denial",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-maintaining-composure-during-humiliation",
+      "label": "Maintaining composure during humiliation",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-obedience-drills-for-an-audience",
+      "label": "Obedience drills for an audience",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-struggling-against-personal-urges",
+      "label": "Struggling against personal urges",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-displaying-submission-despite-conflict",
+      "label": "Displaying submission despite conflict",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-being-told-to-act-normal-while-struggling-internally",
+      "label": "Being told to act normal while struggling internally",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-pleasing-through-high-functioning-obedience",
+      "label": "Pleasing through high-functioning obedience",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-performing-submission-while-masking-resistance",
+      "label": "Performing submission while masking resistance",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-the-pressure-of-appearing-good-while-feeling-conflicted",
+      "label": "The pressure of appearing 'good' while feeling conflicted",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-being-made-to-perform-emotions-on-command-cry-beg-moan",
+      "label": "Being made to perform emotions on command (cry, beg, moan)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-struggling-openly-while-still-obeying",
+      "label": "Struggling openly while still obeying",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-performing-exaggerated-resistance-or-denial",
+      "label": "Performing exaggerated resistance or denial",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-being-punished-for-breaking-character",
+      "label": "Being punished for 'breaking character'",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-putting-on-a-show-for-someone-else-s-pleasure",
+      "label": "Putting on a show for someone else’s pleasure",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "performance-internal-struggle-rehearsed-degradation-or-humiliation-scripts",
+      "label": "Rehearsed degradation or humiliation scripts",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Performance & Internal Struggle"
+    },
+    {
+      "id": "mindfuck-manipulation-confusing-commands-and-reality-shifts",
+      "label": "Confusing commands and reality shifts",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-gaslighting-or-contradictory-cues",
+      "label": "Gaslighting or contradictory cues",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-presenting-false-choices",
+      "label": "Presenting false choices",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-hidden-motives-or-secret-tasks",
+      "label": "Hidden motives or secret tasks",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-illogical-rules-meant-to-confuse",
+      "label": "Illogical rules meant to confuse",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-gaslight-style-scenes-with-consent-and-clarity",
+      "label": "Gaslight-style scenes (with consent and clarity)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-false-threats-or-staged-surprises",
+      "label": "False threats or staged surprises",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-confusing-commands-to-prompt-hesitation",
+      "label": "Confusing commands to prompt hesitation",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-emotional-trickery-as-arousal",
+      "label": "Emotional trickery as arousal",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-being-misled-or-deceived-on-purpose-during-play",
+      "label": "Being misled or deceived on purpose during play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-surprise-rule-changes-or-twists-mid-scene",
+      "label": "Surprise rule changes or twists mid-scene",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-false-safeword-games-with-negotiated-limits",
+      "label": "False safeword games (with negotiated limits)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-withholding-or-delaying-aftercare-for-effect",
+      "label": "Withholding or delaying aftercare for effect",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-being-gaslit-or-doubted-in-a-controlled-roleplay",
+      "label": "Being gaslit or doubted in a controlled roleplay",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mindfuck-manipulation-told-you-asked-for-this-or-you-love-this-when-resisting",
+      "label": "Told 'you asked for this' or 'you love this' when resisting",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mindfuck & Manipulation"
+    },
+    {
+      "id": "mouth-play-holding-tools-or-restraints-in-teeth-while-crawling",
+      "label": "Holding tools or restraints in teeth while crawling",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-placing-objects-from-mouth-into-dominant-s-palm",
+      "label": "Placing objects from mouth into Dominant’s palm",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-using-mouth-instead-of-hands-for-service-rituals",
+      "label": "Using mouth instead of hands for service rituals",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-gag-presentation-and-silent-waiting-protocol",
+      "label": "Gag presentation and silent waiting protocol",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-holding-objects-in-teeth-while-crawling",
+      "label": "Holding objects in teeth while crawling",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-returning-items-using-mouth-only",
+      "label": "Returning items using mouth only",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-gag-rituals-or-waiting-silently",
+      "label": "Gag rituals or waiting silently",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-leash-held-in-mouth",
+      "label": "Leash held in mouth",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-being-gagged-or-forced-silent",
+      "label": "Being gagged or forced silent",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-having-to-hold-objects-in-your-mouth-spoon-hairbrush-leash",
+      "label": "Having to hold objects in your mouth (spoon, hairbrush, leash)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-being-used-for-oral-service-without-reciprocal-pleasure",
+      "label": "Being used for oral service without reciprocal pleasure",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-being-fed-by-hand-mouth-to-mouth-or-with-utensils",
+      "label": "Being fed by hand, mouth-to-mouth, or with utensils",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-verbal-control-e-g-only-speak-when-spoken-to",
+      "label": "Verbal control (e.g., only speak when spoken to)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "mouth-play-mouth-as-a-symbol-of-ownership-or-control",
+      "label": "Mouth as a symbol of ownership or control",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Mouth Play"
+    },
+    {
+      "id": "impact-play-hand-spanking",
+      "label": "Hand spanking",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-paddle-strikes",
+      "label": "Paddle strikes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-crop-snaps",
+      "label": "Crop snaps",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-flogger-swings",
+      "label": "Flogger swings",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-cane-strokes",
+      "label": "Cane strokes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-belt-or-strap-hits",
+      "label": "Belt or strap hits",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-whip-cracks",
+      "label": "Whip cracks",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-preferred-intensity-levels",
+      "label": "Preferred intensity levels",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-aftercare-for-bruises",
+      "label": "Aftercare for bruises",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-target-body-areas",
+      "label": "Target body areas",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "impact-play-implement-selection",
+      "label": "Implement selection",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Impact Play"
+    },
+    {
+      "id": "medical-play-needle-play",
+      "label": "Needle play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-catheter-insertion",
+      "label": "Catheter insertion",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-speculum-exams",
+      "label": "Speculum exams",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-enema-administration",
+      "label": "Enema administration",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-temperature-taking",
+      "label": "Temperature taking",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-medical-restraints",
+      "label": "Medical restraints",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-doctor-nurse-roleplay",
+      "label": "Doctor/nurse roleplay",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-sterilization-procedures",
+      "label": "Sterilization procedures",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-professional-vs-roleplay-scenes",
+      "label": "Professional vs roleplay scenes",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-consent-for-invasive-acts",
+      "label": "Consent for invasive acts",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "medical-play-access-to-medical-equipment",
+      "label": "Access to medical equipment",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Medical Play"
+    },
+    {
+      "id": "pet-play-puppy-or-kitten-play",
+      "label": "Puppy or kitten play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-pony-play",
+      "label": "Pony play",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-wearing-collar-and-leash",
+      "label": "Wearing collar and leash",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-eating-from-a-bowl",
+      "label": "Eating from a bowl",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-kenneling-or-caging",
+      "label": "Kenneling or caging",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-pet-training-commands",
+      "label": "Pet training commands",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-animal-costumes-or-gear",
+      "label": "Animal costumes or gear",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-preferred-animal-identities",
+      "label": "Preferred animal identities",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-public-vs-private-play",
+      "label": "Public vs private play",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-training-style-and-discipline",
+      "label": "Training style and discipline",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "pet-play-use-of-pet-names-and-commands",
+      "label": "Use of pet names and commands",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Pet Play"
+    },
+    {
+      "id": "body-modification-piercings",
+      "label": "Piercings",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-tattoos",
+      "label": "Tattoos",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-branding",
+      "label": "Branding",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-scarification",
+      "label": "Scarification",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-permanent-chastity-devices",
+      "label": "Permanent chastity devices",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-cosmetic-implants",
+      "label": "Cosmetic implants",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-stretching-or-gauges",
+      "label": "Stretching or gauges",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-temporary-vs-permanent-changes",
+      "label": "Temporary vs permanent changes",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-professional-vs-diy-methods",
+      "label": "Professional vs DIY methods",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-body-placement-considerations",
+      "label": "Body placement considerations",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "body-modification-healing-and-aftercare",
+      "label": "Healing and aftercare",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Body Modification"
+    },
+    {
+      "id": "relationship-preferences-preferred-relationship-style",
+      "label": "Preferred relationship style",
+      "type": "text",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-relationship-goals",
+      "label": "Relationship goals",
+      "type": "text",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-monogamous",
+      "label": "Monogamous",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-polyamorous",
+      "label": "Polyamorous",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-hierarchical-dynamics",
+      "label": "Hierarchical dynamics",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-non-hierarchical-poly",
+      "label": "Non-hierarchical poly",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-solo-poly",
+      "label": "Solo-poly",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-open-with-boundaries",
+      "label": "Open with boundaries",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-closed-but-kinky-with-others",
+      "label": "Closed but kinky with others",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "relationship-preferences-switch-friendly-dynamics",
+      "label": "Switch-friendly dynamics",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Relationship Preferences"
+    },
+    {
+      "id": "gender-play-transformation-crossdressing",
+      "label": "Crossdressing",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-forced-feminization",
+      "label": "Forced feminization",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-forced-masculinization",
+      "label": "Forced masculinization",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-gender-role-reversal",
+      "label": "Gender role reversal",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-pronoun-changes",
+      "label": "Pronoun changes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-voice-or-mannerism-training",
+      "label": "Voice or mannerism training",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-sissy-or-tomboy-persona",
+      "label": "Sissy or tomboy persona",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-preferred-pronouns-and-names",
+      "label": "Preferred pronouns and names",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-public-presentation-comfort",
+      "label": "Public presentation comfort",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-clothing-and-appearance",
+      "label": "Clothing and appearance",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "gender-play-transformation-exploration-of-identity",
+      "label": "Exploration of identity",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Gender Play & Transformation"
+    },
+    {
+      "id": "chastity-devices-wearing-a-chastity-cage-short-term",
+      "label": "Wearing a chastity cage (short term)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-long-term-chastity-training",
+      "label": "Long-term chastity training",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-chastity-device-control-with-permission-to-unlock",
+      "label": "Chastity device control with permission to unlock",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-locked-remotely-by-another-person",
+      "label": "Locked remotely by another person",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-orgasm-denial-enforced-by-chastity",
+      "label": "Orgasm denial enforced by chastity",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-wearing-a-belt-style-chastity-device",
+      "label": "Wearing a belt-style chastity device",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-humiliation-while-locked-in-chastity",
+      "label": "Humiliation while locked in chastity",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-sleep-in-chastity-overnight",
+      "label": "Sleep in chastity (overnight)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-being-teased-while-unable-to-touch-yourself",
+      "label": "Being teased while unable to touch yourself",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "chastity-devices-begging-for-release-from-chastity",
+      "label": "Begging for release from chastity",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Chastity Devices"
+    },
+    {
+      "id": "shibari-rope-bondage-being-tied-in-aesthetic-rope-patterns-shibari",
+      "label": "Being tied in aesthetic rope patterns (Shibari)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-rope-bondage-for-restraint-and-control",
+      "label": "Rope bondage for restraint and control",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-rope-suspension-partial-or-full",
+      "label": "Rope suspension (partial or full)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-learning-to-tie-rope-as-a-form-of-dominance",
+      "label": "Learning to tie rope as a form of dominance",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-being-tied-in-vulnerable-or-exposing-poses",
+      "label": "Being tied in vulnerable or exposing poses",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-practicing-rope-with-emotional-connection",
+      "label": "Practicing rope with emotional connection",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-enduring-discomfort-for-the-beauty-of-the-rope",
+      "label": "Enduring discomfort for the beauty of the rope",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-being-tied-in-a-mirror-and-told-to-look",
+      "label": "Being tied in a mirror and told to look",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-punishment-ties-e-g-uncomfortable-or-humiliating-positions",
+      "label": "Punishment ties (e.g., uncomfortable or humiliating positions)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "shibari-rope-bondage-solo-rope-practice-for-mindfulness-or-masochism",
+      "label": "Solo rope practice for mindfulness or masochism",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Shibari & Rope Bondage"
+    },
+    {
+      "id": "cosplay-identity-play-dressing-up-in-costumes-for-scenes",
+      "label": "Dressing up in costumes for scenes",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "cosplay-identity-play-playing-as-fictional-characters",
+      "label": "Playing as fictional characters",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "cosplay-identity-play-petplay-with-collars-ears-or-tails",
+      "label": "Petplay with collars, ears, or tails",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "cosplay-identity-play-pretending-to-be-a-doll-robot-or-object",
+      "label": "Pretending to be a doll, robot, or object",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "cosplay-identity-play-master-slave-cosplay-dynamic-non-24-7",
+      "label": "Master/slave cosplay dynamic (non-24/7)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "cosplay-identity-play-roleplaying-as-a-fantasy-species-or-non-human",
+      "label": "Roleplaying as a fantasy species or non-human",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "cosplay-identity-play-using-cosplay-to-deepen-power-exchange",
+      "label": "Using cosplay to deepen power exchange",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "cosplay-identity-play-scene-built-around-a-character-s-story-or-world",
+      "label": "Scene built around a character’s story or world",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "cosplay-identity-play-fantasy-uniforms-nurse-teacher-etc",
+      "label": "Fantasy uniforms (nurse, teacher, etc.)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "Cosplay & Identity Play"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-intense-breath-play-e-g-smothering-or-pressure",
+      "label": "Intense breath play (e.g., smothering or pressure)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-knife-play-or-blade-play-without-injury",
+      "label": "Knife play or blade play (without injury)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-fear-play-using-known-or-negotiated-triggers",
+      "label": "Fear play using known or negotiated triggers",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-abduction-or-home-invasion-style-roleplay-negotiated",
+      "label": "Abduction or home-invasion style roleplay (negotiated)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-medical-themed-scenes-with-sharp-objects-not-bloodletting",
+      "label": "Medical-themed scenes with sharp objects (not bloodletting)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-sensory-deprivation-with-added-disorientation-or-helplessness",
+      "label": "Sensory deprivation with added disorientation or helplessness",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-scenes-involving-heavy-objectification-or-emotional-manipulation-with-care",
+      "label": "Scenes involving heavy objectification or emotional manipulation (with care)",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-mock-interrogation-or-intense-role-pressure",
+      "label": "Mock interrogation or intense role pressure",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-consensual-threats-without-follow-through-e-g-if-you-don-t",
+      "label": "Consensual threats without follow-through (e.g. 'If you don’t...')",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "high-intensity-kinks-ssc-aware-high-intensity-primal-scenes-involving-struggle-or-fear",
+      "label": "High-intensity primal scenes involving struggle or fear",
+      "type": "scale",
+      "roles": [
+        "Giving",
+        "Receiving"
+      ],
+      "category": "High-Intensity Kinks (SSC-Aware)"
+    },
+    {
+      "id": "behavioral-play-assigning-corner-time-or-time-outs",
+      "label": "Assigning corner time or time-outs",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-writing-lines-or-apology-letters-as-correction",
+      "label": "Writing lines or apology letters as correction",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-removing-privileges-phone-tv-sweets",
+      "label": "Removing privileges (phone, TV, sweets)",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-playful-punishments-that-still-reinforce-rules",
+      "label": "Playful punishments that still reinforce rules",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-lecturing-or-scolding-to-modify-behavior",
+      "label": "Lecturing or scolding to modify behavior",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-being-placed-in-the-corner-or-given-a-time-out",
+      "label": "Being placed in the corner or given a time-out",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-writing-lines-or-apology-letters-when-misbehaving",
+      "label": "Writing lines or apology letters when misbehaving",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-having-privileges-revoked-phone-tv",
+      "label": "Having privileges revoked (phone, TV)",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-receiving-playful-funishments-for-minor-rule-breaking",
+      "label": "Receiving playful 'funishments' for minor rule-breaking",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-getting-scolded-or-lectured-for-correction",
+      "label": "Getting scolded or lectured for correction",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-preferred-style-of-discipline-strict-vs-lenient",
+      "label": "Preferred style of discipline (strict vs lenient)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-attitude-toward-funishment-vs-serious-correction",
+      "label": "Attitude toward funishment vs serious correction",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "behavioral-play-use-of-behavior-contracts-or-rule-agreements",
+      "label": "Use of behavior contracts or rule agreements",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Behavioral Play"
+    },
+    {
+      "id": "appearance-play-choosing-my-partner-s-outfit-for-the-day-or-a-scene",
+      "label": "Choosing my partner’s outfit for the day or a scene",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-selecting-their-underwear-lingerie-or-base-layers",
+      "label": "Selecting their underwear, lingerie, or base layers",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-styling-their-hair-braiding-brushing-tying-etc",
+      "label": "Styling their hair (braiding, brushing, tying, etc.)",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-picking-head-coverings-bonnets-veils-hoods-hats-for-mood-or-protocol",
+      "label": "Picking head coverings (bonnets, veils, hoods, hats) for mood or protocol",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-offering-makeup-polish-or-accessories-as-part-of-ritual-or-play",
+      "label": "Offering makeup, polish, or accessories as part of ritual or play",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-creating-themed-looks-slutty-innocent-doll-like-sharp-etc",
+      "label": "Creating themed looks (slutty, innocent, doll-like, sharp, etc.)",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-dressing-them-in-role-specific-costumes-maid-bunny-doll-etc",
+      "label": "Dressing them in role-specific costumes (maid, bunny, doll, etc.)",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-curating-time-period-or-historical-outfits-e-g-victorian-50s",
+      "label": "Curating time-period or historical outfits (e.g., Victorian, 50s)",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-helping-them-present-more-femme-masc-or-androgynous-by-request",
+      "label": "Helping them present more femme, masc, or androgynous by request",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-coordinating-their-look-with-mine-for-public-or-private-scenes",
+      "label": "Coordinating their look with mine for public or private scenes",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-implementing-a-dress-ritual-or-aesthetic-preparation",
+      "label": "Implementing a “dress ritual” or aesthetic preparation",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-enforcing-a-visual-protocol-e-g-no-bra-heels-required-tied-hair",
+      "label": "Enforcing a visual protocol (e.g., no bra, heels required, tied hair)",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-having-my-outfit-selected-for-me-by-a-partner",
+      "label": "Having my outfit selected for me by a partner",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-wearing-the-underwear-or-lingerie-they-choose",
+      "label": "Wearing the underwear or lingerie they choose",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-having-my-hair-brushed-braided-tied-or-styled-for-them",
+      "label": "Having my hair brushed, braided, tied, or styled for them",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-putting-on-a-head-covering-e-g-bonnet-veil-hood-they-chose",
+      "label": "Putting on a head covering (e.g., bonnet, veil, hood) they chose",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-following-visual-appearance-rules-as-part-of-submission",
+      "label": "Following visual appearance rules as part of submission",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-wearing-makeup-polish-or-accessories-they-request",
+      "label": "Wearing makeup, polish, or accessories they request",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-dressing-to-please-their-vision-cute-filthy-classy-etc",
+      "label": "Dressing to please their vision (cute, filthy, classy, etc.)",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-wearing-roleplay-costumes-or-character-looks",
+      "label": "Wearing roleplay costumes or character looks",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-presenting-in-a-way-that-matches-their-chosen-aesthetic",
+      "label": "Presenting in a way that matches their chosen aesthetic",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-participating-in-dressing-rituals-or-undressing-ceremonies",
+      "label": "Participating in dressing rituals or undressing ceremonies",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-being-admired-for-the-way-i-look-under-their-direction",
+      "label": "Being admired for the way I look under their direction",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-receiving-praise-or-gentle-teasing-about-my-appearance",
+      "label": "Receiving praise or gentle teasing about my appearance",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-cosplay-or-fantasy-looks-anime-game-fairytale-etc",
+      "label": "Cosplay or fantasy looks (anime, game, fairytale, etc.)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-time-period-dress-up-regency-gothic-1920s-etc",
+      "label": "Time-period dress-up (regency, gothic, 1920s, etc.)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-dollification-or-polished-presented-object-aesthetics",
+      "label": "Dollification or polished/presented object aesthetics",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-uniforms-schoolgirl-military-clerical-nurse-etc",
+      "label": "Uniforms (schoolgirl, military, clerical, nurse, etc.)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-hair-based-play-forced-brushing-ribbons-or-tied-styles",
+      "label": "Hair-based play (forced brushing, ribbons, or tied styles)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-head-coverings-or-symbolic-hoods-in-ritualized-dynamics",
+      "label": "Head coverings or symbolic hoods in ritualized dynamics",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-matching-looks-or-coordinated-dress-codes",
+      "label": "Matching looks or coordinated dress codes",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-ritualized-grooming-before-scenes",
+      "label": "Ritualized grooming before scenes",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-praise-or-positive-attention-for-pleasing-visual-display",
+      "label": "Praise or positive attention for pleasing visual display",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-formal-appearance-protocols-for-scenes-or-dynamics",
+      "label": "Formal appearance protocols for scenes or dynamics",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "appearance-play-using-clothing-or-style-to-embody-emotional-or-power-roles",
+      "label": "Using clothing or style to embody emotional or power roles",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Appearance Play"
+    },
+    {
+      "id": "psychology-play-emotional-sadism-giving-teasing-feelings-orchestrating-reactions-savoring-anticipation-without-shame-based-harm",
+      "label": "Emotional Sadism (giving): teasing feelings, orchestrating reactions, savoring anticipation without shame-based harm",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-psychological-control-mind-games-double-binds-deliberate-pacing-and-strategic-ambiguity",
+      "label": "Psychological Control: mind games, double binds, deliberate pacing, and strategic ambiguity",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-sadistic-attention-enjoying-being-the-focal-point-of-a-partner-s-fear-arousal-or-resistance",
+      "label": "Sadistic Attention: enjoying being the focal point of a partner’s fear, arousal, or resistance",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-teasing-humiliation-playful-status-play-without-degradation-or-shame",
+      "label": "Teasing Humiliation: playful status play without degradation or shame",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-emotional-sadism-receiving-enjoying-engineered-emotional-intensity-such-as-fluster-exposure-or-playful-embarrassment",
+      "label": "Emotional Sadism (receiving): enjoying engineered emotional intensity such as fluster, exposure, or playful embarrassment",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-psychological-control-receiving-arousal-from-being-studied-contained-or-outmaneuvered",
+      "label": "Psychological Control (receiving): arousal from being studied, contained, or outmaneuvered",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-being-the-focus-enjoying-being-watched-tracked-or-held-in-a-partner-s-intense-focus",
+      "label": "Being the Focus: enjoying being watched, tracked, or held in a partner’s intense focus",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-teasing-humiliation-receiving-enjoying-playful-embarrassment-or-affectionate-mockery-that-builds-intimacy",
+      "label": "Teasing Humiliation (receiving): enjoying playful embarrassment or affectionate mockery that builds intimacy",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-prey-attention-neediness-craving-focus-pursuit-or-intense-awareness-from-a-partner",
+      "label": "Prey Attention/Neediness: craving focus, pursuit, or intense awareness from a partner",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "psychology-play-primal-recognition-being-seen-understood-or-tracked-without-needing-words",
+      "label": "Primal Recognition: being seen, understood, or tracked without needing words",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Psychology Play"
+    },
+    {
+      "id": "breeding-impregnation-giving-arousal-from-attempting-to-impregnate-a-partner",
+      "label": "Impregnation (giving): arousal from attempting to impregnate a partner",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-feeding-milk-giving-arousal-from-producing-and-feeding-milk-to-a-partner",
+      "label": "Feeding Milk (giving): arousal from producing and feeding milk to a partner",
+      "type": "scale",
+      "roles": [
+        "Giving"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-impregnation-receiving-arousal-from-being-inseminated-pregnancy-risk-or-being-bred",
+      "label": "Impregnation (receiving): arousal from being inseminated, pregnancy risk, or being bred",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-feeding-milk-receiving-arousal-from-drinking-a-partner-s-milk",
+      "label": "Feeding Milk (receiving): arousal from drinking a partner’s milk",
+      "type": "scale",
+      "roles": [
+        "Receiving"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-pregnancy-fantasy-erotic-focus-on-pregnancy-mine-partner-s-or-fictional-scenarios",
+      "label": "Pregnancy Fantasy: erotic focus on pregnancy (mine, partner’s, or fictional scenarios)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-primal-breeding-drive-animalistic-instinctual-framing-of-sex-reproduction-territory",
+      "label": "Primal Breeding Drive: animalistic/instinctual framing of sex, reproduction, territory",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-breeding-as-control-ownership-authority-expressed-through-breeding-talk-or-pregnancy-risk",
+      "label": "Breeding as Control: ownership/authority expressed through breeding talk or pregnancy risk",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-creampie-marking-erotic-meaning-placed-on-internal-ejaculation-or-visible-claimed-markers",
+      "label": "Creampie/Marking: erotic meaning placed on internal ejaculation or visible ‘claimed’ markers",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-risk-no-contraception-talk-fantasy-dirty-talk-about-risk-or-breeding-without-actual-risk",
+      "label": "Risk/‘No Contraception’ Talk (fantasy): dirty talk about risk or breeding without actual risk",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-heat-ovulation-tracking-timing-in-heat-roleplay-or-cycle-focused-arousal",
+      "label": "Heat/Ovulation Tracking: timing, ‘in heat’ roleplay, or cycle-focused arousal",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-artificial-insemination-device-play-syringes-cups-or-medical-style-scenarios-consensual-fantasy",
+      "label": "Artificial Insemination/Device Play: syringes, cups, or medical-style scenarios (consensual fantasy)",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-breeding-denial-ruined-breeding-building-toward-impregnation-talk-then-denying-or-ruining-it",
+      "label": "Breeding Denial/Ruined Breeding: building toward impregnation talk then denying or ‘ruining’ it",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-pregnancy-body-focus-belly-worship-movement-weight-changes-glow-and-attention",
+      "label": "Pregnancy Body Focus: belly worship, movement/weight changes, glow, and attention",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-pregnancy-protocol-care-protective-rules-pedestal-treatment-dedicated-aftercare",
+      "label": "Pregnancy Protocol/Care: protective rules, pedestal treatment, dedicated aftercare",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-lactation-induction-maintenance-interest-in-inducing-or-sustaining-milk-production",
+      "label": "Lactation Induction/Maintenance: interest in inducing or sustaining milk production",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-milking-scenes-manual-oral-or-pump-based-milking-as-play-or-ritual",
+      "label": "Milking Scenes: manual, oral, or pump-based ‘milking’ as play or ritual",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-contraception-boundaries-preference-to-use-protection-bc-methods-or-simulation-only",
+      "label": "Contraception Boundaries: preference to use protection, BC methods, or simulation-only",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    },
+    {
+      "id": "breeding-sti-testing-medical-boundaries-testing-cadence-disclosures-and-comfort-levels",
+      "label": "STI/Testing & Medical Boundaries: testing cadence, disclosures, and comfort levels",
+      "type": "scale",
+      "roles": [
+        "General"
+      ],
+      "category": "Breeding"
+    }
+  ]
+}

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -80,7 +80,14 @@
           var tkw=box.querySelector('#tkw');
           fetch('/data/kinks.json?v='+Date.now(),{cache:'no-store'}).then(r=>r.text()).then(t=>{
             if(/^<!doctype html/i.test(t)||/<html[\s>]/i.test(t)){ if(tkw) tkw.textContent='Server sent HTML instead of JSON (rewrite). Start enabled; proceed.'; return; }
-            try{ var j=JSON.parse(t); var arr=Array.isArray(j)?j:(j&&Array.isArray(j.kinks)?j.kinks:[]); if(tkw) tkw.textContent='Data OK ('+arr.length+'). Start enabled; proceed.' }
+            try{
+              var j=JSON.parse(t);
+              var arr=[];
+              if (Array.isArray(j)) arr=j;
+              else if (j && Array.isArray(j.categories)) arr=j.categories;
+              else if (j && Array.isArray(j.kinks)) arr=j.kinks;
+              if(tkw) tkw.textContent='Data OK ('+arr.length+'). Start enabled; proceed.'
+            }
             catch(e){ if(tkw) tkw.textContent='JSON invalid. Start enabled; proceed.' }
           }).catch(()=>{ if(tkw) tkw.textContent='Fetch failed. Start enabled; proceed.' });
         }catch(e){}
@@ -652,6 +659,11 @@
   }
 
   function normalizeBank(raw){
+    if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+      if (Array.isArray(raw.categories)) return normalizeBank(raw.categories);
+      if (Array.isArray(raw.kinks)) return normalizeBank(raw.kinks);
+      if (Array.isArray(raw.data)) return normalizeBank(raw.data);
+    }
     // Accepts:
     //  A) [ {category, items:[{id,label,type?}]} ]
     //  B) { \"Category\":[{id,label,type?}], ... }

--- a/scripts/kinks_quicktest.mjs
+++ b/scripts/kinks_quicktest.mjs
@@ -77,7 +77,10 @@ async function checkLive(base="https://talkkink.org"){
     else {
       try {
         const j = JSON.parse(data.body||"");
-        const arr = Array.isArray(j) ? j : (j && Array.isArray(j.kinks) ? j.kinks : []);
+        let arr = [];
+        if (Array.isArray(j)) arr = j;
+        else if (j && Array.isArray(j.categories)) arr = j.categories;
+        else if (j && Array.isArray(j.kinks)) arr = j.kinks;
         jsonOk = true; jsonItems = Array.isArray(arr) ? arr.length : "unknown";
       } catch { /* fallthrough */ }
     }
@@ -135,7 +138,10 @@ async function checkLocal(){
     else {
       try {
         const j = JSON.parse(json.body||"");
-        const arr = Array.isArray(j) ? j : (j && Array.isArray(j.kinks) ? j.kinks : []);
+        let arr = [];
+        if (Array.isArray(j)) arr = j;
+        else if (j && Array.isArray(j.categories)) arr = j.categories;
+        else if (j && Array.isArray(j.kinks)) arr = j.kinks;
         jsonOk = true; jsonItems = Array.isArray(arr) ? arr.length : "unknown";
       } catch {}
     }

--- a/scripts/reason-kinks-json.mjs
+++ b/scripts/reason-kinks-json.mjs
@@ -56,7 +56,10 @@ async function probe(u) {
   try {
     const r = await fetch(good.url, { cache: "no-store" });
     const j = await r.json();
-    const arr = Array.isArray(j) ? j : (j && Array.isArray(j.kinks) ? j.kinks : []);
+    let arr = [];
+    if (Array.isArray(j)) arr = j;
+    else if (j && Array.isArray(j.categories)) arr = j.categories;
+    else if (j && Array.isArray(j.kinks)) arr = j.kinks;
     console.log(`✅ OK: ${good.url} (${good.ct||"application/json"}), items: ${Array.isArray(arr) ? arr.length : "unknown"}`);
     process.exit(0);
   } catch (e) {

--- a/snippet-kinks-survey-resilient-loader.html
+++ b/snippet-kinks-survey-resilient-loader.html
@@ -81,6 +81,11 @@
 
   /*** 3) Validate/normalize the JSON so one bad row doesn’t stop render ***/
   function normalizeBank(raw){
+    if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+      if (Array.isArray(raw.categories)) return normalizeBank(raw.categories);
+      if (Array.isArray(raw.kinks)) return normalizeBank(raw.kinks);
+      if (Array.isArray(raw.data)) return normalizeBank(raw.data);
+    }
     // Expected shapes supported:
     //  A) [{ category:"Appearance Play", items:[{id:"x", label:"...", type:"scale"}] }]
     //  B) { "Appearance Play": [ {id,label,type} ] }

--- a/test/kinksAccess.test.js
+++ b/test/kinksAccess.test.js
@@ -19,7 +19,9 @@ test('kink survey available without authentication', async t => {
   assert.strictEqual(jsonRes.status, 200);
   assert.match(jsonRes.headers.get('content-type') || '', /^application\/json/i);
   const data = await jsonRes.json();
-  assert.ok(Array.isArray(data.categories) || data.length);
+  assert.ok(data && typeof data === 'object');
+  assert.ok(data.labels && typeof data.labels === 'object' && Object.keys(data.labels).length > 0);
+  assert.ok(Array.isArray(data.categories) && data.categories.length > 0);
 
   const fallbackRes = await fetch(`${base}/kinks.json`);
   assert.strictEqual(fallbackRes.status, 200);


### PR DESCRIPTION
## Summary
- add a combined `/data/kinks.json` payload that exposes the label dictionary alongside the full kink categories
- add a reusable `tk-labels.js` helper and load it on the compatibility page to replace `cb_*` ids with readable labels
- update kink survey pages, guards, and tooling to understand the new JSON structure while keeping existing fallbacks working

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dccd368510832c8b44e9623cd2aceb