### PR TITLE
Improve compatibility upload selectors and kink survey layout

### DIFF
--- a/css/kinksurvey_overrides.css
+++ b/css/kinksurvey_overrides.css
@@ -185,6 +185,69 @@ body.tk-drawer-open #tkCategoryDrawer{transform:translateX(0)}
   gap:12px; padding:10px 8px 12px;
 }
 .tk-catbar button{min-width:0}
+
+/* Responsive category grids + buttons (TalkKink + KSV variants) */
+.tk-category-grid,
+.ksv-category-grid,
+.category-chooser {
+  display:grid !important;
+  grid-template-columns:repeat(2, minmax(260px, 1fr));
+  gap:12px;
+  align-items:stretch;
+}
+.tk-category-grid:not(:has(.tk-cat-btn)),
+.ksv-category-grid:not(:has(.tk-cat-btn)),
+.category-chooser:not(:has(button)) {
+  grid-template-columns:repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.tk-cat-btn,
+.ksv-cat-btn,
+.category-chooser button {
+  display:flex !important;
+  align-items:center;
+  justify-content:flex-start;
+  gap:10px;
+  width:100%;
+  min-height:64px;
+  padding:16px 18px;
+  box-sizing:border-box;
+  white-space:normal;
+  overflow:hidden;
+}
+
+@media (max-width: 600px) {
+  .tk-category-grid,
+  .ksv-category-grid,
+  .category-chooser {
+    grid-template-columns:1fr;
+  }
+}
+
+/* Rating rows: keep select + summary inline */
+li:has(> select),
+.ksv-row:has(> select),
+.tk-row:has(> select) {
+  display:flex !important;
+  align-items:center;
+  gap:12px;
+  min-height:40px;
+}
+li:has(> select) > select,
+.ksv-row:has(> select) > select,
+.tk-row:has(> select) > select {
+  flex:0 0 88px;
+  max-width:120px;
+}
+li:has(> select) > :not(select),
+.ksv-row:has(> select) > :not(select),
+.tk-row:has(> select) > :not(select) {
+  flex:1 1 auto;
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
+  line-height:1.25;
+}
 .tk-counter{
   display:inline-flex; align-items:center; gap:7px; font-weight:800;
   background:var(--tk-chip); border:1px solid #00e6ff22; color:var(--tk-fg);

--- a/docs/kinks/css/kinksurvey_overrides.css
+++ b/docs/kinks/css/kinksurvey_overrides.css
@@ -185,6 +185,69 @@ body.tk-drawer-open #tkCategoryDrawer{transform:translateX(0)}
   gap:12px; padding:10px 8px 12px;
 }
 .tk-catbar button{min-width:0}
+
+/* Responsive category grids + buttons (TalkKink + KSV variants) */
+.tk-category-grid,
+.ksv-category-grid,
+.category-chooser {
+  display:grid !important;
+  grid-template-columns:repeat(2, minmax(260px, 1fr));
+  gap:12px;
+  align-items:stretch;
+}
+.tk-category-grid:not(:has(.tk-cat-btn)),
+.ksv-category-grid:not(:has(.tk-cat-btn)),
+.category-chooser:not(:has(button)) {
+  grid-template-columns:repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.tk-cat-btn,
+.ksv-cat-btn,
+.category-chooser button {
+  display:flex !important;
+  align-items:center;
+  justify-content:flex-start;
+  gap:10px;
+  width:100%;
+  min-height:64px;
+  padding:16px 18px;
+  box-sizing:border-box;
+  white-space:normal;
+  overflow:hidden;
+}
+
+@media (max-width: 600px) {
+  .tk-category-grid,
+  .ksv-category-grid,
+  .category-chooser {
+    grid-template-columns:1fr;
+  }
+}
+
+/* Rating rows: keep select + summary inline */
+li:has(> select),
+.ksv-row:has(> select),
+.tk-row:has(> select) {
+  display:flex !important;
+  align-items:center;
+  gap:12px;
+  min-height:40px;
+}
+li:has(> select) > select,
+.ksv-row:has(> select) > select,
+.tk-row:has(> select) > select {
+  flex:0 0 88px;
+  max-width:120px;
+}
+li:has(> select) > :not(select),
+.ksv-row:has(> select) > :not(select),
+.tk-row:has(> select) > :not(select) {
+  flex:1 1 auto;
+  white-space:nowrap;
+  overflow:hidden;
+  text-overflow:ellipsis;
+  line-height:1.25;
+}
 .tk-counter{
   display:inline-flex; align-items:center; gap:7px; font-weight:800;
   background:var(--tk-chip); border:1px solid #00e6ff22; color:var(--tk-fg);

--- a/js/compatibilityPage.js
+++ b/js/compatibilityPage.js
@@ -433,9 +433,34 @@ if (typeof window.processSurveyB !== 'function') {
 }
 
 (function wireUploads() {
-  const upA = document.getElementById('uploadA');
-  const upB = document.getElementById('uploadB');
-  if (!upA || !upB) { console.warn('[compat] upload inputs not found'); return; }
+  const findUpload = (which) => {
+    const selectors = which === 'A'
+      ? [
+          'input#uploadA',
+          'input#uploadSurveyA',
+          'input[data-upload-a]',
+          'input[data-upload="a"]',
+        ]
+      : [
+          'input#uploadB',
+          'input#uploadSurveyB',
+          'input[data-upload-b]',
+          'input[data-upload="b"]',
+        ];
+    for (const sel of selectors) {
+      const el = document.querySelector(sel);
+      if (el && el.tagName === 'INPUT' && el.type === 'file') return el;
+    }
+    return null;
+  };
+
+  const upA = findUpload('A');
+  const upB = findUpload('B');
+
+  if (!upA || !upB) {
+    console.warn('[compat] upload inputs not found (looked for #uploadA/#uploadSurveyA and #uploadB/#uploadSurveyB)');
+    return;
+  }
 
   upA.setAttribute('accept', 'application/json');
   upB.setAttribute('accept', 'application/json');


### PR DESCRIPTION
## Summary
- extend the compatibility upload wiring to recognize the newer #uploadSurveyA/#uploadSurveyB inputs
- refresh kink survey category grid styles for better responsiveness and spacing
- keep rating rows aligned when selects are present for TalkKink and KSV layouts

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e094adddb4832c86e91525eb6c767c