### PR TITLE
Restore central survey dataset and resilient loader

### DIFF
--- a/data/kinks.json
+++ b/data/kinks.json
@@ -1,40 +1,4943 @@
-{
-  "cb_zsnrb": "Dress partner’s outfit",
-  "cb_6jd2f": "Pick lingerie / base layers",
-  "cb_kgrnn": "Uniforms (schoolgirl, military, nurse, etc.)",
-  "cb_169ma": "Time-period dress-up",
-  "cb_4yyxa": "Dollification / polished object aesthetics",
-  "cb_2c0f9": "Hair-based play (brushing, ribbons, tying)",
-  "cb_qwnhi": "Head coverings / symbolic hoods",
-  "cb_zvchg": "Coordinated looks / dress codes",
-  "cb_qw9jg": "Ritualized grooming",
-  "cb_3ozhq": "Praise for pleasing visual display",
-  "cb_hqakm": "Formal appearance protocols",
-  "cb_rn136": "Clothing as power-role signal",
-
-  "cb_kua8l": "Matching looks / coordinated dress codes",
-  "cb_yzegd": "Ritualized grooming before scenes",
-  "cb_2gxmo": "Praise/positive attention for pleasing visual display",
-  "cb_kaku7": "Formal appearance protocols for scenes or dynamics",
-  "cb_qflrp": "Using clothing/style to embody power roles",
-  "cb_gkzbu": "Dollification—polished/presented object aesthetics",
-  "cb_r7cwr": "Uniforms (schoolgirl, military, clerical, nurse, etc.)",
-  "cb_w2dc1": "Time-period dress-up (regency, gothic, 1920s, etc.)",
-  "cb_ss4gf": "Hair-based play (forced brushing, ribbons, tied styles)",
-  "cb_fsnmj": "Head coverings/symbolic hoods in ritualized dynamics",
-  "cb_065gv": "Coordinated looks / dress codes (formal, scene-specific)",
-  "cb_ifkmg": "Ritualized grooming before scenes",
-  "cb_qege6": "Praise/positive attention for pleasing visual display",
-  "cb_s9861": "Formal appearance protocols (dress rules, standards)",
-  "cb_46bc3": "Clothing or style as explicit power-role signal",
-
-  "cb_zlfd1": "Dress partner’s outfit (directive/decision)",
-  "cb_tdbox": "Makeup as protocol or control",
-  "cb_ox5yg": "Makeup as protocol or control",
-  "cb_wwf76": "Makeup specifics (brands, palette, rules)",
-  "cb_swujj": "Accessory or ornament rules",
-  "cb_05hqj": "Wardrobe restrictions or permissions",
-  "cb_ykj4f": "Wardrobe restrictions or permissions",
-  "cb_swuij": "Scene-specific hair/face styling expectations",
-  "cb_6vf76": "Cosplay / character presentation"
-}
+[
+  {
+    "category": "Body Part Torture",
+    "items": [
+      {
+        "id": "body-part-torture-nipple-clips",
+        "label": "Nipple clips",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-torture-nipple-weights",
+        "label": "Nipple weights",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-torture-nipple-suction-cups",
+        "label": "Nipple suction cups",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-torture-cock-ball-torture-cbt",
+        "label": "Cock, Ball Torture (CBT)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-torture-clit-clips-weights-suction",
+        "label": "Clit clips/weights/suction",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-torture-hair-pulling",
+        "label": "Hair pulling",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-torture-face-slapping",
+        "label": "Face slapping",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-torture-butt-slapping",
+        "label": "Butt slapping",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-torture-breast-slapping",
+        "label": "Breast slapping",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-torture-genital-slapping",
+        "label": "Genital slapping",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Bondage and Suspension",
+    "items": [
+      {
+        "id": "bondage-and-suspension-blindfolds",
+        "label": "Blindfolds",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-bondage-heavy",
+        "label": "Bondage (heavy)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-bondage-light",
+        "label": "Bondage (light)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-immobilisation",
+        "label": "Immobilisation",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-bondage-multi-day",
+        "label": "Bondage (multi-day)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-bondage-public-under-clothing",
+        "label": "Bondage (public, under clothing)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-leather-restraints",
+        "label": "Leather restraints",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-chains",
+        "label": "Chains",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-ropes",
+        "label": "Ropes",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-intricate-japanese-rope-bondage",
+        "label": "Intricate (Japanese) rope bondage",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-rope-body-harness",
+        "label": "Rope body harness",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-arm-leg-sleeves-armbinders",
+        "label": "Arm & leg sleeves (armbinders)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-harnesses-leather",
+        "label": "Harnesses (leather)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-harnesses-rope",
+        "label": "Harnesses (rope)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-cuffs-leather",
+        "label": "Cuffs (leather)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-cuffs-metal",
+        "label": "Cuffs (metal)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-manacles-irons",
+        "label": "Manacles & Irons",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-gags-cloth",
+        "label": "Gags (cloth)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-gags-rubber",
+        "label": "Gags (rubber)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-gags-tape",
+        "label": "Gags (tape)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-gags-phallic",
+        "label": "Gags (phallic)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-gags-ring",
+        "label": "Gags (ring)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-gags-ball",
+        "label": "Gags (ball)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-mouth-bits",
+        "label": "Mouth bits",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-full-head-hoods",
+        "label": "Full head hoods",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-mummification-saran-wrapping",
+        "label": "Mummification/saran wrapping",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-straight-jackets",
+        "label": "Straight jackets",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-suspension-upright",
+        "label": "Suspension (upright)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-suspension-horizontal",
+        "label": "Suspension (horizontal)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-suspension-inverted",
+        "label": "Suspension (inverted)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-breath-play",
+        "label": "Breath play",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-smothering",
+        "label": "Smothering",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-forced-self-breath-control",
+        "label": "Forced self-breath-control",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-gas-mask",
+        "label": "Gas mask",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Breath Play",
+    "items": [
+      {
+        "id": "breath-play-asphyxiation",
+        "label": "Asphyxiation",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "breath-play-breath-control",
+        "label": "Breath control",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "breath-play-choking",
+        "label": "Choking",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "breath-play-drowning",
+        "label": "Drowning",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "breath-play-rebreathing-into-a-bag-or-object",
+        "label": "Rebreathing into a bag or object",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "breath-play-verbal-control-of-breath-e-g-hold-it-on-command",
+        "label": "Verbal control of breath (e.g., 'hold it' on command)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Sexual Activity",
+    "items": [
+      {
+        "id": "sexual-activity-licking",
+        "label": "Licking",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sexual-activity-fellatio-cunnilingus",
+        "label": "Fellatio/Cunnilingus",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sexual-activity-swallowing-semen",
+        "label": "Swallowing semen",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sexual-activity-cumming-on-partner",
+        "label": "Cumming on Partner",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sexual-activity-hand-jobs",
+        "label": "Hand jobs",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sexual-activity-anal-sex",
+        "label": "Anal sex",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sexual-activity-anal-plugs-small",
+        "label": "Anal plugs (small)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sexual-activity-anal-plugs-large",
+        "label": "Anal plugs (large)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sexual-activity-anal-beads",
+        "label": "Anal beads",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sexual-activity-vibrator-on-genitals",
+        "label": "Vibrator on genitals",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sexual-activity-fisting",
+        "label": "Fisting",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sexual-activity-oral-anal-play-rimming",
+        "label": "Oral/anal play (rimming)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sexual-activity-double-penetration-oral-and-vaginal",
+        "label": "Double penetration (oral and vaginal)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sexual-activity-double-penetration-oral-and-anal",
+        "label": "Double penetration (oral and anal)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sexual-activity-double-penetration-anal-and-vaginal",
+        "label": "Double penetration (anal and vaginal)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sexual-activity-triple-oral-vaginal-and-anal",
+        "label": "Triple (Oral, Vaginal and Anal)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Sensation Play",
+    "items": [
+      {
+        "id": "sensation-play-abrasion",
+        "label": "Abrasion",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sensation-play-scratching",
+        "label": "Scratching",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sensation-play-biting",
+        "label": "Biting",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sensation-play-tickling",
+        "label": "Tickling",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sensation-play-kissing",
+        "label": "Kissing",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sensation-play-zapping-e-g-electric-fly-swatter",
+        "label": "Zapping (e.g. electric fly swatter)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sensation-play-ice-cubes",
+        "label": "Ice cubes",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sensation-play-wax-play",
+        "label": "Wax Play",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sensation-play-fire",
+        "label": "Fire",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sensation-play-clothespins",
+        "label": "Clothespins",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sensation-play-needles",
+        "label": "Needles",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sensation-play-sensory-deprivation",
+        "label": "Sensory deprivation",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sensation-play-physical-overpowering-manhandling",
+        "label": "Physical overpowering / Manhandling",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sensation-play-figging",
+        "label": "Figging",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Other",
+    "items": [
+      {
+        "id": "other-feet",
+        "label": "Feet",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "other-boots",
+        "label": "Boots",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "other-underwear",
+        "label": "Underwear",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "other-chastity-devices",
+        "label": "Chastity devices",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "other-masks",
+        "label": "Masks",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "other-breeding",
+        "label": "Breeding",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "other-leather-clothing",
+        "label": "Leather clothing",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "other-training-protocols-outside-scenes-e-g-etiquette-memory",
+        "label": "Training protocols outside scenes (e.g., etiquette, memory)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "other-long-distance-training-structure",
+        "label": "Long-distance training/structure",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "other-scene-journaling-and-reflection",
+        "label": "Scene journaling and reflection",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Roleplaying",
+    "items": [
+      {
+        "id": "roleplaying-fantasy-abandonment",
+        "label": "Fantasy abandonment",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "roleplaying-kidnapping",
+        "label": "Kidnapping",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "roleplaying-interrogation",
+        "label": "Interrogation",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "roleplaying-sleep-deprivation",
+        "label": "Sleep deprivation",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "roleplaying-cnc",
+        "label": "CNC",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "roleplaying-gang-bang",
+        "label": "Gang bang",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "roleplaying-initiation-rites",
+        "label": "Initiation rites",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "roleplaying-religious-scenes",
+        "label": "Religious scenes",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "roleplaying-medical-scenes",
+        "label": "Medical scenes",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "roleplaying-prison-scenes",
+        "label": "Prison scenes",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "roleplaying-primal-prey",
+        "label": "Primal/Prey",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "roleplaying-schoolroom-scenes",
+        "label": "Schoolroom scenes",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Service and Restrictive Behaviour",
+    "items": [
+      {
+        "id": "service-and-restrictive-behaviour-following-orders",
+        "label": "(Following) orders",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-forced-servitude",
+        "label": "Forced servitude",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-restrictive-rules-on-behaviour",
+        "label": "Restrictive rules on behaviour",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-eye-contact-restrictions",
+        "label": "Eye contact restrictions",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-speech-restrictions-when-what-to-whom",
+        "label": "Speech restrictions (when, what, to whom)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-washroom-restrictions",
+        "label": "Washroom restrictions",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-punishments",
+        "label": "Punishments",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-tasks",
+        "label": "Tasks",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-massage",
+        "label": "Massage",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-domestic-tasks",
+        "label": "Domestic tasks",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-serving-food-and-drink",
+        "label": "Serving food and drink",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-personal-care-rituals",
+        "label": "Personal care rituals",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-being-on-call-at-specified-times",
+        "label": "Being on-call at specified times",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-daily-task-assignments",
+        "label": "Daily task assignments",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-corrections-for-imperfection",
+        "label": "Corrections for imperfection",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-uniforms-dress-codes",
+        "label": "Uniforms / Dress codes",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-kneeling-posture-presentation",
+        "label": "Kneeling / Posture presentation",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-silent-service",
+        "label": "Silent service",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-public-service-at-parties-or-events",
+        "label": "Public service (at parties or events)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-erotic-service-pleasure-on-command-without-seeking-your-own",
+        "label": "Erotic service (pleasure on command, without seeking your own)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Voyeurism/Exhibitionism",
+    "items": [
+      {
+        "id": "voyeurism-exhibitionism-forced-nudity-private",
+        "label": "Forced nudity (private)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "voyeurism-exhibitionism-forced-nudity-around-others",
+        "label": "Forced nudity (around others)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "voyeurism-exhibitionism-exhibitionism-friends",
+        "label": "Exhibitionism (friends)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "voyeurism-exhibitionism-exhibitionism-strangers",
+        "label": "Exhibitionism (strangers)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "voyeurism-exhibitionism-modelling-for-erotic-photos",
+        "label": "Modelling for erotic photos",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "voyeurism-exhibitionism-toys-under-clothes-in-public",
+        "label": "Toys under clothes in public",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Virtual & Long-Distance Play",
+    "items": [
+      {
+        "id": "virtual-long-distance-play-sending-tasks-or-orders-digitally",
+        "label": "Sending tasks or orders digitally",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-recording-dominant-voice-clips-commands-edging-praise-degradation-etc",
+        "label": "Recording dominant voice clips (commands, edging, praise, degradation, etc.)",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-remote-control-of-a-sex-toy",
+        "label": "Remote control of a sex toy",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-monitoring-behavior-via-app-or-shared-doc",
+        "label": "Monitoring behavior via app or shared doc",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-giving-punishment-assignments-remotely",
+        "label": "Giving punishment assignments remotely",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-creating-countdowns-timers-or-denial-periods",
+        "label": "Creating countdowns, timers, or denial periods",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-sending-written-instructions-with-delayed-permissions",
+        "label": "Sending written instructions with delayed permissions",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-creating-custom-video-or-audio-tasks",
+        "label": "Creating custom video or audio tasks",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-voice-message-control-during-scenes",
+        "label": "Voice message control during scenes",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-being-on-call-at-specified-times",
+        "label": "Being on-call at specified times",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-receiving-tasks-or-orders-digitally",
+        "label": "Receiving tasks or orders digitally",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-listening-to-dominant-voice-clips",
+        "label": "Listening to dominant voice clips",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-using-a-remote-controlled-toy-controlled-by-another",
+        "label": "Using a remote-controlled toy controlled by another",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-completing-daily-protocol-assignments",
+        "label": "Completing daily protocol assignments",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-submitting-proof-photo-video-text",
+        "label": "Submitting proof (photo, video, text)",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-following-recorded-or-timed-commands",
+        "label": "Following recorded or timed commands",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-receiving-surprise-instructions",
+        "label": "Receiving surprise instructions",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-hearing-name-praise-spoken-in-a-custom-clip",
+        "label": "Hearing name/praise spoken in a custom clip",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-sending-submissive-voice-clips-obedience-begging-thank-you-messages-affirmations-etc",
+        "label": "Sending submissive voice clips (obedience, begging, thank-you messages, affirmations, etc.)",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-scheduling-digital-rituals-or-reminders",
+        "label": "Scheduling digital rituals or reminders",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-using-training-habit-or-behavior-tracking-apps",
+        "label": "Using training, habit, or behavior-tracking apps",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-online-rituals-digital-kneeling-posture-protocols",
+        "label": "Online rituals (digital kneeling, posture protocols)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-role-based-texting-e-g-use-honorifics-in-chat",
+        "label": "Role-based texting (e.g., \"Use honorifics in chat\")",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-shared-playlists-affirmations-or-mantras",
+        "label": "Shared playlists, affirmations, or mantras",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-countdown-timers-to-next-task-release-or-interaction",
+        "label": "Countdown timers to next task, release, or interaction",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-scheduled-good-morning-night-rituals",
+        "label": "Scheduled good morning/night rituals",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-participating-in-video-call-scenes",
+        "label": "Participating in video call scenes",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-digital-aftercare-texts-voice-images",
+        "label": "Digital aftercare (texts, voice, images)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-sexting-or-digital-roleplay-scenes",
+        "label": "Sexting or digital roleplay scenes",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-voice-notes-or-submissive-dominant-affirmations",
+        "label": "Voice notes or submissive/dominant affirmations",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Communication",
+    "items": [
+      {
+        "id": "communication-playful-and-teasing",
+        "label": "Playful and teasing",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-quiet-and-intense",
+        "label": "Quiet and intense",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-observant-and-intentional",
+        "label": "Observant and intentional",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-praise-heavy",
+        "label": "Praise-heavy",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-blunt-and-efficient",
+        "label": "Blunt and efficient",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-affirming-and-soft",
+        "label": "Affirming and soft",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-psychological-interrogation",
+        "label": "Psychological interrogation",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-verbal-coercion-teasing-traps",
+        "label": "Verbal coercion / teasing traps",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-verbal-misdirection",
+        "label": "Verbal misdirection",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-mocking-shaming",
+        "label": "Mocking / shaming",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-predatory-pacing",
+        "label": "Predatory pacing",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-reluctant-obedience",
+        "label": "Reluctant obedience",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-stammering-submission",
+        "label": "Stammering submission",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-challenging-until-caught",
+        "label": "Challenging until caught",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-quiet-surrender",
+        "label": "Quiet surrender",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-sarcastic-teasing",
+        "label": "Sarcastic teasing",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-provoking-tone",
+        "label": "Provoking tone",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-challenge-based-dialogue",
+        "label": "Challenge-based dialogue",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-double-meaning-banter",
+        "label": "Double-meaning banter",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-soft-spoken-guidance",
+        "label": "Soft-spoken guidance",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-protective-but-firm-tone",
+        "label": "Protective but firm tone",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-emotional-redirection",
+        "label": "Emotional redirection",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-steady-reassurance",
+        "label": "Steady reassurance",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-direct-and-clear",
+        "label": "Direct and clear",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-gentle-and-nurturing",
+        "label": "Gentle and nurturing",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-commanding-and-firm",
+        "label": "Commanding and firm",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-quiet-and-observant",
+        "label": "Quiet and observant",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-instructive-teacher-like",
+        "label": "Instructive / teacher-like",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-emotionally-intense",
+        "label": "Emotionally intense",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-dismissive-withholding",
+        "label": "Dismissive / withholding",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-mocking-sarcastic",
+        "label": "Mocking / sarcastic",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-blunt-tactless",
+        "label": "Blunt / tactless",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-predatory-hunting-tone",
+        "label": "Predatory / hunting tone",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-stalking-or-circling-speech",
+        "label": "Stalking or circling speech",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-you-re-mine-control-language",
+        "label": "You’re mine / control language",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-threatening-consensual",
+        "label": "Threatening (consensual)",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-verbal-cornering-coaxing",
+        "label": "Verbal cornering / coaxing",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-watching-you-unravel",
+        "label": "Watching you unravel",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-cruel-and-cutting",
+        "label": "Cruel and cutting",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-psychological-baiting",
+        "label": "Psychological baiting",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-brat-breaking-language",
+        "label": "Brat-breaking language",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-mock-affection",
+        "label": "Mock affection",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-shaming-or-emotional-edge",
+        "label": "Shaming or emotional edge",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-disappointed-dom-voice",
+        "label": "Disappointed dom voice",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-mild-scolding-mocking-affection",
+        "label": "Mild scolding / mocking affection",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-verbal-power-struggle",
+        "label": "Verbal power struggle",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-challenge-response-dynamics",
+        "label": "Challenge-response dynamics",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-warm-tone-with-expectation",
+        "label": "Warm tone with expectation",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-nurturing-dominance",
+        "label": "Nurturing dominance",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-reassuring-commands",
+        "label": "Reassuring commands",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-phrases-that-work-on-you",
+        "label": "Phrases that work on you",
+        "type": "text",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "communication-phrases-you-use-or-like-to-give",
+        "label": "Phrases you use or like to give",
+        "type": "text",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "communication-what-helps-you-feel-emotionally-safe",
+        "label": "What helps you feel emotionally safe",
+        "type": "text",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "communication-how-you-tend-to-show-affection",
+        "label": "How you tend to show affection",
+        "type": "text",
+        "options": [
+          "Words of affirmation",
+          "Acts of service",
+          "Through teasing / play",
+          "Through obedience",
+          "Through caretaking",
+          "Withholding / teasing love",
+          "Physical closeness",
+          "Quality time"
+        ],
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "communication-emotional-check-in-style",
+        "label": "Emotional check-in style",
+        "type": "text",
+        "options": [
+          "Daily texting",
+          "After-scene debriefs",
+          "Scheduled check-ins",
+          "Mix of text/video check-ins",
+          "In-person check-ins",
+          "Journaling together",
+          "Minimal / low contact",
+          "Other"
+        ],
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "communication-when-emotionally-activated-i-tend-to",
+        "label": "When emotionally activated, I tend to...",
+        "type": "text",
+        "options": [
+          "Shut down",
+          "Overexplain / fawn",
+          "Get sarcastic / prickly",
+          "Spiral internally",
+          "Ask for reassurance",
+          "Withdraw",
+          "Other"
+        ],
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Body Fluids and Functions",
+    "items": [
+      {
+        "id": "body-fluids-and-functions-watersports-golden-showers",
+        "label": "Watersports/golden showers",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-fluids-and-functions-cum",
+        "label": "Cum",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-fluids-and-functions-blood",
+        "label": "Blood",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-fluids-and-functions-scat",
+        "label": "Scat",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-fluids-and-functions-sweat",
+        "label": "Sweat",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-fluids-and-functions-vomit",
+        "label": "Vomit",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-fluids-and-functions-tears-crying",
+        "label": "Tears/crying",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Psychological Primal / Prey",
+    "items": [
+      {
+        "id": "psychological-primal-prey-primal-prey",
+        "label": "Primal/Prey",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychological-primal-prey-conditioning",
+        "label": "Conditioning",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychological-primal-prey-coc",
+        "label": "COC",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychological-primal-prey-psycholagny-hands-free-mentally-stimulated-orgasm",
+        "label": "Psycholagny (hands free, mentally stimulated orgasm)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychological-primal-prey-hypno-play",
+        "label": "Hypno Play",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychological-primal-prey-praise",
+        "label": "Praise",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychological-primal-prey-degradation",
+        "label": "Degradation",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychological-primal-prey-traditional-primal-prey",
+        "label": "Traditional primal/prey",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychological-primal-prey-fear-play",
+        "label": "Fear play",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychological-primal-prey-objectification",
+        "label": "Objectification",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychological-primal-prey-gaslighting",
+        "label": "Gaslighting",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychological-primal-prey-role-erosion-identity-play-loss-of-self",
+        "label": "Role erosion (identity play / loss of self)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychological-primal-prey-jealousy-play",
+        "label": "Jealousy play",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychological-primal-prey-manipulation",
+        "label": "Manipulation",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Body Part / Fetish Play",
+    "items": [
+      {
+        "id": "body-part-fetish-play-belly-fucking",
+        "label": "Belly fucking",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-navel-play",
+        "label": "Navel play",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-feet-foot-worship",
+        "label": "Feet / Foot worship",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-hands",
+        "label": "Hands",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-hair",
+        "label": "Hair",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-thighs",
+        "label": "Thighs",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-neck",
+        "label": "Neck",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-ears",
+        "label": "Ears",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-belly",
+        "label": "Belly",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-voice-fetish",
+        "label": "Voice fetish",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-nails-makeup-fetish",
+        "label": "Nails / Makeup fetish",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-cuddles",
+        "label": "Cuddles",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-food-play",
+        "label": "Food Play",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-kisses",
+        "label": "Kisses",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-masturbation",
+        "label": "Masturbation",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-romance-affection",
+        "label": "Romance / affection",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-sex-toys",
+        "label": "Sex toys",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-sexting-chat-etc",
+        "label": "Sexting /Chat etc",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-sexting-via-phone-or-video-call",
+        "label": "Sexting via phone or video call",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-strip-tease",
+        "label": "Strip tease",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-vanilla-sex",
+        "label": "Vanilla Sex",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-voice-notes",
+        "label": "Voice Notes",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-shaving-body-hair",
+        "label": "Shaving (body hair)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-sexy-clothing-private",
+        "label": "Sexy clothing (private)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-sexy-clothing-public",
+        "label": "Sexy clothing (public)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-outdoor-scenes",
+        "label": "Outdoor scenes",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-public-exposure",
+        "label": "Public exposure",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Orgasm Control & Sexual Manipulation",
+    "items": [
+      {
+        "id": "orgasm-control-sexual-manipulation-edging",
+        "label": "Edging",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-short-term-denial",
+        "label": "Short term denial",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-long-term-denial",
+        "label": "Long term denial",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-forced-orgasms-overstimulation",
+        "label": "Forced orgasms / Overstimulation",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-ruined-orgasms",
+        "label": "Ruined orgasms",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-no-touch-periods",
+        "label": "No touch periods",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-milking",
+        "label": "Milking",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-chastity-devices",
+        "label": "Chastity devices",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-consensual-orgasm-control",
+        "label": "Consensual orgasm control",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-forced-masturbation",
+        "label": "Forced masturbation",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Protocol and Ritual",
+    "items": [
+      {
+        "id": "protocol-and-ritual-formal-language",
+        "label": "Formal language",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-greeting-and-departure-rituals-kneeling-verbal-scripts-gestures",
+        "label": "Greeting and departure rituals (kneeling, verbal scripts, gestures)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-requiring-permission-for-things-speech-movement-attire",
+        "label": "Requiring permission for things (speech, movement, attire)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-daily-rituals-morning-check-ins-status-reports-mantra-repetitions",
+        "label": "Daily rituals (morning check-ins, status reports, mantra repetitions)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-specific-postures-for-rest-attention-punishment-waiting",
+        "label": "Specific postures for rest, attention, punishment, waiting",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-restricted-behavior-no-eye-contact-silence-no-questions",
+        "label": "Restricted behavior (no eye contact, silence, no questions)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-ritual-object-use-collar-cuffs-leash-tokens",
+        "label": "Ritual object use (collar, cuffs, leash, tokens)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-tracking-obedience-journals-apps",
+        "label": "Tracking obedience (journals, apps)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-formalized-rules-for-misbehavior-and-correction",
+        "label": "Formalized rules for misbehavior and correction",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-ritualized-aftercare-or-scene-closure",
+        "label": "Ritualized aftercare or scene closure",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-object-retrieval-on-all-fours-with-item-in-mouth",
+        "label": "Object retrieval on all fours with item in mouth",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-fetching-hairbrush-or-punishment-tool-from-dresser-while-crawling",
+        "label": "Fetching hairbrush or punishment tool from dresser while crawling",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-presenting-chosen-discipline-tool-in-kneeling-posture",
+        "label": "Presenting chosen discipline tool in kneeling posture",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-assigned-posture-or-kneeling-positions-as-ritual",
+        "label": "Assigned posture or kneeling positions as ritual",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-requesting-permission-using-specific-protocol-phrases",
+        "label": "Requesting permission using specific protocol phrases",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-carrying-items-in-mouth-as-submissive-gesture",
+        "label": "Carrying items in mouth as submissive gesture",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-crawling-back-with-object-to-dominant-after-retrieval",
+        "label": "Crawling back with object to Dominant after retrieval",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-following-via-nipple-leash-as-protocol-or-punishment",
+        "label": "Following via nipple leash as protocol or punishment",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-crawling-assigned-paths-as-ritual-or-obedience-training",
+        "label": "Crawling assigned paths as ritual or obedience training",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-crawling-rituals-e-g-object-retrieval",
+        "label": "Crawling rituals (e.g., object retrieval)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-carrying-objects-in-mouth-as-obedience",
+        "label": "Carrying objects in mouth as obedience",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-presenting-tools-or-toys-in-posture",
+        "label": "Presenting tools or toys in posture",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-using-honorifics-or-preset-protocol-language",
+        "label": "Using honorifics or preset protocol language",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-greeting-rituals-e-g-kneeling-kissing-feet",
+        "label": "Greeting rituals (e.g., kneeling, kissing feet)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-daily-check-ins-or-structured-reports",
+        "label": "Daily check-ins or structured reports",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-clothing-restrictions-or-uniforms",
+        "label": "Clothing restrictions or uniforms",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-posture-training-sitting-kneeling-standing",
+        "label": "Posture training (sitting, kneeling, standing)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-punishments-for-incorrect-behavior-or-tone",
+        "label": "Punishments for incorrect behavior or tone",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-crawling-with-items-in-mouth-e-g-hairbrush-spoon",
+        "label": "Crawling with items in mouth (e.g., hairbrush, spoon)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-earning-permission-for-meals-bathroom-use-or-rest",
+        "label": "Earning permission for meals, bathroom use, or rest",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-following-daily-rituals-or-protocol",
+        "label": "Following daily rituals or protocol",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-structured-speech-rules-e-g-titles-third-person",
+        "label": "Structured speech rules (e.g., titles, third person)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-receiving-correction-when-out-of-line",
+        "label": "Receiving correction when out of line",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-inspection-rituals-or-readiness-checks",
+        "label": "Inspection rituals or readiness checks",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Primal & Bratting",
+    "items": [
+      {
+        "id": "primal-bratting-chase-and-capture-play",
+        "label": "Chase and capture play",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "primal-bratting-bratting-for-punishment",
+        "label": "Bratting for punishment",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "primal-bratting-playful-growling-and-biting",
+        "label": "Playful growling and biting",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "primal-bratting-provoking-with-teasing-or-taunts",
+        "label": "Provoking with teasing or taunts",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "primal-bratting-escaping-or-hiding-to-encourage-pursuit",
+        "label": "Escaping or hiding to encourage pursuit",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "primal-bratting-refusing-commands-just-for-fun",
+        "label": "Refusing commands just for fun",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "primal-bratting-provoking-your-partner-to-chase-or-discipline-you",
+        "label": "Provoking your partner to chase or discipline you",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "primal-bratting-taunting-or-teasing-as-a-form-of-play",
+        "label": "Taunting or teasing as a form of play",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "primal-bratting-intentional-resistance-during-power-exchange",
+        "label": "Intentional resistance during power exchange",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "primal-bratting-being-caught-and-overpowered",
+        "label": "Being caught and overpowered",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Headspace & Regression",
+    "items": [
+      {
+        "id": "headspace-regression-caregiver-little-regression-play",
+        "label": "Caregiver/little regression play",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "headspace-regression-using-pacifiers-or-sippy-cups",
+        "label": "Using pacifiers or sippy cups",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "headspace-regression-coloring-or-childlike-crafts",
+        "label": "Coloring or childlike crafts",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "headspace-regression-stuffed-animal-comfort",
+        "label": "Stuffed animal comfort",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "headspace-regression-speaking-in-a-childlike-voice",
+        "label": "Speaking in a childlike voice",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "headspace-regression-bedtime-stories-or-lullabies",
+        "label": "Bedtime stories or lullabies",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "headspace-regression-entering-altered-headspaces-e-g-prey-pet-little",
+        "label": "Entering altered headspaces (e.g., prey, pet, little)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "headspace-regression-regressive-behaviors-as-comfort-coloring-babytalk",
+        "label": "Regressive behaviors as comfort (coloring, babytalk)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "headspace-regression-being-cared-for-during-emotional-vulnerability",
+        "label": "Being cared for during emotional vulnerability",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "headspace-regression-guided-emotional-headspace-entry",
+        "label": "Guided emotional headspace entry",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Performance & Internal Struggle",
+    "items": [
+      {
+        "id": "performance-internal-struggle-obedience-under-observation",
+        "label": "Obedience under observation",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "performance-internal-struggle-speech-restriction-and-self-denial",
+        "label": "Speech restriction and self-denial",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "performance-internal-struggle-maintaining-composure-during-humiliation",
+        "label": "Maintaining composure during humiliation",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "performance-internal-struggle-obedience-drills-for-an-audience",
+        "label": "Obedience drills for an audience",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "performance-internal-struggle-struggling-against-personal-urges",
+        "label": "Struggling against personal urges",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "performance-internal-struggle-displaying-submission-despite-conflict",
+        "label": "Displaying submission despite conflict",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "performance-internal-struggle-being-told-to-act-normal-while-struggling-internally",
+        "label": "Being told to act normal while struggling internally",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "performance-internal-struggle-pleasing-through-high-functioning-obedience",
+        "label": "Pleasing through high-functioning obedience",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "performance-internal-struggle-performing-submission-while-masking-resistance",
+        "label": "Performing submission while masking resistance",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "performance-internal-struggle-the-pressure-of-appearing-good-while-feeling-conflicted",
+        "label": "The pressure of appearing 'good' while feeling conflicted",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "performance-internal-struggle-being-made-to-perform-emotions-on-command-cry-beg-moan",
+        "label": "Being made to perform emotions on command (cry, beg, moan)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "performance-internal-struggle-struggling-openly-while-still-obeying",
+        "label": "Struggling openly while still obeying",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "performance-internal-struggle-performing-exaggerated-resistance-or-denial",
+        "label": "Performing exaggerated resistance or denial",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "performance-internal-struggle-being-punished-for-breaking-character",
+        "label": "Being punished for 'breaking character'",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "performance-internal-struggle-putting-on-a-show-for-someone-else-s-pleasure",
+        "label": "Putting on a show for someone else’s pleasure",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "performance-internal-struggle-rehearsed-degradation-or-humiliation-scripts",
+        "label": "Rehearsed degradation or humiliation scripts",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Mindfuck & Manipulation",
+    "items": [
+      {
+        "id": "mindfuck-manipulation-confusing-commands-and-reality-shifts",
+        "label": "Confusing commands and reality shifts",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mindfuck-manipulation-gaslighting-or-contradictory-cues",
+        "label": "Gaslighting or contradictory cues",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mindfuck-manipulation-presenting-false-choices",
+        "label": "Presenting false choices",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mindfuck-manipulation-hidden-motives-or-secret-tasks",
+        "label": "Hidden motives or secret tasks",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mindfuck-manipulation-illogical-rules-meant-to-confuse",
+        "label": "Illogical rules meant to confuse",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mindfuck-manipulation-gaslight-style-scenes-with-consent-and-clarity",
+        "label": "Gaslight-style scenes (with consent and clarity)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mindfuck-manipulation-false-threats-or-staged-surprises",
+        "label": "False threats or staged surprises",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mindfuck-manipulation-confusing-commands-to-prompt-hesitation",
+        "label": "Confusing commands to prompt hesitation",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mindfuck-manipulation-emotional-trickery-as-arousal",
+        "label": "Emotional trickery as arousal",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mindfuck-manipulation-being-misled-or-deceived-on-purpose-during-play",
+        "label": "Being misled or deceived on purpose during play",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mindfuck-manipulation-surprise-rule-changes-or-twists-mid-scene",
+        "label": "Surprise rule changes or twists mid-scene",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mindfuck-manipulation-false-safeword-games-with-negotiated-limits",
+        "label": "False safeword games (with negotiated limits)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mindfuck-manipulation-withholding-or-delaying-aftercare-for-effect",
+        "label": "Withholding or delaying aftercare for effect",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mindfuck-manipulation-being-gaslit-or-doubted-in-a-controlled-roleplay",
+        "label": "Being gaslit or doubted in a controlled roleplay",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mindfuck-manipulation-told-you-asked-for-this-or-you-love-this-when-resisting",
+        "label": "Told 'you asked for this' or 'you love this' when resisting",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Mouth Play",
+    "items": [
+      {
+        "id": "mouth-play-holding-tools-or-restraints-in-teeth-while-crawling",
+        "label": "Holding tools or restraints in teeth while crawling",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mouth-play-placing-objects-from-mouth-into-dominant-s-palm",
+        "label": "Placing objects from mouth into Dominant’s palm",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mouth-play-using-mouth-instead-of-hands-for-service-rituals",
+        "label": "Using mouth instead of hands for service rituals",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mouth-play-gag-presentation-and-silent-waiting-protocol",
+        "label": "Gag presentation and silent waiting protocol",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mouth-play-holding-objects-in-teeth-while-crawling",
+        "label": "Holding objects in teeth while crawling",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mouth-play-returning-items-using-mouth-only",
+        "label": "Returning items using mouth only",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mouth-play-gag-rituals-or-waiting-silently",
+        "label": "Gag rituals or waiting silently",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mouth-play-leash-held-in-mouth",
+        "label": "Leash held in mouth",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mouth-play-being-gagged-or-forced-silent",
+        "label": "Being gagged or forced silent",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mouth-play-having-to-hold-objects-in-your-mouth-spoon-hairbrush-leash",
+        "label": "Having to hold objects in your mouth (spoon, hairbrush, leash)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mouth-play-being-used-for-oral-service-without-reciprocal-pleasure",
+        "label": "Being used for oral service without reciprocal pleasure",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mouth-play-being-fed-by-hand-mouth-to-mouth-or-with-utensils",
+        "label": "Being fed by hand, mouth-to-mouth, or with utensils",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mouth-play-verbal-control-e-g-only-speak-when-spoken-to",
+        "label": "Verbal control (e.g., only speak when spoken to)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mouth-play-mouth-as-a-symbol-of-ownership-or-control",
+        "label": "Mouth as a symbol of ownership or control",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Impact Play",
+    "items": [
+      {
+        "id": "impact-play-hand-spanking",
+        "label": "Hand spanking",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "impact-play-paddle-strikes",
+        "label": "Paddle strikes",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "impact-play-crop-snaps",
+        "label": "Crop snaps",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "impact-play-flogger-swings",
+        "label": "Flogger swings",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "impact-play-cane-strokes",
+        "label": "Cane strokes",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "impact-play-belt-or-strap-hits",
+        "label": "Belt or strap hits",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "impact-play-whip-cracks",
+        "label": "Whip cracks",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "impact-play-preferred-intensity-levels",
+        "label": "Preferred intensity levels",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "impact-play-aftercare-for-bruises",
+        "label": "Aftercare for bruises",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "impact-play-target-body-areas",
+        "label": "Target body areas",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "impact-play-implement-selection",
+        "label": "Implement selection",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Medical Play",
+    "items": [
+      {
+        "id": "medical-play-needle-play",
+        "label": "Needle play",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "medical-play-catheter-insertion",
+        "label": "Catheter insertion",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "medical-play-speculum-exams",
+        "label": "Speculum exams",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "medical-play-enema-administration",
+        "label": "Enema administration",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "medical-play-temperature-taking",
+        "label": "Temperature taking",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "medical-play-medical-restraints",
+        "label": "Medical restraints",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "medical-play-doctor-nurse-roleplay",
+        "label": "Doctor/nurse roleplay",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "medical-play-sterilization-procedures",
+        "label": "Sterilization procedures",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "medical-play-professional-vs-roleplay-scenes",
+        "label": "Professional vs roleplay scenes",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "medical-play-consent-for-invasive-acts",
+        "label": "Consent for invasive acts",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "medical-play-access-to-medical-equipment",
+        "label": "Access to medical equipment",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Pet Play",
+    "items": [
+      {
+        "id": "pet-play-puppy-or-kitten-play",
+        "label": "Puppy or kitten play",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "pet-play-pony-play",
+        "label": "Pony play",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "pet-play-wearing-collar-and-leash",
+        "label": "Wearing collar and leash",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "pet-play-eating-from-a-bowl",
+        "label": "Eating from a bowl",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "pet-play-kenneling-or-caging",
+        "label": "Kenneling or caging",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "pet-play-pet-training-commands",
+        "label": "Pet training commands",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "pet-play-animal-costumes-or-gear",
+        "label": "Animal costumes or gear",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "pet-play-preferred-animal-identities",
+        "label": "Preferred animal identities",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "pet-play-public-vs-private-play",
+        "label": "Public vs private play",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "pet-play-training-style-and-discipline",
+        "label": "Training style and discipline",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "pet-play-use-of-pet-names-and-commands",
+        "label": "Use of pet names and commands",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Body Modification",
+    "items": [
+      {
+        "id": "body-modification-piercings",
+        "label": "Piercings",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-modification-tattoos",
+        "label": "Tattoos",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-modification-branding",
+        "label": "Branding",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-modification-scarification",
+        "label": "Scarification",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-modification-permanent-chastity-devices",
+        "label": "Permanent chastity devices",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-modification-cosmetic-implants",
+        "label": "Cosmetic implants",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-modification-stretching-or-gauges",
+        "label": "Stretching or gauges",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-modification-temporary-vs-permanent-changes",
+        "label": "Temporary vs permanent changes",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-modification-professional-vs-diy-methods",
+        "label": "Professional vs DIY methods",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-modification-body-placement-considerations",
+        "label": "Body placement considerations",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-modification-healing-and-aftercare",
+        "label": "Healing and aftercare",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Relationship Preferences",
+    "items": [
+      {
+        "id": "relationship-preferences-preferred-relationship-style",
+        "label": "Preferred relationship style",
+        "type": "text",
+        "options": [
+          "Monogamous",
+          "Open relationship",
+          "Polyamorous",
+          "No preference"
+        ],
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "relationship-preferences-relationship-goals",
+        "label": "Relationship goals",
+        "type": "text",
+        "options": [
+          "One night stand",
+          "Short-term play",
+          "Long-term relationship",
+          "Platonic play partners",
+          "Romantic partners",
+          "Kink partners"
+        ],
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "relationship-preferences-monogamous",
+        "label": "Monogamous",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "relationship-preferences-polyamorous",
+        "label": "Polyamorous",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "relationship-preferences-hierarchical-dynamics",
+        "label": "Hierarchical dynamics",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "relationship-preferences-non-hierarchical-poly",
+        "label": "Non-hierarchical poly",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "relationship-preferences-solo-poly",
+        "label": "Solo-poly",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "relationship-preferences-open-with-boundaries",
+        "label": "Open with boundaries",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "relationship-preferences-closed-but-kinky-with-others",
+        "label": "Closed but kinky with others",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "relationship-preferences-switch-friendly-dynamics",
+        "label": "Switch-friendly dynamics",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Gender Play & Transformation",
+    "items": [
+      {
+        "id": "gender-play-transformation-crossdressing",
+        "label": "Crossdressing",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "gender-play-transformation-forced-feminization",
+        "label": "Forced feminization",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "gender-play-transformation-forced-masculinization",
+        "label": "Forced masculinization",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "gender-play-transformation-gender-role-reversal",
+        "label": "Gender role reversal",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "gender-play-transformation-pronoun-changes",
+        "label": "Pronoun changes",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "gender-play-transformation-voice-or-mannerism-training",
+        "label": "Voice or mannerism training",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "gender-play-transformation-sissy-or-tomboy-persona",
+        "label": "Sissy or tomboy persona",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "gender-play-transformation-preferred-pronouns-and-names",
+        "label": "Preferred pronouns and names",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "gender-play-transformation-public-presentation-comfort",
+        "label": "Public presentation comfort",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "gender-play-transformation-clothing-and-appearance",
+        "label": "Clothing and appearance",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "gender-play-transformation-exploration-of-identity",
+        "label": "Exploration of identity",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Chastity Devices",
+    "items": [
+      {
+        "id": "chastity-devices-wearing-a-chastity-cage-short-term",
+        "label": "Wearing a chastity cage (short term)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "chastity-devices-long-term-chastity-training",
+        "label": "Long-term chastity training",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "chastity-devices-chastity-device-control-with-permission-to-unlock",
+        "label": "Chastity device control with permission to unlock",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "chastity-devices-locked-remotely-by-another-person",
+        "label": "Locked remotely by another person",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "chastity-devices-orgasm-denial-enforced-by-chastity",
+        "label": "Orgasm denial enforced by chastity",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "chastity-devices-wearing-a-belt-style-chastity-device",
+        "label": "Wearing a belt-style chastity device",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "chastity-devices-humiliation-while-locked-in-chastity",
+        "label": "Humiliation while locked in chastity",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "chastity-devices-sleep-in-chastity-overnight",
+        "label": "Sleep in chastity (overnight)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "chastity-devices-being-teased-while-unable-to-touch-yourself",
+        "label": "Being teased while unable to touch yourself",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "chastity-devices-begging-for-release-from-chastity",
+        "label": "Begging for release from chastity",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Shibari & Rope Bondage",
+    "items": [
+      {
+        "id": "shibari-rope-bondage-being-tied-in-aesthetic-rope-patterns-shibari",
+        "label": "Being tied in aesthetic rope patterns (Shibari)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "shibari-rope-bondage-rope-bondage-for-restraint-and-control",
+        "label": "Rope bondage for restraint and control",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "shibari-rope-bondage-rope-suspension-partial-or-full",
+        "label": "Rope suspension (partial or full)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "shibari-rope-bondage-learning-to-tie-rope-as-a-form-of-dominance",
+        "label": "Learning to tie rope as a form of dominance",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "shibari-rope-bondage-being-tied-in-vulnerable-or-exposing-poses",
+        "label": "Being tied in vulnerable or exposing poses",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "shibari-rope-bondage-practicing-rope-with-emotional-connection",
+        "label": "Practicing rope with emotional connection",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "shibari-rope-bondage-enduring-discomfort-for-the-beauty-of-the-rope",
+        "label": "Enduring discomfort for the beauty of the rope",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "shibari-rope-bondage-being-tied-in-a-mirror-and-told-to-look",
+        "label": "Being tied in a mirror and told to look",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "shibari-rope-bondage-punishment-ties-e-g-uncomfortable-or-humiliating-positions",
+        "label": "Punishment ties (e.g., uncomfortable or humiliating positions)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "shibari-rope-bondage-solo-rope-practice-for-mindfulness-or-masochism",
+        "label": "Solo rope practice for mindfulness or masochism",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Cosplay & Identity Play",
+    "items": [
+      {
+        "id": "cosplay-identity-play-dressing-up-in-costumes-for-scenes",
+        "label": "Dressing up in costumes for scenes",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "cosplay-identity-play-playing-as-fictional-characters",
+        "label": "Playing as fictional characters",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "cosplay-identity-play-petplay-with-collars-ears-or-tails",
+        "label": "Petplay with collars, ears, or tails",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "cosplay-identity-play-pretending-to-be-a-doll-robot-or-object",
+        "label": "Pretending to be a doll, robot, or object",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "cosplay-identity-play-master-slave-cosplay-dynamic-non-24-7",
+        "label": "Master/slave cosplay dynamic (non-24/7)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "cosplay-identity-play-roleplaying-as-a-fantasy-species-or-non-human",
+        "label": "Roleplaying as a fantasy species or non-human",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "cosplay-identity-play-using-cosplay-to-deepen-power-exchange",
+        "label": "Using cosplay to deepen power exchange",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "cosplay-identity-play-scene-built-around-a-character-s-story-or-world",
+        "label": "Scene built around a character’s story or world",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "cosplay-identity-play-fantasy-uniforms-nurse-teacher-etc",
+        "label": "Fantasy uniforms (nurse, teacher, etc.)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "High-Intensity Kinks (SSC-Aware)",
+    "items": [
+      {
+        "id": "high-intensity-kinks-ssc-aware-intense-breath-play-e-g-smothering-or-pressure",
+        "label": "Intense breath play (e.g., smothering or pressure)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-knife-play-or-blade-play-without-injury",
+        "label": "Knife play or blade play (without injury)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-fear-play-using-known-or-negotiated-triggers",
+        "label": "Fear play using known or negotiated triggers",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-abduction-or-home-invasion-style-roleplay-negotiated",
+        "label": "Abduction or home-invasion style roleplay (negotiated)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-medical-themed-scenes-with-sharp-objects-not-bloodletting",
+        "label": "Medical-themed scenes with sharp objects (not bloodletting)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-sensory-deprivation-with-added-disorientation-or-helplessness",
+        "label": "Sensory deprivation with added disorientation or helplessness",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-scenes-involving-heavy-objectification-or-emotional-manipulation-with-care",
+        "label": "Scenes involving heavy objectification or emotional manipulation (with care)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-mock-interrogation-or-intense-role-pressure",
+        "label": "Mock interrogation or intense role pressure",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-consensual-threats-without-follow-through-e-g-if-you-don-t",
+        "label": "Consensual threats without follow-through (e.g. 'If you don’t...')",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-high-intensity-primal-scenes-involving-struggle-or-fear",
+        "label": "High-intensity primal scenes involving struggle or fear",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Behavioral Play",
+    "items": [
+      {
+        "id": "behavioral-play-assigning-corner-time-or-time-outs",
+        "label": "Assigning corner time or time-outs",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "behavioral-play-writing-lines-or-apology-letters-as-correction",
+        "label": "Writing lines or apology letters as correction",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "behavioral-play-removing-privileges-phone-tv-sweets",
+        "label": "Removing privileges (phone, TV, sweets)",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "behavioral-play-playful-punishments-that-still-reinforce-rules",
+        "label": "Playful punishments that still reinforce rules",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "behavioral-play-lecturing-or-scolding-to-modify-behavior",
+        "label": "Lecturing or scolding to modify behavior",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "behavioral-play-being-placed-in-the-corner-or-given-a-time-out",
+        "label": "Being placed in the corner or given a time-out",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "behavioral-play-writing-lines-or-apology-letters-when-misbehaving",
+        "label": "Writing lines or apology letters when misbehaving",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "behavioral-play-having-privileges-revoked-phone-tv",
+        "label": "Having privileges revoked (phone, TV)",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "behavioral-play-receiving-playful-funishments-for-minor-rule-breaking",
+        "label": "Receiving playful 'funishments' for minor rule-breaking",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "behavioral-play-getting-scolded-or-lectured-for-correction",
+        "label": "Getting scolded or lectured for correction",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "behavioral-play-preferred-style-of-discipline-strict-vs-lenient",
+        "label": "Preferred style of discipline (strict vs lenient)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "behavioral-play-attitude-toward-funishment-vs-serious-correction",
+        "label": "Attitude toward funishment vs serious correction",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "behavioral-play-use-of-behavior-contracts-or-rule-agreements",
+        "label": "Use of behavior contracts or rule agreements",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Appearance Play",
+    "items": [
+      {
+        "id": "appearance-play-choosing-my-partner-s-outfit-for-the-day-or-a-scene",
+        "label": "Choosing my partner’s outfit for the day or a scene",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "appearance-play-selecting-their-underwear-lingerie-or-base-layers",
+        "label": "Selecting their underwear, lingerie, or base layers",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "appearance-play-styling-their-hair-braiding-brushing-tying-etc",
+        "label": "Styling their hair (braiding, brushing, tying, etc.)",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "appearance-play-picking-head-coverings-bonnets-veils-hoods-hats-for-mood-or-protocol",
+        "label": "Picking head coverings (bonnets, veils, hoods, hats) for mood or protocol",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "appearance-play-offering-makeup-polish-or-accessories-as-part-of-ritual-or-play",
+        "label": "Offering makeup, polish, or accessories as part of ritual or play",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "appearance-play-creating-themed-looks-slutty-innocent-doll-like-sharp-etc",
+        "label": "Creating themed looks (slutty, innocent, doll-like, sharp, etc.)",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "appearance-play-dressing-them-in-role-specific-costumes-maid-bunny-doll-etc",
+        "label": "Dressing them in role-specific costumes (maid, bunny, doll, etc.)",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "appearance-play-curating-time-period-or-historical-outfits-e-g-victorian-50s",
+        "label": "Curating time-period or historical outfits (e.g., Victorian, 50s)",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "appearance-play-helping-them-present-more-femme-masc-or-androgynous-by-request",
+        "label": "Helping them present more femme, masc, or androgynous by request",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "appearance-play-coordinating-their-look-with-mine-for-public-or-private-scenes",
+        "label": "Coordinating their look with mine for public or private scenes",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "appearance-play-implementing-a-dress-ritual-or-aesthetic-preparation",
+        "label": "Implementing a “dress ritual” or aesthetic preparation",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "appearance-play-enforcing-a-visual-protocol-e-g-no-bra-heels-required-tied-hair",
+        "label": "Enforcing a visual protocol (e.g., no bra, heels required, tied hair)",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "appearance-play-having-my-outfit-selected-for-me-by-a-partner",
+        "label": "Having my outfit selected for me by a partner",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "appearance-play-wearing-the-underwear-or-lingerie-they-choose",
+        "label": "Wearing the underwear or lingerie they choose",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "appearance-play-having-my-hair-brushed-braided-tied-or-styled-for-them",
+        "label": "Having my hair brushed, braided, tied, or styled for them",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "appearance-play-putting-on-a-head-covering-e-g-bonnet-veil-hood-they-chose",
+        "label": "Putting on a head covering (e.g., bonnet, veil, hood) they chose",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "appearance-play-following-visual-appearance-rules-as-part-of-submission",
+        "label": "Following visual appearance rules as part of submission",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "appearance-play-wearing-makeup-polish-or-accessories-they-request",
+        "label": "Wearing makeup, polish, or accessories they request",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "appearance-play-dressing-to-please-their-vision-cute-filthy-classy-etc",
+        "label": "Dressing to please their vision (cute, filthy, classy, etc.)",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "appearance-play-wearing-roleplay-costumes-or-character-looks",
+        "label": "Wearing roleplay costumes or character looks",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "appearance-play-presenting-in-a-way-that-matches-their-chosen-aesthetic",
+        "label": "Presenting in a way that matches their chosen aesthetic",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "appearance-play-participating-in-dressing-rituals-or-undressing-ceremonies",
+        "label": "Participating in dressing rituals or undressing ceremonies",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "appearance-play-being-admired-for-the-way-i-look-under-their-direction",
+        "label": "Being admired for the way I look under their direction",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "appearance-play-receiving-praise-or-gentle-teasing-about-my-appearance",
+        "label": "Receiving praise or gentle teasing about my appearance",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "appearance-play-cosplay-or-fantasy-looks-anime-game-fairytale-etc",
+        "label": "Cosplay or fantasy looks (anime, game, fairytale, etc.)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "appearance-play-time-period-dress-up-regency-gothic-1920s-etc",
+        "label": "Time-period dress-up (regency, gothic, 1920s, etc.)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "appearance-play-dollification-or-polished-presented-object-aesthetics",
+        "label": "Dollification or polished/presented object aesthetics",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "appearance-play-uniforms-schoolgirl-military-clerical-nurse-etc",
+        "label": "Uniforms (schoolgirl, military, clerical, nurse, etc.)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "appearance-play-hair-based-play-forced-brushing-ribbons-or-tied-styles",
+        "label": "Hair-based play (forced brushing, ribbons, or tied styles)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "appearance-play-head-coverings-or-symbolic-hoods-in-ritualized-dynamics",
+        "label": "Head coverings or symbolic hoods in ritualized dynamics",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "appearance-play-matching-looks-or-coordinated-dress-codes",
+        "label": "Matching looks or coordinated dress codes",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "appearance-play-ritualized-grooming-before-scenes",
+        "label": "Ritualized grooming before scenes",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "appearance-play-praise-or-positive-attention-for-pleasing-visual-display",
+        "label": "Praise or positive attention for pleasing visual display",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "appearance-play-formal-appearance-protocols-for-scenes-or-dynamics",
+        "label": "Formal appearance protocols for scenes or dynamics",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "appearance-play-using-clothing-or-style-to-embody-emotional-or-power-roles",
+        "label": "Using clothing or style to embody emotional or power roles",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Psychology Play",
+    "items": [
+      {
+        "id": "psychology-play-emotional-sadism-giving-teasing-feelings-orchestrating-reactions-savoring-anticipation-without-shame-based-harm",
+        "label": "Emotional Sadism (giving): teasing feelings, orchestrating reactions, savoring anticipation without shame-based harm",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-psychological-control-mind-games-double-binds-deliberate-pacing-and-strategic-ambiguity",
+        "label": "Psychological Control: mind games, double binds, deliberate pacing, and strategic ambiguity",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-sadistic-attention-enjoying-being-the-focal-point-of-a-partner-s-fear-arousal-or-resistance",
+        "label": "Sadistic Attention: enjoying being the focal point of a partner’s fear, arousal, or resistance",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-teasing-humiliation-playful-status-play-without-degradation-or-shame",
+        "label": "Teasing Humiliation: playful status play without degradation or shame",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-emotional-sadism-receiving-enjoying-engineered-emotional-intensity-such-as-fluster-exposure-or-playful-embarrassment",
+        "label": "Emotional Sadism (receiving): enjoying engineered emotional intensity such as fluster, exposure, or playful embarrassment",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-psychological-control-receiving-arousal-from-being-studied-contained-or-outmaneuvered",
+        "label": "Psychological Control (receiving): arousal from being studied, contained, or outmaneuvered",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-being-the-focus-enjoying-being-watched-tracked-or-held-in-a-partner-s-intense-focus",
+        "label": "Being the Focus: enjoying being watched, tracked, or held in a partner’s intense focus",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-teasing-humiliation-receiving-enjoying-playful-embarrassment-or-affectionate-mockery-that-builds-intimacy",
+        "label": "Teasing Humiliation (receiving): enjoying playful embarrassment or affectionate mockery that builds intimacy",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-prey-attention-neediness-craving-focus-pursuit-or-intense-awareness-from-a-partner",
+        "label": "Prey Attention/Neediness: craving focus, pursuit, or intense awareness from a partner",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-primal-recognition-being-seen-understood-or-tracked-without-needing-words",
+        "label": "Primal Recognition: being seen, understood, or tracked without needing words",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Breeding",
+    "items": [
+      {
+        "id": "breeding-impregnation-giving-arousal-from-attempting-to-impregnate-a-partner",
+        "label": "Impregnation (giving): arousal from attempting to impregnate a partner",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "breeding-feeding-milk-giving-arousal-from-producing-and-feeding-milk-to-a-partner",
+        "label": "Feeding Milk (giving): arousal from producing and feeding milk to a partner",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "breeding-impregnation-receiving-arousal-from-being-inseminated-pregnancy-risk-or-being-bred",
+        "label": "Impregnation (receiving): arousal from being inseminated, pregnancy risk, or being bred",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "breeding-feeding-milk-receiving-arousal-from-drinking-a-partner-s-milk",
+        "label": "Feeding Milk (receiving): arousal from drinking a partner’s milk",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "breeding-pregnancy-fantasy-erotic-focus-on-pregnancy-mine-partner-s-or-fictional-scenarios",
+        "label": "Pregnancy Fantasy: erotic focus on pregnancy (mine, partner’s, or fictional scenarios)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-primal-breeding-drive-animalistic-instinctual-framing-of-sex-reproduction-territory",
+        "label": "Primal Breeding Drive: animalistic/instinctual framing of sex, reproduction, territory",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-breeding-as-control-ownership-authority-expressed-through-breeding-talk-or-pregnancy-risk",
+        "label": "Breeding as Control: ownership/authority expressed through breeding talk or pregnancy risk",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-creampie-marking-erotic-meaning-placed-on-internal-ejaculation-or-visible-claimed-markers",
+        "label": "Creampie/Marking: erotic meaning placed on internal ejaculation or visible ‘claimed’ markers",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-risk-no-contraception-talk-fantasy-dirty-talk-about-risk-or-breeding-without-actual-risk",
+        "label": "Risk/‘No Contraception’ Talk (fantasy): dirty talk about risk or breeding without actual risk",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-heat-ovulation-tracking-timing-in-heat-roleplay-or-cycle-focused-arousal",
+        "label": "Heat/Ovulation Tracking: timing, ‘in heat’ roleplay, or cycle-focused arousal",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-artificial-insemination-device-play-syringes-cups-or-medical-style-scenarios-consensual-fantasy",
+        "label": "Artificial Insemination/Device Play: syringes, cups, or medical-style scenarios (consensual fantasy)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-breeding-denial-ruined-breeding-building-toward-impregnation-talk-then-denying-or-ruining-it",
+        "label": "Breeding Denial/Ruined Breeding: building toward impregnation talk then denying or ‘ruining’ it",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-pregnancy-body-focus-belly-worship-movement-weight-changes-glow-and-attention",
+        "label": "Pregnancy Body Focus: belly worship, movement/weight changes, glow, and attention",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-pregnancy-protocol-care-protective-rules-pedestal-treatment-dedicated-aftercare",
+        "label": "Pregnancy Protocol/Care: protective rules, pedestal treatment, dedicated aftercare",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-lactation-induction-maintenance-interest-in-inducing-or-sustaining-milk-production",
+        "label": "Lactation Induction/Maintenance: interest in inducing or sustaining milk production",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-milking-scenes-manual-oral-or-pump-based-milking-as-play-or-ritual",
+        "label": "Milking Scenes: manual, oral, or pump-based ‘milking’ as play or ritual",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-contraception-boundaries-preference-to-use-protection-bc-methods-or-simulation-only",
+        "label": "Contraception Boundaries: preference to use protection, BC methods, or simulation-only",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-sti-testing-medical-boundaries-testing-cadence-disclosures-and-comfort-levels",
+        "label": "STI/Testing & Medical Boundaries: testing cadence, disclosures, and comfort levels",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  }
+]

--- a/docs/kinks/data/kinks.json
+++ b/docs/kinks/data/kinks.json
@@ -1,40 +1,4943 @@
-{
-  "cb_zsnrb": "Dress partner’s outfit",
-  "cb_6jd2f": "Pick lingerie / base layers",
-  "cb_kgrnn": "Uniforms (schoolgirl, military, nurse, etc.)",
-  "cb_169ma": "Time-period dress-up",
-  "cb_4yyxa": "Dollification / polished object aesthetics",
-  "cb_2c0f9": "Hair-based play (brushing, ribbons, tying)",
-  "cb_qwnhi": "Head coverings / symbolic hoods",
-  "cb_zvchg": "Coordinated looks / dress codes",
-  "cb_qw9jg": "Ritualized grooming",
-  "cb_3ozhq": "Praise for pleasing visual display",
-  "cb_hqakm": "Formal appearance protocols",
-  "cb_rn136": "Clothing as power-role signal",
-
-  "cb_kua8l": "Matching looks / coordinated dress codes",
-  "cb_yzegd": "Ritualized grooming before scenes",
-  "cb_2gxmo": "Praise/positive attention for pleasing visual display",
-  "cb_kaku7": "Formal appearance protocols for scenes or dynamics",
-  "cb_qflrp": "Using clothing/style to embody power roles",
-  "cb_gkzbu": "Dollification—polished/presented object aesthetics",
-  "cb_r7cwr": "Uniforms (schoolgirl, military, clerical, nurse, etc.)",
-  "cb_w2dc1": "Time-period dress-up (regency, gothic, 1920s, etc.)",
-  "cb_ss4gf": "Hair-based play (forced brushing, ribbons, tied styles)",
-  "cb_fsnmj": "Head coverings/symbolic hoods in ritualized dynamics",
-  "cb_065gv": "Coordinated looks / dress codes (formal, scene-specific)",
-  "cb_ifkmg": "Ritualized grooming before scenes",
-  "cb_qege6": "Praise/positive attention for pleasing visual display",
-  "cb_s9861": "Formal appearance protocols (dress rules, standards)",
-  "cb_46bc3": "Clothing or style as explicit power-role signal",
-
-  "cb_zlfd1": "Dress partner’s outfit (directive/decision)",
-  "cb_tdbox": "Makeup as protocol or control",
-  "cb_ox5yg": "Makeup as protocol or control",
-  "cb_wwf76": "Makeup specifics (brands, palette, rules)",
-  "cb_swujj": "Accessory or ornament rules",
-  "cb_05hqj": "Wardrobe restrictions or permissions",
-  "cb_ykj4f": "Wardrobe restrictions or permissions",
-  "cb_swuij": "Scene-specific hair/face styling expectations",
-  "cb_6vf76": "Cosplay / character presentation"
-}
+[
+  {
+    "category": "Body Part Torture",
+    "items": [
+      {
+        "id": "body-part-torture-nipple-clips",
+        "label": "Nipple clips",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-torture-nipple-weights",
+        "label": "Nipple weights",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-torture-nipple-suction-cups",
+        "label": "Nipple suction cups",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-torture-cock-ball-torture-cbt",
+        "label": "Cock, Ball Torture (CBT)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-torture-clit-clips-weights-suction",
+        "label": "Clit clips/weights/suction",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-torture-hair-pulling",
+        "label": "Hair pulling",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-torture-face-slapping",
+        "label": "Face slapping",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-torture-butt-slapping",
+        "label": "Butt slapping",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-torture-breast-slapping",
+        "label": "Breast slapping",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-torture-genital-slapping",
+        "label": "Genital slapping",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Bondage and Suspension",
+    "items": [
+      {
+        "id": "bondage-and-suspension-blindfolds",
+        "label": "Blindfolds",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-bondage-heavy",
+        "label": "Bondage (heavy)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-bondage-light",
+        "label": "Bondage (light)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-immobilisation",
+        "label": "Immobilisation",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-bondage-multi-day",
+        "label": "Bondage (multi-day)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-bondage-public-under-clothing",
+        "label": "Bondage (public, under clothing)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-leather-restraints",
+        "label": "Leather restraints",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-chains",
+        "label": "Chains",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-ropes",
+        "label": "Ropes",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-intricate-japanese-rope-bondage",
+        "label": "Intricate (Japanese) rope bondage",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-rope-body-harness",
+        "label": "Rope body harness",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-arm-leg-sleeves-armbinders",
+        "label": "Arm & leg sleeves (armbinders)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-harnesses-leather",
+        "label": "Harnesses (leather)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-harnesses-rope",
+        "label": "Harnesses (rope)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-cuffs-leather",
+        "label": "Cuffs (leather)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-cuffs-metal",
+        "label": "Cuffs (metal)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-manacles-irons",
+        "label": "Manacles & Irons",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-gags-cloth",
+        "label": "Gags (cloth)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-gags-rubber",
+        "label": "Gags (rubber)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-gags-tape",
+        "label": "Gags (tape)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-gags-phallic",
+        "label": "Gags (phallic)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-gags-ring",
+        "label": "Gags (ring)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-gags-ball",
+        "label": "Gags (ball)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-mouth-bits",
+        "label": "Mouth bits",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-full-head-hoods",
+        "label": "Full head hoods",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-mummification-saran-wrapping",
+        "label": "Mummification/saran wrapping",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-straight-jackets",
+        "label": "Straight jackets",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-suspension-upright",
+        "label": "Suspension (upright)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-suspension-horizontal",
+        "label": "Suspension (horizontal)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-suspension-inverted",
+        "label": "Suspension (inverted)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-breath-play",
+        "label": "Breath play",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-smothering",
+        "label": "Smothering",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-forced-self-breath-control",
+        "label": "Forced self-breath-control",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "bondage-and-suspension-gas-mask",
+        "label": "Gas mask",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Breath Play",
+    "items": [
+      {
+        "id": "breath-play-asphyxiation",
+        "label": "Asphyxiation",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "breath-play-breath-control",
+        "label": "Breath control",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "breath-play-choking",
+        "label": "Choking",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "breath-play-drowning",
+        "label": "Drowning",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "breath-play-rebreathing-into-a-bag-or-object",
+        "label": "Rebreathing into a bag or object",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "breath-play-verbal-control-of-breath-e-g-hold-it-on-command",
+        "label": "Verbal control of breath (e.g., 'hold it' on command)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Sexual Activity",
+    "items": [
+      {
+        "id": "sexual-activity-licking",
+        "label": "Licking",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sexual-activity-fellatio-cunnilingus",
+        "label": "Fellatio/Cunnilingus",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sexual-activity-swallowing-semen",
+        "label": "Swallowing semen",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sexual-activity-cumming-on-partner",
+        "label": "Cumming on Partner",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sexual-activity-hand-jobs",
+        "label": "Hand jobs",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sexual-activity-anal-sex",
+        "label": "Anal sex",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sexual-activity-anal-plugs-small",
+        "label": "Anal plugs (small)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sexual-activity-anal-plugs-large",
+        "label": "Anal plugs (large)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sexual-activity-anal-beads",
+        "label": "Anal beads",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sexual-activity-vibrator-on-genitals",
+        "label": "Vibrator on genitals",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sexual-activity-fisting",
+        "label": "Fisting",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sexual-activity-oral-anal-play-rimming",
+        "label": "Oral/anal play (rimming)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sexual-activity-double-penetration-oral-and-vaginal",
+        "label": "Double penetration (oral and vaginal)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sexual-activity-double-penetration-oral-and-anal",
+        "label": "Double penetration (oral and anal)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sexual-activity-double-penetration-anal-and-vaginal",
+        "label": "Double penetration (anal and vaginal)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sexual-activity-triple-oral-vaginal-and-anal",
+        "label": "Triple (Oral, Vaginal and Anal)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Sensation Play",
+    "items": [
+      {
+        "id": "sensation-play-abrasion",
+        "label": "Abrasion",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sensation-play-scratching",
+        "label": "Scratching",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sensation-play-biting",
+        "label": "Biting",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sensation-play-tickling",
+        "label": "Tickling",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sensation-play-kissing",
+        "label": "Kissing",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sensation-play-zapping-e-g-electric-fly-swatter",
+        "label": "Zapping (e.g. electric fly swatter)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sensation-play-ice-cubes",
+        "label": "Ice cubes",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sensation-play-wax-play",
+        "label": "Wax Play",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sensation-play-fire",
+        "label": "Fire",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sensation-play-clothespins",
+        "label": "Clothespins",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sensation-play-needles",
+        "label": "Needles",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sensation-play-sensory-deprivation",
+        "label": "Sensory deprivation",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sensation-play-physical-overpowering-manhandling",
+        "label": "Physical overpowering / Manhandling",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "sensation-play-figging",
+        "label": "Figging",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Other",
+    "items": [
+      {
+        "id": "other-feet",
+        "label": "Feet",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "other-boots",
+        "label": "Boots",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "other-underwear",
+        "label": "Underwear",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "other-chastity-devices",
+        "label": "Chastity devices",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "other-masks",
+        "label": "Masks",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "other-breeding",
+        "label": "Breeding",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "other-leather-clothing",
+        "label": "Leather clothing",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "other-training-protocols-outside-scenes-e-g-etiquette-memory",
+        "label": "Training protocols outside scenes (e.g., etiquette, memory)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "other-long-distance-training-structure",
+        "label": "Long-distance training/structure",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "other-scene-journaling-and-reflection",
+        "label": "Scene journaling and reflection",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Roleplaying",
+    "items": [
+      {
+        "id": "roleplaying-fantasy-abandonment",
+        "label": "Fantasy abandonment",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "roleplaying-kidnapping",
+        "label": "Kidnapping",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "roleplaying-interrogation",
+        "label": "Interrogation",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "roleplaying-sleep-deprivation",
+        "label": "Sleep deprivation",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "roleplaying-cnc",
+        "label": "CNC",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "roleplaying-gang-bang",
+        "label": "Gang bang",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "roleplaying-initiation-rites",
+        "label": "Initiation rites",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "roleplaying-religious-scenes",
+        "label": "Religious scenes",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "roleplaying-medical-scenes",
+        "label": "Medical scenes",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "roleplaying-prison-scenes",
+        "label": "Prison scenes",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "roleplaying-primal-prey",
+        "label": "Primal/Prey",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "roleplaying-schoolroom-scenes",
+        "label": "Schoolroom scenes",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Service and Restrictive Behaviour",
+    "items": [
+      {
+        "id": "service-and-restrictive-behaviour-following-orders",
+        "label": "(Following) orders",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-forced-servitude",
+        "label": "Forced servitude",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-restrictive-rules-on-behaviour",
+        "label": "Restrictive rules on behaviour",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-eye-contact-restrictions",
+        "label": "Eye contact restrictions",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-speech-restrictions-when-what-to-whom",
+        "label": "Speech restrictions (when, what, to whom)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-washroom-restrictions",
+        "label": "Washroom restrictions",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-punishments",
+        "label": "Punishments",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-tasks",
+        "label": "Tasks",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-massage",
+        "label": "Massage",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-domestic-tasks",
+        "label": "Domestic tasks",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-serving-food-and-drink",
+        "label": "Serving food and drink",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-personal-care-rituals",
+        "label": "Personal care rituals",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-being-on-call-at-specified-times",
+        "label": "Being on-call at specified times",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-daily-task-assignments",
+        "label": "Daily task assignments",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-corrections-for-imperfection",
+        "label": "Corrections for imperfection",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-uniforms-dress-codes",
+        "label": "Uniforms / Dress codes",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-kneeling-posture-presentation",
+        "label": "Kneeling / Posture presentation",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-silent-service",
+        "label": "Silent service",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-public-service-at-parties-or-events",
+        "label": "Public service (at parties or events)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "service-and-restrictive-behaviour-erotic-service-pleasure-on-command-without-seeking-your-own",
+        "label": "Erotic service (pleasure on command, without seeking your own)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Voyeurism/Exhibitionism",
+    "items": [
+      {
+        "id": "voyeurism-exhibitionism-forced-nudity-private",
+        "label": "Forced nudity (private)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "voyeurism-exhibitionism-forced-nudity-around-others",
+        "label": "Forced nudity (around others)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "voyeurism-exhibitionism-exhibitionism-friends",
+        "label": "Exhibitionism (friends)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "voyeurism-exhibitionism-exhibitionism-strangers",
+        "label": "Exhibitionism (strangers)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "voyeurism-exhibitionism-modelling-for-erotic-photos",
+        "label": "Modelling for erotic photos",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "voyeurism-exhibitionism-toys-under-clothes-in-public",
+        "label": "Toys under clothes in public",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Virtual & Long-Distance Play",
+    "items": [
+      {
+        "id": "virtual-long-distance-play-sending-tasks-or-orders-digitally",
+        "label": "Sending tasks or orders digitally",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-recording-dominant-voice-clips-commands-edging-praise-degradation-etc",
+        "label": "Recording dominant voice clips (commands, edging, praise, degradation, etc.)",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-remote-control-of-a-sex-toy",
+        "label": "Remote control of a sex toy",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-monitoring-behavior-via-app-or-shared-doc",
+        "label": "Monitoring behavior via app or shared doc",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-giving-punishment-assignments-remotely",
+        "label": "Giving punishment assignments remotely",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-creating-countdowns-timers-or-denial-periods",
+        "label": "Creating countdowns, timers, or denial periods",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-sending-written-instructions-with-delayed-permissions",
+        "label": "Sending written instructions with delayed permissions",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-creating-custom-video-or-audio-tasks",
+        "label": "Creating custom video or audio tasks",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-voice-message-control-during-scenes",
+        "label": "Voice message control during scenes",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-being-on-call-at-specified-times",
+        "label": "Being on-call at specified times",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-receiving-tasks-or-orders-digitally",
+        "label": "Receiving tasks or orders digitally",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-listening-to-dominant-voice-clips",
+        "label": "Listening to dominant voice clips",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-using-a-remote-controlled-toy-controlled-by-another",
+        "label": "Using a remote-controlled toy controlled by another",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-completing-daily-protocol-assignments",
+        "label": "Completing daily protocol assignments",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-submitting-proof-photo-video-text",
+        "label": "Submitting proof (photo, video, text)",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-following-recorded-or-timed-commands",
+        "label": "Following recorded or timed commands",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-receiving-surprise-instructions",
+        "label": "Receiving surprise instructions",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-hearing-name-praise-spoken-in-a-custom-clip",
+        "label": "Hearing name/praise spoken in a custom clip",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-sending-submissive-voice-clips-obedience-begging-thank-you-messages-affirmations-etc",
+        "label": "Sending submissive voice clips (obedience, begging, thank-you messages, affirmations, etc.)",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-scheduling-digital-rituals-or-reminders",
+        "label": "Scheduling digital rituals or reminders",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-using-training-habit-or-behavior-tracking-apps",
+        "label": "Using training, habit, or behavior-tracking apps",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-online-rituals-digital-kneeling-posture-protocols",
+        "label": "Online rituals (digital kneeling, posture protocols)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-role-based-texting-e-g-use-honorifics-in-chat",
+        "label": "Role-based texting (e.g., \"Use honorifics in chat\")",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-shared-playlists-affirmations-or-mantras",
+        "label": "Shared playlists, affirmations, or mantras",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-countdown-timers-to-next-task-release-or-interaction",
+        "label": "Countdown timers to next task, release, or interaction",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-scheduled-good-morning-night-rituals",
+        "label": "Scheduled good morning/night rituals",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-participating-in-video-call-scenes",
+        "label": "Participating in video call scenes",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-digital-aftercare-texts-voice-images",
+        "label": "Digital aftercare (texts, voice, images)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-sexting-or-digital-roleplay-scenes",
+        "label": "Sexting or digital roleplay scenes",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "virtual-long-distance-play-voice-notes-or-submissive-dominant-affirmations",
+        "label": "Voice notes or submissive/dominant affirmations",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Communication",
+    "items": [
+      {
+        "id": "communication-playful-and-teasing",
+        "label": "Playful and teasing",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-quiet-and-intense",
+        "label": "Quiet and intense",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-observant-and-intentional",
+        "label": "Observant and intentional",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-praise-heavy",
+        "label": "Praise-heavy",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-blunt-and-efficient",
+        "label": "Blunt and efficient",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-affirming-and-soft",
+        "label": "Affirming and soft",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-psychological-interrogation",
+        "label": "Psychological interrogation",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-verbal-coercion-teasing-traps",
+        "label": "Verbal coercion / teasing traps",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-verbal-misdirection",
+        "label": "Verbal misdirection",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-mocking-shaming",
+        "label": "Mocking / shaming",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-predatory-pacing",
+        "label": "Predatory pacing",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-reluctant-obedience",
+        "label": "Reluctant obedience",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-stammering-submission",
+        "label": "Stammering submission",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-challenging-until-caught",
+        "label": "Challenging until caught",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-quiet-surrender",
+        "label": "Quiet surrender",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-sarcastic-teasing",
+        "label": "Sarcastic teasing",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-provoking-tone",
+        "label": "Provoking tone",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-challenge-based-dialogue",
+        "label": "Challenge-based dialogue",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-double-meaning-banter",
+        "label": "Double-meaning banter",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-soft-spoken-guidance",
+        "label": "Soft-spoken guidance",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-protective-but-firm-tone",
+        "label": "Protective but firm tone",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-emotional-redirection",
+        "label": "Emotional redirection",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-steady-reassurance",
+        "label": "Steady reassurance",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "communication-direct-and-clear",
+        "label": "Direct and clear",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-gentle-and-nurturing",
+        "label": "Gentle and nurturing",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-commanding-and-firm",
+        "label": "Commanding and firm",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-quiet-and-observant",
+        "label": "Quiet and observant",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-instructive-teacher-like",
+        "label": "Instructive / teacher-like",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-emotionally-intense",
+        "label": "Emotionally intense",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-dismissive-withholding",
+        "label": "Dismissive / withholding",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-mocking-sarcastic",
+        "label": "Mocking / sarcastic",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-blunt-tactless",
+        "label": "Blunt / tactless",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-predatory-hunting-tone",
+        "label": "Predatory / hunting tone",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-stalking-or-circling-speech",
+        "label": "Stalking or circling speech",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-you-re-mine-control-language",
+        "label": "You’re mine / control language",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-threatening-consensual",
+        "label": "Threatening (consensual)",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-verbal-cornering-coaxing",
+        "label": "Verbal cornering / coaxing",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-watching-you-unravel",
+        "label": "Watching you unravel",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-cruel-and-cutting",
+        "label": "Cruel and cutting",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-psychological-baiting",
+        "label": "Psychological baiting",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-brat-breaking-language",
+        "label": "Brat-breaking language",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-mock-affection",
+        "label": "Mock affection",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-shaming-or-emotional-edge",
+        "label": "Shaming or emotional edge",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-disappointed-dom-voice",
+        "label": "Disappointed dom voice",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-mild-scolding-mocking-affection",
+        "label": "Mild scolding / mocking affection",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-verbal-power-struggle",
+        "label": "Verbal power struggle",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-challenge-response-dynamics",
+        "label": "Challenge-response dynamics",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-warm-tone-with-expectation",
+        "label": "Warm tone with expectation",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-nurturing-dominance",
+        "label": "Nurturing dominance",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-reassuring-commands",
+        "label": "Reassuring commands",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "communication-phrases-that-work-on-you",
+        "label": "Phrases that work on you",
+        "type": "text",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "communication-phrases-you-use-or-like-to-give",
+        "label": "Phrases you use or like to give",
+        "type": "text",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "communication-what-helps-you-feel-emotionally-safe",
+        "label": "What helps you feel emotionally safe",
+        "type": "text",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "communication-how-you-tend-to-show-affection",
+        "label": "How you tend to show affection",
+        "type": "text",
+        "options": [
+          "Words of affirmation",
+          "Acts of service",
+          "Through teasing / play",
+          "Through obedience",
+          "Through caretaking",
+          "Withholding / teasing love",
+          "Physical closeness",
+          "Quality time"
+        ],
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "communication-emotional-check-in-style",
+        "label": "Emotional check-in style",
+        "type": "text",
+        "options": [
+          "Daily texting",
+          "After-scene debriefs",
+          "Scheduled check-ins",
+          "Mix of text/video check-ins",
+          "In-person check-ins",
+          "Journaling together",
+          "Minimal / low contact",
+          "Other"
+        ],
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "communication-when-emotionally-activated-i-tend-to",
+        "label": "When emotionally activated, I tend to...",
+        "type": "text",
+        "options": [
+          "Shut down",
+          "Overexplain / fawn",
+          "Get sarcastic / prickly",
+          "Spiral internally",
+          "Ask for reassurance",
+          "Withdraw",
+          "Other"
+        ],
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Body Fluids and Functions",
+    "items": [
+      {
+        "id": "body-fluids-and-functions-watersports-golden-showers",
+        "label": "Watersports/golden showers",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-fluids-and-functions-cum",
+        "label": "Cum",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-fluids-and-functions-blood",
+        "label": "Blood",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-fluids-and-functions-scat",
+        "label": "Scat",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-fluids-and-functions-sweat",
+        "label": "Sweat",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-fluids-and-functions-vomit",
+        "label": "Vomit",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-fluids-and-functions-tears-crying",
+        "label": "Tears/crying",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Psychological Primal / Prey",
+    "items": [
+      {
+        "id": "psychological-primal-prey-primal-prey",
+        "label": "Primal/Prey",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychological-primal-prey-conditioning",
+        "label": "Conditioning",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychological-primal-prey-coc",
+        "label": "COC",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychological-primal-prey-psycholagny-hands-free-mentally-stimulated-orgasm",
+        "label": "Psycholagny (hands free, mentally stimulated orgasm)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychological-primal-prey-hypno-play",
+        "label": "Hypno Play",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychological-primal-prey-praise",
+        "label": "Praise",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychological-primal-prey-degradation",
+        "label": "Degradation",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychological-primal-prey-traditional-primal-prey",
+        "label": "Traditional primal/prey",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychological-primal-prey-fear-play",
+        "label": "Fear play",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychological-primal-prey-objectification",
+        "label": "Objectification",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychological-primal-prey-gaslighting",
+        "label": "Gaslighting",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychological-primal-prey-role-erosion-identity-play-loss-of-self",
+        "label": "Role erosion (identity play / loss of self)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychological-primal-prey-jealousy-play",
+        "label": "Jealousy play",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychological-primal-prey-manipulation",
+        "label": "Manipulation",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Body Part / Fetish Play",
+    "items": [
+      {
+        "id": "body-part-fetish-play-belly-fucking",
+        "label": "Belly fucking",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-navel-play",
+        "label": "Navel play",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-feet-foot-worship",
+        "label": "Feet / Foot worship",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-hands",
+        "label": "Hands",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-hair",
+        "label": "Hair",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-thighs",
+        "label": "Thighs",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-neck",
+        "label": "Neck",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-ears",
+        "label": "Ears",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-belly",
+        "label": "Belly",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-voice-fetish",
+        "label": "Voice fetish",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-nails-makeup-fetish",
+        "label": "Nails / Makeup fetish",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-cuddles",
+        "label": "Cuddles",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-food-play",
+        "label": "Food Play",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-kisses",
+        "label": "Kisses",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-masturbation",
+        "label": "Masturbation",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-romance-affection",
+        "label": "Romance / affection",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-sex-toys",
+        "label": "Sex toys",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-sexting-chat-etc",
+        "label": "Sexting /Chat etc",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-sexting-via-phone-or-video-call",
+        "label": "Sexting via phone or video call",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-strip-tease",
+        "label": "Strip tease",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-vanilla-sex",
+        "label": "Vanilla Sex",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-voice-notes",
+        "label": "Voice Notes",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-shaving-body-hair",
+        "label": "Shaving (body hair)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-sexy-clothing-private",
+        "label": "Sexy clothing (private)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-sexy-clothing-public",
+        "label": "Sexy clothing (public)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-outdoor-scenes",
+        "label": "Outdoor scenes",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-part-fetish-play-public-exposure",
+        "label": "Public exposure",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Orgasm Control & Sexual Manipulation",
+    "items": [
+      {
+        "id": "orgasm-control-sexual-manipulation-edging",
+        "label": "Edging",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-short-term-denial",
+        "label": "Short term denial",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-long-term-denial",
+        "label": "Long term denial",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-forced-orgasms-overstimulation",
+        "label": "Forced orgasms / Overstimulation",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-ruined-orgasms",
+        "label": "Ruined orgasms",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-no-touch-periods",
+        "label": "No touch periods",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-milking",
+        "label": "Milking",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-chastity-devices",
+        "label": "Chastity devices",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-consensual-orgasm-control",
+        "label": "Consensual orgasm control",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "orgasm-control-sexual-manipulation-forced-masturbation",
+        "label": "Forced masturbation",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Protocol and Ritual",
+    "items": [
+      {
+        "id": "protocol-and-ritual-formal-language",
+        "label": "Formal language",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-greeting-and-departure-rituals-kneeling-verbal-scripts-gestures",
+        "label": "Greeting and departure rituals (kneeling, verbal scripts, gestures)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-requiring-permission-for-things-speech-movement-attire",
+        "label": "Requiring permission for things (speech, movement, attire)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-daily-rituals-morning-check-ins-status-reports-mantra-repetitions",
+        "label": "Daily rituals (morning check-ins, status reports, mantra repetitions)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-specific-postures-for-rest-attention-punishment-waiting",
+        "label": "Specific postures for rest, attention, punishment, waiting",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-restricted-behavior-no-eye-contact-silence-no-questions",
+        "label": "Restricted behavior (no eye contact, silence, no questions)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-ritual-object-use-collar-cuffs-leash-tokens",
+        "label": "Ritual object use (collar, cuffs, leash, tokens)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-tracking-obedience-journals-apps",
+        "label": "Tracking obedience (journals, apps)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-formalized-rules-for-misbehavior-and-correction",
+        "label": "Formalized rules for misbehavior and correction",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-ritualized-aftercare-or-scene-closure",
+        "label": "Ritualized aftercare or scene closure",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-object-retrieval-on-all-fours-with-item-in-mouth",
+        "label": "Object retrieval on all fours with item in mouth",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-fetching-hairbrush-or-punishment-tool-from-dresser-while-crawling",
+        "label": "Fetching hairbrush or punishment tool from dresser while crawling",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-presenting-chosen-discipline-tool-in-kneeling-posture",
+        "label": "Presenting chosen discipline tool in kneeling posture",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-assigned-posture-or-kneeling-positions-as-ritual",
+        "label": "Assigned posture or kneeling positions as ritual",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-requesting-permission-using-specific-protocol-phrases",
+        "label": "Requesting permission using specific protocol phrases",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-carrying-items-in-mouth-as-submissive-gesture",
+        "label": "Carrying items in mouth as submissive gesture",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-crawling-back-with-object-to-dominant-after-retrieval",
+        "label": "Crawling back with object to Dominant after retrieval",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-following-via-nipple-leash-as-protocol-or-punishment",
+        "label": "Following via nipple leash as protocol or punishment",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-crawling-assigned-paths-as-ritual-or-obedience-training",
+        "label": "Crawling assigned paths as ritual or obedience training",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-crawling-rituals-e-g-object-retrieval",
+        "label": "Crawling rituals (e.g., object retrieval)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-carrying-objects-in-mouth-as-obedience",
+        "label": "Carrying objects in mouth as obedience",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-presenting-tools-or-toys-in-posture",
+        "label": "Presenting tools or toys in posture",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-using-honorifics-or-preset-protocol-language",
+        "label": "Using honorifics or preset protocol language",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-greeting-rituals-e-g-kneeling-kissing-feet",
+        "label": "Greeting rituals (e.g., kneeling, kissing feet)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-daily-check-ins-or-structured-reports",
+        "label": "Daily check-ins or structured reports",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-clothing-restrictions-or-uniforms",
+        "label": "Clothing restrictions or uniforms",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-posture-training-sitting-kneeling-standing",
+        "label": "Posture training (sitting, kneeling, standing)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-punishments-for-incorrect-behavior-or-tone",
+        "label": "Punishments for incorrect behavior or tone",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-crawling-with-items-in-mouth-e-g-hairbrush-spoon",
+        "label": "Crawling with items in mouth (e.g., hairbrush, spoon)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-earning-permission-for-meals-bathroom-use-or-rest",
+        "label": "Earning permission for meals, bathroom use, or rest",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-following-daily-rituals-or-protocol",
+        "label": "Following daily rituals or protocol",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-structured-speech-rules-e-g-titles-third-person",
+        "label": "Structured speech rules (e.g., titles, third person)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-receiving-correction-when-out-of-line",
+        "label": "Receiving correction when out of line",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "protocol-and-ritual-inspection-rituals-or-readiness-checks",
+        "label": "Inspection rituals or readiness checks",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Primal & Bratting",
+    "items": [
+      {
+        "id": "primal-bratting-chase-and-capture-play",
+        "label": "Chase and capture play",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "primal-bratting-bratting-for-punishment",
+        "label": "Bratting for punishment",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "primal-bratting-playful-growling-and-biting",
+        "label": "Playful growling and biting",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "primal-bratting-provoking-with-teasing-or-taunts",
+        "label": "Provoking with teasing or taunts",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "primal-bratting-escaping-or-hiding-to-encourage-pursuit",
+        "label": "Escaping or hiding to encourage pursuit",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "primal-bratting-refusing-commands-just-for-fun",
+        "label": "Refusing commands just for fun",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "primal-bratting-provoking-your-partner-to-chase-or-discipline-you",
+        "label": "Provoking your partner to chase or discipline you",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "primal-bratting-taunting-or-teasing-as-a-form-of-play",
+        "label": "Taunting or teasing as a form of play",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "primal-bratting-intentional-resistance-during-power-exchange",
+        "label": "Intentional resistance during power exchange",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "primal-bratting-being-caught-and-overpowered",
+        "label": "Being caught and overpowered",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Headspace & Regression",
+    "items": [
+      {
+        "id": "headspace-regression-caregiver-little-regression-play",
+        "label": "Caregiver/little regression play",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "headspace-regression-using-pacifiers-or-sippy-cups",
+        "label": "Using pacifiers or sippy cups",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "headspace-regression-coloring-or-childlike-crafts",
+        "label": "Coloring or childlike crafts",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "headspace-regression-stuffed-animal-comfort",
+        "label": "Stuffed animal comfort",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "headspace-regression-speaking-in-a-childlike-voice",
+        "label": "Speaking in a childlike voice",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "headspace-regression-bedtime-stories-or-lullabies",
+        "label": "Bedtime stories or lullabies",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "headspace-regression-entering-altered-headspaces-e-g-prey-pet-little",
+        "label": "Entering altered headspaces (e.g., prey, pet, little)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "headspace-regression-regressive-behaviors-as-comfort-coloring-babytalk",
+        "label": "Regressive behaviors as comfort (coloring, babytalk)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "headspace-regression-being-cared-for-during-emotional-vulnerability",
+        "label": "Being cared for during emotional vulnerability",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "headspace-regression-guided-emotional-headspace-entry",
+        "label": "Guided emotional headspace entry",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Performance & Internal Struggle",
+    "items": [
+      {
+        "id": "performance-internal-struggle-obedience-under-observation",
+        "label": "Obedience under observation",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "performance-internal-struggle-speech-restriction-and-self-denial",
+        "label": "Speech restriction and self-denial",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "performance-internal-struggle-maintaining-composure-during-humiliation",
+        "label": "Maintaining composure during humiliation",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "performance-internal-struggle-obedience-drills-for-an-audience",
+        "label": "Obedience drills for an audience",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "performance-internal-struggle-struggling-against-personal-urges",
+        "label": "Struggling against personal urges",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "performance-internal-struggle-displaying-submission-despite-conflict",
+        "label": "Displaying submission despite conflict",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "performance-internal-struggle-being-told-to-act-normal-while-struggling-internally",
+        "label": "Being told to act normal while struggling internally",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "performance-internal-struggle-pleasing-through-high-functioning-obedience",
+        "label": "Pleasing through high-functioning obedience",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "performance-internal-struggle-performing-submission-while-masking-resistance",
+        "label": "Performing submission while masking resistance",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "performance-internal-struggle-the-pressure-of-appearing-good-while-feeling-conflicted",
+        "label": "The pressure of appearing 'good' while feeling conflicted",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "performance-internal-struggle-being-made-to-perform-emotions-on-command-cry-beg-moan",
+        "label": "Being made to perform emotions on command (cry, beg, moan)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "performance-internal-struggle-struggling-openly-while-still-obeying",
+        "label": "Struggling openly while still obeying",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "performance-internal-struggle-performing-exaggerated-resistance-or-denial",
+        "label": "Performing exaggerated resistance or denial",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "performance-internal-struggle-being-punished-for-breaking-character",
+        "label": "Being punished for 'breaking character'",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "performance-internal-struggle-putting-on-a-show-for-someone-else-s-pleasure",
+        "label": "Putting on a show for someone else’s pleasure",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "performance-internal-struggle-rehearsed-degradation-or-humiliation-scripts",
+        "label": "Rehearsed degradation or humiliation scripts",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Mindfuck & Manipulation",
+    "items": [
+      {
+        "id": "mindfuck-manipulation-confusing-commands-and-reality-shifts",
+        "label": "Confusing commands and reality shifts",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mindfuck-manipulation-gaslighting-or-contradictory-cues",
+        "label": "Gaslighting or contradictory cues",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mindfuck-manipulation-presenting-false-choices",
+        "label": "Presenting false choices",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mindfuck-manipulation-hidden-motives-or-secret-tasks",
+        "label": "Hidden motives or secret tasks",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mindfuck-manipulation-illogical-rules-meant-to-confuse",
+        "label": "Illogical rules meant to confuse",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mindfuck-manipulation-gaslight-style-scenes-with-consent-and-clarity",
+        "label": "Gaslight-style scenes (with consent and clarity)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mindfuck-manipulation-false-threats-or-staged-surprises",
+        "label": "False threats or staged surprises",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mindfuck-manipulation-confusing-commands-to-prompt-hesitation",
+        "label": "Confusing commands to prompt hesitation",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mindfuck-manipulation-emotional-trickery-as-arousal",
+        "label": "Emotional trickery as arousal",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mindfuck-manipulation-being-misled-or-deceived-on-purpose-during-play",
+        "label": "Being misled or deceived on purpose during play",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mindfuck-manipulation-surprise-rule-changes-or-twists-mid-scene",
+        "label": "Surprise rule changes or twists mid-scene",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mindfuck-manipulation-false-safeword-games-with-negotiated-limits",
+        "label": "False safeword games (with negotiated limits)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mindfuck-manipulation-withholding-or-delaying-aftercare-for-effect",
+        "label": "Withholding or delaying aftercare for effect",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mindfuck-manipulation-being-gaslit-or-doubted-in-a-controlled-roleplay",
+        "label": "Being gaslit or doubted in a controlled roleplay",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mindfuck-manipulation-told-you-asked-for-this-or-you-love-this-when-resisting",
+        "label": "Told 'you asked for this' or 'you love this' when resisting",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Mouth Play",
+    "items": [
+      {
+        "id": "mouth-play-holding-tools-or-restraints-in-teeth-while-crawling",
+        "label": "Holding tools or restraints in teeth while crawling",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mouth-play-placing-objects-from-mouth-into-dominant-s-palm",
+        "label": "Placing objects from mouth into Dominant’s palm",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mouth-play-using-mouth-instead-of-hands-for-service-rituals",
+        "label": "Using mouth instead of hands for service rituals",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mouth-play-gag-presentation-and-silent-waiting-protocol",
+        "label": "Gag presentation and silent waiting protocol",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mouth-play-holding-objects-in-teeth-while-crawling",
+        "label": "Holding objects in teeth while crawling",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mouth-play-returning-items-using-mouth-only",
+        "label": "Returning items using mouth only",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mouth-play-gag-rituals-or-waiting-silently",
+        "label": "Gag rituals or waiting silently",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mouth-play-leash-held-in-mouth",
+        "label": "Leash held in mouth",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mouth-play-being-gagged-or-forced-silent",
+        "label": "Being gagged or forced silent",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mouth-play-having-to-hold-objects-in-your-mouth-spoon-hairbrush-leash",
+        "label": "Having to hold objects in your mouth (spoon, hairbrush, leash)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mouth-play-being-used-for-oral-service-without-reciprocal-pleasure",
+        "label": "Being used for oral service without reciprocal pleasure",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mouth-play-being-fed-by-hand-mouth-to-mouth-or-with-utensils",
+        "label": "Being fed by hand, mouth-to-mouth, or with utensils",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mouth-play-verbal-control-e-g-only-speak-when-spoken-to",
+        "label": "Verbal control (e.g., only speak when spoken to)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "mouth-play-mouth-as-a-symbol-of-ownership-or-control",
+        "label": "Mouth as a symbol of ownership or control",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Impact Play",
+    "items": [
+      {
+        "id": "impact-play-hand-spanking",
+        "label": "Hand spanking",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "impact-play-paddle-strikes",
+        "label": "Paddle strikes",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "impact-play-crop-snaps",
+        "label": "Crop snaps",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "impact-play-flogger-swings",
+        "label": "Flogger swings",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "impact-play-cane-strokes",
+        "label": "Cane strokes",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "impact-play-belt-or-strap-hits",
+        "label": "Belt or strap hits",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "impact-play-whip-cracks",
+        "label": "Whip cracks",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "impact-play-preferred-intensity-levels",
+        "label": "Preferred intensity levels",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "impact-play-aftercare-for-bruises",
+        "label": "Aftercare for bruises",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "impact-play-target-body-areas",
+        "label": "Target body areas",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "impact-play-implement-selection",
+        "label": "Implement selection",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Medical Play",
+    "items": [
+      {
+        "id": "medical-play-needle-play",
+        "label": "Needle play",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "medical-play-catheter-insertion",
+        "label": "Catheter insertion",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "medical-play-speculum-exams",
+        "label": "Speculum exams",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "medical-play-enema-administration",
+        "label": "Enema administration",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "medical-play-temperature-taking",
+        "label": "Temperature taking",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "medical-play-medical-restraints",
+        "label": "Medical restraints",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "medical-play-doctor-nurse-roleplay",
+        "label": "Doctor/nurse roleplay",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "medical-play-sterilization-procedures",
+        "label": "Sterilization procedures",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "medical-play-professional-vs-roleplay-scenes",
+        "label": "Professional vs roleplay scenes",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "medical-play-consent-for-invasive-acts",
+        "label": "Consent for invasive acts",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "medical-play-access-to-medical-equipment",
+        "label": "Access to medical equipment",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Pet Play",
+    "items": [
+      {
+        "id": "pet-play-puppy-or-kitten-play",
+        "label": "Puppy or kitten play",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "pet-play-pony-play",
+        "label": "Pony play",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "pet-play-wearing-collar-and-leash",
+        "label": "Wearing collar and leash",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "pet-play-eating-from-a-bowl",
+        "label": "Eating from a bowl",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "pet-play-kenneling-or-caging",
+        "label": "Kenneling or caging",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "pet-play-pet-training-commands",
+        "label": "Pet training commands",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "pet-play-animal-costumes-or-gear",
+        "label": "Animal costumes or gear",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "pet-play-preferred-animal-identities",
+        "label": "Preferred animal identities",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "pet-play-public-vs-private-play",
+        "label": "Public vs private play",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "pet-play-training-style-and-discipline",
+        "label": "Training style and discipline",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "pet-play-use-of-pet-names-and-commands",
+        "label": "Use of pet names and commands",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Body Modification",
+    "items": [
+      {
+        "id": "body-modification-piercings",
+        "label": "Piercings",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-modification-tattoos",
+        "label": "Tattoos",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-modification-branding",
+        "label": "Branding",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-modification-scarification",
+        "label": "Scarification",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-modification-permanent-chastity-devices",
+        "label": "Permanent chastity devices",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-modification-cosmetic-implants",
+        "label": "Cosmetic implants",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-modification-stretching-or-gauges",
+        "label": "Stretching or gauges",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "body-modification-temporary-vs-permanent-changes",
+        "label": "Temporary vs permanent changes",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-modification-professional-vs-diy-methods",
+        "label": "Professional vs DIY methods",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-modification-body-placement-considerations",
+        "label": "Body placement considerations",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "body-modification-healing-and-aftercare",
+        "label": "Healing and aftercare",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Relationship Preferences",
+    "items": [
+      {
+        "id": "relationship-preferences-preferred-relationship-style",
+        "label": "Preferred relationship style",
+        "type": "text",
+        "options": [
+          "Monogamous",
+          "Open relationship",
+          "Polyamorous",
+          "No preference"
+        ],
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "relationship-preferences-relationship-goals",
+        "label": "Relationship goals",
+        "type": "text",
+        "options": [
+          "One night stand",
+          "Short-term play",
+          "Long-term relationship",
+          "Platonic play partners",
+          "Romantic partners",
+          "Kink partners"
+        ],
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "relationship-preferences-monogamous",
+        "label": "Monogamous",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "relationship-preferences-polyamorous",
+        "label": "Polyamorous",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "relationship-preferences-hierarchical-dynamics",
+        "label": "Hierarchical dynamics",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "relationship-preferences-non-hierarchical-poly",
+        "label": "Non-hierarchical poly",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "relationship-preferences-solo-poly",
+        "label": "Solo-poly",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "relationship-preferences-open-with-boundaries",
+        "label": "Open with boundaries",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "relationship-preferences-closed-but-kinky-with-others",
+        "label": "Closed but kinky with others",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "relationship-preferences-switch-friendly-dynamics",
+        "label": "Switch-friendly dynamics",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Gender Play & Transformation",
+    "items": [
+      {
+        "id": "gender-play-transformation-crossdressing",
+        "label": "Crossdressing",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "gender-play-transformation-forced-feminization",
+        "label": "Forced feminization",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "gender-play-transformation-forced-masculinization",
+        "label": "Forced masculinization",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "gender-play-transformation-gender-role-reversal",
+        "label": "Gender role reversal",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "gender-play-transformation-pronoun-changes",
+        "label": "Pronoun changes",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "gender-play-transformation-voice-or-mannerism-training",
+        "label": "Voice or mannerism training",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "gender-play-transformation-sissy-or-tomboy-persona",
+        "label": "Sissy or tomboy persona",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "gender-play-transformation-preferred-pronouns-and-names",
+        "label": "Preferred pronouns and names",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "gender-play-transformation-public-presentation-comfort",
+        "label": "Public presentation comfort",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "gender-play-transformation-clothing-and-appearance",
+        "label": "Clothing and appearance",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "gender-play-transformation-exploration-of-identity",
+        "label": "Exploration of identity",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Chastity Devices",
+    "items": [
+      {
+        "id": "chastity-devices-wearing-a-chastity-cage-short-term",
+        "label": "Wearing a chastity cage (short term)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "chastity-devices-long-term-chastity-training",
+        "label": "Long-term chastity training",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "chastity-devices-chastity-device-control-with-permission-to-unlock",
+        "label": "Chastity device control with permission to unlock",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "chastity-devices-locked-remotely-by-another-person",
+        "label": "Locked remotely by another person",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "chastity-devices-orgasm-denial-enforced-by-chastity",
+        "label": "Orgasm denial enforced by chastity",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "chastity-devices-wearing-a-belt-style-chastity-device",
+        "label": "Wearing a belt-style chastity device",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "chastity-devices-humiliation-while-locked-in-chastity",
+        "label": "Humiliation while locked in chastity",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "chastity-devices-sleep-in-chastity-overnight",
+        "label": "Sleep in chastity (overnight)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "chastity-devices-being-teased-while-unable-to-touch-yourself",
+        "label": "Being teased while unable to touch yourself",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "chastity-devices-begging-for-release-from-chastity",
+        "label": "Begging for release from chastity",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Shibari & Rope Bondage",
+    "items": [
+      {
+        "id": "shibari-rope-bondage-being-tied-in-aesthetic-rope-patterns-shibari",
+        "label": "Being tied in aesthetic rope patterns (Shibari)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "shibari-rope-bondage-rope-bondage-for-restraint-and-control",
+        "label": "Rope bondage for restraint and control",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "shibari-rope-bondage-rope-suspension-partial-or-full",
+        "label": "Rope suspension (partial or full)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "shibari-rope-bondage-learning-to-tie-rope-as-a-form-of-dominance",
+        "label": "Learning to tie rope as a form of dominance",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "shibari-rope-bondage-being-tied-in-vulnerable-or-exposing-poses",
+        "label": "Being tied in vulnerable or exposing poses",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "shibari-rope-bondage-practicing-rope-with-emotional-connection",
+        "label": "Practicing rope with emotional connection",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "shibari-rope-bondage-enduring-discomfort-for-the-beauty-of-the-rope",
+        "label": "Enduring discomfort for the beauty of the rope",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "shibari-rope-bondage-being-tied-in-a-mirror-and-told-to-look",
+        "label": "Being tied in a mirror and told to look",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "shibari-rope-bondage-punishment-ties-e-g-uncomfortable-or-humiliating-positions",
+        "label": "Punishment ties (e.g., uncomfortable or humiliating positions)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "shibari-rope-bondage-solo-rope-practice-for-mindfulness-or-masochism",
+        "label": "Solo rope practice for mindfulness or masochism",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Cosplay & Identity Play",
+    "items": [
+      {
+        "id": "cosplay-identity-play-dressing-up-in-costumes-for-scenes",
+        "label": "Dressing up in costumes for scenes",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "cosplay-identity-play-playing-as-fictional-characters",
+        "label": "Playing as fictional characters",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "cosplay-identity-play-petplay-with-collars-ears-or-tails",
+        "label": "Petplay with collars, ears, or tails",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "cosplay-identity-play-pretending-to-be-a-doll-robot-or-object",
+        "label": "Pretending to be a doll, robot, or object",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "cosplay-identity-play-master-slave-cosplay-dynamic-non-24-7",
+        "label": "Master/slave cosplay dynamic (non-24/7)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "cosplay-identity-play-roleplaying-as-a-fantasy-species-or-non-human",
+        "label": "Roleplaying as a fantasy species or non-human",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "cosplay-identity-play-using-cosplay-to-deepen-power-exchange",
+        "label": "Using cosplay to deepen power exchange",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "cosplay-identity-play-scene-built-around-a-character-s-story-or-world",
+        "label": "Scene built around a character’s story or world",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "cosplay-identity-play-fantasy-uniforms-nurse-teacher-etc",
+        "label": "Fantasy uniforms (nurse, teacher, etc.)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "High-Intensity Kinks (SSC-Aware)",
+    "items": [
+      {
+        "id": "high-intensity-kinks-ssc-aware-intense-breath-play-e-g-smothering-or-pressure",
+        "label": "Intense breath play (e.g., smothering or pressure)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-knife-play-or-blade-play-without-injury",
+        "label": "Knife play or blade play (without injury)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-fear-play-using-known-or-negotiated-triggers",
+        "label": "Fear play using known or negotiated triggers",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-abduction-or-home-invasion-style-roleplay-negotiated",
+        "label": "Abduction or home-invasion style roleplay (negotiated)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-medical-themed-scenes-with-sharp-objects-not-bloodletting",
+        "label": "Medical-themed scenes with sharp objects (not bloodletting)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-sensory-deprivation-with-added-disorientation-or-helplessness",
+        "label": "Sensory deprivation with added disorientation or helplessness",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-scenes-involving-heavy-objectification-or-emotional-manipulation-with-care",
+        "label": "Scenes involving heavy objectification or emotional manipulation (with care)",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-mock-interrogation-or-intense-role-pressure",
+        "label": "Mock interrogation or intense role pressure",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-consensual-threats-without-follow-through-e-g-if-you-don-t",
+        "label": "Consensual threats without follow-through (e.g. 'If you don’t...')",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      },
+      {
+        "id": "high-intensity-kinks-ssc-aware-high-intensity-primal-scenes-involving-struggle-or-fear",
+        "label": "High-intensity primal scenes involving struggle or fear",
+        "type": "scale",
+        "roles": [
+          "Giving",
+          "Receiving"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Behavioral Play",
+    "items": [
+      {
+        "id": "behavioral-play-assigning-corner-time-or-time-outs",
+        "label": "Assigning corner time or time-outs",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "behavioral-play-writing-lines-or-apology-letters-as-correction",
+        "label": "Writing lines or apology letters as correction",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "behavioral-play-removing-privileges-phone-tv-sweets",
+        "label": "Removing privileges (phone, TV, sweets)",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "behavioral-play-playful-punishments-that-still-reinforce-rules",
+        "label": "Playful punishments that still reinforce rules",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "behavioral-play-lecturing-or-scolding-to-modify-behavior",
+        "label": "Lecturing or scolding to modify behavior",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "behavioral-play-being-placed-in-the-corner-or-given-a-time-out",
+        "label": "Being placed in the corner or given a time-out",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "behavioral-play-writing-lines-or-apology-letters-when-misbehaving",
+        "label": "Writing lines or apology letters when misbehaving",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "behavioral-play-having-privileges-revoked-phone-tv",
+        "label": "Having privileges revoked (phone, TV)",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "behavioral-play-receiving-playful-funishments-for-minor-rule-breaking",
+        "label": "Receiving playful 'funishments' for minor rule-breaking",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "behavioral-play-getting-scolded-or-lectured-for-correction",
+        "label": "Getting scolded or lectured for correction",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "behavioral-play-preferred-style-of-discipline-strict-vs-lenient",
+        "label": "Preferred style of discipline (strict vs lenient)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "behavioral-play-attitude-toward-funishment-vs-serious-correction",
+        "label": "Attitude toward funishment vs serious correction",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "behavioral-play-use-of-behavior-contracts-or-rule-agreements",
+        "label": "Use of behavior contracts or rule agreements",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Appearance Play",
+    "items": [
+      {
+        "id": "appearance-play-choosing-my-partner-s-outfit-for-the-day-or-a-scene",
+        "label": "Choosing my partner’s outfit for the day or a scene",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "appearance-play-selecting-their-underwear-lingerie-or-base-layers",
+        "label": "Selecting their underwear, lingerie, or base layers",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "appearance-play-styling-their-hair-braiding-brushing-tying-etc",
+        "label": "Styling their hair (braiding, brushing, tying, etc.)",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "appearance-play-picking-head-coverings-bonnets-veils-hoods-hats-for-mood-or-protocol",
+        "label": "Picking head coverings (bonnets, veils, hoods, hats) for mood or protocol",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "appearance-play-offering-makeup-polish-or-accessories-as-part-of-ritual-or-play",
+        "label": "Offering makeup, polish, or accessories as part of ritual or play",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "appearance-play-creating-themed-looks-slutty-innocent-doll-like-sharp-etc",
+        "label": "Creating themed looks (slutty, innocent, doll-like, sharp, etc.)",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "appearance-play-dressing-them-in-role-specific-costumes-maid-bunny-doll-etc",
+        "label": "Dressing them in role-specific costumes (maid, bunny, doll, etc.)",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "appearance-play-curating-time-period-or-historical-outfits-e-g-victorian-50s",
+        "label": "Curating time-period or historical outfits (e.g., Victorian, 50s)",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "appearance-play-helping-them-present-more-femme-masc-or-androgynous-by-request",
+        "label": "Helping them present more femme, masc, or androgynous by request",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "appearance-play-coordinating-their-look-with-mine-for-public-or-private-scenes",
+        "label": "Coordinating their look with mine for public or private scenes",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "appearance-play-implementing-a-dress-ritual-or-aesthetic-preparation",
+        "label": "Implementing a “dress ritual” or aesthetic preparation",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "appearance-play-enforcing-a-visual-protocol-e-g-no-bra-heels-required-tied-hair",
+        "label": "Enforcing a visual protocol (e.g., no bra, heels required, tied hair)",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "appearance-play-having-my-outfit-selected-for-me-by-a-partner",
+        "label": "Having my outfit selected for me by a partner",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "appearance-play-wearing-the-underwear-or-lingerie-they-choose",
+        "label": "Wearing the underwear or lingerie they choose",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "appearance-play-having-my-hair-brushed-braided-tied-or-styled-for-them",
+        "label": "Having my hair brushed, braided, tied, or styled for them",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "appearance-play-putting-on-a-head-covering-e-g-bonnet-veil-hood-they-chose",
+        "label": "Putting on a head covering (e.g., bonnet, veil, hood) they chose",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "appearance-play-following-visual-appearance-rules-as-part-of-submission",
+        "label": "Following visual appearance rules as part of submission",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "appearance-play-wearing-makeup-polish-or-accessories-they-request",
+        "label": "Wearing makeup, polish, or accessories they request",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "appearance-play-dressing-to-please-their-vision-cute-filthy-classy-etc",
+        "label": "Dressing to please their vision (cute, filthy, classy, etc.)",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "appearance-play-wearing-roleplay-costumes-or-character-looks",
+        "label": "Wearing roleplay costumes or character looks",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "appearance-play-presenting-in-a-way-that-matches-their-chosen-aesthetic",
+        "label": "Presenting in a way that matches their chosen aesthetic",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "appearance-play-participating-in-dressing-rituals-or-undressing-ceremonies",
+        "label": "Participating in dressing rituals or undressing ceremonies",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "appearance-play-being-admired-for-the-way-i-look-under-their-direction",
+        "label": "Being admired for the way I look under their direction",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "appearance-play-receiving-praise-or-gentle-teasing-about-my-appearance",
+        "label": "Receiving praise or gentle teasing about my appearance",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "appearance-play-cosplay-or-fantasy-looks-anime-game-fairytale-etc",
+        "label": "Cosplay or fantasy looks (anime, game, fairytale, etc.)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "appearance-play-time-period-dress-up-regency-gothic-1920s-etc",
+        "label": "Time-period dress-up (regency, gothic, 1920s, etc.)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "appearance-play-dollification-or-polished-presented-object-aesthetics",
+        "label": "Dollification or polished/presented object aesthetics",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "appearance-play-uniforms-schoolgirl-military-clerical-nurse-etc",
+        "label": "Uniforms (schoolgirl, military, clerical, nurse, etc.)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "appearance-play-hair-based-play-forced-brushing-ribbons-or-tied-styles",
+        "label": "Hair-based play (forced brushing, ribbons, or tied styles)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "appearance-play-head-coverings-or-symbolic-hoods-in-ritualized-dynamics",
+        "label": "Head coverings or symbolic hoods in ritualized dynamics",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "appearance-play-matching-looks-or-coordinated-dress-codes",
+        "label": "Matching looks or coordinated dress codes",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "appearance-play-ritualized-grooming-before-scenes",
+        "label": "Ritualized grooming before scenes",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "appearance-play-praise-or-positive-attention-for-pleasing-visual-display",
+        "label": "Praise or positive attention for pleasing visual display",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "appearance-play-formal-appearance-protocols-for-scenes-or-dynamics",
+        "label": "Formal appearance protocols for scenes or dynamics",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "appearance-play-using-clothing-or-style-to-embody-emotional-or-power-roles",
+        "label": "Using clothing or style to embody emotional or power roles",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Psychology Play",
+    "items": [
+      {
+        "id": "psychology-play-emotional-sadism-giving-teasing-feelings-orchestrating-reactions-savoring-anticipation-without-shame-based-harm",
+        "label": "Emotional Sadism (giving): teasing feelings, orchestrating reactions, savoring anticipation without shame-based harm",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-psychological-control-mind-games-double-binds-deliberate-pacing-and-strategic-ambiguity",
+        "label": "Psychological Control: mind games, double binds, deliberate pacing, and strategic ambiguity",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-sadistic-attention-enjoying-being-the-focal-point-of-a-partner-s-fear-arousal-or-resistance",
+        "label": "Sadistic Attention: enjoying being the focal point of a partner’s fear, arousal, or resistance",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-teasing-humiliation-playful-status-play-without-degradation-or-shame",
+        "label": "Teasing Humiliation: playful status play without degradation or shame",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "psychology-play-emotional-sadism-receiving-enjoying-engineered-emotional-intensity-such-as-fluster-exposure-or-playful-embarrassment",
+        "label": "Emotional Sadism (receiving): enjoying engineered emotional intensity such as fluster, exposure, or playful embarrassment",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-psychological-control-receiving-arousal-from-being-studied-contained-or-outmaneuvered",
+        "label": "Psychological Control (receiving): arousal from being studied, contained, or outmaneuvered",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-being-the-focus-enjoying-being-watched-tracked-or-held-in-a-partner-s-intense-focus",
+        "label": "Being the Focus: enjoying being watched, tracked, or held in a partner’s intense focus",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-teasing-humiliation-receiving-enjoying-playful-embarrassment-or-affectionate-mockery-that-builds-intimacy",
+        "label": "Teasing Humiliation (receiving): enjoying playful embarrassment or affectionate mockery that builds intimacy",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-prey-attention-neediness-craving-focus-pursuit-or-intense-awareness-from-a-partner",
+        "label": "Prey Attention/Neediness: craving focus, pursuit, or intense awareness from a partner",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "psychology-play-primal-recognition-being-seen-understood-or-tracked-without-needing-words",
+        "label": "Primal Recognition: being seen, understood, or tracked without needing words",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  },
+  {
+    "category": "Breeding",
+    "items": [
+      {
+        "id": "breeding-impregnation-giving-arousal-from-attempting-to-impregnate-a-partner",
+        "label": "Impregnation (giving): arousal from attempting to impregnate a partner",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "breeding-feeding-milk-giving-arousal-from-producing-and-feeding-milk-to-a-partner",
+        "label": "Feeding Milk (giving): arousal from producing and feeding milk to a partner",
+        "type": "scale",
+        "roles": [
+          "Giving"
+        ]
+      },
+      {
+        "id": "breeding-impregnation-receiving-arousal-from-being-inseminated-pregnancy-risk-or-being-bred",
+        "label": "Impregnation (receiving): arousal from being inseminated, pregnancy risk, or being bred",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "breeding-feeding-milk-receiving-arousal-from-drinking-a-partner-s-milk",
+        "label": "Feeding Milk (receiving): arousal from drinking a partner’s milk",
+        "type": "scale",
+        "roles": [
+          "Receiving"
+        ]
+      },
+      {
+        "id": "breeding-pregnancy-fantasy-erotic-focus-on-pregnancy-mine-partner-s-or-fictional-scenarios",
+        "label": "Pregnancy Fantasy: erotic focus on pregnancy (mine, partner’s, or fictional scenarios)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-primal-breeding-drive-animalistic-instinctual-framing-of-sex-reproduction-territory",
+        "label": "Primal Breeding Drive: animalistic/instinctual framing of sex, reproduction, territory",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-breeding-as-control-ownership-authority-expressed-through-breeding-talk-or-pregnancy-risk",
+        "label": "Breeding as Control: ownership/authority expressed through breeding talk or pregnancy risk",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-creampie-marking-erotic-meaning-placed-on-internal-ejaculation-or-visible-claimed-markers",
+        "label": "Creampie/Marking: erotic meaning placed on internal ejaculation or visible ‘claimed’ markers",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-risk-no-contraception-talk-fantasy-dirty-talk-about-risk-or-breeding-without-actual-risk",
+        "label": "Risk/‘No Contraception’ Talk (fantasy): dirty talk about risk or breeding without actual risk",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-heat-ovulation-tracking-timing-in-heat-roleplay-or-cycle-focused-arousal",
+        "label": "Heat/Ovulation Tracking: timing, ‘in heat’ roleplay, or cycle-focused arousal",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-artificial-insemination-device-play-syringes-cups-or-medical-style-scenarios-consensual-fantasy",
+        "label": "Artificial Insemination/Device Play: syringes, cups, or medical-style scenarios (consensual fantasy)",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-breeding-denial-ruined-breeding-building-toward-impregnation-talk-then-denying-or-ruining-it",
+        "label": "Breeding Denial/Ruined Breeding: building toward impregnation talk then denying or ‘ruining’ it",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-pregnancy-body-focus-belly-worship-movement-weight-changes-glow-and-attention",
+        "label": "Pregnancy Body Focus: belly worship, movement/weight changes, glow, and attention",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-pregnancy-protocol-care-protective-rules-pedestal-treatment-dedicated-aftercare",
+        "label": "Pregnancy Protocol/Care: protective rules, pedestal treatment, dedicated aftercare",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-lactation-induction-maintenance-interest-in-inducing-or-sustaining-milk-production",
+        "label": "Lactation Induction/Maintenance: interest in inducing or sustaining milk production",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-milking-scenes-manual-oral-or-pump-based-milking-as-play-or-ritual",
+        "label": "Milking Scenes: manual, oral, or pump-based ‘milking’ as play or ritual",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-contraception-boundaries-preference-to-use-protection-bc-methods-or-simulation-only",
+        "label": "Contraception Boundaries: preference to use protection, BC methods, or simulation-only",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      },
+      {
+        "id": "breeding-sti-testing-medical-boundaries-testing-cadence-disclosures-and-comfort-levels",
+        "label": "STI/Testing & Medical Boundaries: testing cadence, disclosures, and comfort levels",
+        "type": "scale",
+        "roles": [
+          "General"
+        ]
+      }
+    ]
+  }
+]

--- a/docs/kinksurvey/index.html
+++ b/docs/kinksurvey/index.html
@@ -317,24 +317,29 @@
 <script>
 (async function(){
   // Keep your existing data sources (will use your published dataset when present)
-  const here = new URL(window.location.href);
-  const DEFAULT_URLS=[
-    '/data/kinks.json',
-    '/kinksurvey/data/kinks.json',
-    '/kinksurvey/kinks.json',
-    '/kinks.json',
-    '/assets/kinks.json'
-  ];
-  const overrideUrls = Array.isArray(window.KSV?.KINKS_URLS) ? window.KSV.KINKS_URLS : null;
-  const DATA_URLS = Array.from(new Set(
-    (overrideUrls && overrideUrls.length ? overrideUrls : DEFAULT_URLS)
-      .map(url => {
-        try { return new URL(url, here).pathname; }
-        catch { return url; }
-      })
-      .filter(Boolean)
-  ));
-  if (!DATA_URLS.length) DATA_URLS.push('/data/kinks.json');
+  async function safeJson(url) {
+    try {
+      const res = await fetch(url, { cache: 'no-store' });
+      if (!res.ok) return null;
+      return await res.json();
+    } catch {
+      return null;
+    }
+  }
+
+  async function loadKinksDataset() {
+    const v = Date.now();
+    const urls = [
+      `/data/kinks.json?v=${v}`,
+      `/kinksurvey/data/kinks.json?v=${v}`,
+      `data/kinks.json?v=${v}`
+    ];
+    for (const u of urls) {
+      const j = await safeJson(u);
+      if (j) return j;
+    }
+    return null;
+  }
 
   // Elements
   const $ = (id)=>document.getElementById(id);
@@ -490,87 +495,6 @@
   const S = { cats:[], sel:[], i:0 };
 
   const tidy = s=>String(s??'').replace(/\s+/g,' ').trim();
-  const looksHTML = t => /^\s*<!doctype html/i.test(t) || /<html[\s>]/i.test(t);
-
-  const DEBUG_FETCH = (()=>{
-    if (window.kinkSurveyFetchDebug === true) return true;
-    try {
-      const qs = new URLSearchParams(location.search);
-      if (qs.has('debug')) return true;
-    } catch (_){}
-    return /localhost|127\.0\.0\.1/.test(location.hostname);
-  })();
-
-  const FETCH_NOTE_ID = 'tkFetchNote';
-
-  function removeFetchNote(){
-    const existing = document.getElementById(FETCH_NOTE_ID);
-    if (existing) existing.remove();
-  }
-
-  function showFetchNote(notes){
-    if (!notes?.length) return;
-    if (!DEBUG_FETCH){
-      console.warn('[kinksurvey] Fetch notes:', notes.join('  -  '));
-      return;
-    }
-    let note = document.getElementById(FETCH_NOTE_ID);
-    if (!note){
-      note = document.createElement('div');
-      note.id = FETCH_NOTE_ID;
-      note.style.cssText = [
-        'position:fixed','left:0','right:0','bottom:0','z-index:2147483600',
-        'padding:.55rem 1rem','background:#001316','color:#57f7ff',
-        'border-top:1px solid #00e6ff33',
-        'font:600 14px/1.35 system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif',
-        'text-align:center'
-      ].join(';');
-    }
-    note.textContent = 'Fetch notes: ' + notes.join('  -  ');
-    if (!note.isConnected) document.body?.appendChild(note);
-  }
-  window.showFetchNote = showFetchNote;
-
-  async function fetchFirstInternal(urls){
-    const notes = [];
-    for (const url of urls){
-      try{
-        const res = await fetch(url, {cache:'no-store'});
-        if (!res.ok){
-          notes.push(`${url}: HTTP ${res.status}`);
-          console.warn('[kinksurvey] Not found:', url, res.status);
-          continue;
-        }
-        const text = await res.text();
-        if (looksHTML(text)){
-          notes.push(`${url}: HTML fallback`);
-          console.warn('[kinksurvey] HTML fallback:', url);
-          continue;
-        }
-        const json = JSON.parse(text);
-        console.info('[kinksurvey] Loaded:', url);
-        removeFetchNote();
-        return { json, src: url, errs: [] };
-      }catch(err){
-        const message = err?.message || String(err);
-        notes.push(`${url}: ${message}`);
-        console.warn('[kinksurvey] Fetch failed:', url, message);
-      }
-    }
-    showFetchNote(notes);
-    const error = new Error('kinks.json not found in any candidate location');
-    error.notes = notes;
-    throw error;
-  }
-  window.fetchFirst = fetchFirstInternal;
-
-  async function fetchData(){
-    const fetcher = typeof window.fetchFirst === 'function' ? window.fetchFirst : fetchFirstInternal;
-    const result = await fetcher(DATA_URLS);
-    if (result && typeof result === 'object' && 'json' in result) return result;
-    return { json: result, src: DATA_URLS[0], errs: [] };
-  }
-
   function normalize(raw){
     const out=[];
     const push=(name,items)=>{
@@ -660,27 +584,16 @@
 
   // Boot
   try{
-    const {json,src,errs} = await fetchData();
-    S.cats = normalize(json);
+    const dataset = await loadKinksDataset();
+    if (!dataset) throw new Error('Dataset unavailable. Expected /data/kinks.json');
+    S.cats = normalize(dataset);
     renderPanel(S.cats);
     status.textContent = `Loaded ${S.cats.length} categories`;
     maybeRevealPanel();
-    if (errs?.length){
-      if (DEBUG_FETCH) showDiag('Fetch notes:\n- ' + errs.join('\n- '));
-      else console.warn('[kinksurvey] Fetch notes:', errs.join(' | '));
-    }
   }catch(e){
-    const msg = e?.message || e;
-    const notes = Array.isArray(e?.notes) ? e.notes : [];
-    showFetchNote(notes);
-    const baseMessage = 'This page will populate once /data/kinks.json is published.';
-    if (DEBUG_FETCH && notes.length){
-      const extra = '\nFetch notes:\n- ' + notes.join('\n- ');
-      showDiag(msg + extra + '\n' + baseMessage);
-    } else {
-      console.warn('[kinksurvey] Fetch failed:', msg, notes);
-      showDiag(baseMessage);
-    }
+    const msg = e?.message || 'Dataset unavailable. Expected /data/kinks.json';
+    console.warn('[kinksurvey] Fetch failed:', msg);
+    showDiag('Dataset unavailable. Expected /data/kinks.json');
     status.textContent = 'Dataset unavailable';
   }
 })();

--- a/kinksurvey/index.html
+++ b/kinksurvey/index.html
@@ -362,25 +362,29 @@
 
 <script>
 (async function(){
-  // Keep your existing data sources (will use your published dataset when present)
-  const here = new URL(window.location.href);
-  const DEFAULT_URLS=[
-    '/data/kinks.json',
-    '/kinksurvey/data/kinks.json',
-    '/kinksurvey/kinks.json',
-    '/kinks.json',
-    '/assets/kinks.json'
-  ];
-  const overrideUrls = Array.isArray(window.KSV?.KINKS_URLS) ? window.KSV.KINKS_URLS : null;
-  const DATA_URLS = Array.from(new Set(
-    (overrideUrls && overrideUrls.length ? overrideUrls : DEFAULT_URLS)
-      .map(url => {
-        try { return new URL(url, here).pathname; }
-        catch { return url; }
-      })
-      .filter(Boolean)
-  ));
-  if (!DATA_URLS.length) DATA_URLS.push('/data/kinks.json');
+  async function safeJson(url) {
+    try {
+      const res = await fetch(url, { cache: 'no-store' });
+      if (!res.ok) return null;
+      return await res.json();
+    } catch {
+      return null;
+    }
+  }
+
+  async function loadKinksDataset() {
+    const v = Date.now();
+    const urls = [
+      `/data/kinks.json?v=${v}`,
+      `/kinksurvey/data/kinks.json?v=${v}`,
+      `data/kinks.json?v=${v}`
+    ];
+    for (const u of urls) {
+      const j = await safeJson(u);
+      if (j) return j;
+    }
+    return null;
+  }
 
   // Elements
   const $ = (id)=>document.getElementById(id);
@@ -536,87 +540,6 @@
   const S = { cats:[], sel:[], i:0 };
 
   const tidy = s=>String(s??'').replace(/\s+/g,' ').trim();
-  const looksHTML = t => /^\s*<!doctype html/i.test(t) || /<html[\s>]/i.test(t);
-
-  const DEBUG_FETCH = (()=>{
-    if (window.kinkSurveyFetchDebug === true) return true;
-    try {
-      const qs = new URLSearchParams(location.search);
-      if (qs.has('debug')) return true;
-    } catch (_){}
-    return /localhost|127\.0\.0\.1/.test(location.hostname);
-  })();
-
-  const FETCH_NOTE_ID = 'tkFetchNote';
-
-  function removeFetchNote(){
-    const existing = document.getElementById(FETCH_NOTE_ID);
-    if (existing) existing.remove();
-  }
-
-  function showFetchNote(notes){
-    if (!notes?.length) return;
-    if (!DEBUG_FETCH){
-      console.warn('[kinksurvey] Fetch notes:', notes.join('  -  '));
-      return;
-    }
-    let note = document.getElementById(FETCH_NOTE_ID);
-    if (!note){
-      note = document.createElement('div');
-      note.id = FETCH_NOTE_ID;
-      note.style.cssText = [
-        'position:fixed','left:0','right:0','bottom:0','z-index:2147483600',
-        'padding:.55rem 1rem','background:#001316','color:#57f7ff',
-        'border-top:1px solid #00e6ff33',
-        'font:600 14px/1.35 system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif',
-        'text-align:center'
-      ].join(';');
-    }
-    note.textContent = 'Fetch notes: ' + notes.join('  -  ');
-    if (!note.isConnected) document.body?.appendChild(note);
-  }
-  window.showFetchNote = showFetchNote;
-
-  async function fetchFirstInternal(urls){
-    const notes = [];
-    for (const url of urls){
-      try{
-        const res = await fetch(url, {cache:'no-store'});
-        if (!res.ok){
-          notes.push(`${url}: HTTP ${res.status}`);
-          console.warn('[kinksurvey] Not found:', url, res.status);
-          continue;
-        }
-        const text = await res.text();
-        if (looksHTML(text)){
-          notes.push(`${url}: HTML fallback`);
-          console.warn('[kinksurvey] HTML fallback:', url);
-          continue;
-        }
-        const json = JSON.parse(text);
-        console.info('[kinksurvey] Loaded:', url);
-        removeFetchNote();
-        return { json, src: url, errs: [] };
-      }catch(err){
-        const message = err?.message || String(err);
-        notes.push(`${url}: ${message}`);
-        console.warn('[kinksurvey] Fetch failed:', url, message);
-      }
-    }
-    showFetchNote(notes);
-    const error = new Error('kinks.json not found in any candidate location');
-    error.notes = notes;
-    throw error;
-  }
-  window.fetchFirst = fetchFirstInternal;
-
-  async function fetchData(){
-    const fetcher = typeof window.fetchFirst === 'function' ? window.fetchFirst : fetchFirstInternal;
-    const result = await fetcher(DATA_URLS);
-    if (result && typeof result === 'object' && 'json' in result) return result;
-    return { json: result, src: DATA_URLS[0], errs: [] };
-  }
-
   function normalize(raw){
     const out=[];
     const push=(name,items)=>{
@@ -706,27 +629,16 @@
 
   // Boot
   try{
-    const {json,src,errs} = await fetchData();
-    S.cats = normalize(json);
+    const dataset = await loadKinksDataset();
+    if (!dataset) throw new Error('Dataset unavailable. Expected /data/kinks.json');
+    S.cats = normalize(dataset);
     renderPanel(S.cats);
     status.textContent = `Loaded ${S.cats.length} categories`;
     maybeRevealPanel();
-    if (errs?.length){
-      if (DEBUG_FETCH) showDiag('Fetch notes:\n- ' + errs.join('\n- '));
-      else console.warn('[kinksurvey] Fetch notes:', errs.join(' | '));
-    }
   }catch(e){
-    const msg = e?.message || e;
-    const notes = Array.isArray(e?.notes) ? e.notes : [];
-    showFetchNote(notes);
-    const baseMessage = 'This page will populate once /data/kinks.json is published.';
-    if (DEBUG_FETCH && notes.length){
-      const extra = '\nFetch notes:\n- ' + notes.join('\n- ');
-      showDiag(msg + extra + '\n' + baseMessage);
-    } else {
-      console.warn('[kinksurvey] Fetch failed:', msg, notes);
-      showDiag(baseMessage);
-    }
+    const msg = e?.message || 'Dataset unavailable. Expected /data/kinks.json';
+    console.warn('[kinksurvey] Fetch failed:', msg);
+    showDiag('Dataset unavailable. Expected /data/kinks.json');
     status.textContent = 'Dataset unavailable';
   }
 })();

--- a/talk-kink-new-survey.html
+++ b/talk-kink-new-survey.html
@@ -207,16 +207,29 @@
 <script>
 (async function(){
   /* ---------- data fetch ---------- */
-  const DATA_URLS = [
-    '/data/kinks.json',
-    '/kinksurvey/data/kinks.json',
-    '/kinksurvey/kinks.json',
-    '/kinks.json',
-    '/assets/kinks.json',
-    './data/kinks.json',
-    './kinks.json',
-    './assets/kinks.json'
-  ];
+  async function safeJson(url) {
+    try {
+      const res = await fetch(url, { cache: 'no-store' });
+      if (!res.ok) return null;
+      return await res.json();
+    } catch {
+      return null;
+    }
+  }
+
+  async function loadKinksDataset() {
+    const v = Date.now();
+    const urls = [
+      `/data/kinks.json?v=${v}`,
+      `/kinksurvey/data/kinks.json?v=${v}`,
+      `data/kinks.json?v=${v}`
+    ];
+    for (const u of urls) {
+      const j = await safeJson(u);
+      if (j) return j;
+    }
+    return null;
+  }
 
   const el = (id)=>document.getElementById(id);
   const $panel = el('categoryPanel');
@@ -240,23 +253,6 @@
     const base = tidy(s).toLowerCase().replace(/[^a-z0-9]+/g,'_').replace(/^_+|_+$/g,'');
     return base || 'cat_'+Math.random().toString(36).slice(2,8);
   };
-  const looksHTML = (t)=>/^\s*<!doctype html/i.test(t)||/<html[\s>]/i.test(t);
-
-  async function getData(){
-    const errs=[];
-    for (const u of DATA_URLS){
-      try{
-        const res = await fetch(u,{cache:'no-store'});
-        if(!res.ok) throw new Error('HTTP '+res.status);
-        const txt = await res.text();
-        if (looksHTML(txt)) throw new Error('HTML fallback received');
-        const j = JSON.parse(txt);
-        return {json:j, src:u, errs};
-      }catch(e){ errs.push(u+': '+e.message); }
-    }
-    throw new Error('All dataset fetches failed:\n- '+errs.join('\n- '));
-  }
-
   function normalize(raw){
     const out = [];
     const push = (name, items)=>{
@@ -418,13 +414,15 @@
 
   /* ---------- boot ---------- */
   try{
-    const {json,src,errs} = await getData();
-    state.cats = normalize(json);
+    const dataset = await loadKinksDataset();
+    if (!dataset) throw new Error('Dataset unavailable. Expected /data/kinks.json');
+    state.cats = normalize(dataset);
     state.cats.sort((a,b)=>a.category.localeCompare(b.category,'en',{sensitivity:'base'}));
     renderPanel(state.cats);
-    if (errs?.length) showDiag('Fetch notes:\n- ' + errs.join('\n- '));
   }catch(e){
-    showDiag(e.message + '\nYou can still use this page once /data/kinks.json is published.');
+    const msg = e?.message || 'Dataset unavailable. Expected /data/kinks.json';
+    console.warn('[talkkink] kinks dataset fetch failed:', msg);
+    showDiag('Dataset unavailable. Expected /data/kinks.json');
     $status.textContent = 'Dataset unavailable';
   }
 })();


### PR DESCRIPTION
## Summary
- restore the full kink survey dataset at `data/kinks.json` and sync the published copy
- update survey pages to use a resilient loader that targets the centralized `/data/kinks.json`

## Testing
- NODE_TEST_WORKERS=1 node --test test/kinksDatasetPublication.test.js

------
https://chatgpt.com/codex/tasks/task_e_68ddae403ff4832c93827da2af8508df