### PR TITLE
Require manual confirmation before auto PDF export

### DIFF
--- a/auto-pdf.html
+++ b/auto-pdf.html
@@ -52,6 +52,7 @@
       <span>Upload Partner’s Survey</span>
       <input type="file" id="fileB" hidden />
     </label>
+    <button id="downloadPdfBtn" class="download-button" disabled>Download PDF</button>
   </div>
 
   <!-- ✅ COMPATIBILITY RESULTS WRAPPER -->


### PR DESCRIPTION
## Summary
- add a dedicated Download PDF button to the auto PDF page
- gate PDF generation on both surveys being loaded and the user clicking Download
- manage button state while exporting and surface basic error handling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e0a5ef6f00832cbc9cbdb83f8676b8