### PR TITLE
Ensure basic survey renders full-bleed black background

### DIFF
--- a/basic-survey.html
+++ b/basic-survey.html
@@ -5,12 +5,21 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Kink Interest Survey</title>
   <style>
+    html,
     body {
+      margin: 0;
+      padding: 0;
       background-color: #000000;
       color: #fff;
+      height: 100%;
+    }
+
+    body {
       font-family: Arial, sans-serif;
       text-align: center;
       padding: 20px;
+      min-height: 100vh;
+      box-sizing: border-box;
     }
 
     .progress-container {
@@ -82,6 +91,25 @@
 
     .rating-scale select {
       margin-top: 5px;
+    }
+
+    @media print {
+      @page {
+        margin: 0;
+      }
+
+      html,
+      body {
+        background-color: #000000 !important;
+        color: #ffffff !important;
+      }
+
+      body {
+        padding: 0;
+        min-height: 100vh;
+        -webkit-print-color-adjust: exact;
+        print-color-adjust: exact;
+      }
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- remove default page margins so the survey background fills the viewport
- add print styles to preserve the black background and remove page margins when printing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1869635c4832c82594572f4fd9cde