### PR TITLE
Gate PDF export until both surveys are loaded

### DIFF
--- a/compat-upload.html
+++ b/compat-upload.html
@@ -366,6 +366,13 @@ function updateComparison() {
   // ---- main export function
   async function exportCompatibilityPDF() {
     try {
+      const aReady = partnerAData?.items?.some(i => typeof i.score === "number");
+      const bReady = partnerBData?.items?.some(i => typeof i.score === "number");
+      if (!aReady || !bReady) {
+        alert("Upload both surveys with scored items before downloading the compatibility PDF.");
+        return;
+      }
+
       if (!(window.jspdf && window.jspdf.jsPDF)) {
         alert("Missing jsPDF. Add the CDN script before this exporter.");
         return;


### PR DESCRIPTION
## Summary
- block compatibility PDF export when either survey lacks scored items
- prompt users to upload both surveys before downloading

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0a50dc2ac832c9ce71aa52712f95e