### PR TITLE
Ensure print layout stays full-bleed black

### DIFF
--- a/talk-kink-compatibility.html
+++ b/talk-kink-compatibility.html
@@ -61,7 +61,12 @@ html,body{
   .pct-bar{height:100%;background:var(--accent);width:0%}
   /* Print: preserve the on-screen colors in the PDF */
   @media print{
+    html,body,.wrap,table,th,td{
+      background:#000 !important;
+      color:#fff !important;
+    }
     body{-webkit-print-color-adjust:exact;print-color-adjust:exact}
+    .wrap{padding:0 !important}
     .bar,.note{display:none}
     thead th{position:static}
   }


### PR DESCRIPTION
## Summary
- force the print stylesheet to apply a pure black background and white text to the page container and table elements
- remove print padding from the wrapper so the PDF exports without white gutters

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68e1928d400c832ca345f8869895340d