### PR TITLE
Ensure touch move and wheel listeners remain non-passive

### DIFF
--- a/js/tk_click_rerouter.js
+++ b/js/tk_click_rerouter.js
@@ -5,7 +5,7 @@
       const ET=(window.EventTarget||window.Node||function(){}).prototype;
       const orig=ET.addEventListener;
       ET.addEventListener=function(type,fn,opts){
-        if(type==='touchend'||type==='touchcancel'){
+        if(type==='touchend'||type==='touchcancel'||type==='touchmove'||type==='wheel'){
           if (opts==null) opts={}; else if (typeof opts==='boolean') opts={capture:opts};
           opts.passive=false; return orig.call(this,type,fn,opts);
         }

--- a/js/tk_unblock_clicks.js
+++ b/js/tk_unblock_clicks.js
@@ -3,12 +3,12 @@
   const START_SELECTOR = '#start,#startSurvey,#startSurveyBtn';
   const BOX_SELECTOR = '.category-panel input[type="checkbox"],input[name="category"][type="checkbox"]';
 
-  // Make touchend/touchcancel non-passive so tap handlers can preventDefault when needed
+  // Make touchend/touchcancel/touchmove/wheel non-passive so handlers can preventDefault when needed
   try{
     const ET=(window.EventTarget||window.Node||function(){}).prototype;
     const orig=ET.addEventListener;
     ET.addEventListener=function(type,listener,opts){
-      if(type==='touchend'||type==='touchcancel'){
+      if(type==='touchend'||type==='touchcancel'||type==='touchmove'||type==='wheel'){
         if (opts==null) opts={}; else if (typeof opts==='boolean') opts={capture:opts};
         opts.passive=false;
         return orig.call(this,type,listener,opts);


### PR DESCRIPTION
## Summary
- update the touch/click helper shims to explicitly mark touchmove and wheel listeners as passive: false
- keep existing prevention logic working when these handlers call event.preventDefault()

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68deff8f731c832cb6eb963de6ae62a0