### PR TITLE
Expand compat upload label overrides

### DIFF
--- a/compat-upload.html
+++ b/compat-upload.html
@@ -573,11 +573,19 @@ const bothReady = () => !!(tkState?.A?.cells?.length && tkState?.B?.cells?.lengt
 })();
 
 /* ----------------------------- LABELS MAP ----------------------------- */
-const TK_LABELS = {
-  cb_wwf76: 'Makeup as protocol or control',
-  cb_swujj: 'Accessory or ornament rules',
-  cb_05hqj: 'Wardrobe restrictions or permissions'
-};
+const TK_LABELS = window.TK_LABELS = Object.assign(
+  {},
+  window.TK_LABELS,
+  {
+    cb_e4bdv: "Dress partner’s outfit",
+    cb_hhxwj: "Pick lingerie / base layers",
+    cb_a19iy: "Uniforms (school, military, nurse, etc.)",
+    cb_5gzwk: "Time-period dress-up",
+    cb_wwf76: "Makeup as protocol or control",
+    cb_swujj: "Accessory or ornament rules",
+    cb_05hqj: "Wardrobe restrictions or permissions"
+  }
+);
 // Optional: site-wide overrides if present
 (async ()=>{ try{
   const r = await fetch('/data/labels-overrides.json',{cache:'no-store'});


### PR DESCRIPTION
## Summary
- expose the compat upload label map on window for reuse
- seed the overrides with additional dress and uniform codes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1e3d1ea68832c9e0bb505c5d1a0f7