### PR TITLE
Enable full-bleed PDF export on Talk Kink compatibility page

### DIFF
--- a/talk-kink-compatibility.html
+++ b/talk-kink-compatibility.html
@@ -132,6 +132,137 @@ html,body{
     }
   }
 
+  // --- pdf helpers ---------------------------------------------------------
+  const scriptCache = new Map();
+
+  function loadScript(src) {
+    if (scriptCache.has(src)) return scriptCache.get(src);
+
+    const existing = document.querySelector(`script[src="${src}"]`);
+    if (existing) {
+      const pending = new Promise((resolve, reject) => {
+        const onLoad = () => { existing.removeEventListener("load", onLoad); existing.removeEventListener("error", onError); resolve(); };
+        const onError = () => { existing.removeEventListener("load", onLoad); existing.removeEventListener("error", onError); reject(new Error("Failed to load " + src)); };
+        existing.addEventListener("load", onLoad, { once:true });
+        existing.addEventListener("error", onError, { once:true });
+      });
+      scriptCache.set(src, pending);
+      return pending;
+    }
+
+    const s = document.createElement("script");
+    s.src = src;
+    s.async = true;
+
+    const promise = new Promise((resolve, reject) => {
+      s.onload = () => { s.onload = s.onerror = null; resolve(); };
+      s.onerror = () => { s.onload = s.onerror = null; reject(new Error("Failed to load " + src)); };
+    });
+
+    scriptCache.set(src, promise);
+    document.head.appendChild(s);
+    return promise;
+  }
+
+  async function ensureLib(srcList, readyCheck, label) {
+    const check = typeof readyCheck === "function" ? readyCheck : () => !!window[readyCheck];
+    if (check()) return;
+
+    let lastError = null;
+    for (const src of srcList) {
+      try {
+        await loadScript(src);
+      } catch (err) {
+        lastError = err;
+        console.warn("[PDF] loader failed", src, err);
+        continue;
+      }
+      if (check()) return;
+    }
+
+    if (!check()) {
+      throw lastError || new Error((label || "Library") + " failed to load");
+    }
+  }
+
+  async function makeFullBleedPDF(){
+    await ensureLib([
+      "/js/vendor/jspdf.umd.min.js",
+      "https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js",
+      "https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"
+    ], () => window.jspdf && window.jspdf.jsPDF, "jsPDF");
+
+    if (window.jspdf && window.jspdf.jsPDF) {
+      window.jsPDF = window.jspdf.jsPDF;
+    }
+
+    await ensureLib([
+      "/js/vendor/html2canvas.min.js",
+      "https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js",
+      "https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"
+    ], () => typeof window.html2canvas === "function", "html2canvas");
+
+    const jsPDFCtor = window.jspdf?.jsPDF;
+    const html2canvasFn = window.html2canvas;
+    if (!jsPDFCtor || !html2canvasFn) throw new Error("PDF libraries missing");
+
+    const node = document.querySelector(".wrap") || document.body;
+    const prevHtmlBg = document.documentElement.style.backgroundColor;
+    const prevBodyBg = document.body.style.backgroundColor;
+
+    document.documentElement.style.backgroundColor = "#000";
+    document.body.style.backgroundColor = "#000";
+
+    if (document.fonts && document.fonts.ready) {
+      try { await document.fonts.ready; } catch { /* ignore */ }
+    }
+
+    const dpr = Math.min(window.devicePixelRatio || 1, 3);
+    const scale = 2 * dpr;
+
+    let canvas;
+    try {
+      canvas = await html2canvasFn(node, {
+        backgroundColor: "#000",
+        scale,
+        useCORS: true,
+        allowTaint: true,
+        logging: false,
+        windowWidth: Math.max(
+          document.documentElement.scrollWidth,
+          document.body.scrollWidth
+        ),
+        windowHeight: Math.max(
+          document.documentElement.scrollHeight,
+          document.body.scrollHeight
+        )
+      });
+    } finally {
+      document.documentElement.style.backgroundColor = prevHtmlBg || "";
+      document.body.style.backgroundColor = prevBodyBg || "";
+    }
+
+    if (!canvas) throw new Error("Canvas capture failed");
+
+    const imgData = canvas.toDataURL("image/png", 1.0);
+    const pxToPt = 72 / 96;
+    const pdfW = canvas.width * pxToPt;
+    const pdfH = canvas.height * pxToPt;
+
+    const pdf = new jsPDFCtor({
+      orientation: (pdfW >= pdfH) ? "landscape" : "portrait",
+      unit: "pt",
+      format: [pdfW, pdfH],
+      compress: true,
+      putOnlyUsedFonts: true
+    });
+
+    pdf.setFillColor(0, 0, 0);
+    pdf.rect(0, 0, pdfW, pdfH, "F");
+    pdf.addImage(imgData, "PNG", 0, 0, pdfW, pdfH, undefined, "FAST");
+    pdf.save("compatibility.pdf");
+  }
+
   // never expose cb_* in UI. If unknown -> "—" and remember for the side list.
   function prettyLabel(code) {
     const name = LABELS[code];
@@ -262,10 +393,27 @@ html,body{
     finally { e.target.value = ""; }
   });
 
-  document.getElementById("dl").addEventListener("click", ()=> {
-    // Use native print → Save as PDF to keep the exact black styling.
-    window.print();
-  });
+  const downloadBtn = document.getElementById("dl");
+  if (downloadBtn) {
+    downloadBtn.addEventListener("click", async (ev) => {
+      ev.preventDefault();
+      ev.stopPropagation();
+      if (downloadBtn.dataset.busy === "1") return;
+      downloadBtn.dataset.busy = "1";
+      downloadBtn.setAttribute("aria-busy", "true");
+      downloadBtn.disabled = true;
+      try {
+        await makeFullBleedPDF();
+      } catch (err) {
+        console.error("[PDF] export failed:", err);
+        alert("Sorry — the PDF export failed. Check console for details.");
+      } finally {
+        delete downloadBtn.dataset.busy;
+        downloadBtn.removeAttribute("aria-busy");
+        downloadBtn.disabled = false;
+      }
+    });
+  }
 
   document.getElementById("missingBtn").addEventListener("click", ()=> {
     if (!missing.size) { alert("Great! No missing labels."); return; }


### PR DESCRIPTION
## Summary
- add a reusable loader that fetches jsPDF and html2canvas before export
- generate a full-bleed canvas snapshot and save it as compatibility.pdf instead of invoking window.print
- guard the download button during export and surface friendly errors on failure

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1984dbf40832c848ff2dd1f577480