### PR TITLE
Add full-bleed PDF exporter snippet with label map and column dividers

### DIFF
--- a/snippet-compatibility-report-dark-pdf-export-full-bleed-black-dividers.html
+++ b/snippet-compatibility-report-dark-pdf-export-full-bleed-black-dividers.html
@@ -1,0 +1,176 @@
+<!-- === Full-Bleed Black PDF + Label Map + Vertical Column Dividers === -->
+<script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.2/dist/jspdf.umd.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jspdf-autotable@3.8.3/dist/jspdf.plugin.autotable.min.js"></script>
+<script>
+/* ---------------- Label map helpers ---------------- */
+function _tkNormalizeLabels(obj){
+  const out = {};
+  for (const [k,v] of Object.entries(obj || {})) {
+    const key = String(k || '').trim().toLowerCase();
+    if (!key) continue;
+    out[key] = String((v == null || String(v).trim() === '') ? k : v);
+  }
+  return out;
+}
+async function _tkGetLabelMap(){
+  if (typeof window.buildLabelMapSafely === 'function') {
+    try { return _tkNormalizeLabels(await window.buildLabelMapSafely() || {}); }
+    catch(e){ console.warn('[tk] buildLabelMapSafely failed; falling back', e); }
+  }
+  const [base, overrides] = await Promise.all([
+    fetch('/data/kinks.json').then(r => r.ok ? r.json() : {}).catch(()=> ({})),
+    fetch('/data/labels-overrides.json').then(r => r.ok ? r.json() : {}).catch(()=> ({})),
+  ]);
+  let map = { ...(base||{}), ...(overrides||{}) };
+  if (window.tkLabels && typeof window.tkLabels === 'object') map = { ...map, ...window.tkLabels };
+  return _tkNormalizeLabels(map);
+}
+const _tkLabelFor = (code, map) => code ? (map[String(code).trim().toLowerCase()] ?? code) : '';
+
+/* ---------------- Exporter ---------------- */
+async function tkExportPDF_WithLabelsBlackDividers({
+  filename='compatibility.pdf',
+  blank=' ',           // use '' for truly empty
+  dividerRGBA=[120,120,120] // column divider color (on black)
+} = {}) {
+  if (!confirm("Consent check:\nDo you have your partner’s consent to export/share this PDF?")) return;
+
+  const labelMap = await _tkGetLabelMap();
+
+  // Pull data from the visible table
+  const table = document.querySelector('table');
+  if (!table) { alert('No table found.'); return; }
+
+  const headers = [...table.querySelectorAll('thead th')].map(th => th.textContent.trim());
+  const rowsDom = [...table.querySelectorAll('tbody tr')];
+
+  const columns = (headers.length ? headers : ['Category','Partner A','Match %','Partner B'])
+    .map((h,i)=>({ header:h, dataKey:String(i) }));
+
+  // rows as arrays
+  const rows = rowsDom.map(tr => [...tr.children].map(td => td.textContent.trim()));
+  // force label mapping on first column (cb_* → human)
+  const missing = new Set();
+  for (let r=0; r<rows.length; r++) {
+    const code = rows[r][0];
+    const label = _tkLabelFor(code, labelMap);
+    if (label === code) missing.add(code);
+    rows[r][0] = (label == null || label === '') ? blank : String(label);
+  }
+  if (missing.size) console.log(`[tk] ${missing.size} codes missing label (sample):`, [...missing].slice(0,20));
+
+  // to AutoTable shapes
+  const head = [columns.map(c => c.header)];
+  const body = rows.map(r => columns.map((c,i) => {
+    const v = r[i];
+    return (v === undefined || v === null || v === '') ? blank : String(v);
+  }));
+
+  // PDF
+  const { jsPDF } = window.jspdf;
+  const doc = new jsPDF({ unit:'pt', format:'letter', compress:true, putOnlyUsedFonts:true });
+  const W = doc.internal.pageSize.getWidth();
+  const H = doc.internal.pageSize.getHeight();
+  const BLEED = 12;
+
+  const paint = () => { doc.setFillColor(0,0,0); doc.rect(-BLEED,-BLEED, W+BLEED*2, H+BLEED*2, 'F'); };
+  paint();
+  doc.setTextColor(255,255,255);
+  doc.setDrawColor(0,0,0);
+  doc.setLineWidth(0);
+
+  // Track column boundaries so we can draw vertical dividers
+  let columnXs = null;
+
+  doc.autoTable({
+    head, body,
+    startY: -BLEED,
+    startX: -BLEED,
+    tableWidth: W + BLEED*2,
+    margin: { top:0, right:0, bottom:0, left:0 },
+    theme: 'plain',
+    horizontalPageBreak: true,
+    styles: {
+      font:'helvetica',
+      fontSize:10,
+      textColor:[255,255,255],
+      cellPadding:0,
+      lineWidth:0,
+      fillColor:null,
+      overflow:'linebreak',
+      minCellHeight:14
+    },
+    headStyles: {
+      fontStyle:'bold',
+      textColor:[255,255,255],
+      fillColor:null,
+      cellPadding:0,
+      lineWidth:0,
+      minCellHeight:16
+    },
+    tableLineWidth: 0,
+    tableLineColor: [0,0,0],
+    columnStyles: {
+      0:{halign:'left'},
+      1:{halign:'center'},
+      2:{halign:'center'},
+      3:{halign:'center'}
+    },
+
+    // capture column x positions on the first head row
+    didParseCell(data){
+      data.cell.styles.fillColor = null;
+      data.cell.styles.lineWidth = 0;
+      data.cell.styles.lineColor = [0,0,0];
+      if (data.section === 'head' && data.row.index === 0) {
+        columnXs = columnXs || [];
+        // x at the right edge of this cell
+        columnXs[data.column.index] = data.cell.x + data.cell.width;
+      }
+    },
+
+    // draw vertical dividers at column boundaries (no horizontal lines)
+    didDrawCell(data){
+      if (!columnXs) return;
+      // draw only once per cell on its right edge except for last column
+      if (data.section !== 'head' && data.section !== 'body') return;
+      if (data.column.index >= data.table.columns.length - 1) return;
+
+      const x = data.cell.x + data.cell.width;  // right edge of this cell
+      const y0 = data.cell.y;
+      const y1 = data.cell.y + data.cell.height;
+
+      doc.setDrawColor(...dividerRGBA);
+      doc.setLineWidth(0.5); // thin divider
+      doc.line(x, y0, x, y1);
+      // restore no-stroke for subsequent calls
+      doc.setDrawColor(0,0,0);
+      doc.setLineWidth(0);
+    },
+
+    didAddPage(){
+      paint();
+      doc.setTextColor(255,255,255);
+      doc.setDrawColor(0,0,0);
+      doc.setLineWidth(0);
+      columnXs = null; // recalc per page
+    }
+  });
+
+  doc.save(filename);
+}
+
+/* ---------------- Wire the Download PDF button ---------------- */
+(function wireDownloadButton(){
+  const btn = [...document.querySelectorAll('a,button,input[type="button"],input[type="submit"]')]
+    .find(el => /download pdf/i.test((el.textContent||el.value||'').trim()));
+  if (btn) {
+    btn.onclick = null;
+    btn.removeAttribute('href');
+    btn.addEventListener('click', e => { e.preventDefault(); e.stopImmediatePropagation(); tkExportPDF_WithLabelsBlackDividers({}); }, { capture:true });
+    console.log('[tk] Download PDF → tkExportPDF_WithLabelsBlackDividers');
+  } else {
+    console.warn('[tk] Download PDF button not found; call tkExportPDF_WithLabelsBlackDividers() manually.');
+  }
+})();
+</script>


### PR DESCRIPTION
## Summary
- add a drop-in snippet that exports the compatibility table to a full-bleed black PDF
- normalize labels from multiple sources before exporting and log any missing codes
- render vertical column dividers for clearer column separation in the PDF output

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e59865031c832cb3ef1b61e2a1c414