### PR TITLE
Add missing labels helper button to compatibility page

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -296,6 +296,10 @@
         Upload Partner’s Survey
       </label>
 
+      <button id="tk-missing-labels-btn" class="ksvBtn" style="display:none;margin-top:12px">
+        Missing labels
+      </button>
+
       <button class="themed-button wide-button" id="downloadBtn">Download PDF</button>
       <p id="exportTip" class="export-tip">Upload both surveys before exporting.</p>
     </div>
@@ -323,7 +327,7 @@
   </div>
 
   <script src="js/template-survey.js"></script>
-  <script type="module" src="js/compatibilityPage.js"></script>
+  <script type="module" src="/js/compatibilityPage.js"></script>
   <script type="module">
     import { initTheme, applyThemeColors } from './js/theme.js';
     initTheme();
@@ -2334,7 +2338,7 @@ document.getElementById('copyAtoB')?.addEventListener('click', () => {
 </script>
 
 
-<script src="/js/tk-labels.js" defer></script>
+<script type="module" src="/js/tk-labels.js"></script>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add the Missing labels helper button to the compatibility page controls so it can be toggled when needed
- load the compatibility enhancements from module scripts using root-relative paths to match the helper snippet requirements

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd890ad6fc832c9e7c3049abff29be