### PR TITLE
Add black-edge PDF export snippet

### DIFF
--- a/snippet-compatibility-report-dark-pdf-export-black-edge.html
+++ b/snippet-compatibility-report-dark-pdf-export-black-edge.html
@@ -1,0 +1,142 @@
+<!-- jsPDF + AutoTable (UMD builds) -->
+<script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.2/dist/jspdf.umd.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jspdf-autotable@3.8.3/dist/jspdf.plugin.autotable.min.js"></script>
+
+<style>
+/* Minimal consent modal (always asks) */
+#tk-consent-overlay{position:fixed;inset:0;display:none;align-items:center;justify-content:center;background:rgba(0,0,0,.55);z-index:99999}
+#tk-consent-card{max-width:520px;width:90%;background:#111;color:#fff;border:1px solid #333;border-radius:10px;padding:16px;font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif}
+#tk-consent-actions{display:flex;gap:10px;justify-content:flex-end;margin-top:12px}
+.tk-btn{padding:8px 14px;border-radius:8px;border:1px solid #555;background:#1f1f1f;color:#fff;cursor:pointer}
+.tk-btn.primary{background:#2a7;border-color:#2a7}
+</style>
+
+<!-- Consent modal -->
+<div id="tk-consent-overlay" aria-modal="true" role="dialog">
+  <div id="tk-consent-card">
+    <h3 style="margin:0 0 8px 0;font:600 16px system-ui">Consent Check</h3>
+    <p style="margin:0 0 10px 0;line-height:1.4">Do you have your partner’s consent to export or share this compatibility PDF?</p>
+    <div id="tk-consent-actions">
+      <button class="tk-btn" id="tk-consent-cancel">Cancel</button>
+      <button class="tk-btn primary" id="tk-consent-confirm">I Confirm</button>
+    </div>
+  </div>
+</div>
+
+<script>
+/* ---------- Consent (always ask) ---------- */
+function showConsentModal(){
+  return new Promise(resolve=>{
+    const overlay=document.getElementById('tk-consent-overlay');
+    const btnCancel=document.getElementById('tk-consent-cancel');
+    const btnOk=document.getElementById('tk-consent-confirm');
+    overlay.style.display='flex';
+    const cleanup=(ok)=>{ document.removeEventListener('keydown',onKey); overlay.style.display='none'; resolve(ok); };
+    const onKey=(e)=>{ if(e.key==='Escape') cleanup(false); };
+    document.addEventListener('keydown',onKey);
+    btnCancel.onclick=()=>cleanup(false);
+    btnOk.onclick=()=>cleanup(true);
+    overlay.onclick=(e)=>{ if(e.target===overlay) cleanup(false); };
+  });
+}
+
+/* ---------- FINAL: Ultra full-bleed black export (no margins/padding/borders/headers) ---------- */
+async function exportCompatPDF_vBlackEdge({
+  filename='compatibility.pdf',
+  columns=[
+    { header:'Category', dataKey:'category' },
+    { header:'Partner A', dataKey:'a' },
+    { header:'Match %',  dataKey:'m' },
+    { header:'Partner B',dataKey:'b' },
+  ],
+  rows=[]
+} = {}) {
+  const ok = await showConsentModal();
+  if(!ok) return;
+
+  console.log('USING vBlackEdge'); // verify in console
+
+  const { jsPDF } = window.jspdf;
+  const doc = new jsPDF({ unit:'pt', format:'letter', compress:true, putOnlyUsedFonts:true });
+
+  const W = doc.internal.pageSize.getWidth();
+  const H = doc.internal.pageSize.getHeight();
+  const BLEED = 4; // overpaint beyond page bounds to avoid any anti-aliased rim
+
+  const paintBlack = () => { doc.setFillColor(0,0,0); doc.rect(-BLEED,-BLEED,W+BLEED*2,H+BLEED*2,'F'); };
+  paintBlack();                         // Page 1 background first
+  doc.setTextColor(255,255,255);        // White text
+  doc.setDrawColor(0,0,0);              // Black stroke
+  doc.setLineWidth(0);                  // No strokes anywhere
+
+  // Build table arrays (no padding/fills/borders)
+  const head = [columns.map(c => c.header ?? c.title ?? c)];
+  const body = rows.map(r => columns.map(c => {
+    const k=c.dataKey ?? c.key ?? c; const v=r[k];
+    return (v===undefined || v===null || v==='') ? '—' : String(v);
+  }));
+
+  doc.autoTable({
+    head, body,
+    startY: -BLEED,                     // start outside page to cover top edge
+    startX: -BLEED,                     // left edge
+    tableWidth: W + BLEED*2,            // span past both sides
+    margin: { top:0, right:0, bottom:0, left:0 },
+    theme: 'plain',
+    horizontalPageBreak: true,
+
+    styles: {
+      font: 'helvetica',
+      fontSize: 10,
+      textColor: [255,255,255],
+      cellPadding: 0,                   // zero padding
+      lineWidth: 0,                     // no borders
+      fillColor: null,                  // let page black show through
+      overflow: 'linebreak',
+      minCellHeight: 14
+    },
+    headStyles: {
+      fontStyle: 'bold',
+      textColor: [255,255,255],
+      fillColor: null,
+      cellPadding: 0,
+      lineWidth: 0,
+      minCellHeight: 16
+    },
+    tableLineWidth: 0,
+    tableLineColor: [0,0,0],
+    columnStyles: {
+      0:{halign:'left'},
+      1:{halign:'center'},
+      2:{halign:'center'},
+      3:{halign:'center'}
+    },
+
+    // Hard override any external fills/borders that might sneak in
+    didParseCell(data){
+      data.cell.styles.fillColor = null;
+      data.cell.styles.lineWidth = 0;
+      data.cell.styles.lineColor = [0,0,0];
+    },
+
+    // Repaint every new page BEFORE any table content
+    didAddPage(){
+      paintBlack();
+      doc.setTextColor(255,255,255);
+      doc.setDrawColor(0,0,0);
+      doc.setLineWidth(0);
+    }
+  });
+
+  doc.save(filename);
+}
+
+/* ---------- Example usage ----------
+exportCompatPDF_vBlackEdge({
+  rows: [
+    { category:'Bondage', a:'5', m:'92%', b:'5' },
+    { category:'Impact',  a:'4', m:'78%', b:'3' },
+  ]
+});
+*/
+</script>


### PR DESCRIPTION
## Summary
- add a standalone snippet for exporting compatibility tables to a full-bleed black PDF
- include a minimal consent modal and configurable column mapping for the export helper

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e443eba240832ca9b3b0e885187547