### PR TITLE
Fix overlapping category buttons layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -215,10 +215,15 @@ body.light-mode #closeRoleDefinitionsBtn {
 .category-panel .category-list label {
   display: flex;
   align-items: center;
-  border: 1px solid var(--accent-color);
-  padding: 6px 8px;
-  margin-bottom: 8px;
+  gap: 0.75rem;
+  padding: 14px 16px;
+  border: 2px solid var(--accent-color);
+  border-radius: 12px;
   background: transparent;
+  box-sizing: border-box;
+  width: auto;
+  max-width: 100%;
+  overflow: hidden;
 }
 
 .start-survey-btn {
@@ -990,8 +995,7 @@ body.theme-rainbow #comparisonResult {
 }
 
 
-.scroll-container,
-.category-list {
+.scroll-container {
   display: flex;
   flex-wrap: wrap;
   align-items: flex-start;
@@ -999,6 +1003,15 @@ body.theme-rainbow #comparisonResult {
   padding-top: 20px;
   padding-bottom: 20px;
   flex: 1 1 auto;
+}
+
+.category-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 12px;
+  padding: 20px 0;
+  margin: 0;
+  list-style: none;
 }
 
 /* Category selection checkboxes */
@@ -3543,35 +3556,33 @@ input[type="file"] {
 }
 #categorySurveyPanel .category-list {
   flex: 1 1 auto;
-  padding: 0 0 3rem 1rem;
+  padding: 0 1rem 3rem;
 }
 #categorySurveyPanel .category-list label {
   width: 100%;
   min-height: 48px;
   display: flex;
   align-items: center;
-  padding: 0.5rem 1.25rem 0.5rem 0.5rem;
-  margin: 0.25rem 0 0.25rem 0;
-  border: 1px solid var(--accent-color);
-  border-radius: 6px;
-  font-size: 0.9rem;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border: 2px solid var(--accent-color);
+  border-radius: 12px;
+  font-size: 0.95rem;
   font-weight: 600;
   font-family: 'Fredoka One', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
-  line-height: 1.1rem;
+  line-height: 1.2;
   color: var(--text-color);
   background-color: transparent;
   cursor: pointer;
-  white-space: nowrap;
   overflow: hidden;
-  text-overflow: ellipsis;
-  box-shadow: none;
 }
 #categorySurveyPanel .category-list label span {
   flex: 1;
   text-align: left;
+  word-break: break-word;
 }
 #categorySurveyPanel .category-list input[type="checkbox"] {
   margin-right: 0.75rem;

--- a/docs/kinks/css/style.css
+++ b/docs/kinks/css/style.css
@@ -217,10 +217,15 @@ body.light-mode #closeRoleDefinitionsBtn {
 .category-panel .category-list label {
   display: flex;
   align-items: center;
-  border: 1px solid var(--accent-color);
-  padding: 6px 8px;
-  margin-bottom: 8px;
+  gap: 0.75rem;
+  padding: 14px 16px;
+  border: 2px solid var(--accent-color);
+  border-radius: 12px;
   background: transparent;
+  box-sizing: border-box;
+  width: auto;
+  max-width: 100%;
+  overflow: hidden;
 }
 
 .start-survey-btn {
@@ -992,8 +997,7 @@ body.theme-rainbow #comparisonResult {
 }
 
 
-.scroll-container,
-.category-list {
+.scroll-container {
   display: flex;
   flex-wrap: wrap;
   align-items: flex-start;
@@ -1001,6 +1005,15 @@ body.theme-rainbow #comparisonResult {
   padding-top: 20px;
   padding-bottom: 20px;
   flex: 1 1 auto;
+}
+
+.category-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 12px;
+  padding: 20px 0;
+  margin: 0;
+  list-style: none;
 }
 
 /* Category selection checkboxes */
@@ -3545,35 +3558,33 @@ input[type="file"] {
 }
 #categorySurveyPanel .category-list {
   flex: 1 1 auto;
-  padding: 0 0 3rem 1rem;
+  padding: 0 1rem 3rem;
 }
 #categorySurveyPanel .category-list label {
   width: 100%;
   min-height: 48px;
   display: flex;
   align-items: center;
-  padding: 0.5rem 1.25rem 0.5rem 0.5rem;
-  margin: 0.25rem 0 0.25rem 0;
-  border: 1px solid var(--accent-color);
-  border-radius: 6px;
-  font-size: 0.9rem;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border: 2px solid var(--accent-color);
+  border-radius: 12px;
+  font-size: 0.95rem;
   font-weight: 600;
   font-family: 'Fredoka One', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   text-rendering: optimizeLegibility;
-  line-height: 1.1rem;
+  line-height: 1.2;
   color: var(--text-color);
   background-color: transparent;
   cursor: pointer;
-  white-space: nowrap;
   overflow: hidden;
-  text-overflow: ellipsis;
-  box-shadow: none;
 }
 #categorySurveyPanel .category-list label span {
   flex: 1;
   text-align: left;
+  word-break: break-word;
 }
 #categorySurveyPanel .category-list input[type="checkbox"] {
   margin-right: 0.75rem;


### PR DESCRIPTION
## Summary
- update the category selection list styling to use a responsive grid and consistent pill appearance so buttons no longer overlap
- mirror the same layout and styling improvements in the generated docs bundle

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e08d106908832c856bcbd77ea448c1