### PR TITLE
Add compatibility label helpers and unanswered coverage

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -8,33 +8,9 @@
   <link rel="stylesheet" href="/css/theme.css" />
   <link rel="stylesheet" href="/css/global.css" />
   <link rel="stylesheet" href="/css/compat-table.css" />
-<link rel="stylesheet" href="/css/font-failopen.css">
+  <link rel="stylesheet" href="/css/font-failopen.css">
+  <link rel="stylesheet" href="/css/compatibility.css" />
 
-  <style>
-  /* The table already looks great — we only layer a bar *inside* Match % cells */
-  .compatTbl td.pct {
-    position: relative;
-  }
-  .compatTbl td.pct .pctVal {
-    position: relative;
-    z-index: 1;
-  }
-  .compatTbl td.pct .pctBar {
-    position: absolute;
-    left: 10px;
-    right: 10px;
-    top: 50%;
-    height: 8px;
-    transform: translateY(-50%);
-    border-radius: 999px;
-    background: linear-gradient(90deg, #00e6ff 0%, #19f5d3 100%);
-    opacity: .35;
-    pointer-events: none;
-  }
-  /* If you ever want a tiny legend line under the Category WITHOUT layout shift:
-     we’ll keep it disabled. Native title tooltips are zero-layout and perfect. */
-  .compatTbl td.cat { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-  </style>
   <style>
   /* --- Compatibility: tiny progress bar & safe truncation for Category --- */
   .tk-cat {
@@ -296,10 +272,6 @@
         Upload Partner’s Survey
       </label>
 
-      <button id="tk-missing-labels-btn" class="ksvBtn" style="display:none;margin-top:12px">
-        Missing labels
-      </button>
-
       <button class="themed-button wide-button" id="downloadBtn">Download PDF</button>
       <p id="exportTip" class="export-tip">Upload both surveys before exporting.</p>
     </div>
@@ -322,12 +294,23 @@
           <tbody></tbody>
         </table>
       </section>
+      <table id="tk-unanswered" class="compatTable" style="margin-top:24px; width:100%; border-collapse:collapse">
+        <thead>
+          <tr>
+            <th>Unanswered Categories (0 or blank)</th>
+            <th>Partner A</th>
+            <th>Partner B</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
       <div class="print-footer"></div>
     </div>
   </div>
 
   <script src="js/template-survey.js"></script>
-  <script type="module" src="/js/compatibilityPage.js"></script>
+  <script src="/js/tk-labels.js" defer></script>
+  <script src="/js/compatibilityPage.js" defer></script>
   <script type="module">
     import { initTheme, applyThemeColors } from './js/theme.js';
     initTheme();
@@ -447,20 +430,18 @@
    */
   function tkMakePctCell(pct) {
     const td = document.createElement('td');
-    td.className = 'pct';
-    const span = document.createElement('span');
-    span.className = 'pctVal';
-
+    td.className = 'tk-pct';
     const isNum = Number.isFinite(pct);
-    span.textContent = isNum ? Math.round(pct) : '—';
-    td.appendChild(span);
+    const pctSafe = isNum ? Math.max(0, Math.min(100, Math.round(pct))) : null;
 
-    if (isNum && pct > 0) {
-      const bar = document.createElement('div');
-      bar.className = 'pctBar';
-      bar.style.width = Math.max(0, Math.min(100, pct)) + '%';
-      td.appendChild(bar);
-    }
+    const bar = document.createElement('div');
+    bar.className = 'tk-pct__bar';
+    bar.style.width = `${pctSafe ?? 0}%`;
+    td.appendChild(bar);
+
+    const span = document.createElement('span');
+    span.textContent = pctSafe != null ? `${pctSafe}%` : '—';
+    td.appendChild(span);
     return td;
   }
 
@@ -2337,8 +2318,6 @@ document.getElementById('copyAtoB')?.addEventListener('click', () => {
 });
 </script>
 
-
-<script type="module" src="/js/tk-labels.js"></script>
 
 </body>
 </html>

--- a/css/compatibility.css
+++ b/css/compatibility.css
@@ -1,0 +1,13 @@
+/* A thin bar that sits behind the Match % text. Keeps your existing table. */
+.tk-pct {
+  position: relative;
+}
+
+.tk-pct__bar {
+  position: absolute;
+  inset: 6px 6px 6px 6px;
+  width: 0;
+  background: rgba(0, 255, 255, 0.18);
+  border-radius: 2px;
+  pointer-events: none;
+}

--- a/data/labels-overrides.json
+++ b/data/labels-overrides.json
@@ -1,1 +1,5 @@
-{}
+{
+  "cb_wwf76": "Makeup as protocol or control",
+  "cb_swujj": "Accessory or ornament rules",
+  "cb_k55xd": "Wardrobe restrictions or permissions"
+}

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -1,374 +1,271 @@
-/* SAVE THIS AS: /js/compatibilityPage.js
- *
- * What it does
- * ------------
- * 1) Loads Survey A & B JSON files exactly as before.
- * 2) Loads your site label map from kinks.json (multiple fallback URLs supported) and merges in
- *    automatic labels scraped from the uploaded Survey A/B JSON plus optional manual overrides.
- * 3) Renders the table with readable Category names (no more cb_xxxxx) and a match % bar.
- * 4) If any ids are still missing from all sources, they show once in the console and the raw code is
- *    shown in the table so you can spot it.
- *
- * How to wire (no HTML redesign required)
- * ---------------------------------------
- * - Make sure one of the paths in LABEL_URLS points to the same kinks.json your survey uses.
- * - Your page should already have file inputs/buttons and a table container. This script looks for:
- *     #btnUploadA (or #uploadA)       -> click to select Survey A
- *     #btnUploadB (or #uploadB)       -> click to select Survey B
- *     #fileA  (or #surveyA)           -> <input type="file"> for Survey A
- *     #fileB  (or #surveyB)           -> <input type="file"> for Survey B
- *     #compatTable (or #compat-container or #table) -> where the table renders
- * - Include this script on compatibility.html:
- *     <script defer src="/js/compatibilityPage.js"></script>
- */
+'use strict';
 
-import { loadLabels, fmtCell } from './tk-labels.js';
-
-(() => {
-  // ---------- CONFIG ----------
+(function () {
   const ID_PREFIXES = ['cb_', 'gn_', 'sa_', 'sh_', 'bd_', 'pl_', 'ps_', 'vr_', 'vo_'];
-
-  // If a small number of ids truly aren’t in your kinks.json, you can hardcode them here:
-  const FALLBACK_LABELS = {
-    // 'cb_wwf76': 'Makeup as protocol or control',
-    // 'cb_swujj': 'Accessory or ornament rules',
-    // 'cb_05hqj': 'Wardrobe restrictions or permissions',
+  const GROUPS = {
+    'Bodily Fluids and Functions': [],
+    'Body Part Torture': [],
+    'Bondage and Suspension': [],
+    'Breath Play': [],
+    'Psychological': [],
+    'Sexual Activity': [],
+    'Appearance Play': [
+      'cb_zsnrb', 'cb_6jd2f', 'cb_kgrnn', 'cb_169ma', 'cb_4yyxa', 'cb_2c0f9',
+      'cb_qwnhi', 'cb_zvchg', 'cb_qw9jg', 'cb_3ozhq', 'cb_hqakm', 'cb_rn136',
+      'cb_wwf76', 'cb_swujj', 'cb_k55xd'
+    ]
   };
 
-  // ---------- LITTLE UTILITIES ----------
-  const $ = sel => document.querySelector(sel);
-  function hasPrefix(id) { return typeof id === 'string' && ID_PREFIXES.some(p => id.startsWith(p)); }
-  const normalizeId = (id) => {
-    if (id == null) return '';
-    return hasPrefix(id) ? String(id).trim().toLowerCase() : '';
-  };
+  const seenIds = new Set();
+  let missingBtn = null;
 
-  // ---------- LABELS: AUTO-BUILD FROM kinks.json ----------
-  let LABELS = {}; // id -> friendly text from site kinks.json
-  let AUTO_LABELS = {}; // id -> friendly text sourced from uploads
-  let labelGetter = (id) => (id == null ? '' : String(id));
-  let loggedMissingOnce = false;
+  document.addEventListener('DOMContentLoaded', init);
+  document.addEventListener('tk-labels:ready', () => {
+    if (lastState.rendered) render(lastState.rendered);
+  });
 
-  function tighten(s) {
-    const t = String(s).replace(/\s+/g, ' ').trim();
-    return t.length > 140 ? `${t.slice(0, 137)}…` : t;
+  const lastState = { rendered: null };
+
+  function init() {
+    const uploadA = document.getElementById('uploadSurveyA') || document.getElementById('fileA') || document.getElementById('surveyA');
+    const uploadB = document.getElementById('uploadSurveyB') || document.getElementById('fileB') || document.getElementById('surveyB');
+    const tbody = document.querySelector('#compatTable tbody');
+    if (!tbody) return;
+
+    let listA = [];
+    let listB = [];
+
+    attachFileHandler(uploadA, async file => {
+      listA = await parseSurveyFile(file, 'A');
+      refresh();
+    });
+    attachFileHandler(uploadB, async file => {
+      listB = await parseSurveyFile(file, 'B');
+      refresh();
+    });
+
+    function refresh() {
+      const rendered = buildRows(listA, listB);
+      lastState.rendered = rendered;
+      render(rendered);
+    }
   }
-  function friendlyLabel(id) {
-    const key = normalizeId(id);
-    if (!key) return labelGetter(id);
-    if (AUTO_LABELS[key]) return tighten(AUTO_LABELS[key]);
-    if (LABELS[key]) return tighten(LABELS[key]);
-    return tighten(labelGetter(id));
-  }
 
-  function hasKnownLabel(id) {
-    const key = normalizeId(id);
-    if (!key) return false;
-    return Boolean(AUTO_LABELS[key] || LABELS[key]);
-  }
-
-  // ---------- SURVEY LOADING ----------
-  function readJsonFile(file) {
-    return new Promise((res, rej) => {
-      const fr = new FileReader();
-      fr.onerror = () => rej(new Error('File read error'));
-      fr.onload = () => {
-        try { res(JSON.parse(String(fr.result || 'null'))); }
-        catch { rej(new Error('Invalid JSON')); }
-      };
-      fr.readAsText(file);
+  function attachFileHandler(input, onFile) {
+    if (!input) return;
+    input.addEventListener('change', async () => {
+      const file = input.files && input.files[0];
+      if (!file) return;
+      try {
+        await onFile(file);
+      } catch (err) {
+        const which = input === document.getElementById('uploadSurveyB') || input === document.getElementById('fileB') || input === document.getElementById('surveyB') ? 'B' : 'A';
+        alert(`Invalid JSON for Survey ${which}. Please upload the unmodified JSON exported from this site.`);
+        console.error(err);
+      }
     });
   }
 
-  // Normalize multiple shapes to [{id, value}]
-  // Supports { answers: [ {id, value}, ... ] } or a flat { id: value, ... }
+  async function parseSurveyFile(file, which) {
+    const raw = await readJsonFile(file);
+    const normalized = normalizeSurvey(raw);
+    if (!Array.isArray(normalized)) {
+      throw new Error(`Survey ${which} failed to normalize.`);
+    }
+    return normalized;
+  }
+
+  function render(rendered) {
+    const table = document.querySelector('#compatTable tbody');
+    if (!table) return;
+
+    table.innerHTML = '';
+    seenIds.clear();
+
+    const labelsApi = window.tkLabels || window.TK_LABELS;
+    const labelGetter = labelsApi && typeof labelsApi.getLabel === 'function'
+      ? labelsApi.getLabel
+      : (id) => id;
+
+    const rowsWithLabels = rendered.rows.map(row => ({
+      ...row,
+      label: labelGetter(row.id)
+    }));
+
+    rowsWithLabels.sort((a, b) => a.label.localeCompare(b.label, undefined, { sensitivity: 'base' }));
+
+    rowsWithLabels.forEach(row => {
+      seenIds.add(row.id);
+      table.appendChild(renderRow(row));
+    });
+
+    buildUnansweredTable(rendered.mapA, rendered.mapB);
+    mountMissingLabelsButton();
+  }
+
+  function readJsonFile(file) {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onerror = () => reject(new Error('File read error'));
+      reader.onload = () => {
+        try {
+          const json = JSON.parse(String(reader.result || 'null'));
+          resolve(json);
+        } catch (err) {
+          reject(err);
+        }
+      };
+      reader.readAsText(file);
+    });
+  }
+
   function normalizeSurvey(raw) {
     if (!raw) return [];
     if (Array.isArray(raw.answers)) {
       return raw.answers
-        .filter(a => a && hasPrefix(a.id))
-        .map(a => ({ id: normalizeId(a.id), value: Number(a.value ?? 0) || 0 }))
-        .filter(a => !!a.id);
+        .map(entry => ({ id: normalizeId(entry?.id), value: Number(entry?.value ?? 0) || 0 }))
+        .filter(entry => entry.id);
     }
     const out = [];
-    for (const [id, v] of Object.entries(raw)) {
+    for (const [id, value] of Object.entries(raw)) {
       const norm = normalizeId(id);
-      if (norm) out.push({ id: norm, value: Number(v ?? 0) || 0 });
+      if (norm) out.push({ id: norm, value: Number(value ?? 0) || 0 });
     }
     return out;
   }
 
-  // ---------- RENDER ----------
-  async function renderTable(container, rows) {
-    const tbl = document.createElement('table');
-    tbl.className = 'compat-table'; // keep your CSS
-
-    const thead = document.createElement('thead');
-    const trh = document.createElement('tr');
-    ['Category', 'Partner A', 'Match %', 'Partner B'].forEach(h => {
-      const th = document.createElement('th'); th.textContent = h; trh.appendChild(th);
-    });
-    thead.appendChild(trh);
-    tbl.appendChild(thead);
-
-    const tbody = document.createElement('tbody');
-
-    const labelledRows = applyLabelsToRows(rows)
-      .sort((x, y) => x.label.localeCompare(y.label, undefined, { sensitivity: 'base' }));
-
-    const usedIds = labelledRows.map(r => r.id);
-    const missing = [];
-
-    for (let i = 0; i < labelledRows.length; i += 1) {
-      const r = labelledRows[i];
-      const tr = document.createElement('tr');
-
-      const nameCell = document.createElement('td');
-      nameCell.classList.add('compatNameCell');
-      if (!hasKnownLabel(r.id)) missing.push(r.id);
-      nameCell.textContent = r.label;
-
-      const tdA = document.createElement('td');
-      tdA.textContent = fmtCell(r.a);
-
-      const pctCell = document.createElement('td');
-      const pctRaw = Number.isFinite(r.pct) ? Math.max(0, Math.min(100, Math.round(r.pct))) : NaN;
-      const pctText = fmtCell(pctRaw, '%');
-      if (pctText !== '—') {
-        pctCell.innerHTML = `<div class="pctBar" style="--pct:${pctRaw}%"><i></i><span>${pctText}</span></div>`;
-      } else {
-        pctCell.textContent = pctText;
-      }
-
-      const tdB = document.createElement('td');
-      tdB.textContent = fmtCell(r.b);
-
-      tr.appendChild(nameCell);
-      tr.appendChild(tdA);
-      tr.appendChild(pctCell);
-      tr.appendChild(tdB);
-      tbody.appendChild(tr);
-
-      if (i > 0 && i % 250 === 0) {
-        await new Promise(rf => requestAnimationFrame(rf));
-      }
-    }
-
-    tbl.appendChild(tbody);
-    container.innerHTML = '';
-    container.appendChild(tbl);
-
-    const uniqMissing = [...new Set(missing)].sort();
-    if (uniqMissing.length && !loggedMissingOnce) {
-      console.warn(`[labels] Missing ${uniqMissing.length} labels (showing raw codes):`, uniqMissing);
-      loggedMissingOnce = true;
-    }
-
-    updateMissingButton([...new Set(usedIds)]);
-    document.dispatchEvent(new Event('tk:compat:table-ready'));
+  function normalizeId(id) {
+    if (id == null) return '';
+    const key = String(id).trim().toLowerCase();
+    return ID_PREFIXES.some(prefix => key.startsWith(prefix)) ? key : '';
   }
 
-  function computeRows(aList, bList) {
-    const mapA = new Map(aList.map(x => [x.id, x.value]));
-    const mapB = new Map(bList.map(x => [x.id, x.value]));
-    const all = new Set([...mapA.keys(), ...mapB.keys()]);
-    const out = [];
-    for (const id of all) {
+  function buildRows(listA, listB) {
+    const mapA = listToMap(listA);
+    const mapB = listToMap(listB);
+    const ids = new Set([...mapA.keys(), ...mapB.keys()]);
+    const rows = [];
+    ids.forEach(id => {
       const a = mapA.has(id) ? mapA.get(id) : null;
       const b = mapB.has(id) ? mapB.get(id) : null;
-      let pct = null;
-      if (a !== null && b !== null) {
-        const diff = Math.abs(a - b);
-        pct = Math.max(0, 100 - diff * 20); // 0..5 scale → 100,80,60,40,20,0
-      }
-      out.push({ id, a, b, pct });
-    }
-    return out;
+      const pct = (Number.isFinite(a) && Number.isFinite(b))
+        ? Math.max(0, Math.min(100, Math.round(100 - Math.abs(a - b) * 20)))
+        : null;
+      rows.push({ id, a, b, pct });
+    });
+    return { rows, mapA, mapB };
   }
 
-  function applyLabelsToRows(rows) {
-    return rows.map(r => ({ ...r, label: friendlyLabel(r.id) }));
-  }
-
-  function mergeLabelsFromExports(list) {
-    const out = {};
-    for (const src of list) {
-      if (!src) continue;
-      const m = extractLabelsFromExport(src);
-      for (const k in m) {
-        const norm = normalizeId(k);
-        if (norm && !out[norm]) out[norm] = tighten(m[k]);
-      }
-    }
-    return out;
-  }
-
-  function extractLabelsFromExport(json) {
-    const map = {};
-    const ID_KEYS = ['id', 'code', 'key', 'slug', 'value'];
-    const TEXT_KEYS = ['text', 'label', 'name', 'question', 'title', 'prompt', 'short', 'summary', 'desc', 'description', 'caption', 'heading'];
-    const LIST_KEYS = ['choices', 'options', 'answers', 'items', 'children', 'content', 'rows', 'elements', 'fields'];
-
-    walk(json);
+  function listToMap(list) {
+    const map = new Map();
+    (list || []).forEach(item => {
+      if (!item || !item.id) return;
+      map.set(item.id, Number(item.value ?? 0) || 0);
+    });
     return map;
+  }
 
-    function isCbId(v) { return typeof v === 'string' && /^cb_[a-z0-9]+$/i.test(v); }
-    function pickText(obj) {
-      for (const k of TEXT_KEYS) {
-        if (typeof obj?.[k] === 'string' && obj[k].trim()) return obj[k];
+  function fmtScore(value) {
+    const num = Number(value);
+    return Number.isFinite(num) ? String(num) : '—';
+  }
+
+  function renderRow({ id, a, b, pct, label }) {
+    const tr = document.createElement('tr');
+    tr.dataset.id = id;
+
+    const tdCat = document.createElement('td');
+    tdCat.textContent = label || id;
+    tr.appendChild(tdCat);
+
+    const tdA = document.createElement('td');
+    tdA.textContent = fmtScore(a);
+    tr.appendChild(tdA);
+
+    const tdPct = document.createElement('td');
+    tdPct.className = 'tk-pct';
+    const pctSafe = Number.isFinite(pct) ? Math.max(0, Math.min(100, pct)) : null;
+    const pctText = Number.isFinite(pctSafe) ? `${pctSafe}%` : '—';
+    tdPct.innerHTML = `
+      <div class="tk-pct__bar" style="width:${pctSafe ?? 0}%;"></div>
+      <span>${pctText}</span>
+    `;
+    tr.appendChild(tdPct);
+
+    const tdB = document.createElement('td');
+    tdB.textContent = fmtScore(b);
+    tr.appendChild(tdB);
+
+    return tr;
+  }
+
+  function mountMissingLabelsButton() {
+    const labelsApi = window.tkLabels || window.TK_LABELS;
+    if (!labelsApi || typeof labelsApi.collectMissing !== 'function') return;
+
+    const missing = labelsApi.collectMissing(seenIds);
+    if (!missing.length) {
+      if (missingBtn) {
+        missingBtn.remove();
+        missingBtn = null;
       }
-      return null;
+      return;
     }
 
-    function walk(node) {
-      if (!node) return;
-      if (Array.isArray(node)) { node.forEach(walk); return; }
-      if (typeof node !== 'object') return;
-
-      let cid = null;
-      for (const k of ID_KEYS) {
-        if (isCbId(node[k])) { cid = node[k]; break; }
-      }
-      if (cid) {
-        const t = pickText(node);
-        if (t && !map[cid]) map[cid] = tighten(t);
-      }
-
-      for (const k of LIST_KEYS) {
-        const v = node[k];
-        if (Array.isArray(v)) v.forEach(item => {
-          if (item && typeof item === 'object') {
-            let id2 = null;
-            for (const kk of ID_KEYS) if (isCbId(item[kk])) { id2 = item[kk]; break; }
-            if (id2) {
-              const t2 = pickText(item);
-              if (t2 && !map[id2]) map[id2] = tighten(t2);
-            }
-          }
-          walk(item);
-        });
-      }
-
-      for (const k in node) walk(node[k]);
+    if (!missingBtn) {
+      missingBtn = document.createElement('button');
+      missingBtn.className = 'ksvBtn';
+      missingBtn.style.position = 'fixed';
+      missingBtn.style.right = '24px';
+      missingBtn.style.bottom = '24px';
+      document.body.appendChild(missingBtn);
     }
+
+    missingBtn.textContent = missing.length > 0 ? `Missing labels (${missing.length})` : 'Missing labels';
+    missingBtn.onclick = () => {
+      const api = window.tkLabels || window.TK_LABELS;
+      if (!api) return;
+      const latest = api.collectMissing(seenIds);
+      const msg = [
+        `You have ${latest.length} ids without labels.`,
+        'Add them to /data/labels-overrides.json.',
+        '',
+        latest.slice(0, 25).join(', ') + (latest.length > 25 ? ' …' : '')
+      ].join('\n');
+      alert(msg);
+      api.downloadMissing(seenIds);
+    };
+    missingBtn.style.display = '';
   }
 
-  function updateMissingButton(usedIds) {
-    const btn = document.getElementById('tk-missing-labels-btn');
-    if (!btn) return;
-    const uniqueIds = Array.from(new Set(usedIds)).filter(Boolean);
-    const missing = uniqueIds.filter(id => !hasKnownLabel(id));
-    if (missing.length) {
-      btn.style.display = '';
-      btn.onclick = () => downloadMissingLabels(missing.slice());
-    } else {
-      btn.style.display = 'none';
-      btn.onclick = null;
-    }
-  }
+  function buildUnansweredTable(aMap, bMap) {
+    const table = document.querySelector('#tk-unanswered tbody');
+    if (!table) return;
 
-  function downloadMissingLabels(missingIds) {
-    const stub = Object.fromEntries(missingIds.map(id => [id, '']));
-    downloadJSON('missing-labels.json', stub);
-  }
+    table.innerHTML = '';
 
-  function downloadJSON(filename, data) {
-    const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = filename;
-    document.body.appendChild(a);
-    a.click();
-    setTimeout(() => {
-      URL.revokeObjectURL(url);
-      a.remove();
-    }, 0);
-  }
-
-  // ---------- WIRE UP ----------
-  async function init() {
-    try {
-      const loaded = await loadLabels();
-      labelGetter = loaded.getLabel;
-      LABELS = { ...loaded.map };
-    } catch (err) {
-      console.warn('[labels] unable to load base labels:', err);
-      LABELS = {};
+    const hasResponses = (aMap && aMap.size) || (bMap && bMap.size);
+    if (!hasResponses) {
+      return;
     }
 
-    // Merge hard-coded fallbacks (normalized)
-    for (const [key, value] of Object.entries(FALLBACK_LABELS || {})) {
-      const norm = normalizeId(key);
-      if (norm && typeof value === 'string') LABELS[norm] = tighten(value);
-    }
+    Object.entries(GROUPS).forEach(([group, ids]) => {
+      if (!Array.isArray(ids) || !ids.length) return;
+      const anyA = ids.some(id => (aMap.get(id) ?? 0) > 0);
+      const anyB = ids.some(id => (bMap.get(id) ?? 0) > 0);
+      if (anyA || anyB) return;
 
-    const aBtn = $('#btnUploadA') || $('#uploadA');
-    const bBtn = $('#btnUploadB') || $('#uploadB');
-    const aFile = $('#fileA') || $('#surveyA');
-    const bFile = $('#fileB') || $('#surveyB');
-    const tableHost = $('#compatTable') || $('#compat-container') || $('#table');
-
-    let aAnswers = [];
-    let bAnswers = [];
-    let surveyARaw = null;
-    let surveyBRaw = null;
-
-    async function refresh() {
-      if (!tableHost) return;
-      await renderTable(tableHost, computeRows(aAnswers, bAnswers));
-    }
-
-    async function pickAndLoad(which) {
-      const inp = which === 'A' ? aFile : bFile;
-      if (!inp || !inp.files || !inp.files[0]) return;
-      try {
-        const raw = await readJsonFile(inp.files[0]);
-        const norm = normalizeSurvey(raw);
-        if (which === 'A') {
-          aAnswers = norm;
-          surveyARaw = raw;
-        } else {
-          bAnswers = norm;
-          surveyBRaw = raw;
-        }
-        AUTO_LABELS = mergeLabelsFromExports([surveyARaw, surveyBRaw]);
-        await refresh();
-      } catch (e) {
-        alert(`Invalid JSON for Survey ${which}. Please upload the unmodified JSON exported from this site.`);
-      }
-    }
-
-    if (aBtn && aFile) aBtn.addEventListener('click', () => aFile.click());
-    if (bBtn && bFile) bBtn.addEventListener('click', () => bFile.click());
-    if (aFile) aFile.addEventListener('change', () => pickAndLoad('A'));
-    if (bFile) bFile.addEventListener('change', () => pickAndLoad('B'));
-
-    // If you pre-hydrate from storage/cookies, do it here then refresh()
-  }
-
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', init);
-  } else {
-    init();
-  }
-})();
-
-(function addHardLabelOverrides(){
-  const HARD = {
-    "cb_wwf76": "Makeup specifics (brands, palette, rules)",
-    "cb_swujj": "Accessory or ornament rules"
-  };
-
-  // If you’re using the LabelService helper:
-  if (window.LabelService) {
-    const _get = LabelService.get.bind(LabelService);
-    LabelService.get = (id) => HARD[id] || _get(id);
-
-    // also exclude these from “missing labels”
-    if (typeof LabelService.missing === 'function') {
-      const _missing = LabelService.missing.bind(LabelService);
-      LabelService.missing = (ids) => _missing(ids).filter(id => !HARD[id]);
-    }
+      const tr = document.createElement('tr');
+      const tdGroup = document.createElement('td');
+      tdGroup.textContent = group;
+      const tdA = document.createElement('td');
+      const tdB = document.createElement('td');
+      tdA.textContent = '’';
+      tdB.textContent = '’';
+      tr.appendChild(tdGroup);
+      tr.appendChild(tdA);
+      tr.appendChild(tdB);
+      table.appendChild(tr);
+    });
   }
 })();


### PR DESCRIPTION
## Summary
- replace the compatibility label loader with a lightweight helper that merges base ids with optional overrides and exposes download tooling
- refresh the compatibility page script to use the new labels, render inline match bars, and populate a persistent unanswered categories table
- wire the page to the new helper by loading the supporting CSS/JS, updating the fallback percent cell builder, and seeding overrides for the requested ids

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68dda5a02938832cb1f41792a4a6a328