### PR TITLE
Simplify black grid PDF export snippet

### DIFF
--- a/snippet-compatibility-report-dark-pdf-export-full-bleed-black-grid-names.html
+++ b/snippet-compatibility-report-dark-pdf-export-full-bleed-black-grid-names.html
@@ -1,123 +1,177 @@
 <!-- === Full-Bleed Black PDF + Full Grid + Label Mapping === -->
 <script>
-/* === TK Codex One-Box: labels + black grid + nice outline + button hijack === */
-const tk = window.tk || (window.tk={});
-tk.clean = s => String(s||'').normalize('NFKC').replace(/[\u200B-\u200D\uFEFF]/g,'').trim();
-tk.keyVars = k => { const b=tk.clean(k).toLowerCase(); return [b, b.replace(/^cb_/,'')]; };
-tk.titleize = s => tk.clean(s).replace(/^cb_/i,'').replace(/[_-]+/g,' ')
-  .replace(/\b([a-z])([a-z]*)/gi,(_,a,b)=>a.toUpperCase()+b.toLowerCase());
+(async function () {
+  // ---- load libs ----
+  const need = (ok, src) => ok ? Promise.resolve() : new Promise((res, rej) => {
+    const s = document.createElement('script');
+    s.src = src;
+    s.onload = res;
+    s.onerror = rej;
+    document.head.appendChild(s);
+  });
+  await need(window.jspdf && window.jspdf.jsPDF, 'https://cdn.jsdelivr.net/npm/jspdf@2.5.2/dist/jspdf.umd.min.js');
+  await need(window.jspdf && window.jspdf.jsPDF?.prototype?.autoTable, 'https://cdn.jsdelivr.net/npm/jspdf-autotable@3.8.3/dist/jspdf.plugin.autotable.min.js');
 
-tk.normalizeAny = (input)=>{ const out={}, put=(k,v)=>{const val=tk.clean(v)||tk.clean(k); tk.keyVars(k).forEach(kk=>{ if(kk) out[kk]=val; });};
-  if(!input) return out;
-  if(Array.isArray(input)){ for(const it of input){
-    if(Array.isArray(it)&&it.length>=2){ put(it[0],it[1]); continue; }
-    if(it&&typeof it==='object'){ const k=it.code??it.id??it.key??it.slug??it.name??it.kink??it.value;
-      const v=it.title??it.label??it.display??it.name??it.text??it.pretty??it.kink??it.value; if(k!=null) put(k, v??k); }
-  } return out; }
-  for(const [k,v] of Object.entries(input||{})){ if(v&&typeof v==='object'){ put(k, v.title??v.label??v.name??v.display??v.text??v.pretty??k); } else put(k,v); }
-  return out;
-};
-tk.fetchJSON = async (url)=>{ try{ const r=await fetch(url,{cache:'no-store'}); return r.ok? r.json():null; }catch{return null;} };
-tk.buildLabelMap = async ()=>{ let raw=null;
-  if(typeof window.buildLabelMapSafely==='function'){ try{ raw=await window.buildLabelMapSafely(); }catch{} }
-  if(!raw){ const [base,over]=await Promise.all([tk.fetchJSON('/data/kinks.json'), tk.fetchJSON('/data/labels-overrides.json')]);
-    raw={...(base||{}), ...(over||{}), ...(window.tkLabels||{})}; }
-  const map=tk.normalizeAny(raw); if(!Object.keys(map).length) console.error('[labels] Empty map'); return map;
-};
-tk.readTable = ()=>{ const tbl=document.querySelector('table'); if(!tbl) throw new Error('No <table> found');
-  const headers=[...tbl.querySelectorAll('thead th')].map(th=>tk.clean(th.textContent));
-  const rows=[...tbl.querySelectorAll('tbody tr')].map(tr=>[...tr.children].map(td=>tk.clean(td.textContent)));
-  return {headers,rows};
-};
-tk.ensurePDFLibs = async ()=>{ const need=(ok,src)=> ok?Promise.resolve():new Promise((res,rej)=>{const s=document.createElement('script');s.src=src;s.onload=res;s.onerror=rej;document.head.appendChild(s);});
-  await need(window.jspdf && window.jspdf.jsPDF,'https://cdn.jsdelivr.net/npm/jspdf@2.5.2/dist/jspdf.umd.min.js');
-  await need(window.jspdf && window.jspdf.jsPDF?.prototype?.autoTable,'https://cdn.jsdelivr.net/npm/jspdf-autotable@3.8.3/dist/jspdf.plugin.autotable.min.js');
-};
+  // ---- helpers ----
+  const clean = s => String(s || '').normalize('NFKC').replace(/[\u200B-\u200D\uFEFF]/g, '').trim();
+  const keyVars = k => {
+    const base = clean(k).toLowerCase();
+    return [base, base.replace(/^cb_/, '')];
+  };
+  const titleize = s => clean(s)
+    .replace(/^cb_/i, '')
+    .replace(/[_-]+/g, ' ')
+    .replace(/\b([a-z])([a-z]*)/gi, (_, a, b) => a.toUpperCase() + b.toLowerCase());
 
-/* Export: strict names + full grid + OUTER OUTLINE */
-tk.export = async ()=> {
-  await tk.ensurePDFLibs();
-  const map = await tk.buildLabelMap();
-  const { headers, rows } = tk.readTable();
+  async function fetchJSON(url) {
+    try {
+      const res = await fetch(url, { cache: 'no-store' });
+      return res.ok ? res.json() : null;
+    } catch {
+      return null;
+    }
+  }
 
-  // Map first column strictly (show code only if truly missing)
-  const missing=new Set();
-  const body = rows.map(r=>{
-    let label=null; for(const kv of tk.keyVars(r[0])) if(map[kv]){ label=map[kv]; break; }
-    if(!label){ missing.add(r[0]); }
-    r[0]=label||tk.titleize(r[0]);
-    for(let i=0;i<r.length;i++) if(r[i]===''||r[i]==='—') r[i]=' ';
+  function normalizeAny(input) {
+    const out = {};
+    const put = (k, v) => {
+      const val = clean(v) || clean(k);
+      keyVars(k).forEach(kk => {
+        if (kk) out[kk] = val;
+      });
+    };
+
+    if (!input) return out;
+
+    if (Array.isArray(input)) {
+      for (const it of input) {
+        if (Array.isArray(it) && it.length >= 2) {
+          put(it[0], it[1]);
+          continue;
+        }
+        if (it && typeof it === 'object') {
+          const k = it.code ?? it.id ?? it.key ?? it.slug ?? it.name ?? it.kink ?? it.value;
+          const v = it.title ?? it.label ?? it.display ?? it.name ?? it.text ?? it.pretty ?? it.kink ?? it.value;
+          if (k != null) put(k, v ?? k);
+        }
+      }
+      return out;
+    }
+
+    for (const [k, v] of Object.entries(input)) {
+      if (v && typeof v === 'object') {
+        put(k, v.title ?? v.label ?? v.name ?? v.display ?? v.text ?? v.pretty ?? k);
+      } else {
+        put(k, v);
+      }
+    }
+    return out;
+  }
+
+  // ---- build label map if available ----
+  let raw = null;
+  if (typeof window.buildLabelMapSafely === 'function') {
+    try {
+      raw = await window.buildLabelMapSafely();
+    } catch {}
+  }
+  if (!raw) {
+    const [base, over] = await Promise.all([
+      fetchJSON('/data/kinks.json'),
+      fetchJSON('/data/labels-overrides.json')
+    ]);
+    raw = { ...(base || {}), ...(over || {}), ...(window.tkLabels || {}) };
+  }
+  const MAP = normalizeAny(raw);
+
+  // ---- read the current table ----
+  const tbl = document.querySelector('table');
+  if (!tbl) {
+    alert('No <table> found.');
+    return;
+  }
+  const headers = [...tbl.querySelectorAll('thead th')].map(th => clean(th.textContent)) || ['Category', 'Partner A', 'Match %', 'Partner B'];
+  const rows = [...tbl.querySelectorAll('tbody tr')].map(tr => [...tr.children].map(td => clean(td.textContent)));
+
+  // ---- swap first column ----
+  const finalRows = rows.map(r => {
+    let label = null;
+    for (const kv of keyVars(r[0])) {
+      if (MAP[kv]) {
+        label = MAP[kv];
+        break;
+      }
+    }
+    r[0] = label || titleize(r[0]);
+    for (let i = 0; i < r.length; i++) {
+      if (r[i] === '' || r[i] === '—') r[i] = ' ';
+    }
     return r;
   });
-  if(missing.size) console.warn('[labels] Missing labels for:', [...missing]);
 
+  // ---- make PDF ----
   const { jsPDF } = window.jspdf;
-  const doc = new jsPDF({ unit:'pt', format:'letter', compress:true, putOnlyUsedFonts:true });
-  const W = doc.internal.pageSize.getWidth(), H = doc.internal.pageSize.getHeight();
+  const doc = new jsPDF({ unit: 'pt', format: 'letter', compress: true, putOnlyUsedFonts: true });
+  const W = doc.internal.pageSize.getWidth();
+  const H = doc.internal.pageSize.getHeight();
 
-  // Background: true full-bleed black
-  doc.setFillColor(0,0,0); doc.rect(0,0,W,H,'F'); doc.setTextColor(255,255,255);
+  doc.setFillColor(0, 0, 0);
+  doc.rect(0, 0, W, H, 'F');
+  doc.setTextColor(255, 255, 255);
 
-  // Layout + grid style
-  const OUTER = 40;               // page margin so text isn't on the edge
-  const GRID  = [160,160,160];    // grid (divider) color
-  const OUTLINE = [200,200,200];  // NICE outline color (slightly brighter)
-  const OUTLINE_W = 1.6;          // NICE outline thickness
-  const head = [ headers.length?headers:['Category','Partner A','Match %','Partner B'] ];
+  const OUTER = 40;
+  const GRID = [160, 160, 160];
+  const OUTLINE = [200, 200, 200];
+  const OUTLINE_W = 1.6;
 
-  // Draw table
   doc.autoTable({
-    head, body, theme:'grid',
-    margin:{ top:OUTER, right:OUTER, bottom:OUTER, left:OUTER },
-    tableWidth: W - OUTER*2,
-    styles:{ font:'helvetica', fontSize:13, textColor:[255,255,255], fillColor:null, cellPadding:12, lineWidth:0.7, lineColor:GRID, minCellHeight:24 },
-    headStyles:{ fontStyle:'bold', textColor:[255,255,255], fillColor:null, lineWidth:0.9, lineColor:GRID },
-    tableLineWidth:0.9, tableLineColor:GRID,
-    columnStyles:{ 0:{halign:'left'}, 1:{halign:'center'}, 2:{halign:'center'}, 3:{halign:'center'} },
-    didAddPage(){
-      // repaint background on every page
-      doc.setFillColor(0,0,0); doc.rect(0,0,W,H,'F'); doc.setTextColor(255,255,255);
+    head: [headers],
+    body: finalRows,
+    theme: 'grid',
+    margin: { top: OUTER, right: OUTER, bottom: OUTER, left: OUTER },
+    tableWidth: W - OUTER * 2,
+    styles: {
+      font: 'helvetica',
+      fontSize: 13,
+      textColor: [255, 255, 255],
+      fillColor: null,
+      cellPadding: 12,
+      lineWidth: 0.7,
+      lineColor: GRID,
+      minCellHeight: 24
+    },
+    headStyles: {
+      fontStyle: 'bold',
+      textColor: [255, 255, 255],
+      fillColor: null,
+      lineWidth: 0.9,
+      lineColor: GRID
+    },
+    tableLineWidth: 0.9,
+    tableLineColor: GRID,
+    columnStyles: {
+      0: { halign: 'left' },
+      1: { halign: 'center' },
+      2: { halign: 'center' },
+      3: { halign: 'center' }
+    },
+    didAddPage() {
+      doc.setFillColor(0, 0, 0);
+      doc.rect(0, 0, W, H, 'F');
+      doc.setTextColor(255, 255, 255);
     }
   });
 
-  // NICE OUTER OUTLINE around the table (after table rendered)
-  const startY = OUTER;                               // because we set margin top to OUTER
-  const endY   = doc.lastAutoTable.finalY;            // bottom of the table
-  const leftX  = OUTER;
-  const width  = W - OUTER*2;
-  const height = Math.max(0, endY - startY);
+  const topY = OUTER;
+  const botY = doc.lastAutoTable.finalY;
+  const leftX = OUTER;
+  const width = W - OUTER * 2;
+  const height = Math.max(0, botY - topY);
 
   doc.setLineWidth(OUTLINE_W);
   doc.setDrawColor(...OUTLINE);
-  doc.rect(leftX, startY, width, height, 'S');        // stroke only
+  doc.rect(leftX, topY, width, height, 'S');
 
   doc.save('compatibility-black-grid-NAMES.pdf');
-};
-
-/* Optional helpers in console */
-tk.list = async ()=>{ const map=await tk.buildLabelMap(); const have=new Set(Object.keys(map));
-  const {rows}=tk.readTable(); const codes=[...new Set(rows.map(r=>r[0]).filter(Boolean))];
-  const rep=codes.map(code=>{const [a,b]=tk.keyVars(code);return {code,has:!!(map[a]||map[b]),label:map[a]||map[b]||'(missing)'};});
-  console.table(rep); const miss=rep.filter(x=>!x.has).map(x=>x.code); if(miss.length) console.warn('[labels] Missing:',miss); return rep; };
-
-tk.generateOverrides = async ()=>{ const {rows}=tk.readTable();
-  const codes=[...new Set(rows.map(r=>r[0]).filter(Boolean))];
-  const overrides=Object.fromEntries(codes.map(c=>[c, tk.clean(c).replace(/^cb_/i,'').replace(/_/g,' ').replace(/\b([a-z])([a-z]*)/gi,(_,a,b)=>a.toUpperCase()+b.toLowerCase())]));
-  const blob=new Blob([JSON.stringify(overrides,null,2)],{type:'application/json'});
-  const a=document.createElement('a'); a.href=URL.createObjectURL(blob); a.download='labels-overrides.json'; a.click(); URL.revokeObjectURL(a.href);
-  console.log('[overrides] downloaded labels-overrides.json with', codes.length, 'entries — edit to real names, upload to /data'); return overrides;
-};
-
-/* Hijack ANY “Download PDF” / “Export PDF” / “Save PDF” click so old exporter can’t run */
-window.addEventListener('click', function(e){
-  const t=e.target.closest('a,button,input');
-  const label=(t?.textContent||t?.value||'').toLowerCase();
-  if (/download\s*pdf|export\s*pdf|save\s*pdf/.test(label)) { e.stopImmediatePropagation(); e.preventDefault(); tk.export(); }
-}, true);
-
-/* Quick usage:
-   tk.export()                // export now (strict names, black, grid, nice outline)
-   tk.list()                  // see which codes are missing labels
-   tk.generateOverrides()     // download full overrides skeleton to /data/labels-overrides.json
-*/
+})();
 </script>


### PR DESCRIPTION
## Summary
- replace the tk namespace helper with a self-invoking PDF export script
- load jspdf and autotable on demand and normalize labels inline before exporting
- keep the full-bleed black styling with a grid and outer outline when saving the PDF

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5b78e910c832cb3f7e2f156bb8fa3