### PR TITLE
Add script and table listing cb identifiers

### DIFF
--- a/cb-identifiers.md
+++ b/cb-identifiers.md
@@ -1,0 +1,67 @@
+| Code | Label | Sources |
+| --- | --- | --- |
+| cb_05hqj | Wardrobe restrictions or permissions | kinksurvey/data/kinks.json |
+| cb_065gv | Formal appearance protocols | kinks.json, data/kinks-labels.json |
+| cb_0n2io | No edge-play this session | data/labels-overrides.json |
+| cb_0zk14 | No-go list acknowledged | data/labels-overrides.json |
+| cb_169ma | Time-period dress-up | kinks.json, kinksurvey/data/kinks.json |
+| cb_28flb | Allergy/trigger review | data/labels-overrides.json |
+| cb_2c0f9 | Hair-based play (brushing, ribbons, tying) | kinks.json, kinksurvey/data/kinks.json |
+| cb_2gxmo | Uniforms (school, military, nurse, etc.) | kinks.json, data/kinks-labels.json |
+| cb_2th5l | Aftercare: physical touch | data/labels-overrides.json |
+| cb_3201z | End-of-day debrief | data/labels-overrides.json |
+| cb_3ozhq | Praise for pleasing visual display | kinks.json, kinksurvey/data/kinks.json |
+| cb_3xp2v | Protocol extends post-scene | data/labels-overrides.json |
+| cb_46k59 | No photos/audio | data/labels-overrides.json |
+| cb_4yyxa | Dollification / polished object aesthetics | kinks.json, kinksurvey/data/kinks.json |
+| cb_57aax | Check-in during scene | data/labels-overrides.json |
+| cb_5t4ff | Scheduling or routine adherence | data/labels-overrides.json |
+| cb_6ay8i | Eye contact rule | data/labels-overrides.json |
+| cb_6jd2f | Pick lingerie / base layers | kinks.json, kinksurvey/data/kinks.json |
+| cb_6x608 | Sober play only | data/labels-overrides.json |
+| cb_8f9lu | Health considerations | data/labels-overrides.json |
+| cb_9qszt | Title / honorific usage | data/labels-overrides.json |
+| cb_a1eg2 | Hydration reminder | data/labels-overrides.json |
+| cb_abkgw | Stop at first sign of discomfort | data/labels-overrides.json |
+| cb_audvl | No surprises / no ambush kink | data/labels-overrides.json |
+| cb_bb9wv | Device/gear preparation | data/labels-overrides.json |
+| cb_bhbhi | Use of honorifics outside scene | data/labels-overrides.json |
+| cb_c2zy8 | Negotiated flexibility | data/labels-overrides.json |
+| cb_cr4qi | Decision-making authority (lite) | data/labels-overrides.json |
+| cb_e0gun | Hygiene / cleanup expectations | data/labels-overrides.json |
+| cb_eo3uk | Light service or protocol | data/labels-overrides.json |
+| cb_fsnmj | Praise for pleasing visual display | kinks.json, data/kinks-labels.json |
+| cb_gkzbu | Hair-based play (brushing, ribbons, tying) | kinks.json, data/kinks-labels.json |
+| cb_hqakm | Formal appearance protocols | kinks.json, kinksurvey/data/kinks.json |
+| cb_ifkmg | Clothing as power-role signal | kinks.json, data/kinks-labels.json |
+| cb_jr5l5 | Obedience/comply tests (playful) | data/labels-overrides.json |
+| cb_k55xd | Wardrobe restrictions or permissions | data/labels-overrides.json |
+| cb_kaku7 | Time-period dress-up | kinks.json, data/kinks-labels.json |
+| cb_kgrnn | Uniforms (school, military, nurse, etc.) | kinks.json, kinksurvey/data/kinks.json |
+| cb_kua8l | Dress partner’s outfit | kinks.json, data/kinks-labels.json |
+| cb_kzskf | Explicit check-out at end | data/labels-overrides.json |
+| cb_ldaec | Establish safe words / signals | data/labels-overrides.json |
+| cb_leapq | Aftercare: quiet/space | data/labels-overrides.json |
+| cb_lsco7 | Public discretion phrase | data/labels-overrides.json |
+| cb_n5azr | Protocol in scene only | data/labels-overrides.json |
+| cb_pc14l | Safeguards in place | data/labels-overrides.json |
+| cb_pphe1 | Consent refresh / reaffirmation | data/labels-overrides.json |
+| cb_qflrp | Dollification / polished object aesthetics | kinks.json, data/kinks-labels.json |
+| cb_qw9jg | Ritualized grooming | kinks.json, kinksurvey/data/kinks.json |
+| cb_qwnhi | Head coverings / symbolic hoods | kinks.json, kinksurvey/data/kinks.json |
+| cb_r7cwr | Head coverings / symbolic hoods | kinks.json, data/kinks-labels.json |
+| cb_rhwlo | Aftercare: reassurance/affirmation | data/labels-overrides.json |
+| cb_rn136 | Clothing as power-role signal | kinks.json, kinksurvey/data/kinks.json |
+| cb_ss4gf | Ritualized grooming | kinks.json, data/kinks-labels.json |
+| cb_swujj | Accessory or ornament rules | kinksurvey/data/kinks.json, data/labels-overrides.json |
+| cb_tdbox | Makeup as protocol or control | kinksurvey/data/kinks.json |
+| cb_ttnvq | Mutual interest: Acknowledgment/Check-in | data/labels-overrides.json |
+| cb_w2dc1 | Coordinated looks / dress codes | kinks.json, data/kinks-labels.json |
+| cb_ww16h | Scene boundaries: public vs private | data/labels-overrides.json |
+| cb_wwf76 | Makeup as protocol or control | kinksurvey/data/kinks.json, data/labels-overrides.json |
+| cb_x0t48 | No marks/visible evidence | data/labels-overrides.json |
+| cb_ybidt | Aftercare expectation | data/labels-overrides.json |
+| cb_yzegd | Pick lingerie / base layers | kinks.json, data/kinks-labels.json |
+| cb_zlfd1 | Dress partner’s outfit (directive/decision) | kinksurvey/data/kinks.json |
+| cb_zsnrb | Dress partner’s outfit | kinks.json, kinksurvey/data/kinks.json |
+| cb_zvchg | Coordinated looks / dress codes | kinks.json, kinksurvey/data/kinks.json |

--- a/scripts/list-cb-identifiers.mjs
+++ b/scripts/list-cb-identifiers.mjs
@@ -1,0 +1,61 @@
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, '..');
+
+const sources = [
+  {
+    file: path.join(rootDir, 'kinks.json'),
+    extract: (json) => json.labels ?? {}
+  },
+  {
+    file: path.join(rootDir, 'kinksurvey', 'data', 'kinks.json'),
+    extract: (json) => json
+  },
+  {
+    file: path.join(rootDir, 'data', 'kinks-labels.json'),
+    extract: (json) => json.labels ?? {}
+  },
+  {
+    file: path.join(rootDir, 'data', 'labels-overrides.json'),
+    extract: (json) => json
+  }
+];
+
+const combined = new Map();
+const provenance = new Map();
+
+for (const { file, extract } of sources) {
+  try {
+    const content = await readFile(file, 'utf8');
+    const json = JSON.parse(content);
+    const entries = Object.entries(extract(json));
+    for (const [code, label] of entries) {
+      if (!code.startsWith('cb_')) continue;
+      combined.set(code, label);
+      const locations = provenance.get(code) ?? [];
+      locations.push(path.relative(rootDir, file));
+      provenance.set(code, locations);
+    }
+  } catch (error) {
+    console.error(`Could not read ${file}:`, error);
+    process.exitCode = 1;
+  }
+}
+
+const sorted = Array.from(combined.entries()).sort(([a], [b]) => a.localeCompare(b));
+
+const header = ['Code', 'Label', 'Sources'];
+const table = [
+  `| ${header.join(' | ')} |`,
+  `| ${header.map(() => '---').join(' | ')} |`,
+  ...sorted.map(([code, label]) => {
+    const sourcesList = (provenance.get(code) ?? []).join(', ');
+    return `| ${code} | ${label} | ${sourcesList} |`;
+  })
+];
+
+console.log(table.join('\n'));


### PR DESCRIPTION
## Summary
- add a script that aggregates every cb_* identifier from existing survey data sources
- generate a markdown table enumerating each cb code with its display label and source files for easy copy/paste

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0c41b2ab8832c82ab040662c11765