### PR TITLE
Handle answersByKey uploads in compatibility parser

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -1972,13 +1972,35 @@ function ksvParseSurveyJsonText(rawText, who) {
   try { obj = JSON.parse(text); }
   catch { return { ok:false, reason:'Not valid JSON' }; }
 
+  const fromKeyMap = (maybeMap) => {
+    if (!maybeMap || typeof maybeMap !== 'object' || Array.isArray(maybeMap)) return null;
+    const entries = Object.entries(maybeMap);
+    if (!entries.length) return null;
+    entries.sort(([ak], [bk]) => {
+      const na = Number(ak);
+      const nb = Number(bk);
+      const fa = Number.isFinite(na);
+      const fb = Number.isFinite(nb);
+      if (fa && fb) return na - nb;
+      if (fa) return -1;
+      if (fb) return 1;
+      return String(ak).localeCompare(String(bk));
+    });
+    return entries.map(([, value]) => value);
+  };
+
   let answers = null;
   if (Array.isArray(obj?.answers)) answers = obj.answers;          // canonical
   if (!answers && Array.isArray(obj)) answers = obj;                // raw array
   if (!answers && Array.isArray(obj?.cells)) answers = obj.cells;   // {cells:[…]}
   if (!answers && Array.isArray(obj?.data?.cells)) answers = obj.data.cells;
-  if (!answers && obj && typeof obj === 'object' && obj.map && typeof obj.map === 'object') {
-    answers = Object.values(obj.map);
+  if (!answers) {
+    answers = fromKeyMap(obj?.answersByKey)
+           || fromKeyMap(obj?.data?.answersByKey)
+           || fromKeyMap(obj?.data?.ratings)
+           || fromKeyMap(obj?.data?.answers)
+           || fromKeyMap(obj?.map)
+           || fromKeyMap(obj?.data?.map);
   }
   if (!answers) return { ok:false, reason:'Missing answers/cells array' };
 

--- a/test/compatibilityAnswersByKeyUpload.test.js
+++ b/test/compatibilityAnswersByKeyUpload.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const extractParser = async () => {
+  const html = await readFile(new URL('../compatibility.html', import.meta.url), 'utf8');
+  const match = html.match(/function ksvParseSurveyJsonText[\s\S]*?return { ok:true, cells };\n}/);
+  assert(match, 'ksvParseSurveyJsonText definition not found');
+  // eslint-disable-next-line no-new-func
+  return new Function(`${match[0]}; return ksvParseSurveyJsonText;`)();
+};
+
+test('ksvParseSurveyJsonText accepts answersByKey payloads', async () => {
+  const parse = await extractParser();
+  const answersByKey = {};
+  for (let i = 35; i >= 1; i -= 1) {
+    answersByKey[String(i)] = i % 6; // intentionally reverse order to exercise sorting
+  }
+  const json = JSON.stringify({ answersByKey });
+  const result = parse(json, 'A');
+  assert.equal(result.ok, true, result.reason || 'expected ok');
+  assert.strictEqual(result.cells.length, 35);
+  const expected = Array.from({ length: 35 }, (_, idx) => (idx + 1) % 6);
+  assert.deepEqual(result.cells, expected);
+});


### PR DESCRIPTION
## Summary
- extend the compatibility upload parser to convert keyed answer maps into ordered arrays
- keep the existing normalization flow while supporting answersByKey and similar map shapes
- add a node-based test to exercise uploads that only provide answersByKey

## Testing
- npm test *(fails: existing kink survey fixture is missing labels in /data/kinks.json)*
- node --test test/compatibilityAnswersByKeyUpload.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e08e8aead0832cb886473f67a109b3