### PR TITLE
Add consent modal before compatibility PDF exports

### DIFF
--- a/docs/kinks/js/downloadCompatibilityPDF.ts
+++ b/docs/kinks/js/downloadCompatibilityPDF.ts
@@ -1,3 +1,172 @@
+const CONSENT_IDS = {
+  style: 'tk-consent-style',
+  overlay: 'tk-consent-overlay',
+  card: 'tk-consent-card',
+  title: 'tk-consent-title',
+  message: 'tk-consent-message',
+  actions: 'tk-consent-actions',
+  confirm: 'tk-consent-confirm',
+  cancel: 'tk-consent-cancel'
+} as const;
+
+const CONSENT_COPY = {
+  title: 'Consent Check',
+  message: "Do you have your partner's consent to export or share this compatibility PDF?"
+} as const;
+
+let pendingConsent: Promise<boolean> | null = null;
+
+function shouldBypassConsent(): boolean {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return true;
+  const doc = document;
+  if (!doc || !doc.body || typeof doc.createElement !== 'function') return true;
+  if (typeof doc.getElementById !== 'function' || typeof doc.addEventListener !== 'function') return true;
+  try {
+    const probe = doc.createElement('button');
+    if (!probe || typeof (probe as HTMLElement).addEventListener !== 'function') return true;
+    if (typeof doc.body.appendChild !== 'function') return true;
+  } catch {
+    return true;
+  }
+  return false;
+}
+
+function injectConsentStyle(): void {
+  if (shouldBypassConsent()) return;
+  const doc = document;
+  if (doc.getElementById(CONSENT_IDS.style)) return;
+  const style = doc.createElement('style');
+  style.id = CONSENT_IDS.style;
+  style.textContent = `
+    #${CONSENT_IDS.overlay}{position:fixed;inset:0;display:none;align-items:center;justify-content:center;background:rgba(0,0,0,.55);z-index:99999}
+    #${CONSENT_IDS.card}{max-width:520px;width:90%;background:#111;color:#fff;border:1px solid #444;border-radius:10px;padding:18px 16px;box-shadow:0 10px 30px rgba(0,0,0,.6);font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
+    #${CONSENT_IDS.card} h3{margin:0 0 10px 0;font-size:18px}
+    #${CONSENT_IDS.card} p{margin:0 0 12px 0;line-height:1.4}
+    #${CONSENT_IDS.actions}{display:flex;gap:10px;justify-content:flex-end;margin-top:12px}
+    .tk-btn{padding:8px 14px;border-radius:8px;border:1px solid #555;background:#1f1f1f;color:#fff;cursor:pointer}
+    .tk-btn:hover{filter:brightness(1.15)}
+    .tk-btn.primary{background:#2a7;border-color:#2a7}
+  `;
+  doc.head?.appendChild(style);
+}
+
+type ConsentElements = {
+  overlay: HTMLDivElement;
+  titleEl: HTMLElement | null;
+  messageEl: HTMLElement | null;
+  confirmBtn: HTMLButtonElement | null;
+  cancelBtn: HTMLButtonElement | null;
+};
+
+function ensureConsentModal(): ConsentElements | null {
+  if (shouldBypassConsent()) return null;
+  injectConsentStyle();
+  const doc = document;
+  let overlay = doc.getElementById(CONSENT_IDS.overlay) as HTMLDivElement | null;
+  if (overlay) {
+    return {
+      overlay,
+      titleEl: doc.getElementById(CONSENT_IDS.title),
+      messageEl: doc.getElementById(CONSENT_IDS.message),
+      confirmBtn: doc.getElementById(CONSENT_IDS.confirm) as HTMLButtonElement | null,
+      cancelBtn: doc.getElementById(CONSENT_IDS.cancel) as HTMLButtonElement | null,
+    };
+  }
+
+  overlay = doc.createElement('div');
+  overlay.id = CONSENT_IDS.overlay;
+  overlay.setAttribute('role', 'dialog');
+  overlay.setAttribute('aria-modal', 'true');
+  overlay.style.display = 'none';
+
+  const card = doc.createElement('div');
+  card.id = CONSENT_IDS.card;
+
+  const titleEl = doc.createElement('h3');
+  titleEl.id = CONSENT_IDS.title;
+  titleEl.textContent = CONSENT_COPY.title;
+
+  const messageEl = doc.createElement('p');
+  messageEl.id = CONSENT_IDS.message;
+  messageEl.textContent = CONSENT_COPY.message;
+
+  const actions = doc.createElement('div');
+  actions.id = CONSENT_IDS.actions;
+
+  const cancelBtn = doc.createElement('button');
+  cancelBtn.id = CONSENT_IDS.cancel;
+  cancelBtn.className = 'tk-btn';
+  cancelBtn.type = 'button';
+  cancelBtn.textContent = 'Cancel';
+
+  const confirmBtn = doc.createElement('button');
+  confirmBtn.id = CONSENT_IDS.confirm;
+  confirmBtn.className = 'tk-btn primary';
+  confirmBtn.type = 'button';
+  confirmBtn.textContent = 'I Confirm';
+
+  actions.append(cancelBtn, confirmBtn);
+  card.append(titleEl, messageEl, actions);
+  overlay.appendChild(card);
+  (doc.body || doc.documentElement).appendChild(overlay);
+
+  return { overlay, titleEl, messageEl, confirmBtn, cancelBtn };
+}
+
+function requestConsent(): Promise<boolean> {
+  if (shouldBypassConsent()) return Promise.resolve(true);
+  if (pendingConsent) return pendingConsent;
+
+  const modal = ensureConsentModal();
+  if (!modal) return Promise.resolve(true);
+
+  const { overlay, titleEl, messageEl, confirmBtn, cancelBtn } = modal;
+  if (!overlay || !confirmBtn || !cancelBtn) return Promise.resolve(true);
+
+  if (titleEl) titleEl.textContent = CONSENT_COPY.title;
+  if (messageEl) messageEl.textContent = CONSENT_COPY.message;
+
+  overlay.style.display = 'flex';
+  overlay.setAttribute('data-open', 'true');
+
+  pendingConsent = new Promise<boolean>((resolve) => {
+    let settled = false;
+    const cleanup = (result: boolean) => {
+      if (settled) return;
+      settled = true;
+      overlay.style.display = 'none';
+      overlay.removeAttribute('data-open');
+      confirmBtn.removeEventListener('click', onConfirm);
+      cancelBtn.removeEventListener('click', onCancel);
+      overlay.removeEventListener('click', onOverlayClick);
+      document.removeEventListener?.('keydown', onKey);
+      resolve(result);
+    };
+
+    const onConfirm = () => cleanup(true);
+    const onCancel = () => cleanup(false);
+    const onOverlayClick = (ev: Event) => {
+      if (ev.target === overlay) cleanup(false);
+    };
+    const onKey = (ev: KeyboardEvent) => {
+      if (ev.key === 'Escape') cleanup(false);
+    };
+
+    confirmBtn.addEventListener('click', onConfirm);
+    cancelBtn.addEventListener('click', onCancel);
+    overlay.addEventListener('click', onOverlayClick);
+    document.addEventListener?.('keydown', onKey);
+  }).finally(() => {
+    pendingConsent = null;
+  });
+
+  if (typeof confirmBtn.focus === 'function') {
+    confirmBtn.focus();
+  }
+
+  return pendingConsent;
+}
+
 export async function downloadCompatibilityPDF(): Promise<void> {
   const loadScript = (src: string): Promise<void> =>
     new Promise((resolve, reject) => {
@@ -66,6 +235,9 @@ export async function downloadCompatibilityPDF(): Promise<void> {
   }
 
   try {
+    const consentOk = await requestConsent();
+    if (!consentOk) return;
+
     await ensureLibs();
     const JsPDF: any = (window as any).jspdf?.jsPDF || (window as any).jsPDF;
     const table =

--- a/docs/kinks/js/pdfDownload.js
+++ b/docs/kinks/js/pdfDownload.js
@@ -10,6 +10,170 @@
 // If you were calling a previous function (e.g., downloadCompatibilityPDFCanvas),
 // replace that call with: downloadCompatibilityPDF();
 
+const CONSENT_IDS = {
+  style: 'tk-consent-style',
+  overlay: 'tk-consent-overlay',
+  card: 'tk-consent-card',
+  title: 'tk-consent-title',
+  message: 'tk-consent-message',
+  actions: 'tk-consent-actions',
+  confirm: 'tk-consent-confirm',
+  cancel: 'tk-consent-cancel'
+};
+
+const CONSENT_COPY = {
+  title: 'Consent Check',
+  message: 'Do you have your partner\'s consent to export or share this compatibility PDF?'
+};
+
+let _pendingConsent = null;
+
+function _shouldBypassConsent(){
+  if (typeof window === 'undefined' || typeof document === 'undefined') return true;
+  const doc = document;
+  if (!doc || !doc.body || typeof doc.createElement !== 'function') return true;
+  if (typeof doc.getElementById !== 'function' || typeof doc.addEventListener !== 'function') return true;
+  try {
+    const probe = doc.createElement('button');
+    if (!probe) return true;
+    if (typeof probe.addEventListener !== 'function') return true;
+    if (typeof doc.body.appendChild !== 'function') return true;
+  } catch (_) {
+    return true;
+  }
+  return false;
+}
+
+function _injectConsentStyle(){
+  if (_shouldBypassConsent()) return;
+  const doc = document;
+  if (doc.getElementById(CONSENT_IDS.style)) return;
+  const style = doc.createElement('style');
+  style.id = CONSENT_IDS.style;
+  style.textContent = `
+    #${CONSENT_IDS.overlay}{position:fixed;inset:0;display:none;align-items:center;justify-content:center;background:rgba(0,0,0,.55);z-index:99999}
+    #${CONSENT_IDS.card}{max-width:520px;width:90%;background:#111;color:#fff;border:1px solid #444;border-radius:10px;padding:18px 16px;box-shadow:0 10px 30px rgba(0,0,0,.6);font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
+    #${CONSENT_IDS.card} h3{margin:0 0 10px 0;font-size:18px}
+    #${CONSENT_IDS.card} p{margin:0 0 12px 0;line-height:1.4}
+    #${CONSENT_IDS.actions}{display:flex;gap:10px;justify-content:flex-end;margin-top:12px}
+    .tk-btn{padding:8px 14px;border-radius:8px;border:1px solid #555;background:#1f1f1f;color:#fff;cursor:pointer}
+    .tk-btn:hover{filter:brightness(1.15)}
+    .tk-btn.primary{background:#2a7;border-color:#2a7}
+  `;
+  doc.head && doc.head.appendChild(style);
+}
+
+function _ensureConsentModal(){
+  if (_shouldBypassConsent()) return null;
+  _injectConsentStyle();
+  const doc = document;
+  let overlay = doc.getElementById(CONSENT_IDS.overlay);
+  if (overlay) {
+    return {
+      overlay,
+      card: doc.getElementById(CONSENT_IDS.card),
+      titleEl: doc.getElementById(CONSENT_IDS.title),
+      messageEl: doc.getElementById(CONSENT_IDS.message),
+      confirmBtn: doc.getElementById(CONSENT_IDS.confirm),
+      cancelBtn: doc.getElementById(CONSENT_IDS.cancel)
+    };
+  }
+
+  overlay = doc.createElement('div');
+  overlay.id = CONSENT_IDS.overlay;
+  overlay.setAttribute('role', 'dialog');
+  overlay.setAttribute('aria-modal', 'true');
+  overlay.style.display = 'none';
+
+  const card = doc.createElement('div');
+  card.id = CONSENT_IDS.card;
+
+  const titleEl = doc.createElement('h3');
+  titleEl.id = CONSENT_IDS.title;
+  titleEl.textContent = CONSENT_COPY.title;
+
+  const messageEl = doc.createElement('p');
+  messageEl.id = CONSENT_IDS.message;
+  messageEl.textContent = CONSENT_COPY.message;
+
+  const actions = doc.createElement('div');
+  actions.id = CONSENT_IDS.actions;
+
+  const cancelBtn = doc.createElement('button');
+  cancelBtn.id = CONSENT_IDS.cancel;
+  cancelBtn.className = 'tk-btn';
+  cancelBtn.type = 'button';
+  cancelBtn.textContent = 'Cancel';
+
+  const confirmBtn = doc.createElement('button');
+  confirmBtn.id = CONSENT_IDS.confirm;
+  confirmBtn.className = 'tk-btn primary';
+  confirmBtn.type = 'button';
+  confirmBtn.textContent = 'I Confirm';
+
+  actions.appendChild(cancelBtn);
+  actions.appendChild(confirmBtn);
+
+  card.appendChild(titleEl);
+  card.appendChild(messageEl);
+  card.appendChild(actions);
+
+  overlay.appendChild(card);
+  (doc.body || doc.documentElement).appendChild(overlay);
+
+  return { overlay, card, titleEl, messageEl, confirmBtn, cancelBtn };
+}
+
+function _requestConsent(){
+  if (_shouldBypassConsent()) return Promise.resolve(true);
+  if (_pendingConsent) return _pendingConsent;
+
+  const modal = _ensureConsentModal();
+  if (!modal) return Promise.resolve(true);
+
+  const { overlay, titleEl, messageEl, confirmBtn, cancelBtn } = modal;
+  if (!overlay || !confirmBtn || !cancelBtn) return Promise.resolve(true);
+
+  titleEl && (titleEl.textContent = CONSENT_COPY.title);
+  messageEl && (messageEl.textContent = CONSENT_COPY.message);
+
+  overlay.style.display = 'flex';
+  overlay.setAttribute('data-open', 'true');
+
+  const doc = document;
+
+  _pendingConsent = new Promise(resolve => {
+    let done = false;
+    const cleanup = (result) => {
+      if (done) return;
+      done = true;
+      overlay.style.display = 'none';
+      overlay.removeAttribute('data-open');
+      confirmBtn.removeEventListener('click', onConfirm);
+      cancelBtn.removeEventListener('click', onCancel);
+      overlay.removeEventListener('click', onOverlayClick);
+      doc.removeEventListener && doc.removeEventListener('keydown', onKey);
+      resolve(result);
+    };
+
+    const onConfirm = () => cleanup(true);
+    const onCancel = () => cleanup(false);
+    const onOverlayClick = (ev) => { if (ev.target === overlay) cleanup(false); };
+    const onKey = (ev) => { if (ev.key === 'Escape') cleanup(false); };
+
+    confirmBtn.addEventListener('click', onConfirm);
+    cancelBtn.addEventListener('click', onCancel);
+    overlay.addEventListener('click', onOverlayClick);
+    doc.addEventListener && doc.addEventListener('keydown', onKey);
+  }).finally(() => {
+    _pendingConsent = null;
+  });
+
+  confirmBtn.focus && confirmBtn.focus();
+
+  return _pendingConsent;
+}
+
 function _loadScript(src) {
   return new Promise((resolve, reject) => {
     if (document.querySelector(`script[src="${src}"]`)) return resolve();
@@ -124,6 +288,9 @@ export async function downloadCompatibilityPDF({
   orientation = 'landscape',
   format = 'a4'
 } = {}) {
+  const consentGiven = await _requestConsent();
+  if (!consentGiven) return;
+
   await _ensurePdfLibs();
 
   const rows = _extractRows();

--- a/js/downloadCompatibilityPDF.ts
+++ b/js/downloadCompatibilityPDF.ts
@@ -1,3 +1,172 @@
+const CONSENT_IDS = {
+  style: 'tk-consent-style',
+  overlay: 'tk-consent-overlay',
+  card: 'tk-consent-card',
+  title: 'tk-consent-title',
+  message: 'tk-consent-message',
+  actions: 'tk-consent-actions',
+  confirm: 'tk-consent-confirm',
+  cancel: 'tk-consent-cancel'
+} as const;
+
+const CONSENT_COPY = {
+  title: 'Consent Check',
+  message: "Do you have your partner's consent to export or share this compatibility PDF?"
+} as const;
+
+let pendingConsent: Promise<boolean> | null = null;
+
+function shouldBypassConsent(): boolean {
+  if (typeof window === 'undefined' || typeof document === 'undefined') return true;
+  const doc = document;
+  if (!doc || !doc.body || typeof doc.createElement !== 'function') return true;
+  if (typeof doc.getElementById !== 'function' || typeof doc.addEventListener !== 'function') return true;
+  try {
+    const probe = doc.createElement('button');
+    if (!probe || typeof (probe as HTMLElement).addEventListener !== 'function') return true;
+    if (typeof doc.body.appendChild !== 'function') return true;
+  } catch {
+    return true;
+  }
+  return false;
+}
+
+function injectConsentStyle(): void {
+  if (shouldBypassConsent()) return;
+  const doc = document;
+  if (doc.getElementById(CONSENT_IDS.style)) return;
+  const style = doc.createElement('style');
+  style.id = CONSENT_IDS.style;
+  style.textContent = `
+    #${CONSENT_IDS.overlay}{position:fixed;inset:0;display:none;align-items:center;justify-content:center;background:rgba(0,0,0,.55);z-index:99999}
+    #${CONSENT_IDS.card}{max-width:520px;width:90%;background:#111;color:#fff;border:1px solid #444;border-radius:10px;padding:18px 16px;box-shadow:0 10px 30px rgba(0,0,0,.6);font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
+    #${CONSENT_IDS.card} h3{margin:0 0 10px 0;font-size:18px}
+    #${CONSENT_IDS.card} p{margin:0 0 12px 0;line-height:1.4}
+    #${CONSENT_IDS.actions}{display:flex;gap:10px;justify-content:flex-end;margin-top:12px}
+    .tk-btn{padding:8px 14px;border-radius:8px;border:1px solid #555;background:#1f1f1f;color:#fff;cursor:pointer}
+    .tk-btn:hover{filter:brightness(1.15)}
+    .tk-btn.primary{background:#2a7;border-color:#2a7}
+  `;
+  doc.head?.appendChild(style);
+}
+
+type ConsentElements = {
+  overlay: HTMLDivElement;
+  titleEl: HTMLElement | null;
+  messageEl: HTMLElement | null;
+  confirmBtn: HTMLButtonElement | null;
+  cancelBtn: HTMLButtonElement | null;
+};
+
+function ensureConsentModal(): ConsentElements | null {
+  if (shouldBypassConsent()) return null;
+  injectConsentStyle();
+  const doc = document;
+  let overlay = doc.getElementById(CONSENT_IDS.overlay) as HTMLDivElement | null;
+  if (overlay) {
+    return {
+      overlay,
+      titleEl: doc.getElementById(CONSENT_IDS.title),
+      messageEl: doc.getElementById(CONSENT_IDS.message),
+      confirmBtn: doc.getElementById(CONSENT_IDS.confirm) as HTMLButtonElement | null,
+      cancelBtn: doc.getElementById(CONSENT_IDS.cancel) as HTMLButtonElement | null,
+    };
+  }
+
+  overlay = doc.createElement('div');
+  overlay.id = CONSENT_IDS.overlay;
+  overlay.setAttribute('role', 'dialog');
+  overlay.setAttribute('aria-modal', 'true');
+  overlay.style.display = 'none';
+
+  const card = doc.createElement('div');
+  card.id = CONSENT_IDS.card;
+
+  const titleEl = doc.createElement('h3');
+  titleEl.id = CONSENT_IDS.title;
+  titleEl.textContent = CONSENT_COPY.title;
+
+  const messageEl = doc.createElement('p');
+  messageEl.id = CONSENT_IDS.message;
+  messageEl.textContent = CONSENT_COPY.message;
+
+  const actions = doc.createElement('div');
+  actions.id = CONSENT_IDS.actions;
+
+  const cancelBtn = doc.createElement('button');
+  cancelBtn.id = CONSENT_IDS.cancel;
+  cancelBtn.className = 'tk-btn';
+  cancelBtn.type = 'button';
+  cancelBtn.textContent = 'Cancel';
+
+  const confirmBtn = doc.createElement('button');
+  confirmBtn.id = CONSENT_IDS.confirm;
+  confirmBtn.className = 'tk-btn primary';
+  confirmBtn.type = 'button';
+  confirmBtn.textContent = 'I Confirm';
+
+  actions.append(cancelBtn, confirmBtn);
+  card.append(titleEl, messageEl, actions);
+  overlay.appendChild(card);
+  (doc.body || doc.documentElement).appendChild(overlay);
+
+  return { overlay, titleEl, messageEl, confirmBtn, cancelBtn };
+}
+
+function requestConsent(): Promise<boolean> {
+  if (shouldBypassConsent()) return Promise.resolve(true);
+  if (pendingConsent) return pendingConsent;
+
+  const modal = ensureConsentModal();
+  if (!modal) return Promise.resolve(true);
+
+  const { overlay, titleEl, messageEl, confirmBtn, cancelBtn } = modal;
+  if (!overlay || !confirmBtn || !cancelBtn) return Promise.resolve(true);
+
+  if (titleEl) titleEl.textContent = CONSENT_COPY.title;
+  if (messageEl) messageEl.textContent = CONSENT_COPY.message;
+
+  overlay.style.display = 'flex';
+  overlay.setAttribute('data-open', 'true');
+
+  pendingConsent = new Promise<boolean>((resolve) => {
+    let settled = false;
+    const cleanup = (result: boolean) => {
+      if (settled) return;
+      settled = true;
+      overlay.style.display = 'none';
+      overlay.removeAttribute('data-open');
+      confirmBtn.removeEventListener('click', onConfirm);
+      cancelBtn.removeEventListener('click', onCancel);
+      overlay.removeEventListener('click', onOverlayClick);
+      document.removeEventListener?.('keydown', onKey);
+      resolve(result);
+    };
+
+    const onConfirm = () => cleanup(true);
+    const onCancel = () => cleanup(false);
+    const onOverlayClick = (ev: Event) => {
+      if (ev.target === overlay) cleanup(false);
+    };
+    const onKey = (ev: KeyboardEvent) => {
+      if (ev.key === 'Escape') cleanup(false);
+    };
+
+    confirmBtn.addEventListener('click', onConfirm);
+    cancelBtn.addEventListener('click', onCancel);
+    overlay.addEventListener('click', onOverlayClick);
+    document.addEventListener?.('keydown', onKey);
+  }).finally(() => {
+    pendingConsent = null;
+  });
+
+  if (typeof confirmBtn.focus === 'function') {
+    confirmBtn.focus();
+  }
+
+  return pendingConsent;
+}
+
 export async function downloadCompatibilityPDF(): Promise<void> {
   const loadScript = (src: string): Promise<void> =>
     new Promise((resolve, reject) => {
@@ -66,6 +235,9 @@ export async function downloadCompatibilityPDF(): Promise<void> {
   }
 
   try {
+    const consentOk = await requestConsent();
+    if (!consentOk) return;
+
     await ensureLibs();
     const JsPDF: any = (window as any).jspdf?.jsPDF || (window as any).jsPDF;
     const table =

--- a/js/pdfDownload.js
+++ b/js/pdfDownload.js
@@ -10,6 +10,170 @@
 // If you were calling a previous function (e.g., downloadCompatibilityPDFCanvas),
 // replace that call with: downloadCompatibilityPDF();
 
+const CONSENT_IDS = {
+  style: 'tk-consent-style',
+  overlay: 'tk-consent-overlay',
+  card: 'tk-consent-card',
+  title: 'tk-consent-title',
+  message: 'tk-consent-message',
+  actions: 'tk-consent-actions',
+  confirm: 'tk-consent-confirm',
+  cancel: 'tk-consent-cancel'
+};
+
+const CONSENT_COPY = {
+  title: 'Consent Check',
+  message: 'Do you have your partner\'s consent to export or share this compatibility PDF?'
+};
+
+let _pendingConsent = null;
+
+function _shouldBypassConsent(){
+  if (typeof window === 'undefined' || typeof document === 'undefined') return true;
+  const doc = document;
+  if (!doc || !doc.body || typeof doc.createElement !== 'function') return true;
+  if (typeof doc.getElementById !== 'function' || typeof doc.addEventListener !== 'function') return true;
+  try {
+    const probe = doc.createElement('button');
+    if (!probe) return true;
+    if (typeof probe.addEventListener !== 'function') return true;
+    if (typeof doc.body.appendChild !== 'function') return true;
+  } catch (_) {
+    return true;
+  }
+  return false;
+}
+
+function _injectConsentStyle(){
+  if (_shouldBypassConsent()) return;
+  const doc = document;
+  if (doc.getElementById(CONSENT_IDS.style)) return;
+  const style = doc.createElement('style');
+  style.id = CONSENT_IDS.style;
+  style.textContent = `
+    #${CONSENT_IDS.overlay}{position:fixed;inset:0;display:none;align-items:center;justify-content:center;background:rgba(0,0,0,.55);z-index:99999}
+    #${CONSENT_IDS.card}{max-width:520px;width:90%;background:#111;color:#fff;border:1px solid #444;border-radius:10px;padding:18px 16px;box-shadow:0 10px 30px rgba(0,0,0,.6);font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
+    #${CONSENT_IDS.card} h3{margin:0 0 10px 0;font-size:18px}
+    #${CONSENT_IDS.card} p{margin:0 0 12px 0;line-height:1.4}
+    #${CONSENT_IDS.actions}{display:flex;gap:10px;justify-content:flex-end;margin-top:12px}
+    .tk-btn{padding:8px 14px;border-radius:8px;border:1px solid #555;background:#1f1f1f;color:#fff;cursor:pointer}
+    .tk-btn:hover{filter:brightness(1.15)}
+    .tk-btn.primary{background:#2a7;border-color:#2a7}
+  `;
+  doc.head && doc.head.appendChild(style);
+}
+
+function _ensureConsentModal(){
+  if (_shouldBypassConsent()) return null;
+  _injectConsentStyle();
+  const doc = document;
+  let overlay = doc.getElementById(CONSENT_IDS.overlay);
+  if (overlay) {
+    return {
+      overlay,
+      card: doc.getElementById(CONSENT_IDS.card),
+      titleEl: doc.getElementById(CONSENT_IDS.title),
+      messageEl: doc.getElementById(CONSENT_IDS.message),
+      confirmBtn: doc.getElementById(CONSENT_IDS.confirm),
+      cancelBtn: doc.getElementById(CONSENT_IDS.cancel)
+    };
+  }
+
+  overlay = doc.createElement('div');
+  overlay.id = CONSENT_IDS.overlay;
+  overlay.setAttribute('role', 'dialog');
+  overlay.setAttribute('aria-modal', 'true');
+  overlay.style.display = 'none';
+
+  const card = doc.createElement('div');
+  card.id = CONSENT_IDS.card;
+
+  const titleEl = doc.createElement('h3');
+  titleEl.id = CONSENT_IDS.title;
+  titleEl.textContent = CONSENT_COPY.title;
+
+  const messageEl = doc.createElement('p');
+  messageEl.id = CONSENT_IDS.message;
+  messageEl.textContent = CONSENT_COPY.message;
+
+  const actions = doc.createElement('div');
+  actions.id = CONSENT_IDS.actions;
+
+  const cancelBtn = doc.createElement('button');
+  cancelBtn.id = CONSENT_IDS.cancel;
+  cancelBtn.className = 'tk-btn';
+  cancelBtn.type = 'button';
+  cancelBtn.textContent = 'Cancel';
+
+  const confirmBtn = doc.createElement('button');
+  confirmBtn.id = CONSENT_IDS.confirm;
+  confirmBtn.className = 'tk-btn primary';
+  confirmBtn.type = 'button';
+  confirmBtn.textContent = 'I Confirm';
+
+  actions.appendChild(cancelBtn);
+  actions.appendChild(confirmBtn);
+
+  card.appendChild(titleEl);
+  card.appendChild(messageEl);
+  card.appendChild(actions);
+
+  overlay.appendChild(card);
+  (doc.body || doc.documentElement).appendChild(overlay);
+
+  return { overlay, card, titleEl, messageEl, confirmBtn, cancelBtn };
+}
+
+function _requestConsent(){
+  if (_shouldBypassConsent()) return Promise.resolve(true);
+  if (_pendingConsent) return _pendingConsent;
+
+  const modal = _ensureConsentModal();
+  if (!modal) return Promise.resolve(true);
+
+  const { overlay, titleEl, messageEl, confirmBtn, cancelBtn } = modal;
+  if (!overlay || !confirmBtn || !cancelBtn) return Promise.resolve(true);
+
+  titleEl && (titleEl.textContent = CONSENT_COPY.title);
+  messageEl && (messageEl.textContent = CONSENT_COPY.message);
+
+  overlay.style.display = 'flex';
+  overlay.setAttribute('data-open', 'true');
+
+  const doc = document;
+
+  _pendingConsent = new Promise(resolve => {
+    let done = false;
+    const cleanup = (result) => {
+      if (done) return;
+      done = true;
+      overlay.style.display = 'none';
+      overlay.removeAttribute('data-open');
+      confirmBtn.removeEventListener('click', onConfirm);
+      cancelBtn.removeEventListener('click', onCancel);
+      overlay.removeEventListener('click', onOverlayClick);
+      doc.removeEventListener && doc.removeEventListener('keydown', onKey);
+      resolve(result);
+    };
+
+    const onConfirm = () => cleanup(true);
+    const onCancel = () => cleanup(false);
+    const onOverlayClick = (ev) => { if (ev.target === overlay) cleanup(false); };
+    const onKey = (ev) => { if (ev.key === 'Escape') cleanup(false); };
+
+    confirmBtn.addEventListener('click', onConfirm);
+    cancelBtn.addEventListener('click', onCancel);
+    overlay.addEventListener('click', onOverlayClick);
+    doc.addEventListener && doc.addEventListener('keydown', onKey);
+  }).finally(() => {
+    _pendingConsent = null;
+  });
+
+  confirmBtn.focus && confirmBtn.focus();
+
+  return _pendingConsent;
+}
+
 function _loadScript(src) {
   return new Promise((resolve, reject) => {
     if (document.querySelector(`script[src="${src}"]`)) return resolve();
@@ -124,6 +288,9 @@ export async function downloadCompatibilityPDF({
   orientation = 'landscape',
   format = 'a4'
 } = {}) {
+  const consentGiven = await _requestConsent();
+  if (!consentGiven) return;
+
   await _ensurePdfLibs();
 
   const rows = _extractRows();


### PR DESCRIPTION
## Summary
- add a reusable consent modal overlay that gates all compatibility PDF exports
- update the js/ts implementations to request consent before loading libraries and generating the PDF
- keep non-browser/test environments working by bypassing the modal when DOM APIs are unavailable

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1fb61ab2c832c9abc36dfa548dfbf