### PR TITLE
Ensure dark PDF exports repaint backgrounds on every page

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -1149,43 +1149,18 @@ RESULT
       const Awidth = 90, Mwidth = 110, Bwidth = 90;
       const CatWidth = usable - (Awidth + Mwidth + Bwidth);
 
-      doc.autoTable({
-        head: [[firstSectionHeader, 'Partner A', 'Match %', 'Partner B']],
-        body: rows,
-        startY: 64,
-        margin: { left: marginLR, right: marginLR },
-        styles: {
-          fontSize: 11,
-          cellPadding: 6,
-          textColor: [255,255,255],
-          fillColor: [0,0,0],
-          lineColor: [255,255,255],
-          lineWidth: 1.2,
-          halign: 'center',
-          valign: 'middle',
-          overflow: 'linebreak'
-        },
-        headStyles: {
-          fillColor: [0,0,0],
-          textColor: [255,255,255],
-          fontStyle: 'bold',
-          lineColor: [255,255,255],
-          lineWidth: 1.4
-        },
-        columnStyles: {
-          0: { cellWidth: CatWidth, halign: 'left' },
-          1: { cellWidth: Awidth },
-          2: { cellWidth: Mwidth },
-          3: { cellWidth: Bwidth }
-        },
-        willDrawPage: paintBg
-      });
+      const originalAddPage = doc.addPage;
+      doc.addPage = function patchedAddPage(...args) {
+        const result = originalAddPage.apply(this, args);
+        paintBg();
+        return result;
+      };
 
-      if (missing.length) {
+      try {
         doc.autoTable({
-          head: [['Unanswered Categories (0 or blank)', 'Partner A', 'Partner B']],
-          body: missing.map(r => r.map(c => ({ content: c, styles: { fillColor: [0,0,0], textColor: [255,255,255] } }))),
-          startY: (doc.lastAutoTable && doc.lastAutoTable.finalY ? doc.lastAutoTable.finalY : 64) + 20,
+          head: [[firstSectionHeader, 'Partner A', 'Match %', 'Partner B']],
+          body: rows,
+          startY: 64,
           margin: { left: marginLR, right: marginLR },
           styles: {
             fontSize: 11,
@@ -1193,12 +1168,48 @@ RESULT
             textColor: [255,255,255],
             fillColor: [0,0,0],
             lineColor: [255,255,255],
-            lineWidth: 1.2
+            lineWidth: 1.2,
+            halign: 'center',
+            valign: 'middle',
+            overflow: 'linebreak'
           },
-          headStyles: { fillColor: [0,0,0], textColor: [255,255,255], fontStyle: 'bold' },
-          columnStyles: { 0: { cellWidth: usable - 180 }, 1: { cellWidth: 90 }, 2: { cellWidth: 90 } },
+          headStyles: {
+            fillColor: [0,0,0],
+            textColor: [255,255,255],
+            fontStyle: 'bold',
+            lineColor: [255,255,255],
+            lineWidth: 1.4
+          },
+          columnStyles: {
+            0: { cellWidth: CatWidth, halign: 'left' },
+            1: { cellWidth: Awidth },
+            2: { cellWidth: Mwidth },
+            3: { cellWidth: Bwidth }
+          },
           willDrawPage: paintBg
         });
+
+        if (missing.length) {
+          doc.autoTable({
+            head: [['Unanswered Categories (0 or blank)', 'Partner A', 'Partner B']],
+            body: missing.map(r => r.map(c => ({ content: c, styles: { fillColor: [0,0,0], textColor: [255,255,255] } }))),
+            startY: (doc.lastAutoTable && doc.lastAutoTable.finalY ? doc.lastAutoTable.finalY : 64) + 20,
+            margin: { left: marginLR, right: marginLR },
+            styles: {
+              fontSize: 11,
+              cellPadding: 6,
+              textColor: [255,255,255],
+              fillColor: [0,0,0],
+              lineColor: [255,255,255],
+              lineWidth: 1.2
+            },
+            headStyles: { fillColor: [0,0,0], textColor: [255,255,255], fontStyle: 'bold' },
+            columnStyles: { 0: { cellWidth: usable - 180 }, 1: { cellWidth: 90 }, 2: { cellWidth: 90 } },
+            willDrawPage: paintBg
+          });
+        }
+      } finally {
+        doc.addPage = originalAddPage;
       }
 
       doc.save('compatibility-dark.pdf');

--- a/docs/kinks/js/downloadCompatibilityPDF.ts
+++ b/docs/kinks/js/downloadCompatibilityPDF.ts
@@ -110,45 +110,56 @@ export async function downloadCompatibilityPDF(): Promise<void> {
       throw new Error("AutoTable not available");
     };
 
-    runAT({
-      head: [["Category", "Partner A", "Match %", "Partner B"]],
-      body,
-      startY: 64,
-      margin: { left: marginLR, right: marginLR, top: 64, bottom: 40 },
-      styles: {
-        fontSize: 11,
-        cellPadding: 6,
-        textColor: [255, 255, 255],
-        fillColor: [0, 0, 0],
-        lineColor: [255, 255, 255],
-        lineWidth: 1.2,
-        halign: "center",
-        valign: "middle",
-      },
-      headStyles: {
-        fillColor: [0, 0, 0],
-        textColor: [255, 255, 255],
-        fontStyle: "bold",
-        lineColor: [255, 255, 255],
-        lineWidth: 1.6,
-      },
-      bodyStyles: {
-        fillColor: [0, 0, 0],
-        textColor: [255, 255, 255],
-      },
-      alternateRowStyles: {
-        fillColor: [0, 0, 0],
-        textColor: [255, 255, 255],
-      },
-      columnStyles: {
-        0: { cellWidth: CatWidth, halign: "left" },
-        1: { cellWidth: Awidth, halign: "center" },
-        2: { cellWidth: Mwidth, halign: "center" },
-        3: { cellWidth: Bwidth, halign: "center" },
-      },
-      tableWidth: usable,
-      willDrawPage: paintBg,
-    });
+    const originalAddPage = doc.addPage;
+    doc.addPage = function patchedAddPage(this: typeof doc, ...args: any[]) {
+      const result = originalAddPage.apply(this, args as any);
+      paintBg();
+      return result;
+    } as typeof doc.addPage;
+
+    try {
+      runAT({
+        head: [["Category", "Partner A", "Match %", "Partner B"]],
+        body,
+        startY: 64,
+        margin: { left: marginLR, right: marginLR, top: 64, bottom: 40 },
+        styles: {
+          fontSize: 11,
+          cellPadding: 6,
+          textColor: [255, 255, 255],
+          fillColor: [0, 0, 0],
+          lineColor: [255, 255, 255],
+          lineWidth: 1.2,
+          halign: "center",
+          valign: "middle",
+        },
+        headStyles: {
+          fillColor: [0, 0, 0],
+          textColor: [255, 255, 255],
+          fontStyle: "bold",
+          lineColor: [255, 255, 255],
+          lineWidth: 1.6,
+        },
+        bodyStyles: {
+          fillColor: [0, 0, 0],
+          textColor: [255, 255, 255],
+        },
+        alternateRowStyles: {
+          fillColor: [0, 0, 0],
+          textColor: [255, 255, 255],
+        },
+        columnStyles: {
+          0: { cellWidth: CatWidth, halign: "left" },
+          1: { cellWidth: Awidth, halign: "center" },
+          2: { cellWidth: Mwidth, halign: "center" },
+          3: { cellWidth: Bwidth, halign: "center" },
+        },
+        tableWidth: usable,
+        willDrawPage: paintBg,
+      });
+    } finally {
+      doc.addPage = originalAddPage;
+    }
 
     doc.save("compatibility-dark.pdf");
   } catch (err) {

--- a/docs/kinks/js/pdfDownload.js
+++ b/docs/kinks/js/pdfDownload.js
@@ -237,46 +237,57 @@ export async function downloadCompatibilityPDF({
     body.forEach(r => drawRow(r, false));
   };
 
-  runAutoTable({
-    head: [['Category', 'Partner A', 'Match %', 'Partner B']],
-    body,
-    startY: 70,
-    margin: { left: 30, right: 30, top: 70, bottom: 40 },
-    styles: {
-      fontSize: 12,
-      cellPadding: 6,
-      textColor: [255, 255, 255],
-      fillColor: [0, 0, 0],
-      lineColor: [255, 255, 255],
-      lineWidth: 0.25,
-      overflow: 'linebreak'
-    },
-    headStyles: {
-      fontStyle: 'bold',
-      fillColor: [0, 0, 0],
-      textColor: [255, 255, 255],
-      lineColor: [255, 255, 255],
-      lineWidth: 0.5
-    },
-    bodyStyles: {
-      fillColor: [0, 0, 0],
-      textColor: [255, 255, 255]
-    },
-    alternateRowStyles: {
-      fillColor: [0, 0, 0],
-      textColor: [255, 255, 255]
-    },
-    columnStyles: {
-      0: { cellWidth: 520, halign: 'left'   }, // Category
-      1: { cellWidth:  80, halign: 'center' }, // Partner A
-      2: { cellWidth:  90, halign: 'center' }, // Match %
-      3: { cellWidth:  80, halign: 'center' }  // Partner B
-    },
-    tableLineColor: [255, 255, 255],
-    tableLineWidth: 0.5,
-    didDrawPage: paintPage,
-    tableWidth: 'wrap'
-  });
+  const originalAddPage = doc.addPage;
+  doc.addPage = function patchedAddPage(...args) {
+    const result = originalAddPage.apply(this, args);
+    paintPage();
+    return result;
+  };
+
+  try {
+    runAutoTable({
+      head: [['Category', 'Partner A', 'Match %', 'Partner B']],
+      body,
+      startY: 70,
+      margin: { left: 30, right: 30, top: 70, bottom: 40 },
+      styles: {
+        fontSize: 12,
+        cellPadding: 6,
+        textColor: [255, 255, 255],
+        fillColor: [0, 0, 0],
+        lineColor: [255, 255, 255],
+        lineWidth: 0.25,
+        overflow: 'linebreak'
+      },
+      headStyles: {
+        fontStyle: 'bold',
+        fillColor: [0, 0, 0],
+        textColor: [255, 255, 255],
+        lineColor: [255, 255, 255],
+        lineWidth: 0.5
+      },
+      bodyStyles: {
+        fillColor: [0, 0, 0],
+        textColor: [255, 255, 255]
+      },
+      alternateRowStyles: {
+        fillColor: [0, 0, 0],
+        textColor: [255, 255, 255]
+      },
+      columnStyles: {
+        0: { cellWidth: 520, halign: 'left'   }, // Category
+        1: { cellWidth:  80, halign: 'center' }, // Partner A
+        2: { cellWidth:  90, halign: 'center' }, // Match %
+        3: { cellWidth:  80, halign: 'center' }  // Partner B
+      },
+      tableLineColor: [255, 255, 255],
+      tableLineWidth: 0.5,
+      didDrawPage: paintPage,
+      tableWidth: 'wrap'
+    });
+  } finally {
+    doc.addPage = originalAddPage;
+  }
 
   doc.save(filename);
 }

--- a/individualkinkanalysis.html
+++ b/individualkinkanalysis.html
@@ -482,34 +482,45 @@ Otherwise, safe fallbacks included below will run.
       : (window.jspdf && typeof window.jspdf.autoTable === 'function') ? window.jspdf.autoTable(doc, opts)
       : (() => { throw new Error('AutoTable not available'); })();
 
-    runAT({
-      head, body,
-      startY: 74,
-      margin: { left: marginLR, right: marginLR, top: 74, bottom: 32 },
-      styles: {
-        fontSize: 11,
-        cellPadding: 6,
-        textColor: [255,255,255],
-        fillColor: [0,0,0],
-        lineColor: [255,255,255],
-        lineWidth: 1,
-        halign: 'left',
-        valign: 'middle'
-      },
-      headStyles: {
-        fillColor: [0,0,0],
-        textColor: [255,255,255],
-        fontStyle: 'bold',
-        lineColor: [255,255,255],
-        lineWidth: 1.4
-      },
-      columnStyles: {
-        0: { cellWidth: 60,  halign: 'left'  },
-        1: { cellWidth: usable - 140, halign: 'left'  },
-        2: { cellWidth: 80,  halign: 'right' }
-      },
-      willDrawPage: paintBg
-    });
+    const originalAddPage = doc.addPage;
+    doc.addPage = function patchedAddPage(...args) {
+      const result = originalAddPage.apply(this, args);
+      paintBg();
+      return result;
+    };
+
+    try {
+      runAT({
+        head, body,
+        startY: 74,
+        margin: { left: marginLR, right: marginLR, top: 74, bottom: 32 },
+        styles: {
+          fontSize: 11,
+          cellPadding: 6,
+          textColor: [255,255,255],
+          fillColor: [0,0,0],
+          lineColor: [255,255,255],
+          lineWidth: 1,
+          halign: 'left',
+          valign: 'middle'
+        },
+        headStyles: {
+          fillColor: [0,0,0],
+          textColor: [255,255,255],
+          fontStyle: 'bold',
+          lineColor: [255,255,255],
+          lineWidth: 1.4
+        },
+        columnStyles: {
+          0: { cellWidth: 60,  halign: 'left'  },
+          1: { cellWidth: usable - 140, halign: 'left'  },
+          2: { cellWidth: 80,  halign: 'right' }
+        },
+        willDrawPage: paintBg
+      });
+    } finally {
+      doc.addPage = originalAddPage;
+    }
 
     doc.save('individual-kink-analysis.pdf');
   }

--- a/js/downloadCompatibilityPDF.ts
+++ b/js/downloadCompatibilityPDF.ts
@@ -110,45 +110,56 @@ export async function downloadCompatibilityPDF(): Promise<void> {
       throw new Error("AutoTable not available");
     };
 
-    runAT({
-      head: [["Category", "Partner A", "Match %", "Partner B"]],
-      body,
-      startY: 64,
-      margin: { left: marginLR, right: marginLR, top: 64, bottom: 40 },
-      styles: {
-        fontSize: 11,
-        cellPadding: 6,
-        textColor: [255, 255, 255],
-        fillColor: [0, 0, 0],
-        lineColor: [255, 255, 255],
-        lineWidth: 1.2,
-        halign: "center",
-        valign: "middle",
-      },
-      headStyles: {
-        fillColor: [0, 0, 0],
-        textColor: [255, 255, 255],
-        fontStyle: "bold",
-        lineColor: [255, 255, 255],
-        lineWidth: 1.6,
-      },
-      bodyStyles: {
-        fillColor: [0, 0, 0],
-        textColor: [255, 255, 255],
-      },
-      alternateRowStyles: {
-        fillColor: [0, 0, 0],
-        textColor: [255, 255, 255],
-      },
-      columnStyles: {
-        0: { cellWidth: CatWidth, halign: "left" },
-        1: { cellWidth: Awidth, halign: "center" },
-        2: { cellWidth: Mwidth, halign: "center" },
-        3: { cellWidth: Bwidth, halign: "center" },
-      },
-      tableWidth: usable,
-      willDrawPage: paintBg,
-    });
+    const originalAddPage = doc.addPage;
+    doc.addPage = function patchedAddPage(this: typeof doc, ...args: any[]) {
+      const result = originalAddPage.apply(this, args as any);
+      paintBg();
+      return result;
+    } as typeof doc.addPage;
+
+    try {
+      runAT({
+        head: [["Category", "Partner A", "Match %", "Partner B"]],
+        body,
+        startY: 64,
+        margin: { left: marginLR, right: marginLR, top: 64, bottom: 40 },
+        styles: {
+          fontSize: 11,
+          cellPadding: 6,
+          textColor: [255, 255, 255],
+          fillColor: [0, 0, 0],
+          lineColor: [255, 255, 255],
+          lineWidth: 1.2,
+          halign: "center",
+          valign: "middle",
+        },
+        headStyles: {
+          fillColor: [0, 0, 0],
+          textColor: [255, 255, 255],
+          fontStyle: "bold",
+          lineColor: [255, 255, 255],
+          lineWidth: 1.6,
+        },
+        bodyStyles: {
+          fillColor: [0, 0, 0],
+          textColor: [255, 255, 255],
+        },
+        alternateRowStyles: {
+          fillColor: [0, 0, 0],
+          textColor: [255, 255, 255],
+        },
+        columnStyles: {
+          0: { cellWidth: CatWidth, halign: "left" },
+          1: { cellWidth: Awidth, halign: "center" },
+          2: { cellWidth: Mwidth, halign: "center" },
+          3: { cellWidth: Bwidth, halign: "center" },
+        },
+        tableWidth: usable,
+        willDrawPage: paintBg,
+      });
+    } finally {
+      doc.addPage = originalAddPage;
+    }
 
     doc.save("compatibility-dark.pdf");
   } catch (err) {

--- a/js/pdfDownload.js
+++ b/js/pdfDownload.js
@@ -237,46 +237,57 @@ export async function downloadCompatibilityPDF({
     body.forEach(r => drawRow(r, false));
   };
 
-  runAutoTable({
-    head: [['Category', 'Partner A', 'Match %', 'Partner B']],
-    body,
-    startY: 70,
-    margin: { left: 30, right: 30, top: 70, bottom: 40 },
-    styles: {
-      fontSize: 12,
-      cellPadding: 6,
-      textColor: [255, 255, 255],
-      fillColor: [0, 0, 0],
-      lineColor: [255, 255, 255],
-      lineWidth: 0.25,
-      overflow: 'linebreak'
-    },
-    headStyles: {
-      fontStyle: 'bold',
-      fillColor: [0, 0, 0],
-      textColor: [255, 255, 255],
-      lineColor: [255, 255, 255],
-      lineWidth: 0.5
-    },
-    bodyStyles: {
-      fillColor: [0, 0, 0],
-      textColor: [255, 255, 255]
-    },
-    alternateRowStyles: {
-      fillColor: [0, 0, 0],
-      textColor: [255, 255, 255]
-    },
-    columnStyles: {
-      0: { cellWidth: 520, halign: 'left'   }, // Category
-      1: { cellWidth:  80, halign: 'center' }, // Partner A
-      2: { cellWidth:  90, halign: 'center' }, // Match %
-      3: { cellWidth:  80, halign: 'center' }  // Partner B
-    },
-    tableLineColor: [255, 255, 255],
-    tableLineWidth: 0.5,
-    didDrawPage: paintPage,
-    tableWidth: 'wrap'
-  });
+  const originalAddPage = doc.addPage;
+  doc.addPage = function patchedAddPage(...args) {
+    const result = originalAddPage.apply(this, args);
+    paintPage();
+    return result;
+  };
+
+  try {
+    runAutoTable({
+      head: [['Category', 'Partner A', 'Match %', 'Partner B']],
+      body,
+      startY: 70,
+      margin: { left: 30, right: 30, top: 70, bottom: 40 },
+      styles: {
+        fontSize: 12,
+        cellPadding: 6,
+        textColor: [255, 255, 255],
+        fillColor: [0, 0, 0],
+        lineColor: [255, 255, 255],
+        lineWidth: 0.25,
+        overflow: 'linebreak'
+      },
+      headStyles: {
+        fontStyle: 'bold',
+        fillColor: [0, 0, 0],
+        textColor: [255, 255, 255],
+        lineColor: [255, 255, 255],
+        lineWidth: 0.5
+      },
+      bodyStyles: {
+        fillColor: [0, 0, 0],
+        textColor: [255, 255, 255]
+      },
+      alternateRowStyles: {
+        fillColor: [0, 0, 0],
+        textColor: [255, 255, 255]
+      },
+      columnStyles: {
+        0: { cellWidth: 520, halign: 'left'   }, // Category
+        1: { cellWidth:  80, halign: 'center' }, // Partner A
+        2: { cellWidth:  90, halign: 'center' }, // Match %
+        3: { cellWidth:  80, halign: 'center' }  // Partner B
+      },
+      tableLineColor: [255, 255, 255],
+      tableLineWidth: 0.5,
+      didDrawPage: paintPage,
+      tableWidth: 'wrap'
+    });
+  } finally {
+    doc.addPage = originalAddPage;
+  }
 
   doc.save(filename);
 }

--- a/pdf-download-test.html
+++ b/pdf-download-test.html
@@ -86,35 +86,46 @@ async function setupPDFExport() {
     ];
 
     // Draw table
-    doc.autoTable({
-      head: [["Category", "Partner A", "Match %", "Partner B"]],
-      body,
-      startY: 60,
-      styles: {
-        fontSize: 11,
-        cellPadding: 6,
-        textColor: [255, 255, 255],
-        fillColor: [0, 0, 0],
-        lineColor: [255, 255, 255],
-        lineWidth: 0.25
-      },
-      headStyles: {
-        fillColor: [0, 0, 0],
-        textColor: [255, 255, 255],
-        fontStyle: "bold",
-        lineColor: [255, 255, 255],   // white header borders
-        lineWidth: 0.5
-      },
-      columnStyles: {
-        0: { cellWidth: 420, halign: "left" },
-        1: { cellWidth: 80, halign: "center" },
-        2: { cellWidth: 90, halign: "center" },
-        3: { cellWidth: 80, halign: "center" }
-      },
-      tableLineColor: [255, 255, 255],
-      tableLineWidth: 0.5,
-      didDrawPage: paintPage
-    });
+    const originalAddPage = doc.addPage;
+    doc.addPage = function patchedAddPage(...args) {
+      const result = originalAddPage.apply(this, args);
+      paintPage();
+      return result;
+    };
+
+    try {
+      doc.autoTable({
+        head: [["Category", "Partner A", "Match %", "Partner B"]],
+        body,
+        startY: 60,
+        styles: {
+          fontSize: 11,
+          cellPadding: 6,
+          textColor: [255, 255, 255],
+          fillColor: [0, 0, 0],
+          lineColor: [255, 255, 255],
+          lineWidth: 0.25
+        },
+        headStyles: {
+          fillColor: [0, 0, 0],
+          textColor: [255, 255, 255],
+          fontStyle: "bold",
+          lineColor: [255, 255, 255],   // white header borders
+          lineWidth: 0.5
+        },
+        columnStyles: {
+          0: { cellWidth: 420, halign: "left" },
+          1: { cellWidth: 80, halign: "center" },
+          2: { cellWidth: 90, halign: "center" },
+          3: { cellWidth: 80, halign: "center" }
+        },
+        tableLineColor: [255, 255, 255],
+        tableLineWidth: 0.5,
+        didDrawPage: paintPage
+      });
+    } finally {
+      doc.addPage = originalAddPage;
+    }
 
     doc.save("compatibility-dark.pdf");
   }

--- a/snippet-compatibility-report-dark-pdf-export-click.html
+++ b/snippet-compatibility-report-dark-pdf-export-click.html
@@ -191,16 +191,24 @@ This snippet:
         throw new Error('AutoTable not available at runtime');
       };
 
-      useAutoTable({
-        head: [['Category', 'Partner A', 'Match %', 'Partner B']],
-        body,
-        startY: 70,
-        margin: { left: marginLR, right: marginLR, top: 70, bottom: 40 },
-        styles: {
-          fontSize: 11,
-          cellPadding: 6,
-          textColor: [255, 255, 255],   // white text
-          fillColor: [0, 0, 0],         // black cells
+        const originalAddPage = doc.addPage;
+        doc.addPage = function patchedAddPage(...args) {
+          const result = originalAddPage.apply(this, args);
+          paintBg();
+          return result;
+        };
+
+        try {
+          useAutoTable({
+            head: [['Category', 'Partner A', 'Match %', 'Partner B']],
+            body,
+            startY: 70,
+            margin: { left: marginLR, right: marginLR, top: 70, bottom: 40 },
+            styles: {
+              fontSize: 11,
+              cellPadding: 6,
+              textColor: [255, 255, 255],   // white text
+              fillColor: [0, 0, 0],         // black cells
           lineColor: [255, 255, 255],   // thick white grid
           lineWidth: 1,
           overflow: 'linebreak',
@@ -220,12 +228,15 @@ This snippet:
           0: { cellWidth: CatWidth, halign: 'left'   }, // Category
           1: { cellWidth: Awidth,   halign: 'center' }, // Partner A
           2: { cellWidth: Mwidth,   halign: 'center' }, // Match %
-          3: { cellWidth: Bwidth,   halign: 'center' }  // Partner B
-        },
-        tableWidth: usable,
-        // CRITICAL: draw background BEFORE table content on every page
-        willDrawPage: paintBg
-      });
+            3: { cellWidth: Bwidth,   halign: 'center' }  // Partner B
+          },
+          tableWidth: usable,
+          // CRITICAL: draw background BEFORE table content on every page
+          willDrawPage: paintBg
+        });
+        } finally {
+          doc.addPage = originalAddPage;
+        }
 
       doc.save('compatibility-dark.pdf');
     } catch (err) {

--- a/snippet-compatibility-report-dark-pdf-export-configurable.html
+++ b/snippet-compatibility-report-dark-pdf-export-configurable.html
@@ -172,44 +172,56 @@
     const catWidth = Math.max(minCatWidth, usable - (aWidth + mWidth + bWidth));
 
     const runAT = getAutoTable(doc);
-    runAT({
-      head: [["Category","Partner A","Match %","Partner B"]],
-      body,
-      startY,
-      margin: { left: marginLR, right: marginLR, top: startY, bottom: 36 },
-      styles: {
-        fontSize: opts.theme.fontSize,
-        cellPadding: 6,
-        textColor: opts.theme.text,
-        fillColor: opts.theme.bodyFill,
-        lineColor: opts.theme.line,
-        lineWidth: opts.theme.bodyLineWidth,
-        overflow: "linebreak",
-        halign: "center",
-        valign: "middle",
-      },
-      headStyles: {
-        fontStyle: "bold",
-        fillColor: opts.theme.headFill,
-        textColor: opts.theme.text,
-        lineColor: opts.theme.line,
-        lineWidth: opts.theme.headLineWidth,
-        halign: "center",
-        valign: "middle",
-      },
-      columnStyles: {
-        0: { cellWidth: catWidth, halign: "left" },
-        1: { cellWidth: aWidth,   halign: "center" },
-        2: { cellWidth: mWidth,   halign: "center" },
-        3: { cellWidth: bWidth,   halign: "center" },
-      },
-      tableWidth: usable,
-      // draw black bg BEFORE table on each page
-      willDrawPage: () => {
-        paintBackground(doc, opts.theme.pageBg);
-        doc.setTextColor(...opts.theme.text);
-      }
-    });
+    const originalAddPage = doc.addPage;
+    doc.addPage = function patchedAddPage(...args) {
+      const result = originalAddPage.apply(this, args);
+      paintBackground(doc, opts.theme.pageBg);
+      doc.setTextColor(...opts.theme.text);
+      return result;
+    };
+
+    try {
+      runAT({
+        head: [["Category","Partner A","Match %","Partner B"]],
+        body,
+        startY,
+        margin: { left: marginLR, right: marginLR, top: startY, bottom: 36 },
+        styles: {
+          fontSize: opts.theme.fontSize,
+          cellPadding: 6,
+          textColor: opts.theme.text,
+          fillColor: opts.theme.bodyFill,
+          lineColor: opts.theme.line,
+          lineWidth: opts.theme.bodyLineWidth,
+          overflow: "linebreak",
+          halign: "center",
+          valign: "middle",
+        },
+        headStyles: {
+          fontStyle: "bold",
+          fillColor: opts.theme.headFill,
+          textColor: opts.theme.text,
+          lineColor: opts.theme.line,
+          lineWidth: opts.theme.headLineWidth,
+          halign: "center",
+          valign: "middle",
+        },
+        columnStyles: {
+          0: { cellWidth: catWidth, halign: "left" },
+          1: { cellWidth: aWidth,   halign: "center" },
+          2: { cellWidth: mWidth,   halign: "center" },
+          3: { cellWidth: bWidth,   halign: "center" },
+        },
+        tableWidth: usable,
+        // draw black bg BEFORE table on each page
+        willDrawPage: () => {
+          paintBackground(doc, opts.theme.pageBg);
+          doc.setTextColor(...opts.theme.text);
+        }
+      });
+    } finally {
+      doc.addPage = originalAddPage;
+    }
 
     doc.save(opts.fileName);
   }

--- a/snippet-compatibility-report-dark-pdf-export-drop-in.html
+++ b/snippet-compatibility-report-dark-pdf-export-drop-in.html
@@ -136,46 +136,57 @@ A PDF called compatibility-dark.pdf will be downloaded.
         throw new Error("AutoTable not available");
       };
 
-      runAT({
-        theme: "grid",
-        head: [["Category", "Partner A", "Match %", "Partner B"]],
-        body,
-        startY: 64,
-        margin: { left: marginLR, right: marginLR, top: 64, bottom: 40 },
-        tableWidth: usable,
-        styles: {
-          fontSize: 11,
-          cellPadding: 6,
-          textColor: [255, 255, 255],
-          fillColor: [0, 0, 0],
-          lineColor: [255, 255, 255],
-          lineWidth: 1.2,
-          halign: "center",
-          valign: "middle",
-        },
-        headStyles: {
-          fillColor: [0, 0, 0],
-          textColor: [255, 255, 255],
-          fontStyle: "bold",
-          lineColor: [255, 255, 255],
-          lineWidth: 1.6,
-        },
-        bodyStyles: {
-          fillColor: [0, 0, 0],
-          textColor: [255, 255, 255],
-        },
-        alternateRowStyles: {
-          fillColor: [0, 0, 0],
-          textColor: [255, 255, 255],
-        },
-        columnStyles: {
-          0: { cellWidth: CatWidth, halign: "left" },
-          1: { cellWidth: Awidth, halign: "center" },
-          2: { cellWidth: Mwidth, halign: "center" },
-          3: { cellWidth: Bwidth, halign: "center" },
-        },
-        willDrawPage: paintBg,
-      });
+      const originalAddPage = doc.addPage;
+      doc.addPage = function patchedAddPage(...args) {
+        const result = originalAddPage.apply(this, args);
+        paintBg();
+        return result;
+      };
+
+      try {
+        runAT({
+          theme: "grid",
+          head: [["Category", "Partner A", "Match %", "Partner B"]],
+          body,
+          startY: 64,
+          margin: { left: marginLR, right: marginLR, top: 64, bottom: 40 },
+          tableWidth: usable,
+          styles: {
+            fontSize: 11,
+            cellPadding: 6,
+            textColor: [255, 255, 255],
+            fillColor: [0, 0, 0],
+            lineColor: [255, 255, 255],
+            lineWidth: 1.2,
+            halign: "center",
+            valign: "middle",
+          },
+          headStyles: {
+            fillColor: [0, 0, 0],
+            textColor: [255, 255, 255],
+            fontStyle: "bold",
+            lineColor: [255, 255, 255],
+            lineWidth: 1.6,
+          },
+          bodyStyles: {
+            fillColor: [0, 0, 0],
+            textColor: [255, 255, 255],
+          },
+          alternateRowStyles: {
+            fillColor: [0, 0, 0],
+            textColor: [255, 255, 255],
+          },
+          columnStyles: {
+            0: { cellWidth: CatWidth, halign: "left" },
+            1: { cellWidth: Awidth, halign: "center" },
+            2: { cellWidth: Mwidth, halign: "center" },
+            3: { cellWidth: Bwidth, halign: "center" },
+          },
+          willDrawPage: paintBg,
+        });
+      } finally {
+        doc.addPage = originalAddPage;
+      }
 
       doc.save("compatibility-dark.pdf");
     } catch (err) {

--- a/snippet-compatibility-report-dark-pdf-export-keep-layout.html
+++ b/snippet-compatibility-report-dark-pdf-export-keep-layout.html
@@ -106,9 +106,24 @@ How to use:
   }
 
   function runAT(doc, opts) {
-    if (typeof doc.autoTable === "function") return doc.autoTable(opts);
-    if (window.jspdf && typeof window.jspdf.autoTable === "function") return window.jspdf.autoTable(doc, opts);
-    throw new Error("AutoTable not available");
+    const originalAddPage = doc.addPage;
+    doc.addPage = function patchedAddPage(...args) {
+      const result = originalAddPage.apply(this, args);
+      try {
+        if (typeof opts?.willDrawPage === "function") opts.willDrawPage();
+      } catch (err) {
+        console.warn("[TK-PDF] Background repaint failed", err);
+      }
+      return result;
+    };
+
+    try {
+      if (typeof doc.autoTable === "function") return doc.autoTable(opts);
+      if (window.jspdf && typeof window.jspdf.autoTable === "function") return window.jspdf.autoTable(doc, opts);
+      throw new Error("AutoTable not available");
+    } finally {
+      doc.addPage = originalAddPage;
+    }
   }
 
   function paintBgFactory(doc, pageW, pageH) {

--- a/snippet-compatibility-report-dark-pdf-export-row-fix.html
+++ b/snippet-compatibility-report-dark-pdf-export-row-fix.html
@@ -117,40 +117,51 @@ If a PDF showed only the title before, it’s because no rows were being collect
       (window.jspdf && typeof window.jspdf.autoTable === "function") ? window.jspdf.autoTable(doc, opts) :
       (() => { throw new Error("AutoTable API not found"); })();
 
-    runAT({
-      head: [["Category", "Partner A", "Match %", "Partner B"]],
-      body,
-      startY: 80,
-      margin: { left: marginLR, right: marginLR, top: 80, bottom: 40 },
-      styles: {
-        fontSize: 11,
-        cellPadding: 6,
-        textColor: [255,255,255],  // white text
-        fillColor: [0,0,0],        // black cells
-        lineColor: [255,255,255],  // white grid
-        lineWidth: 0.9,            // THICK lines
-        overflow: "linebreak",
-        halign: "center",
-        valign: "middle"
-      },
-      headStyles: {
-        fontStyle: "bold",
-        fillColor: [0,0,0],
-        textColor: [255,255,255],
-        lineColor: [255,255,255],
-        lineWidth: 1.2,
-        halign: "center",
-        valign: "middle"
-      },
-      columnStyles: {
-        0: { cellWidth: CatWidth, halign: "left"   }, // Category
-        1: { cellWidth: Awidth,   halign: "center" }, // Partner A
-        2: { cellWidth: Mwidth,   halign: "center" }, // Match %
-        3: { cellWidth: Bwidth,   halign: "center" }  // Partner B
-      },
-      tableWidth: usable,
-      willDrawPage: paintBg   // CRUCIAL: paint bg BEFORE the table on each page
-    });
+    const originalAddPage = doc.addPage;
+    doc.addPage = function patchedAddPage(...args) {
+      const result = originalAddPage.apply(this, args);
+      paintBg();
+      return result;
+    };
+
+    try {
+      runAT({
+        head: [["Category", "Partner A", "Match %", "Partner B"]],
+        body,
+        startY: 80,
+        margin: { left: marginLR, right: marginLR, top: 80, bottom: 40 },
+        styles: {
+          fontSize: 11,
+          cellPadding: 6,
+          textColor: [255,255,255],  // white text
+          fillColor: [0,0,0],        // black cells
+          lineColor: [255,255,255],  // white grid
+          lineWidth: 0.9,            // THICK lines
+          overflow: "linebreak",
+          halign: "center",
+          valign: "middle"
+        },
+        headStyles: {
+          fontStyle: "bold",
+          fillColor: [0,0,0],
+          textColor: [255,255,255],
+          lineColor: [255,255,255],
+          lineWidth: 1.2,
+          halign: "center",
+          valign: "middle"
+        },
+        columnStyles: {
+          0: { cellWidth: CatWidth, halign: "left"   }, // Category
+          1: { cellWidth: Awidth,   halign: "center" }, // Partner A
+          2: { cellWidth: Mwidth,   halign: "center" }, // Match %
+          3: { cellWidth: Bwidth,   halign: "center" }  // Partner B
+        },
+        tableWidth: usable,
+        willDrawPage: paintBg   // CRUCIAL: paint bg BEFORE the table on each page
+      });
+    } finally {
+      doc.addPage = originalAddPage;
+    }
 
     doc.save("compatibility-dark.pdf");
     log("Export: saved compatibility-dark.pdf");

--- a/snippet-compatibility-report-dark-pdf-export-unanswered.html
+++ b/snippet-compatibility-report-dark-pdf-export-unanswered.html
@@ -183,11 +183,22 @@ instead of the literal word “Category”.
       const CatWidth = Math.max(220, usable - (Awidth + Mwidth + Bwidth));
 
       // draw main table
-      const runAT = (opts) => {
-        if (typeof doc.autoTable === "function") return doc.autoTable(opts);
-        if (window.jspdf && typeof window.jspdf.autoTable === "function") return window.jspdf.autoTable(doc, opts);
-        throw new Error("AutoTable not available");
-      };
+        const runAT = (opts) => {
+          const originalAddPage = doc.addPage;
+          doc.addPage = function patchedAddPage(...args) {
+            const result = originalAddPage.apply(this, args);
+            paintBg();
+            return result;
+          };
+
+          try {
+            if (typeof doc.autoTable === "function") return doc.autoTable(opts);
+            if (window.jspdf && typeof window.jspdf.autoTable === "function") return window.jspdf.autoTable(doc, opts);
+            throw new Error("AutoTable not available");
+          } finally {
+            doc.addPage = originalAddPage;
+          }
+        };
 
       runAT({
         head: [[firstColHeader, "Partner A", "Match %", "Partner B"]],

--- a/snippet-compatibility-report-dark-pdf-export.html
+++ b/snippet-compatibility-report-dark-pdf-export.html
@@ -136,46 +136,57 @@ A PDF called compatibility-dark.pdf will be downloaded.
         throw new Error("AutoTable not available");
       };
 
-      runAT({
-        theme: "grid",
-        head: [["Category", "Partner A", "Match %", "Partner B"]],
-        body,
-        startY: 64,
-        margin: { left: marginLR, right: marginLR, top: 64, bottom: 40 },
-        tableWidth: usable,
-        styles: {
-          fontSize: 11,
-          cellPadding: 6,
-          textColor: [255, 255, 255],
-          fillColor: [0, 0, 0],
-          lineColor: [255, 255, 255],
-          lineWidth: 1.2,
-          halign: "center",
-          valign: "middle",
-        },
-        headStyles: {
-          fillColor: [0, 0, 0],
-          textColor: [255, 255, 255],
-          fontStyle: "bold",
-          lineColor: [255, 255, 255],
-          lineWidth: 1.6,
-        },
-        bodyStyles: {
-          fillColor: [0, 0, 0],
-          textColor: [255, 255, 255],
-        },
-        alternateRowStyles: {
-          fillColor: [0, 0, 0],
-          textColor: [255, 255, 255],
-        },
-        columnStyles: {
-          0: { cellWidth: CatWidth, halign: "left" },
-          1: { cellWidth: Awidth, halign: "center" },
-          2: { cellWidth: Mwidth, halign: "center" },
-          3: { cellWidth: Bwidth, halign: "center" },
-        },
-        willDrawPage: paintBg,
-      });
+      const originalAddPage = doc.addPage;
+      doc.addPage = function patchedAddPage(...args) {
+        const result = originalAddPage.apply(this, args);
+        paintBg();
+        return result;
+      };
+
+      try {
+        runAT({
+          theme: "grid",
+          head: [["Category", "Partner A", "Match %", "Partner B"]],
+          body,
+          startY: 64,
+          margin: { left: marginLR, right: marginLR, top: 64, bottom: 40 },
+          tableWidth: usable,
+          styles: {
+            fontSize: 11,
+            cellPadding: 6,
+            textColor: [255, 255, 255],
+            fillColor: [0, 0, 0],
+            lineColor: [255, 255, 255],
+            lineWidth: 1.2,
+            halign: "center",
+            valign: "middle",
+          },
+          headStyles: {
+            fillColor: [0, 0, 0],
+            textColor: [255, 255, 255],
+            fontStyle: "bold",
+            lineColor: [255, 255, 255],
+            lineWidth: 1.6,
+          },
+          bodyStyles: {
+            fillColor: [0, 0, 0],
+            textColor: [255, 255, 255],
+          },
+          alternateRowStyles: {
+            fillColor: [0, 0, 0],
+            textColor: [255, 255, 255],
+          },
+          columnStyles: {
+            0: { cellWidth: CatWidth, halign: "left" },
+            1: { cellWidth: Awidth, halign: "center" },
+            2: { cellWidth: Mwidth, halign: "center" },
+            3: { cellWidth: Bwidth, halign: "center" },
+          },
+          willDrawPage: paintBg,
+        });
+      } finally {
+        doc.addPage = originalAddPage;
+      }
 
       doc.save("compatibility-dark.pdf");
     } catch (err) {

--- a/snippet-compatibility-report-force-run.html
+++ b/snippet-compatibility-report-force-run.html
@@ -33,7 +33,25 @@ If you still “don’t see any change”, open DevTools (F12) → Console and r
     const hasAT=(window.jspdf&&window.jspdf.autoTable)||(window.jsPDF&&window.jsPDF.API&&window.jsPDF.API.autoTable);
     if(!hasAT){ log("Loading AutoTable…"); await load("https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.8.3/jspdf.plugin.autotable.min.js"); }
   }
-  function runAT(doc,opts){ if(typeof doc.autoTable==="function") return doc.autoTable(opts); if(window.jspdf&&typeof window.jspdf.autoTable==="function") return window.jspdf.autoTable(doc,opts); throw new Error("AutoTable missing"); }
+  function runAT(doc,opts){
+    const originalAddPage = doc.addPage;
+    doc.addPage = function patchedAddPage(...args){
+      const result = originalAddPage.apply(this,args);
+      try{
+        if (typeof opts?.willDrawPage === "function") opts.willDrawPage();
+        else if (typeof opts?.didDrawPage === "function") opts.didDrawPage({ pageNumber: doc.getNumberOfPages?.() });
+      }catch(e){ log("Background repaint error", e); }
+      return result;
+    };
+
+    try{
+      if(typeof doc.autoTable==="function") return doc.autoTable(opts);
+      if(window.jspdf&&typeof window.jspdf.autoTable==="function") return window.jspdf.autoTable(doc,opts);
+      throw new Error("AutoTable missing");
+    } finally {
+      doc.addPage = originalAddPage;
+    }
+  }
 
   /* ----------------------- Row collector ----------------------- */
   function headerIndexFrom(ths){


### PR DESCRIPTION
## Summary
- patch each jsPDF exporter to repaint the black background whenever a new PDF page is added
- update HTML snippets and utilities to wrap autoTable calls with the same addPage hook and restoration
- keep documentation and test helper pages in sync with the new background handling logic

## Testing
- npm test *(fails: existing `kink survey available without authentication` assertion)*

------
https://chatgpt.com/codex/tasks/task_e_68e18938f71c832c9cd6ab85d533dc9d