### PR TITLE
Improve compatibility table relabeling observer

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -2183,44 +2183,97 @@ document.getElementById('copyAtoB')?.addEventListener('click', () => {
     return -1;
   }
 
-  function relabelAndBars(){
-    injectBarCSS();
-    const tables = Array.from(document.querySelectorAll("table"));
-    if (!tables.length) return;
+  let compatObserver = null;
+  let compatTimer = 0;
+  let compatBusy = false;
+  let compatRoot = null;
 
-    let catCol=-1, pctCol=-1;
-    for (const t of tables){
-      if (catCol < 0) catCol = findColIdxByHeader(t, "category");
-      if (pctCol < 0) pctCol = findColIdxByHeader(t, "match");
-    }
-    if (catCol < 0) catCol = 0;
-    if (pctCol < 0) pctCol = 2;
+  function observerRoot(){
+    if (compatRoot && compatRoot.isConnected) return compatRoot;
+    compatRoot = document.querySelector("main") || document.body;
+    return compatRoot;
+  }
 
-    for (const tbl of tables){
-      const body = tbl.tBodies[0] || tbl;
-      Array.from(body.rows).forEach(tr=>{
-        const c = tr.cells[catCol];
-        if (c){
-          const raw = tidy(c.textContent);
-          const m = raw.match(CB_RE);
-          if (m){ const pretty = labelFor(m[0]); if (pretty && pretty !== m[0]) c.textContent = pretty; }
-        }
-        const p = tr.cells[pctCol];
-        if (p){
-          const text = tidy(p.textContent);
-          const m = text.match(/^(\d{1,3})%$/);
-          p.classList.add("pct-cell");
-          if (m){
-            const pct = Math.max(0, Math.min(100, parseInt(m[1],10)));
-            const wrap = document.createElement("div");
-            wrap.className = "pct";
-            wrap.innerHTML = '<span class="bar" style="width:'+pct+'%"></span><span class="txt">'+text+'</span>';
-            p.innerHTML = ""; p.appendChild(wrap);
-          } else {
-            p.innerHTML = '<span class="txt">'+text+'</span>';
-          }
-        }
+  function scheduleRelabel(){
+    clearTimeout(compatTimer);
+    compatTimer = window.setTimeout(() => {
+      compatTimer = 0;
+      relabelAndBars();
+    }, 120);
+  }
+
+  function observe(){
+    const root = observerRoot();
+    if (!root) return;
+    if (!compatObserver){
+      compatObserver = new MutationObserver(() => {
+        scheduleRelabel();
       });
+    }
+    compatObserver.observe(root, { childList:true, subtree:true });
+  }
+
+  function relabelAndBars(){
+    if (compatBusy){
+      scheduleRelabel();
+      return;
+    }
+    compatBusy = true;
+    clearTimeout(compatTimer);
+    compatTimer = 0;
+    try {
+      if (compatObserver) compatObserver.disconnect();
+      injectBarCSS();
+      const tables = Array.from(document.querySelectorAll("table"));
+      if (tables.length){
+        let catCol=-1, pctCol=-1;
+        for (const t of tables){
+          if (catCol < 0) catCol = findColIdxByHeader(t, "category");
+          if (pctCol < 0) pctCol = findColIdxByHeader(t, "match");
+        }
+        if (catCol < 0) catCol = 0;
+        if (pctCol < 0) pctCol = 2;
+
+        for (const tbl of tables){
+          const body = tbl.tBodies[0] || tbl;
+          Array.from(body.rows).forEach(tr=>{
+            const c = tr.cells[catCol];
+            if (c){
+              const current = tidy(c.textContent);
+              if (c.dataset.tkLabelValue !== current){
+                const m = current.match(CB_RE);
+                if (m){
+                  const pretty = labelFor(m[0]);
+                  if (pretty && pretty !== m[0]) c.textContent = pretty;
+                }
+                c.dataset.tkLabelValue = tidy(c.textContent);
+              }
+            }
+            const p = tr.cells[pctCol];
+            if (p){
+              p.classList.add("pct-cell");
+              const text = tidy(p.textContent);
+              if (p.dataset.tkPctValue !== text){
+                const m = text.match(/^(\d{1,3})%$/);
+                if (m){
+                  const pct = Math.max(0, Math.min(100, parseInt(m[1],10)));
+                  const wrap = document.createElement("div");
+                  wrap.className = "pct";
+                  wrap.innerHTML = '<span class="bar" style="width:'+pct+'%"></span><span class="txt">'+text+'</span>';
+                  p.innerHTML = "";
+                  p.appendChild(wrap);
+                } else {
+                  p.innerHTML = '<span class="txt">'+text+'</span>';
+                }
+                p.dataset.tkPctValue = tidy(p.textContent);
+              }
+            }
+          });
+        }
+      }
+    } finally {
+      compatBusy = false;
+      observe();
     }
   }
 
@@ -2276,10 +2329,8 @@ document.getElementById('copyAtoB')?.addEventListener('click', () => {
 
   async function init(){
     await loadLabels();
-    relabelAndBars();
     wrapKnownExporters();
-    const root = document.querySelector("main") || document.body;
-    new MutationObserver(() => relabelAndBars()).observe(root, { childList:true, subtree:true });
+    relabelAndBars();
   }
   (document.readyState === "loading")
     ? document.addEventListener("DOMContentLoaded", init, { once:true })


### PR DESCRIPTION
## Summary
- prevent the compatibility table relabeling from rewriting cells that already show the desired content
- manage a debounced MutationObserver that disconnects before DOM updates and reconnects after changes to avoid feedback loops
- simplify init flow to rely on the managed observer for subsequent updates

## Testing
- npm test *(fails: test/kinksAccess.test.js::kink survey available without authentication)*
- node --test test/compatibilityAnswersByKeyUpload.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e095aa03e0832cb876971921cec60a