### PR TITLE
Update full-bleed compatibility PDF export

### DIFF
--- a/talk-kink-compatibility.html
+++ b/talk-kink-compatibility.html
@@ -645,125 +645,122 @@ CODE END
 -->
 <script>
 /**
- * Full-bleed (no margins) black PDF export for the compatibility table.
- * - Replaces any window.print() usage.
- * - Sets AutoTable margins to ZERO and stretches table to page edges.
- * - Styles table rows dark so the page looks solid black edge-to-edge.
- * - Binds to a button with id="dl".
- *
- * If you already load jsPDF / autotable elsewhere, the loader will just skip.
+ * Full-bleed, all-black PDF export for the compatibility table.
+ * - Replaces any existing window.print()/legacy exporters bound to #dl
+ * - Fills the page background black, then draws the table with ZERO margins
+ * - Forces the table to the page edges
+ * - Optionally translates cb_* codes to labels via window.TK_LABELS (mapping)
  */
 (() => {
-  const JSPDF_UMD = 'https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js';
-  const AUTOTABLE = 'https://cdn.jsdelivr.net/npm/jspdf-autotable@3.8.2/dist/jspdf.plugin.autotable.min.js';
+  const CDN_JSPDF     = 'https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js';
+  const CDN_AUTOTABLE = 'https://cdn.jsdelivr.net/npm/jspdf-autotable@3.8.2/dist/jspdf.plugin.autotable.min.js';
 
-  // 1) Attach once
+  // Attach once and neuter any previous click listeners that did window.print()
   document.addEventListener('DOMContentLoaded', () => {
-    const btn = document.querySelector('#dl');
-    if (btn && !btn.dataset.fullBleedBound) {
-      btn.dataset.fullBleedBound = '1';
-      btn.addEventListener('click', async (e) => {
-        e.preventDefault();
-        try {
-          await ensureJsPDF();
-          await exportCompatibilityPDF_fullBleed();
-        } catch (err) {
-          console.error('[PDF] export failed:', err);
-          alert('Sorry, PDF export failed. Check console for details.');
-        }
-      });
-    }
+    const btn = document.getElementById('dl');
+    if (!btn) return;
+
+    // remove any existing listeners by replacing the node with a clone
+    const clone = btn.cloneNode(true);
+    btn.parentNode.replaceChild(clone, btn);
+
+    clone.addEventListener('click', async (ev) => {
+      ev.preventDefault();
+      try {
+        await ensureLibs();
+        await exportFullBleedPDF();
+      } catch (err) {
+        console.error('[PDF] Export failed:', err);
+        alert('PDF export failed. See console for details.');
+      }
+    });
   });
 
-  // 2) Dynamic loader for jsPDF + AutoTable (skips if already present)
-  async function ensureJsPDF() {
+  async function ensureLibs() {
     if (!window.jspdf || !window.jspdf.jsPDF) {
-      await loadScript(JSPDF_UMD);
+      await loadScript(CDN_JSPDF);
     }
     if (!('autoTable' in (window.jspdf || {}))) {
-      await loadScript(AUTOTABLE);
+      await loadScript(CDN_AUTOTABLE);
     }
   }
 
   function loadScript(src) {
-    return new Promise((resolve, reject) => {
+    return new Promise((res, rej) => {
       const s = document.createElement('script');
       s.src = src;
       s.async = true;
-      s.onload = resolve;
-      s.onerror = () => reject(new Error('Failed to load ' + src));
+      s.onload = res;
+      s.onerror = () => rej(new Error('Failed to load ' + src));
       document.head.appendChild(s);
     });
   }
 
-  // 3) Find the visible comparison table
   function findCompatTable() {
-    // Prefer the big results table (contains these header labels)
-    const isCompat = (t) =>
-      t && /Category/i.test(t.textContent) && /Partner A/i.test(t.textContent);
-
-    let table =
-      Array.from(document.querySelectorAll('.wrap table, main table, table'))
-        .find(isCompat);
-
-    // fallback: any first table
+    const isCompat = (t) => t && /Category/i.test(t.textContent) && /Partner A/i.test(t.textContent);
+    let table = Array.from(document.querySelectorAll('.wrap table, main table, table')).find(isCompat);
     if (!table) table = document.querySelector('table');
     return table;
   }
 
-  // 4) Main export
-  async function exportCompatibilityPDF_fullBleed() {
+  async function exportFullBleedPDF() {
     const { jsPDF } = window.jspdf;
-    const pdf = new jsPDF({ unit: 'pt', format: 'a4', orientation: 'landscape' });
 
+    // Landscape A4. Change to "portrait" if you prefer.
+    const pdf = new jsPDF({ unit: 'pt', format: 'a4', orientation: 'landscape' });
     const pageW = pdf.internal.pageSize.getWidth();
     const pageH = pdf.internal.pageSize.getHeight();
 
     const tableEl = findCompatTable();
-    if (!tableEl) {
-      throw new Error('Could not find the compatibility results table on this page.');
-    }
+    if (!tableEl) throw new Error('Compatibility table not found on the page.');
 
-    // OPTIONAL: If your page prints a title/timestamp in the PDF, remove/comment those
-    // DOM elements for the snapshot, or don't draw them here to keep true full-bleed.
+    // 1) Fill the ENTIRE page background in solid black (removes white gutters)
+    pdf.setFillColor(0, 0, 0);
+    pdf.rect(0, 0, pageW, pageH, 'F');
 
-    // Full-bleed AutoTable: zero margins, start at Y=0, span full page width.
+    // 2) Render the table with ZERO margins, spanning full page width
+    //    And translate cb_* codes in first column if window.TK_LABELS is provided
+    const LABELS = (window.TK_LABELS || {});
     pdf.autoTable({
-      html: tableEl,    // let AutoTable parse the DOM table
-      useCss: false,    // ignore external CSS; we fully control styling below
+      html: tableEl,
       theme: 'plain',
+      useCss: false,
 
-      margin: 0,        // <— the key: NO MARGINS
+      // *** ZERO margins, start at 0, force width to page width ***
+      margin: 0,
       startY: 0,
       tableWidth: pageW,
 
-      pageBreak: 'auto',
-
+      // visual styles (dark rows / white text)
       styles: {
         cellPadding: 8,
-        fillColor: [0, 0, 0],     // black row background
-        textColor: 255,           // white text
-        lineColor: [58, 58, 58],  // subtle dividers
+        fillColor: [0, 0, 0],
+        textColor: 255,
+        lineColor: [64, 64, 64],
         lineWidth: 0.6,
         halign: 'left',
         valign: 'middle',
-        fontStyle: 'normal'
       },
       headStyles: {
         fillColor: [10, 10, 10],
         textColor: 255,
-        fontStyle: 'bold'
+        fontStyle: 'bold',
       },
       alternateRowStyles: { fillColor: [18, 18, 18] },
 
-      // Keep headers/footers off to avoid reintroducing margins.
-      didDrawPage: (data) => {
-        // If you *want* a small title without margins, you can draw it here at fixed coords.
-        // Example (commented out to keep pure full-bleed):
-        // pdf.setTextColor(255);
-        // pdf.setFontSize(12);
-        // pdf.text('Talk Kink — Compatibility', 16, 20);
-      }
+      // Translate codes in the first column on the fly
+      didParseCell: (data) => {
+        if (data.section === 'body' && data.column.index === 0) {
+          const raw = String((data.cell.text && data.cell.text[0]) || '');
+          if (raw.startsWith('cb_')) {
+            const pretty = LABELS[raw];
+            if (pretty) data.cell.text = [pretty];
+          }
+        }
+      },
+
+      // Keep it clean: do not add headers/footers that would reintroduce margins
+      didDrawPage: () => { /* no-op */ },
     });
 
     pdf.save('compatibility.pdf');


### PR DESCRIPTION
## Summary
- replace the compatibility PDF exporter binding to rebuild the button listener cleanly
- load jsPDF/AutoTable from CDN if needed and render a solid black, zero-margin background
- translate cb_* codes to labels when window.TK_LABELS is provided before saving the PDF

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1e3e1658c832c8c66637800ae2eae