### PR TITLE
Sort selected categories alphabetically

### DIFF
--- a/js/tk_kinksurvey_enhance.js
+++ b/js/tk_kinksurvey_enhance.js
@@ -373,7 +373,8 @@
       allCategoryBoxes()
         .filter(cb => cb.checked)
         .map(cb => cb.value || cb.getAttribute('value') || (cb.nextElementSibling?.textContent || '').trim())
-        .filter(Boolean);
+        .filter(Boolean)
+        .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
 
     const focusDrawer = () => {
       setTimeout(() => {

--- a/kinks/index.html
+++ b/kinks/index.html
@@ -409,7 +409,9 @@
 
       const getSelectedCategories = () => getCheckboxes()
         .filter(cb => cb.checked)
-        .map(cb => cb.value);
+        .map(cb => cb.value)
+        .filter(Boolean)
+        .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
 
       const showWarning = (message = '') => {
         if (warningEl) warningEl.textContent = message;


### PR DESCRIPTION
## Summary
- ensure the selected category list from the main survey page is normalized and sorted alphabetically
- keep the fullscreen category picker in sync by returning categories in alphabetical order as well

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ddc2748a64832c9e311d060c76585b