### PR TITLE
Sort survey categories alphabetically

### DIFF
--- a/kinks/index.html
+++ b/kinks/index.html
@@ -1378,91 +1378,111 @@ How to use
   <script src="/js/tk_clickfix.js" defer></script>
   <script>
   (function(){
-    const text = (el) => (el?.textContent ?? "").replace(/\s+/g, " ").trim();
+    const text = (el) => (el?.textContent ?? "").trim();
     const normKey = (s) =>
       String(s ?? "")
         .normalize("NFKD")
         .replace(/[\u0300-\u036f]/g, "")
         .toLowerCase()
-        .replace(/&/g, " and ")
         .replace(/[^a-z0-9]+/g, " ")
         .trim();
 
-    const AtoZ = (a, b) => String(a ?? "").localeCompare(String(b ?? ""), undefined, {
+    const AtoZ = (a,b) => a.localeCompare(b, undefined, {
       sensitivity: "base",
       numeric: true,
       ignorePunctuation: true
     });
 
-    function uniq(list){
+    function uniqSorted(list){
       const out = [];
       const seen = new Set();
-      for (const v of list || []){
-        const raw = String(v ?? "").trim();
-        const key = normKey(raw);
-        if (!raw || !key || seen.has(key)) continue;
-        seen.add(key);
-        out.push(raw);
+      for (const c of list || []) {
+        const t = String(c ?? "").trim();
+        const k = normKey(t);
+        if (!k || seen.has(k)) continue;
+        seen.add(k);
+        out.push(t);
       }
-      return out;
-    }
-
-    function sortAZ(values){
-      return uniq(values).sort(AtoZ);
+      return out.sort(AtoZ);
     }
 
     function sortCategoryPanel(){
       const list = document.querySelector(".category-list");
       if (!list) return;
-      const rows = Array.from(list.querySelectorAll('label[role="listitem"], :scope > label'));
+      const rows = Array.from(list.querySelectorAll('label[role="listitem"]'));
       if (!rows.length) return;
+
       rows.sort((ra, rb) => AtoZ(text(ra), text(rb)));
       rows.forEach(r => list.appendChild(r));
     }
 
-    function wrapBootAZ(){
-      const boot = window.KINKS_boot;
-      if (!boot || boot.__ksvAZWrapped) return false;
+    const panelRoot = document.querySelector("#categorySurveyPanel") || document;
+    const mo = new MutationObserver(() => sortCategoryPanel());
+    mo.observe(panelRoot, { childList: true, subtree: true });
 
-      function wrapped(opts){
-        const o = Object.assign({}, opts || {});
-        let chosen = Array.isArray(o.categories) ? o.categories.slice() : null;
+    function wrapBootSorter(){
+      const tryWrap = () => {
+        const boot = window.KINKS_boot;
+        if (!boot || boot.__ksvSortedWrap) return false;
 
-        if (!chosen){
-          chosen = Array.from(document.querySelectorAll(".category-checkbox:checked"))
-            .map(cb => cb.value);
-        }
+        const wrapped = function(opts){
+          const o = Object.assign({}, opts || {});
+          let chosen = Array.isArray(o.categories) ? o.categories : null;
 
-        if (chosen && chosen.length){
-          o.categories = sortAZ(chosen);
-        }
-        return boot(o);
+          if (!chosen || !chosen.length) {
+            const last = Array.isArray(window.__KSV_LAST_SORTED_SELECTION__)
+              ? window.__KSV_LAST_SORTED_SELECTION__
+              : null;
+            if (last && last.length) {
+              chosen = last;
+            } else {
+              const checked = Array.from(document.querySelectorAll(".category-checkbox:checked"));
+              if (checked.length) {
+                chosen = checked.map(cb => cb.value);
+              }
+            }
+          }
+
+          if (chosen && chosen.length) {
+            o.categories = uniqSorted(chosen);
+          }
+          return boot(o);
+        };
+        wrapped.__ksvSortedWrap = true;
+        window.KINKS_boot = wrapped;
+        return true;
+      };
+
+      if (!tryWrap()){
+        const iv = setInterval(() => { if (tryWrap()) clearInterval(iv); }, 100);
+        setTimeout(() => clearInterval(iv), 10000);
       }
-
-      wrapped.__ksvAZWrapped = true;
-      window.KINKS_boot = wrapped;
-      return true;
     }
 
-    function ensureWrap(){
-      if (wrapBootAZ()) return;
-      const iv = setInterval(() => { if (wrapBootAZ()) clearInterval(iv); }, 100);
-      setTimeout(() => clearInterval(iv), 10000);
-    }
+    function hookStartButton(){
+      const btn = document.querySelector("#startSurvey, #startSurveyBtn");
+      if (!btn || btn.__ksvSelHooked) return;
+      btn.__ksvSelHooked = true;
 
-    function init(){
-      sortCategoryPanel();
-      ensureWrap();
-
-      const panelRoot = document.querySelector("#categorySurveyPanel") || document.body || document;
-      const mo = new MutationObserver(() => sortCategoryPanel());
-      mo.observe(panelRoot, { childList: true, subtree: true });
+      btn.addEventListener("click", () => {
+        const checked = Array.from(document.querySelectorAll(".category-checkbox:checked"));
+        if (checked.length) {
+          const vals = checked.map(cb => cb.value);
+          window.__KSV_LAST_SORTED_SELECTION__ = uniqSorted(vals);
+        }
+      }, { capture: true });
     }
 
     if (document.readyState === "loading") {
-      document.addEventListener("DOMContentLoaded", init, { once: true });
+      document.addEventListener("DOMContentLoaded", () => {
+        sortCategoryPanel();
+        wrapBootSorter();
+        hookStartButton();
+      }, { once:true });
     } else {
-      init();
+      sortCategoryPanel();
+      wrapBootSorter();
+      hookStartButton();
     }
   })();
   </script>


### PR DESCRIPTION
## Summary
- keep the category selection panel alphabetized even after dynamic updates
- wrap the survey boot routine so any selected categories are deduplicated and sorted A→Z
- capture the sorted selection when Start Survey is clicked for downstream consumers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddf15c3ec4832cb309f93f262e1709