### PR TITLE
Align survey rating rows in two-column grid

### DIFF
--- a/talk-kink-new-survey.html
+++ b/talk-kink-new-survey.html
@@ -12,6 +12,8 @@
     --btn:#071a1f; --btnb:#00e6ff; --btnfg:#eaffff;
     --barBg:#062028; --barFill:#13e0ff;
     --ksv-panel-w:720px;
+    --tk-rate-w:6rem;
+    --tk-q-gap:.75rem;
   }
   *{box-sizing:border-box}
   html,body{height:100%}
@@ -122,6 +124,49 @@
   .item:first-child{border-top:0}
   select,input[type="text"]{
     padding:6px 8px;border:1px solid #144; border-radius:8px;background:#071820;color:var(--fg)
+  }
+
+  /* Keep question + rating aligned */
+  .item.tk-qrow,
+  .item.item--scale{ /* alias for clarity */
+    display:grid;
+    grid-template-columns:minmax(0,1fr) var(--tk-rate-w);
+    column-gap:var(--tk-q-gap);
+    align-items:center;
+  }
+  .item.tk-qrow .tk-q-label,
+  .item.item--scale .tk-q-label{
+    grid-column:1 / 2;
+    min-width:0;
+    overflow-wrap:anywhere;
+    word-break:normal;
+    line-height:1.35;
+  }
+  .item.tk-qrow select,
+  .item.tk-qrow input[type="number"],
+  .item.tk-qrow input[type="text"][inputmode="numeric"],
+  .item.tk-qrow .tk-rate,
+  .item.item--scale select,
+  .item.item--scale input[type="number"],
+  .item.item--scale input[type="text"][inputmode="numeric"],
+  .item.item--scale .tk-rate{
+    grid-column:2 / 3;
+    justify-self:end;
+    width:100%;
+    max-width:var(--tk-rate-w);
+    box-sizing:border-box;
+  }
+  .item.tk-qrow select,
+  .item.item--scale select{
+    height:2.25rem;
+    padding:0 .5rem;
+  }
+  @media (max-width:480px){
+    :root{ --tk-rate-w:4.75rem; }
+    .item.tk-qrow,
+    .item.item--scale{ column-gap:.5rem; }
+    .item.tk-qrow .tk-q-label,
+    .item.item--scale .tk-q-label{ font-size:.98rem; }
   }
 
   /* PROGRESS */
@@ -390,17 +435,23 @@
     $title.textContent = c.category;
     $items.innerHTML='';
     c.items.forEach(it=>{
-      const row=document.createElement('div'); row.className='item';
+      const row=document.createElement('div');
+      row.className='item';
       const inputId='k_'+it.id;
-      let node='';
-      const t=(it.type||'').toLowerCase();
+      const t=(it.type||'scale').toLowerCase();
+      row.dataset.type = t;
+
       if (t==='bool'){
-        node = `<input type="checkbox" id="${inputId}" name="${it.id}">`;
+        row.classList.add('item--bool');
+        row.innerHTML = `<input type="checkbox" id="${inputId}" name="${it.id}"> <label for="${inputId}">${it.label}</label>`;
       } else if (t==='text'){
-        node = `<input type="text" id="${inputId}" name="${it.id}" placeholder="Your note">`;
+        row.classList.add('item--text');
+        row.innerHTML = `<input type="text" id="${inputId}" name="${it.id}" placeholder="Your note"> <label for="${inputId}">${it.label}</label>`;
       } else {
-        node =
-          `<select id="${inputId}" name="${it.id}">
+        row.classList.add('tk-qrow','item--scale');
+        row.innerHTML =
+          `<label class="tk-q-label" for="${inputId}">${it.label}</label>
+           <select id="${inputId}" name="${it.id}">
              <option value="" selected hidden>–</option>
              <option value="1">1</option>
              <option value="2">2</option>
@@ -409,7 +460,6 @@
              <option value="5">5</option>
            </select>`;
       }
-      row.innerHTML = `${node} <label for="${inputId}">${it.label}</label>`;
       $items.appendChild(row);
     });
     const controls = Array.from($items.querySelectorAll('select,input[type="checkbox"],input[type="text"]'));


### PR DESCRIPTION
## Summary
- add CSS grid helpers so rating selectors stay aligned with their questions across screen sizes
- tag generated rating rows with layout classes and render labels ahead of the select element
- preserve boolean and text inputs while enabling dataset-based styling metadata

## Testing
- Manual validation via local browser

------
https://chatgpt.com/codex/tasks/task_e_68ddf0a1f450832cb19f1ddca06966e5