### PR TITLE
Enforce canonical kink category ordering

### DIFF
--- a/kinks/index.html
+++ b/kinks/index.html
@@ -1378,20 +1378,76 @@ How to use
   <script src="/js/tk_clickfix.js" defer></script>
   <script>
   (function(){
-    const text = (el) => (el?.textContent ?? "").trim();
+    const text = (el) => (el?.textContent ?? "").replace(/\s+/g, " ").trim();
     const normKey = (s) =>
       String(s ?? "")
         .normalize("NFKD")
         .replace(/[\u0300-\u036f]/g, "")
         .toLowerCase()
+        .replace(/&/g, " and ")
         .replace(/[^a-z0-9]+/g, " ")
         .trim();
 
-    const AtoZ = (a, b) => a.localeCompare(b, undefined, {
+    const AtoZ = (a, b) => String(a ?? "").localeCompare(String(b ?? ""), undefined, {
       sensitivity: "base",
       numeric: true,
       ignorePunctuation: true
     });
+
+    const EXACT_ORDER = [
+      "Body Part Torture",
+      "Bondage and Suspension",
+      "Breath Play",
+      "Sexual Activity",
+      "Sensation Play",
+      "Other",
+      "Roleplaying",
+      "Service and Restrictive Behaviour",
+      "Voyeurism/Exhibitionism",
+      "Virtual & Long-Distance Play",
+      "Communication",
+      "Body Fluids and Functions",
+      "Psychological Primal / Prey",
+      "Body Part / Fetish Play",
+      "Orgasm Control & Sexual Manipulation",
+      "Protocol and Ritual",
+      "Primal & Bratting",
+      "Headspace & Regression",
+      "Performance & Internal Struggle",
+      "Mindfuck & Manipulation",
+      "Mouth Play",
+      "Impact Play",
+      "Medical Play",
+      "Pet Play",
+      "Body Modification",
+      "Relationship Preferences",
+      "Gender Play & Transformation",
+      "Chastity Devices",
+      "Shibari & Rope Bondage",
+      "Cosplay & Identity Play",
+      "High-Intensity Kinks (SSC-Aware)",
+      "Behavioral Play",
+      "Appearance Play",
+      "Psychology Play",
+      "Breeding"
+    ];
+
+    window.__KSV_CATEGORY_ORDER__ = EXACT_ORDER.slice();
+
+    const ORDER_MAP = (() => {
+      const m = new Map();
+      EXACT_ORDER.forEach((name, idx) => m.set(normKey(name), idx));
+      return m;
+    })();
+
+    const cmpByExactOrder = (a, b) => {
+      const ka = normKey(a);
+      const kb = normKey(b);
+      const ra = ORDER_MAP.has(ka) ? ORDER_MAP.get(ka) : Infinity;
+      const rb = ORDER_MAP.has(kb) ? ORDER_MAP.get(kb) : Infinity;
+      if (ra !== rb) return ra - rb;
+      return AtoZ(a, b);
+    };
 
     function uniqSorted(list){
       const out = [];
@@ -1403,7 +1459,7 @@ How to use
         seen.add(k);
         out.push(t);
       }
-      return out.sort(AtoZ);
+      return out.sort(cmpByExactOrder);
     }
 
     function sortCategoryPanel(){
@@ -1411,7 +1467,7 @@ How to use
       if (!list) return;
       const rows = Array.from(list.querySelectorAll('label[role="listitem"], :scope > label'));
       if (!rows.length) return;
-      rows.sort((ra, rb) => AtoZ(text(ra), text(rb)));
+      rows.sort((ra, rb) => cmpByExactOrder(text(ra), text(rb)));
       rows.forEach(r => list.appendChild(r));
     }
 


### PR DESCRIPTION
## Summary
- enforce the canonical category order in the /kinks panel and Start button bootstrap helper
- share the same ordering logic with the enhancement script so the drawer UI and survey start flow stay synchronized

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dde3794fb4832cb4759757852061d1