### PR TITLE
Expose full-bleed PDF export helper

### DIFF
--- a/snippet-compatibility-report-dark-pdf-export-full-bleed.html
+++ b/snippet-compatibility-report-dark-pdf-export-full-bleed.html
@@ -104,6 +104,7 @@
       doc.save('compatibility.pdf');
       return;
     }
+    window.makeFullBleedPDF = makeFullBleedPDF;
     const doc = new jsPDF({orientation:'landscape', unit:'pt', format:'a4', compress:true});
     const w = doc.internal.pageSize.getWidth(), h = doc.internal.pageSize.getHeight();
     doc.setFillColor(0,0,0); doc.rect(0,0,w,h,'F'); doc.setTextColor(255);

--- a/talk-kink-compatibility.html
+++ b/talk-kink-compatibility.html
@@ -262,6 +262,7 @@ html,body{
     pdf.addImage(imgData, "PNG", 0, 0, pdfW, pdfH, undefined, "FAST");
     pdf.save("compatibility.pdf");
   }
+  window.makeFullBleedPDF = makeFullBleedPDF;
 
   // never expose cb_* in UI. If unknown -> "—" and remember for the side list.
   function prettyLabel(code) {
@@ -393,28 +394,6 @@ html,body{
     finally { e.target.value = ""; }
   });
 
-  const downloadBtn = document.getElementById("dl");
-  if (downloadBtn) {
-    downloadBtn.addEventListener("click", async (ev) => {
-      ev.preventDefault();
-      ev.stopPropagation();
-      if (downloadBtn.dataset.busy === "1") return;
-      downloadBtn.dataset.busy = "1";
-      downloadBtn.setAttribute("aria-busy", "true");
-      downloadBtn.disabled = true;
-      try {
-        await makeFullBleedPDF();
-      } catch (err) {
-        console.error("[PDF] export failed:", err);
-        alert("Sorry — the PDF export failed. Check console for details.");
-      } finally {
-        delete downloadBtn.dataset.busy;
-        downloadBtn.removeAttribute("aria-busy");
-        downloadBtn.disabled = false;
-      }
-    });
-  }
-
   document.getElementById("missingBtn").addEventListener("click", ()=> {
     if (!missing.size) { alert("Great! No missing labels."); return; }
     const list = [...missing].sort().join("\n");
@@ -424,6 +403,31 @@ html,body{
   // start
   loadLabels().then(render);
 })();
+</script>
+<script type="module">
+/* === Full-bleed PDF export: forcibly replace old window.print handler === */
+document.addEventListener('DOMContentLoaded', () => {
+  const btn = document.querySelector('#dl') || document.querySelector('[data-action="download"]');
+  if (!btn) return;
+
+  const clean = btn.cloneNode(true);
+  clean.removeAttribute('onclick');
+  btn.replaceWith(clean);
+
+  clean.addEventListener('click', async (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    try {
+      if (typeof window.makeFullBleedPDF !== 'function') {
+        throw new Error('makeFullBleedPDF not ready');
+      }
+      await window.makeFullBleedPDF();
+    } catch (err) {
+      console.error('[PDF] export failed:', err);
+      alert('PDF export failed. See console for details.');
+    }
+  }, { passive: false });
+});
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- expose the full-bleed PDF helper so the download button can reuse it
- add a module script that replaces legacy download handlers with the new exporter

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e19a03f8fc832cadea46aeea4f9b09