### PR TITLE
Remove compatibility wrapper print scaling

### DIFF
--- a/css/auto-pdf.css
+++ b/css/auto-pdf.css
@@ -223,7 +223,6 @@ body.exporting {
     max-width: 100% !important;
     text-align: left;
     overflow: hidden;
-    transform: scale(0.85);
     transform-origin: top center;
   }
 
@@ -289,7 +288,6 @@ body.exporting {
     max-width: 100%;
     display: flex;
     justify-content: center; /* Center the table horizontally */
-    transform: scale(0.88) translateX(20px); /* Shift right */
     transform-origin: top center;
   }
 


### PR DESCRIPTION
## Summary
- remove print-specific scaling and translation transforms from the compatibility wrapper so the PDF export uses the full page width

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e18540c500832c8d6728854e143d1b