### PR TITLE
Enhance one-box compatibility snippet with safe label loading and black-edge PDF

### DIFF
--- a/snippet-compatibility-report-one-box.html
+++ b/snippet-compatibility-report-one-box.html
@@ -1,171 +1,348 @@
-<!--
-TALK KINK • COMPATIBILITY REPORT — “ONE BOX” (directions + working code)
-
-WHAT THIS DOES
-- Finds your compatibility table on the page (or uses the one with the most numbers).
-- Builds rows as:  Category | Partner A | Match % | Flag | Partner B
-  • Partner A  = first number in the row
-  • Partner B  = last  number in the row
-  • Match %    = first % seen in the row, or computed from A & B if none
-  • Flag       = ★ ≥ 90, ⚑ ≥ 60, 🚩 ≤ 30, otherwise “+P”
-- Wraps long Category to AT MOST TWO LINES (adds … if truncated).
-- Exports a LANDSCAPE A4 PDF with TRUE BLACK background (no white borders).
-
-HOW TO USE (QUICK RUN — no page edits)
-1) Open your compatibility page in Chrome/Edge/Firefox.
-2) Press F12 → Console.
-3) Paste this entire block and hit Enter.
-   If a popup blocker stops the download, allow it and run again.
-
-HOW TO KEEP IT PERMANENTLY
-- Put this whole <script> before </body> on your page. It will download
-  the libraries if missing and immediately save the PDF.
-  (If you want it on a button instead, search for “AUTO_RUN” below.)
-
-CUSTOMIZE
-- Change column widths under “columnStyles”.
-- Change flag thresholds/symbols in flag() below.
-- Change title text in the didDrawPage() painter.
-
-SECURITY NOTE
-- This loads jsPDF + AutoTable via CDN. If your CSP blocks it, host those
-  two files locally and remove the dynamic loader (two load() calls).
--->
-
+<!-- === TalkKink Compatibility: One-Box Fix + Black-Edge Exporter === -->
+<script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.2/dist/jspdf.umd.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jspdf-autotable@3.8.3/dist/jspdf.plugin.autotable.min.js"></script>
 <script>
-(async () => {
-  /************* utilities *************/
-  const tidy = s => (s||"").replace(/\s+/g," ").trim();
-  const toNum = v => { const n = Number(String(v??"").trim()); return Number.isFinite(n)?n:null; };
-  const pct   = (a,b) => { const A=toNum(a), B=toNum(b); if(A==null||B==null) return null;
-                           return Math.round(100 - (Math.abs(A-B)/5)*100); };
-  const flag  = p => p==null ? "—" : (p>=90 ? "★" : (p>=60 ? "⚑" : (p<=30 ? "🚩" : "+P")));
+/* 0) Patch loadLabels so init() never crashes and iteration is safe */
+(function patchLoadLabels(){
+  const original = window.loadLabels;
+  window.loadLabels = async function loadLabelsPatched(){
+    try{
+      let labelMap = {};
+      if (typeof original === 'function') {
+        const out = await original();
+        if (out && typeof out === 'object') labelMap = out;
+      } else {
+        const raw = localStorage.getItem('tk_labelMap');
+        if (raw) {
+          try { labelMap = JSON.parse(raw); }
+          catch(err){ console.warn('[tk] localStorage labelMap parse failed', err); }
+        }
+        if (window.tkLabelMap && typeof window.tkLabelMap === 'object') labelMap = window.tkLabelMap;
+      }
 
-  // Load jsPDF + AutoTable when needed
-  const load = src => new Promise((res,rej)=>{const s=document.createElement("script");s.src=src;s.onload=res;s.onerror=()=>rej(new Error("Failed to load "+src));document.head.appendChild(s);});
-  if(!(window.jspdf && window.jspdf.jsPDF)) await load("https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js");
-  if(!((window.jspdf&&window.jspdf.autoTable)||(window.jsPDF&&window.jsPDF.API&&window.jsPDF.API.autoTable)))
-    await load("https://cdnjs.cloudflare.com/ajax/libs/jspdf-autotable/3.8.3/jspdf.plugin.autotable.min.js");
+      let entries = [];
+      if (Array.isArray(labelMap)) entries = labelMap;
+      else if (labelMap instanceof Map) entries = Array.from(labelMap.entries());
+      else if (labelMap && typeof labelMap === 'object') entries = Object.entries(labelMap);
 
-  /************* find a table *************/
-  const pickTable = () => {
-    // Prefer #compatibilityTable if present
-    const byId = document.getElementById("compatibilityTable");
-    if (byId) return byId;
-
-    // Else, pick the table with the most numeric-looking rows
-    let best=null, score=-1;
-    for (const t of document.querySelectorAll("table")) {
-      const rows = [...t.querySelectorAll("tbody tr")].length
-        ? [...t.querySelectorAll("tbody tr")]
-        : [...t.querySelectorAll("tr")].filter(r=>r.querySelector("td"));
-      const s = rows.filter(r => /\d/.test(r.textContent)).length;
-      if (s > score) { score = s; best = t; }
+      const byId = {};
+      for (const [id, label] of entries) {
+        if (id == null) continue;
+        const key = String(id);
+        const pretty = label == null ? key : String(label);
+        byId[key] = pretty;
+        byId[key.toLowerCase()] = pretty;
+      }
+      window.__tkLabels = byId;
+      try { localStorage.setItem('tk_labelMap', JSON.stringify(byId)); }
+      catch(_){}
+      return byId;
+    }catch(e){
+      console.warn('[tk] loadLabels patched: using empty map', e);
+      window.__tkLabels = {};
+      return {};
     }
-    return best;
+  };
+})();
+
+/* 1) Kill legacy paths that cause white borders or headers */
+try { window.print = () => console.warn('[tk] window.print() disabled'); } catch(e){}
+(function killOld(){
+  const names = [
+    'downloadCompatibilityPDF','exportCompatibilityPDF','makePDF','createPDF',
+    'saveReportPDF','compatPDF','exportPDF','downloadPDF'
+  ];
+  names.forEach(n => { try { delete window[n]; } catch(_){} });
+})();
+
+/* 2) Always-ask consent (simple, no "remember") */
+async function tkConsent(){ return confirm("Consent check:\nDo you have your partner’s consent to export/share this PDF?"); }
+
+const DEFAULT_COLUMNS = [
+  { header:'Category', dataKey:'category' },
+  { header:'Partner A', dataKey:'a' },
+  { header:'Match %',  dataKey:'m' },
+  { header:'Partner B',dataKey:'b' },
+];
+
+const CB_RE = /\bcb_[a-z0-9]+\b/i;
+const tidy = s => String(s ?? '').replace(/\s+/g,' ').trim();
+const dash = v => { const t = tidy(v); return t ? t : '—'; };
+
+function labelFor(raw){
+  const map = window.__tkLabels || {};
+  const base = tidy(raw);
+  if (!base) return '—';
+  const direct = map[base] || map[base.toLowerCase()];
+  if (direct) return tidy(direct) || '—';
+  const hit = base.match(CB_RE);
+  if (!hit) return base;
+  const key = hit[0];
+  return tidy(map[key] || map[key.toLowerCase()] || base) || '—';
+}
+
+function findCompatTable(){
+  return (
+    document.querySelector('#compatTable') ||
+    document.querySelector('#compatibilityTable') ||
+    document.querySelector('.compat table') ||
+    document.querySelector('.compat-table table') ||
+    document.querySelector('table')
+  );
+}
+
+function rewriteTableLabels(table){
+  if (!table) return;
+  const rows = table.tBodies.length
+    ? Array.from(table.tBodies).flatMap(tb => Array.from(tb.rows))
+    : Array.from(table.rows);
+  rows.forEach(tr => {
+    if (!tr || !tr.cells || !tr.cells.length) return;
+    const cell = tr.cells[0];
+    if (!cell || cell.tagName === 'TH') return;
+    const raw = tidy(cell.textContent);
+    if (!raw) return;
+    const pretty = labelFor(raw);
+    if (!pretty || pretty === raw || cell.dataset.tkLabelValue === pretty) return;
+    cell.textContent = pretty;
+    cell.dataset.tkLabelValue = pretty;
+  });
+}
+
+function buildColumnsFromHeaders(headers){
+  if (!headers || !headers.length) return DEFAULT_COLUMNS.map(col => ({ ...col }));
+  return headers.map((header, idx) => {
+    const fallback = DEFAULT_COLUMNS[idx];
+    const text = dash(header || (fallback && fallback.header));
+    const key = fallback ? fallback.dataKey : String(idx);
+    return { header: text, dataKey: key };
+  });
+}
+
+function gatherTableData(){
+  const table = findCompatTable();
+  if (!table) return { columns: DEFAULT_COLUMNS.map(col => ({ ...col })), rows: [] };
+
+  let headRow = null;
+  if (table.tHead && table.tHead.rows && table.tHead.rows.length) {
+    const headRows = Array.from(table.tHead.rows).filter(row => row && row.cells && row.cells.length);
+    headRow = headRows.length ? headRows[headRows.length - 1] : null;
+  }
+  const headers = headRow ? Array.from(headRow.cells).map(cell => tidy(cell.textContent)) : [];
+  const columns = buildColumnsFromHeaders(headers);
+
+  const bodyRows = table.tBodies.length
+    ? Array.from(table.tBodies).flatMap(tb => Array.from(tb.rows))
+    : Array.from(table.rows).filter(row => row && row.cells && row.cells.length && row.querySelectorAll('td').length);
+
+  const rows = [];
+  bodyRows.forEach(tr => {
+    if (!tr || !tr.cells || !tr.cells.length) return;
+    const cells = Array.from(tr.cells);
+    if (!cells.some(td => tidy(td.textContent))) return;
+    const obj = {};
+    columns.forEach((col, idx) => {
+      const cell = cells[idx];
+      let text = cell ? cell.textContent : '';
+      if (idx === 0) text = labelFor(text);
+      obj[col.dataKey] = dash(text);
+    });
+    rows.push(obj);
+  });
+
+  return { columns, rows };
+}
+
+async function ensureLabelsLoaded(){
+  if (typeof window.loadLabels === 'function') {
+    try { await window.loadLabels(); }
+    catch(err){ console.warn('[tk] loadLabels failed (patched fallback in use)', err); }
+  }
+  if (!window.__tkLabels) window.__tkLabels = {};
+  return window.__tkLabels;
+}
+
+let tableObserver = null;
+let rootObserver = null;
+let rootObserverTimer = 0;
+
+function watchTable(){
+  const table = findCompatTable();
+  if (!table) return;
+  rewriteTableLabels(table);
+  if (tableObserver) tableObserver.disconnect();
+  tableObserver = new MutationObserver(() => rewriteTableLabels(table));
+  const target = table.tBodies.length ? table.tBodies[0] : table;
+  tableObserver.observe(target, { childList:true, subtree:true, characterData:true });
+}
+
+function watchForNewTables(){
+  if (rootObserver) return;
+  const root = document.body;
+  if (!root || !window.MutationObserver) return;
+  rootObserver = new MutationObserver(() => {
+    if (rootObserverTimer) return;
+    rootObserverTimer = window.setTimeout(() => {
+      rootObserverTimer = 0;
+      watchTable();
+    }, 60);
+  });
+  rootObserver.observe(root, { childList:true, subtree:true });
+}
+
+function wireDownloadButton(){
+  const candidates = Array.from(document.querySelectorAll('a,button,input[type="button"],input[type="submit"]'));
+  const btn = candidates.find(el => /download pdf/i.test((el.textContent || el.value || '').trim()));
+  if (!btn) { console.warn('[tk] Download PDF button not found'); return; }
+
+  const handler = async (e) => {
+    e.preventDefault();
+    e.stopImmediatePropagation();
+    const data = gatherTableData();
+    if (!data.rows.length) {
+      alert('No compatibility rows found to export.');
+      return;
+    }
+    await tkExportPDF_BlackEdge({ columns: data.columns, rows: data.rows });
   };
 
-  const table = pickTable();
-  if (!table) { alert("No table found on this page."); return; }
+  btn.onclick = null;
+  if (btn.tagName === 'A') btn.removeAttribute('href');
+  btn.addEventListener('click', handler, { capture:true });
+  console.info('[tk] Download PDF button rewired → BlackEdge exporter');
+}
 
-  /************* extract rows *************/
-  const makeRows = () => {
-    const out = [];
-    const trs = [...table.querySelectorAll("tbody tr")].length
-      ? [...table.querySelectorAll("tbody tr")]
-      : [...table.querySelectorAll("tr")].filter(r=>r.querySelector("td"));
+/* 3) Ultra full-bleed, zero-margin exporter (no title/timestamp/footer) */
+async function tkExportPDF_BlackEdge({
+  filename='compatibility.pdf',
+  columns=DEFAULT_COLUMNS.map(col => ({ ...col })),
+  rows=[]
+} = {}) {
+  if(!(await tkConsent())) return;
 
-    for (const tr of trs) {
-      const tds = [...tr.querySelectorAll("td")];
-      if (!tds.length) continue;
-
-      // Category = first cell's text (dedup any repeated copy)
-      const rawCat = tidy(tds[0]?.textContent || "");
-      if (!rawCat) continue;
-
-      // All numeric cells (first is A, last is B)
-      const nums = tds.map(td => toNum(td.textContent)).filter(v => v !== null);
-      const A = nums.length ? nums[0] : null;
-      const B = nums.length >= 2 ? nums[nums.length - 1] : null;
-
-      // Optional percentage found in row
-      const pctCell = tds.find(td => /%/.test(td.textContent));
-      const P = pctCell ? (tidy(pctCell.textContent).match(/\d+%/)?.[0] || "—")
-                        : (pct(A,B)==null ? "—" : pct(A,B)+"%");
-
-      out.push([rawCat, (A??"—"), P, flag(Number(String(P).replace("%",""))), (B??"—")]);
-    }
-    return out;
+  const lib = window.jspdf;
+  if (!lib || typeof lib.jsPDF !== 'function') {
+    alert('jsPDF is not loaded.');
+    return;
+  }
+  const autoTableFn = (doc, opts) => {
+    if (typeof doc.autoTable === 'function') return doc.autoTable(opts);
+    if (lib && typeof lib.autoTable === 'function') return lib.autoTable(doc, opts);
+    throw new Error('jsPDF AutoTable plugin missing');
   };
 
-  const rowsRaw = makeRows();
-  if (!rowsRaw.length) { alert("Found a table, but no usable rows."); return; }
-
-  /************* build PDF *************/
-  const { jsPDF } = window.jspdf;
-  const doc = new jsPDF({ orientation: "landscape", unit: "pt", format: "a4" });
+  const doc = new lib.jsPDF({ unit:'pt', format:'letter', compress:true, putOnlyUsedFonts:true });
   const W = doc.internal.pageSize.getWidth();
   const H = doc.internal.pageSize.getHeight();
+  const BLEED = 8; // overpaint beyond page to crush any anti-alias halo
 
-  // Paint black background (removes white borders)
   const paint = () => {
     doc.setFillColor(0,0,0);
-    doc.rect(0,0,W,H,"F");
-    doc.setTextColor(255,255,255);
-    doc.setFontSize(32);
-    doc.text("Talk Kink • Compatibility Report", W/2, 56, { align: "center", baseline: "middle" });
+    doc.rect(-BLEED,-BLEED,W+BLEED*2,H+BLEED*2,'F');
   };
+  paint();
+  doc.setTextColor(255,255,255);
+  doc.setDrawColor(0,0,0);
+  doc.setLineWidth(0);
 
-  // Table sizing
-  const marginLR   = 36;
-  const marginTop  = 90;
-  const marginBot  = 36;
-  const tableWidth = W - marginLR*2;
+  if (!rows.length) {
+    const data = gatherTableData();
+    columns = data.columns;
+    rows = data.rows;
+  }
+  if (!rows.length) {
+    alert('No compatibility rows available for PDF export.');
+    return;
+  }
 
-  // Make Category wrap to 2 lines max for the actual column width
-  const narrowTotal = 90 + 90 + 90 + 90; // A + Match + Flag + B
-  const catWidth    = Math.max(420, tableWidth - narrowTotal - 12);
+  const head = [columns.map(c => c.header ?? c.title ?? dash(c))];
+  const body = rows.map(r => columns.map(c => {
+    const key = c.dataKey ?? c.key ?? c;
+    const val = r[key];
+    return dash(val);
+  }));
 
-  const body = rowsRaw.map(r => {
-    const twoLines = doc.splitTextToSize(r[0], catWidth).slice(0,2);
-    if (doc.splitTextToSize(r[0], catWidth).length > 2) {
-      // add ellipsis to last visible line
-      twoLines[1] = (twoLines[1]||"").replace(/\s+$/,"") + "…";
-    }
-    return [twoLines.join("\n"), r[1], r[2], r[3], r[4]];
-  });
-
-  const runAT = (doc.autoTable ? doc.autoTable.bind(doc) : window.jspdf.autoTable);
-
-  runAT({
-    head: [["Category","Partner A","Match %","Flag","Partner B"]],
+  autoTableFn(doc, {
+    head,
     body,
-    margin: { top: marginTop, left: marginLR, right: marginLR, bottom: marginBot },
-    tableWidth,
-    startY: marginTop + 10,
+    startY: -BLEED,
+    startX: -BLEED,
+    tableWidth: W + BLEED*2,
+    margin: { top:0, right:0, bottom:0, left:0 },
+    theme: 'plain',
+    horizontalPageBreak: true,
     styles: {
-      fillColor:[0,0,0],
+      font:'helvetica',
+      fontSize:10,
       textColor:[255,255,255],
-      fontSize: 16,
-      cellPadding: 8,
-      halign: "center",
-      valign: "middle",
-      overflow: "linebreak",
-      lineColor: [255,255,255],
-      lineWidth: 0.25
+      cellPadding:0,
+      lineWidth:0,
+      fillColor:null,
+      overflow:'linebreak',
+      minCellHeight:14
     },
-    headStyles: { fillColor:[0,0,0], textColor:[255,255,255], fontStyle:"bold", halign:"center" },
+    headStyles: {
+      fontStyle:'bold',
+      textColor:[255,255,255],
+      fillColor:null,
+      cellPadding:0,
+      lineWidth:0,
+      minCellHeight:16
+    },
+    tableLineWidth: 0,
+    tableLineColor: [0,0,0],
     columnStyles: {
-      0:{ halign:"left",   cellWidth: catWidth }, // CATEGORY (wide, left)
-      1:{ halign:"center", cellWidth: 90        }, // PARTNER A
-      2:{ halign:"center", cellWidth: 90        }, // MATCH %
-      3:{ halign:"center", cellWidth: 90        }, // FLAG
-      4:{ halign:"center", cellWidth: 90        }  // PARTNER B (always last numeric)
+      0:{halign:'left'},
+      1:{halign:'center'},
+      2:{halign:'center'},
+      3:{halign:'center'}
     },
-    didDrawPage: paint
+    didParseCell(data){
+      data.cell.styles.fillColor = null;
+      data.cell.styles.lineWidth = 0;
+      data.cell.styles.lineColor = [0,0,0];
+    },
+    didAddPage(){
+      paint();
+      doc.setTextColor(255,255,255);
+      doc.setDrawColor(0,0,0);
+      doc.setLineWidth(0);
+    }
   });
 
-  // AUTO_RUN: save right now; to bind to a button instead, comment this line
-  doc.save("compatibility-report.pdf");
-})();
+  doc.save(filename);
+}
+
+window.tkExportPDF_BlackEdge = tkExportPDF_BlackEdge;
+window.tkGatherOneBoxData = gatherTableData;
+
+/* 4) Optional: solid-black proof (no table). Run from console to verify viewer shadows. */
+window.tkSolidBlackTest = function(){
+  const lib = window.jspdf;
+  if (!lib || typeof lib.jsPDF !== 'function') {
+    alert('jsPDF missing');
+    return;
+  }
+  const d = new lib.jsPDF({ unit:'pt', format:'letter' });
+  const w = d.internal.pageSize.getWidth();
+  const h = d.internal.pageSize.getHeight();
+  d.setFillColor(0,0,0);
+  d.rect(-10,-10,w+20,h+20,'F');
+  d.save('solid-black.pdf');
+  console.log('[tk] solid-black.pdf exported');
+};
+
+async function initTKOneBox(){
+  await ensureLabelsLoaded();
+  watchTable();
+  watchForNewTables();
+  wireDownloadButton();
+  console.info('[tk] One-Box patch ready');
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initTKOneBox, { once:true });
+} else {
+  initTKOneBox();
+}
 </script>


### PR DESCRIPTION
## Summary
- patch the compatibility snippet to harden loadLabels and cache normalized label maps
- rewrite tables on the fly using the patched labels and wire the download button to a full-bleed black-edge PDF exporter
- expose helper utilities for gathering rows and validating solid-black rendering

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e451d4d90c832cac213c6a7f5a7135