### PR TITLE
Add permanent compatibility PDF exporter hijack

### DIFF
--- a/compatibility.html
+++ b/compatibility.html
@@ -2874,5 +2874,115 @@ document.getElementById('copyAtoB')?.addEventListener('click', () => {
 })();
 </script>
 <!-- ======================== /TK ONE-PASTE PATCH ======================== -->
+  <script>
+  (() => {
+    const clean = s => String(s||'').normalize('NFKC').replace(/[\u200B-\u200D\uFEFF]/g,'').trim();
+    const keyVars = k => { const b=clean(k).toLowerCase(); return [b, b.replace(/^cb_/,'')]; };
+    const pretty  = s => clean(s).replace(/^cb_/i,'').replace(/[_-]+/g,' ')
+                       .replace(/\b([a-z])([a-z]*)/gi,(_,a,b)=>a.toUpperCase()+b.toLowerCase());
+    const need=(ok,src)=> ok?Promise.resolve():new Promise((res,rej)=>{const s=document.createElement('script');s.src=src;s.onload=res;s.onerror=rej;document.head.appendChild(s);});
+    const fetchJSON = async u => { try{ const r=await fetch(u,{cache:'no-store'}); return r.ok?r.json():null; }catch{return null;} };
+    const normalizeAny = (input)=>{ const out={}, put=(k,v)=>{ const val=clean(v)||clean(k); keyVars(k).forEach(kk=>{ if(kk) out[kk]=val; }); };
+      if(!input) return out;
+      if(Array.isArray(input)){ for(const it of input){ if(Array.isArray(it)&&it.length>=2){ put(it[0],it[1]); continue; }
+        if(it&&typeof it==='object'){ const k=it.code??it.id??it.key??it.slug??it.name??it.kink??it.value;
+          const v=it.title??it.label??it.display??it.name??it.text??it.pretty??it.kink??it.value; if(k!=null) put(k,v??k);} } return out; }
+      for(const [k,v] of Object.entries(input)){ if(v&&typeof v==='object'){ put(k, v.title??v.label??v.name??v.display??v.text??v.pretty??k);} else put(k,v); }
+      return out;
+    };
+
+    async function buildMap(){
+      let raw=null;
+      if(typeof window.buildLabelMapSafely==='function'){ try{ raw=await window.buildLabelMapSafely(); }catch{} }
+      if(!raw){ const [base,over]=await Promise.all([fetchJSON('/data/kinks.json'), fetchJSON('/data/labels-overrides.json')]); raw={...(base||{}),...(over||{}),...(window.tkLabels||{})}; }
+      return normalizeAny(raw);
+    }
+    function readTable(){
+      const tbl=document.querySelector('table'); if(!tbl) throw new Error('No <table> found');
+      const headers=[...tbl.querySelectorAll('thead th')].map(th=>clean(th.textContent))||['Category','Partner A','Match %','Partner B'];
+      const rows=[...tbl.querySelectorAll('tbody tr')].map(tr=>[...tr.children].map(td=>clean(td.textContent)));
+      return {headers,rows};
+    }
+    async function ensurePDF(){ 
+      await need(window.jspdf && window.jspdf.jsPDF,"https://cdn.jsdelivr.net/npm/jspdf@2.5.2/dist/jspdf.umd.min.js");
+      await need(window.jspdf && window.jspdf.jsPDF?.prototype?.autoTable,"https://cdn.jsdelivr.net/npm/jspdf-autotable@3.8.3/dist/jspdf.plugin.autotable.min.js");
+    }
+
+    async function exportPDF(){
+      await ensurePDF();
+      const MAP=await buildMap();
+      const {headers,rows}=readTable();
+
+      const body=rows.map(r=>{
+        let label=null; for(const kv of keyVars(r[0])) if(MAP[kv]){ label=MAP[kv]; break; }
+        r[0]=label || pretty(r[0]);                            // remove cb_ always
+        for(let i=0;i<r.length;i++) if(r[i]===''||r[i]==='—') r[i]=' ';
+        return r;
+      });
+
+      const { jsPDF }=window.jspdf;
+      const doc=new jsPDF({unit:'pt',format:'letter',compress:true,putOnlyUsedFonts:true});
+      const W=doc.internal.pageSize.getWidth(), H=doc.internal.pageSize.getHeight();
+      doc.setFillColor(0,0,0); doc.rect(0,0,W,H,'F'); doc.setTextColor(255,255,255);
+
+      const OUTER=40, GRID=[160,160,160], OUTLINE=[200,200,200], OUTLINE_W=1.6;
+      const tableWidth = W - OUTER*2;
+      const col = {
+        0:{cellWidth:tableWidth*0.40,halign:'left'},
+        1:{cellWidth:tableWidth*0.20,halign:'center'},
+        2:{cellWidth:tableWidth*0.20,halign:'center'},
+        3:{cellWidth:tableWidth*0.20,halign:'center'}
+      };
+
+      doc.autoTable({
+        head:[headers], body, theme:'grid',
+        margin:{top:OUTER,right:OUTER,bottom:OUTER,left:OUTER},
+        tableWidth,
+        styles:{ font:'helvetica', fontSize:13, textColor:[255,255,255], fillColor:null,
+                 cellPadding:12, lineWidth:0.7, lineColor:GRID, minCellHeight:24 },
+        headStyles:{ fontStyle:'bold', textColor:[255,255,255], fillColor:null, lineWidth:0.9, lineColor:GRID },
+        tableLineWidth:0.9, tableLineColor:GRID,
+        columnStyles: col,
+        didAddPage(){ doc.setFillColor(0,0,0); doc.rect(0,0,W,H,'F'); doc.setTextColor(255,255,255); }
+      });
+
+      const topY=OUTER, botY=doc.lastAutoTable.finalY, leftX=OUTER, height=Math.max(0, botY-topY);
+      doc.setLineWidth(OUTLINE_W); doc.setDrawColor(...OUTLINE); doc.rect(leftX, topY, tableWidth, height, 'S');
+      doc.save('compatibility-black-grid-NAMES.pdf');
+    }
+
+    // ---- PERMANENT HIJACK: route ALL PDF-like clicks to exportPDF ----
+    function bindExporter(root=document){
+      const els=[...root.querySelectorAll('a,button,[role="button"],input[type="button"],input[type="submit"]')];
+      for(const el of els){
+        const label=(el.textContent||el.value||'').toLowerCase();
+        const attrs=(el.getAttributeNames?.()||[]).map(n=>(el.getAttribute(n)||'').toLowerCase()).join(' ');
+        const looksPdf=/pdf|export|download|save|print/.test(label+attrs) || /\.pdf(?:\b|$)/.test(el.getAttribute('href')||'');
+        if(!looksPdf) continue;
+        el.removeAttribute('href'); el.onclick=null; el.onmousedown=null; el.onmouseup=null;
+        const clone=el.cloneNode(true); el.replaceWith(clone);
+        clone.addEventListener('click', (e)=>{ e.preventDefault(); e.stopImmediatePropagation(); exportPDF(); }, {capture:true});
+      }
+    }
+    bindExporter();
+    new MutationObserver(()=>bindExporter()).observe(document.documentElement,{childList:true,subtree:true});
+
+    // add a floating button + hotkey too
+    (function addButton(){
+      if (document.getElementById('tk-pdf-btn')) return;
+      const b=document.createElement('button'); b.id='tk-pdf-btn';
+      Object.assign(b.style,{position:'fixed',right:'18px',bottom:'18px',zIndex:2147483647,padding:'10px 14px',
+        borderRadius:'10px',border:'1px solid #aaa',background:'#111',color:'#fff',font:'14px/1 system-ui, sans-serif',
+        boxShadow:'0 2px 10px rgba(0,0,0,.4)',cursor:'pointer'});
+      b.textContent='Download PDF';
+      b.addEventListener('click',e=>{e.preventDefault();e.stopImmediatePropagation();exportPDF();},{capture:true});
+      document.body.appendChild(b);
+      window.addEventListener('keydown',e=>{ if(e.shiftKey&&(e.key==='D'||e.key==='d')){ e.preventDefault(); exportPDF(); } },true);
+    })();
+
+    // expose for console
+    window.tk = Object.assign(window.tk||{}, { export: exportPDF });
+  })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- embed the black-grid PDF exporter snippet directly into `compatibility.html`
- intercept PDF/download triggers to route through the new exporter and add a floating download button
- normalize category labels for cb_ codes when exporting

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5c3cac264832ca61cc55710812a86