### PR TITLE
Add Talk Kink compatibility DOM and PDF enhancements

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -2319,5 +2319,180 @@ document.getElementById('copyAtoB')?.addEventListener('click', () => {
 </script>
 
 
+<!-- ===== TALK KINK — Labels + Match% bars for Compatibility (DOM + PDF) =====
+Drop this right before </body> in /compatibility.html. No other edits required. -->
+<script>
+(function(){
+  /* ---------- 0) Minimal label map and optional fetch to augment ---------- */
+  // If you already publish a full map at /data/labels.json, this will merge it in.
+  // Otherwise, extend the inline LABELS object as needed.
+  const LABELS = {
+    // "cb_xxxxx": "Human Friendly Name",
+    // example:
+    // "cb_e4bdv": "Makeup as protocol or control",
+    // "cb_hhxwj": "Accessory or ornament rules",
+    // add more as you like; fetch() below will also try to fill gaps
+  };
+  const CB_RE = /\bcb_[a-z0-9]{5}\b/i;
+  const nice = (s)=>String(s||"").trim();
+
+  async function loadRemoteLabels(){
+    const urls = ["/data/labels.json","/data/labels-overrides.json"];
+    for (const u of urls){
+      try{
+        const r = await fetch(u, {cache:"no-store"});
+        if (!r.ok) continue;
+        const j = await r.json();
+        if (j && typeof j === "object"){
+          for (const [k,v] of Object.entries(j)) {
+            if (CB_RE.test(k) && nice(v)) LABELS[k.toLowerCase()] = nice(v);
+          }
+        }
+      }catch(_){ }
+    }
+  }
+
+  /* ---------- 1) Apply labels and DOM percent bars ---------- */
+  function labelFor(code){
+    if (!code) return code;
+    const k = code.toLowerCase();
+    return LABELS[k] || code; // fallback to the raw code if unknown
+  }
+
+  function relabelDom(){
+    // Table is usually two tables stacked; relabel the left-most "Category" column
+    const tables = Array.from(document.querySelectorAll("table"));
+    if (!tables.length) return;
+
+    for (const tbl of tables){
+      const rows = tbl.querySelectorAll("tbody tr");
+      rows.forEach(tr=>{
+        const tdCategory = tr.cells?.[0];
+        const tdPercent  = tr.cells?.[2]; // 3rd column is "Match %"
+        if (tdCategory){
+          // Replace any cb_* token inside the cell with a human title
+          const raw = nice(tdCategory.textContent);
+          const m = raw.match(CB_RE);
+          if (m){
+            const code = m[0];
+            const pretty = labelFor(code);
+            if (pretty && pretty !== code) tdCategory.textContent = pretty;
+          }
+        }
+        if (tdPercent){
+          const rawPct = nice(tdPercent.textContent);
+          const m = rawPct.match(/^(\d{1,3})%$/);
+          tdPercent.classList.add("pct-cell");
+          // Build a small DOM bar behind the text (layout-neutral)
+          if (m){
+            const pct = Math.max(0, Math.min(100, parseInt(m[1],10)));
+            const bar = document.createElement("div");
+            bar.className = "pct";
+            bar.innerHTML =
+              '<span class="bar" style="width:'+pct+'%"></span>'+
+              '<span class="txt">'+rawPct+'</span>';
+            tdPercent.innerHTML = "";
+            tdPercent.appendChild(bar);
+          } else {
+            // keep original if not a percentage
+            tdPercent.innerHTML = '<span class="txt">'+rawPct+'</span>';
+          }
+        }
+      });
+    }
+  }
+
+  // Minimal CSS for the DOM bars
+  (function injectCss(){
+    const css = `
+      td.pct-cell{min-width:5.5rem}
+      .pct{position:relative;height:1.15em;line-height:1.15em}
+      .pct .bar{position:absolute;inset:0 auto 0 0;width:0;background:rgba(0,230,255,.25);border-radius:2px}
+      .pct .txt{position:relative;display:block;text-align:center}
+    `;
+    const s = document.createElement("style");
+    s.textContent = css;
+    document.head.appendChild(s);
+  })();
+
+  /* ---------- 2) Patch jsPDF AutoTable to draw match bars in PDF ---------- */
+  function patchAutoTableBars(){
+    const JSPDF = window.jspdf && window.jspdf.jsPDF;
+    if (!JSPDF) return;                      // will be ready at export time
+    const proto = JSPDF.API;
+    if (!proto || !proto.autoTable || proto.autoTable.__tkPatched) return;
+
+    const orig = proto.autoTable;
+    proto.autoTable = function(opts){
+      const userDidDraw = opts && opts.didDrawCell;
+      const wrapped = Object.assign({}, opts, {
+        didDrawCell: function(data){
+          // Run user hook first
+          if (typeof userDidDraw === "function") try { userDidDraw.call(this, data);} catch(_){ }
+          // Body, 3rd column (index 2) expected to be a "NN%" string
+          if (data.section === "body" && data.column.index === 2){
+            const raw = String(data.cell.raw ?? "").trim();
+            const m = raw.match(/^(\d{1,3})%$/);
+            if (m){
+              const pct = Math.max(0, Math.min(100, parseInt(m[1],10)));
+              const pad = 1;
+              const x = data.cell.x + pad;
+              const w = Math.max(0, data.cell.width - pad*2) * (pct/100);
+              const y = data.cell.y + data.cell.height - 2.2;
+              this.setFillColor(0,230,255); // subtle cyan
+              this.rect(x, y, w, 1.8, "F");
+            }
+          }
+        }
+      });
+      wrapped.__tkFromPatched = true;
+      return orig.call(this, wrapped);
+    };
+    proto.autoTable.__tkPatched = true;
+  }
+
+  /* ---------- 3) Wrap common exporters so we relabel + bar before export ---- */
+  function wrapExporter(name){
+    const fn = window[name];
+    if (!fn || fn.__tkWrapped) return false;
+    window[name] = async function(...args){
+      // ensure labels in DOM (for the on-screen table)
+      await loadRemoteLabels();
+      relabelDom();
+      // ensure bars in PDF
+      patchAutoTableBars();
+      return await fn.apply(this, args);
+    };
+    window[name].__tkWrapped = true;
+    return true;
+  }
+
+  function wrapKnownExporters(){
+    // Add your function name here if different
+    ['TKPDF_export','exportCompatibilityPdf','downloadPdf','generatePdf'].forEach(wrapExporter);
+  }
+
+  /* ---------- 4) Keep the page correct even after re-renders ---------------- */
+  async function init(){
+    // Try to bring in any published label maps, then relabel DOM now
+    await loadRemoteLabels();
+    relabelDom();
+    // Observe table changes (uploads, toggles) and re-apply
+    const target = document.querySelector('main') || document.body;
+    const mo = new MutationObserver(() => relabelDom());
+    mo.observe(target, { childList:true, subtree:true });
+    // Prep PDF hooks
+    wrapKnownExporters();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init, {once:true});
+  } else {
+    init();
+  }
+})();
+</script>
+<!-- ===== /END TALK KINK patch ===== -->
+
 </body>
 </html>


### PR DESCRIPTION
## Summary
- integrate the Talk Kink labels and match percentage bar helper into `compatibility.html` so tables render human-friendly labels with inline bars and PDF exports draw meter fills

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de295f9954832ca95ee60c1e69e6c1